### PR TITLE
Fix esbuild: externalize tree-sitter-python and pyright

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -64,6 +64,8 @@ run(
     '--external:tree-sitter',
     '--external:tree-sitter-typescript',
     '--external:tree-sitter-javascript',
+    '--external:tree-sitter-python',
+    '--external:pyright',
     '--external:embedded-postgres',
     '--external:postgres',
     // drizzle-kit is dev only


### PR DESCRIPTION
## Summary

- Add `tree-sitter-python` and `pyright` to esbuild externals in `scripts/build.ts`
- Native `.node` binaries can't be bundled — same treatment as other tree-sitter packages

Fixes the npm publish CI failure for v0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)