### PR TITLE
Fix analytics workspace navigation

### DIFF
--- a/apps/web/src/components/layout/LeftSidebar.tsx
+++ b/apps/web/src/components/layout/LeftSidebar.tsx
@@ -4,6 +4,18 @@ import { AlertTriangle, Shield, FolderTree, Workflow, Database, BarChart3, Clipb
 
 export type LeftTab = 'violations' | 'rules' | 'files' | 'flows' | 'databases' | 'analytics' | 'analyses';
 
+const TAB_LABELS: Record<LeftTab, string> = {
+  violations: 'Violations',
+  rules: 'Rules',
+  files: 'Files',
+  flows: 'Flows',
+  databases: 'Databases',
+  analytics: 'Analytics',
+  analyses: 'Analyses',
+};
+
+const TABS_WITHOUT_PANEL = new Set<LeftTab>(['analytics', 'analyses']);
+
 type LeftSidebarProps = {
   activeTab: LeftTab | null;
   onTabChange: (tab: LeftTab | null) => void;
@@ -70,7 +82,7 @@ export function LeftSidebar({
     [width, minWidth, maxWidth],
   );
 
-  const isOpen = activeTab !== null && activeTab !== 'analytics' && activeTab !== 'analyses';
+  const isOpen = activeTab !== null && !TABS_WITHOUT_PANEL.has(activeTab);
 
   return (
     <div className="flex flex-shrink-0 h-full">
@@ -136,7 +148,7 @@ export function LeftSidebar({
           {/* Panel header */}
           <div className="flex h-10 items-center gap-2 border-b border-border px-3">
             <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              {activeTab === 'violations' ? 'Violations' : activeTab === 'rules' ? 'Rules' : activeTab === 'flows' ? 'Flows' : activeTab === 'databases' ? 'Databases' : activeTab === 'analytics' ? 'Analytics' : 'Files'}
+              {activeTab ? TAB_LABELS[activeTab] : ''}
             </span>
             {(() => {
               const badge = activeTab ? badgeCounts?.[activeTab] : undefined;

--- a/apps/web/src/components/pages/RepoGraphPage.tsx
+++ b/apps/web/src/components/pages/RepoGraphPage.tsx
@@ -1003,7 +1003,7 @@ export default function RepoGraphPage() {
           {/* Tab bar when files or flows are open */}
           {(openFiles.length > 0 || openFlows.length > 0 || openDatabases.length > 0) && (
             <div className="flex shrink-0 items-center border-b border-border bg-card text-xs overflow-x-auto">
-              {/* Graph tab */}
+              {/* Home tab */}
               <button
                 onClick={() => { handleSelectTab(null); setActiveFlowId(null); setActiveDbId(null); }}
                 className={`shrink-0 px-3 py-1.5 border-r border-border transition-colors ${
@@ -1012,7 +1012,7 @@ export default function RepoGraphPage() {
                     : 'text-muted-foreground hover:text-foreground hover:bg-muted'
                 }`}
               >
-                Graph
+                Home
               </button>
               {/* File tabs */}
               {openFiles.map((file) => {

--- a/apps/web/src/components/pages/RepoGraphPage.tsx
+++ b/apps/web/src/components/pages/RepoGraphPage.tsx
@@ -221,6 +221,18 @@ export default function RepoGraphPage() {
     }
   }, []);
 
+  const handleLeftTabChange = useCallback((tab: LeftTab | null) => {
+    setLeftTab(tab);
+
+    // Overview tabs should return to the graph/dashboard area instead of leaving
+    // an old file, flow, or database detail tab active over the main content.
+    if (tab === 'violations' || tab === 'rules' || tab === 'analytics' || tab === 'analyses') {
+      setActiveFilePath(null);
+      setActiveFlowId(null);
+      setActiveDbId(null);
+    }
+  }, [setLeftTab, setActiveFilePath, setActiveFlowId, setActiveDbId]);
+
   const handleOpenDatabase = useCallback((dbId: string, dbName: string, pinned: boolean) => {
     setOpenDatabases((prev) => {
       const existing = prev.find((d) => d.id === dbId);
@@ -897,7 +909,7 @@ export default function RepoGraphPage() {
 
       <div className="flex flex-1 overflow-hidden">
         {/* Left sidebar: icon rail + violations/rules panel */}
-        <LeftSidebar activeTab={leftTab} onTabChange={setLeftTab} isCodeReviewing={isCodeReviewing} badgeCounts={{
+        <LeftSidebar activeTab={leftTab} onTabChange={handleLeftTabChange} isCodeReviewing={isCodeReviewing} badgeCounts={{
           violations: isDiffMode && diffResult
             ? { newCount: diffResult.summary.newCount, resolvedCount: diffResult.summary.resolvedCount }
             : allViolations.length,

--- a/apps/web/src/components/pages/RepoGraphPage.tsx
+++ b/apps/web/src/components/pages/RepoGraphPage.tsx
@@ -51,6 +51,23 @@ type OpenDatabase = {
   pinned: boolean;
 };
 
+const VALID_LEFT_TABS = new Set<LeftTab>([
+  'violations',
+  'rules',
+  'files',
+  'flows',
+  'databases',
+  'analytics',
+  'analyses',
+]);
+
+const MAIN_CONTENT_TABS = new Set<LeftTab>([
+  'violations',
+  'rules',
+  'analytics',
+  'analyses',
+]);
+
 export default function RepoGraphPage() {
   const { repoId = '' } = useParams();
   const [searchParams] = useSearchParams();
@@ -83,7 +100,7 @@ export default function RepoGraphPage() {
   const [isChatOpen, setIsChatOpen] = useState(false);
   const [leftTab, setLeftTabState] = useState<LeftTab | null>(() => {
     const tabParam = searchParams?.get('tab');
-    if (tabParam && ['violations', 'rules', 'files', 'flows', 'databases', 'analytics', 'analyses'].includes(tabParam)) {
+    if (tabParam && VALID_LEFT_TABS.has(tabParam as LeftTab)) {
       return tabParam as LeftTab;
     }
     if (searchParams?.get('flow')) return 'flows';
@@ -157,11 +174,6 @@ export default function RepoGraphPage() {
     }
   }, [openFiles, activeFilePath, setActiveFilePath]);
 
-  const handleSelectTab = useCallback((path: string | null) => {
-    setActiveFilePath(path);
-    if (path) { setActiveFlowIdState(null); setActiveDbIdState(null); }
-  }, []);
-
   // Multi-tab flow viewer state — restore from URL
   const flowFromUrl = searchParams?.get('flow') || null;
   const [openFlows, setOpenFlows] = useState<OpenFlow[]>(() =>
@@ -181,6 +193,58 @@ export default function RepoGraphPage() {
     navigate(url.pathname + url.search, { replace: true });
   }, [navigate]);
 
+  const handleCloseFlow = useCallback((flowId: string) => {
+    setOpenFlows((prev) => prev.filter((f) => f.id !== flowId));
+    if (activeFlowId === flowId) {
+      const remaining = openFlows.filter((f) => f.id !== flowId);
+      setActiveFlowId(remaining.length > 0 ? remaining[remaining.length - 1].id : null);
+    }
+  }, [openFlows, activeFlowId, setActiveFlowId]);
+
+  // Multi-tab database viewer state
+  const [openDatabases, setOpenDatabases] = useState<OpenDatabase[]>([]);
+  const [activeDbId, setActiveDbIdState] = useState<string | null>(null);
+
+  const setActiveDbId = useCallback((id: string | null) => {
+    setActiveDbIdState(id);
+  }, []);
+
+  const clearActiveDetailView = useCallback(() => {
+    setActiveFilePath(null);
+    setActiveFlowId(null);
+    setActiveDbId(null);
+  }, [setActiveFilePath, setActiveFlowId, setActiveDbId]);
+
+  const showFileView = useCallback((path: string | null) => {
+    setActiveFilePath(path);
+    setActiveFlowId(null);
+    setActiveDbId(null);
+  }, [setActiveFilePath, setActiveFlowId, setActiveDbId]);
+
+  const handleSelectTab = useCallback((path: string | null) => {
+    showFileView(path);
+  }, [showFileView]);
+
+  const showFlowView = useCallback((flowId: string | null) => {
+    setActiveFlowId(flowId);
+    setActiveFilePath(null);
+    setActiveDbId(null);
+  }, [setActiveFlowId, setActiveFilePath, setActiveDbId]);
+
+  const showDatabaseView = useCallback((dbId: string | null) => {
+    setActiveDbId(dbId);
+    setActiveFilePath(null);
+    setActiveFlowId(null);
+  }, [setActiveDbId, setActiveFilePath, setActiveFlowId]);
+
+  const handleLeftTabChange = useCallback((tab: LeftTab | null) => {
+    setLeftTab(tab);
+
+    if (tab && MAIN_CONTENT_TABS.has(tab)) {
+      clearActiveDetailView();
+    }
+  }, [setLeftTab, clearActiveDetailView]);
+
   const handleOpenFlow = useCallback((flowId: string, pinned: boolean) => {
     setOpenFlows((prev) => {
       const existing = prev.find((f) => f.id === flowId);
@@ -196,42 +260,8 @@ export default function RepoGraphPage() {
       }
       return [...prev, { id: flowId, name: 'Flow', pinned: false }];
     });
-    setActiveFlowId(flowId);
-    setActiveFilePathState(null);
-    setActiveDbIdState(null);
-  }, [setActiveFlowId]);
-
-  const handleCloseFlow = useCallback((flowId: string) => {
-    setOpenFlows((prev) => prev.filter((f) => f.id !== flowId));
-    if (activeFlowId === flowId) {
-      const remaining = openFlows.filter((f) => f.id !== flowId);
-      setActiveFlowId(remaining.length > 0 ? remaining[remaining.length - 1].id : null);
-    }
-  }, [openFlows, activeFlowId, setActiveFlowId]);
-
-  // Multi-tab database viewer state
-  const [openDatabases, setOpenDatabases] = useState<OpenDatabase[]>([]);
-  const [activeDbId, setActiveDbIdState] = useState<string | null>(null);
-
-  const setActiveDbId = useCallback((id: string | null) => {
-    setActiveDbIdState(id);
-    if (id) {
-      setActiveFilePathState(null);
-      setActiveFlowIdState(null);
-    }
-  }, []);
-
-  const handleLeftTabChange = useCallback((tab: LeftTab | null) => {
-    setLeftTab(tab);
-
-    // Overview tabs should return to the graph/dashboard area instead of leaving
-    // an old file, flow, or database detail tab active over the main content.
-    if (tab === 'violations' || tab === 'rules' || tab === 'analytics' || tab === 'analyses') {
-      setActiveFilePath(null);
-      setActiveFlowId(null);
-      setActiveDbId(null);
-    }
-  }, [setLeftTab, setActiveFilePath, setActiveFlowId, setActiveDbId]);
+    showFlowView(flowId);
+  }, [showFlowView]);
 
   const handleOpenDatabase = useCallback((dbId: string, dbName: string, pinned: boolean) => {
     setOpenDatabases((prev) => {
@@ -248,8 +278,8 @@ export default function RepoGraphPage() {
       }
       return [...prev, { id: dbId, name: dbName, pinned: false }];
     });
-    setActiveDbId(dbId);
-  }, [setActiveDbId]);
+    showDatabaseView(dbId);
+  }, [showDatabaseView]);
 
   const handleCloseDatabase = useCallback((dbId: string) => {
     setOpenDatabases((prev) => prev.filter((d) => d.id !== dbId));
@@ -1005,7 +1035,7 @@ export default function RepoGraphPage() {
             <div className="flex shrink-0 items-center border-b border-border bg-card text-xs overflow-x-auto">
               {/* Home tab */}
               <button
-                onClick={() => { handleSelectTab(null); setActiveFlowId(null); setActiveDbId(null); }}
+                onClick={clearActiveDetailView}
                 className={`shrink-0 px-3 py-1.5 border-r border-border transition-colors ${
                   !showingCodeViewer && !showingFlow && !showingDatabase
                     ? 'bg-background text-foreground'
@@ -1021,7 +1051,7 @@ export default function RepoGraphPage() {
                 return (
                   <div
                     key={file.path}
-                    onClick={() => { handleSelectTab(file.path); setActiveFlowIdState(null); }}
+                    onClick={() => handleSelectTab(file.path)}
                     className={`group shrink-0 flex items-center gap-1 px-3 py-1.5 border-r border-border cursor-pointer transition-colors ${
                       isActive
                         ? 'bg-background text-foreground'
@@ -1050,7 +1080,7 @@ export default function RepoGraphPage() {
                 return (
                   <div
                     key={flow.id}
-                    onClick={() => { setActiveFlowId(flow.id); setActiveFilePathState(null); setActiveDbIdState(null); }}
+                    onClick={() => showFlowView(flow.id)}
                     className={`group shrink-0 flex items-center gap-1 px-3 py-1.5 border-r border-border cursor-pointer transition-colors ${
                       isActive
                         ? 'bg-background text-foreground'
@@ -1080,7 +1110,7 @@ export default function RepoGraphPage() {
                 return (
                   <div
                     key={db.id}
-                    onClick={() => { setActiveDbId(db.id); setActiveFilePathState(null); setActiveFlowIdState(null); }}
+                    onClick={() => showDatabaseView(db.id)}
                     className={`group shrink-0 flex items-center gap-1 px-3 py-1.5 border-r border-border cursor-pointer transition-colors ${
                       isActive
                         ? 'bg-background text-foreground'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "scripts": {
     "dev": "turbo dev",

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"


### PR DESCRIPTION
## Summary
- clear active file, flow, and database detail views when switching back to workspace-level tabs like Analytics and Analyses
- rename the fallback detail tab from Graph to Home to better match the workspace behavior
- refactor repo workspace tab handling to use explicit tab sets and shared view-switch helpers instead of hard-coded checks
- bump publish-facing version metadata to 0.1.18

## Testing
- pnpm --filter @truecourse/web build