### PR TITLE
Fix Node 24 crash, include code violations in CLI summary (v0.2.3)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,8 +298,8 @@ importers:
   tools/cli:
     dependencies:
       '@clack/prompts':
-        specifier: ^0.9.0
-        version: 0.9.1
+        specifier: ^1.2.0
+        version: 1.2.0
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -528,11 +528,11 @@ packages:
       '@types/react':
         optional: true
 
-  '@clack/core@0.4.1':
-    resolution: {integrity: sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==}
+  '@clack/core@1.2.0':
+    resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
 
-  '@clack/prompts@0.9.1':
-    resolution: {integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==}
+  '@clack/prompts@1.2.0':
+    resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
@@ -2916,8 +2916,17 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4920,15 +4929,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@clack/core@0.4.1':
+  '@clack/core@1.2.0':
     dependencies:
-      picocolors: 1.1.1
+      fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
 
-  '@clack/prompts@0.9.1':
+  '@clack/prompts@1.2.0':
     dependencies:
-      '@clack/core': 0.4.1
-      picocolors: 1.1.1
+      '@clack/core': 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
 
   '@codemirror/autocomplete@6.20.1':
@@ -7079,7 +7089,17 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
 
   fastq@1.20.1:
     dependencies:

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"
@@ -15,8 +15,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@clack/prompts": "^1.2.0",
     "commander": "^12.1.0",
-    "@clack/prompts": "^0.9.0",
     "dotenv": "^16.4.0",
     "socket.io-client": "^4.7.0"
   },
@@ -24,8 +24,8 @@
     "node-windows": "^1.0.0-beta.8"
   },
   "devDependencies": {
-    "typescript": "^5.7.0",
     "@types/node": "^22.0.0",
-    "tsx": "^4.19.0"
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
   }
 }

--- a/tools/cli/src/commands/analyze.ts
+++ b/tools/cli/src/commands/analyze.ts
@@ -118,15 +118,22 @@ export async function runAnalyze({ noAutostart = false, codeReview = false, dete
 
     spinner.stop("Analysis complete");
 
-    // Fetch violations
-    const res = await fetch(`${serverUrl}/api/repos/${repo.id}/violations`);
-    if (!res.ok) {
-      p.log.error(`Failed to fetch violations: ${res.status}`);
+    // Fetch architecture violations and code-level violations in parallel
+    const [archRes, codeRes] = await Promise.all([
+      fetch(`${serverUrl}/api/repos/${repo.id}/violations`),
+      fetch(`${serverUrl}/api/repos/${repo.id}/code-violations/summary`),
+    ]);
+
+    if (!archRes.ok) {
+      p.log.error(`Failed to fetch violations: ${archRes.status}`);
       process.exit(1);
     }
 
-    const violations = (await res.json()) as Violation[];
-    renderViolationsSummary(violations);
+    const violations = (await archRes.json()) as Violation[];
+    const codeSummary = codeRes.ok
+      ? (await codeRes.json()) as { total: number; bySeverity: Record<string, number> }
+      : undefined;
+    renderViolationsSummary(violations, codeSummary);
 
     if (!deterministicOnly) {
       p.log.info("Code review running in background — results will appear in the dashboard");

--- a/tools/cli/src/commands/helpers.ts
+++ b/tools/cli/src/commands/helpers.ts
@@ -240,16 +240,29 @@ export function renderViolations(violations: Violation[]): void {
   console.log("");
 }
 
-export function renderViolationsSummary(violations: Violation[]): void {
-  if (violations.length === 0) {
+export function renderViolationsSummary(
+  violations: Violation[],
+  codeSummary?: { total: number; bySeverity: Record<string, number> },
+): void {
+  const codeTotal = codeSummary?.total ?? 0;
+  const totalCount = violations.length + codeTotal;
+
+  if (totalCount === 0) {
     p.log.info("No violations found.");
     return;
   }
 
+  // Merge severity counts from both architecture and code violations
   const counts: Record<string, number> = {};
   for (const v of violations) {
     const sev = v.severity.toLowerCase();
     counts[sev] = (counts[sev] || 0) + 1;
+  }
+  if (codeSummary) {
+    for (const [sev, c] of Object.entries(codeSummary.bySeverity)) {
+      const key = sev.toLowerCase();
+      counts[key] = (counts[key] || 0) + c;
+    }
   }
 
   const parts: string[] = [];
@@ -261,7 +274,10 @@ export function renderViolationsSummary(violations: Violation[]): void {
   }
 
   console.log("");
-  console.log(`  ${violations.length} violations (${parts.join(", ")})`);
+  console.log(`  ${totalCount} violations (${parts.join(", ")})`);
+  if (codeTotal > 0) {
+    console.log(`  ├ ${violations.length} architecture · ${codeTotal} code`);
+  }
   console.log("");
   p.log.info("Run `truecourse list` to see full details.");
 }


### PR DESCRIPTION
## Summary
- Upgrade `@clack/prompts` from 0.9.1 to 1.2.0 to fix `ERR_TTY_INIT_FAILED` crash on Node 24 (`uv_tty_init` returned EINVAL in `@clack/core@0.4.1`)
- Fetch code-level violations from `/code-violations/summary` and merge into CLI analyze output so the total matches the UI
- Bump version to 0.2.3

## Test plan
- [ ] Run `nvm use 24 && npx truecourse setup` — should not crash
- [ ] Run `npx truecourse analyze` on Node 24 — should complete without errors
- [ ] Run `npx truecourse analyze` on Node 22 — should still work
- [ ] Verify CLI summary includes both architecture and code violations in the count

🤖 Generated with [Claude Code](https://claude.com/claude-code)