### PR TITLE
Auto-open dashboard on pnpm dev

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "vite --port 3000",
+    "dev": "vite --port 3000 --open",
     "build": "vite build",
     "preview": "vite preview",
     "clean": "rm -rf dist"


### PR DESCRIPTION
## Summary
- Adds `--open` flag to Vite dev command so the dashboard automatically opens in the browser when running `pnpm dev`

## Test plan
- [ ] Run `pnpm dev` and verify browser opens to `http://localhost:3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)