### PR TITLE
Auto-create GitHub release on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -42,3 +42,8 @@ jobs:
         working-directory: dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        run: gh release create "${{ github.ref_name }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Add `gh release create` step to publish workflow with auto-generated release notes
- Changed `contents` permission from `read` to `write` to allow release creation

Next time a tag is pushed, a GitHub release will be created automatically alongside the npm publish.

Generated with [Claude Code](https://claude.com/claude-code)