### PR TITLE
Fix Node 24 tree-sitter install, add service commands to README (v0.3.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,20 +78,49 @@ truecourse list --all                 # Show all violations (no pagination)
 truecourse list --diff                # Show diff check results
 truecourse add                        # Register repo without analyzing
 
-# Rules
+```
+
+### Rules
+
+Configure which rule categories and LLM-powered rules are enabled per repository:
+
+```bash
 truecourse rules categories           # Show enabled/disabled rule categories
 truecourse rules categories --disable style    # Disable a category
 truecourse rules categories --enable style     # Enable a category
 truecourse rules llm                  # Show LLM rules status
 truecourse rules llm --disable        # Disable LLM rules for this repo
 truecourse rules llm --enable         # Enable LLM rules for this repo
+```
 
-# Git hooks
+### Git Hooks
+
+TrueCourse can install a pre-commit hook that blocks commits with critical violations:
+
+```bash
 truecourse hooks install              # Install pre-commit hook
 truecourse hooks uninstall            # Remove pre-commit hook
 truecourse hooks status               # Show hook installation status
+```
 
-# Telemetry
+### Managing the Background Service
+
+When you choose "Background service" during setup, TrueCourse runs as a system service (launchd on macOS, systemd on Linux). These commands let you manage it directly:
+
+```bash
+truecourse service status             # Show service status
+truecourse service start              # Start the service
+truecourse service stop               # Stop the service
+truecourse service install            # Install as background service
+truecourse service uninstall          # Remove background service
+truecourse service logs               # Tail service logs
+```
+
+### Telemetry
+
+TrueCourse collects anonymous usage data to improve the product. It is automatically disabled in CI environments.
+
+```bash
 truecourse telemetry status           # Check telemetry status
 truecourse telemetry disable          # Opt out of anonymous telemetry
 truecourse telemetry enable           # Opt back in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "truecourse",
-  "version": "0.2.4",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -110,7 +110,11 @@ const skillsSrc = path.join(ROOT, 'tools/cli/skills');
 const skillsDest = path.join(DIST, 'skills');
 copyDir(skillsSrc, skillsDest);
 
-// 7. Copy README and README assets used by npm package page rendering
+// 7. Copy postinstall script (rebuilds tree-sitter with C++20 on Node 24+)
+console.log('Copying postinstall script...');
+fs.copyFileSync(path.join(ROOT, 'scripts/postinstall.js'), path.join(DIST, 'postinstall.js'));
+
+// 7b. Copy README and README assets used by npm package page rendering
 console.log('Copying README and assets...');
 fs.copyFileSync(path.join(ROOT, 'README.md'), path.join(DIST, 'README.md'));
 copyDir(path.join(ROOT, 'assets'), path.join(DIST, 'assets'));
@@ -123,11 +127,14 @@ const serverPkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'apps/server/packag
 const cliPkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'tools/cli/package.json'), 'utf-8'));
 const publishPkg = {
   name: 'truecourse',
-  version: rootPkg.version || '0.1.0',
+  version: cliPkg.version || '0.1.0',
   description: 'Visualize your codebase architecture as an interactive graph',
   type: 'module',
   bin: {
     truecourse: './cli.mjs',
+  },
+  scripts: {
+    postinstall: 'node postinstall.js',
   },
   engines: {
     node: '>=20',

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+/**
+ * Postinstall script for TrueCourse.
+ *
+ * On Node 24+, tree-sitter requires C++20 to compile but its binding.gyp
+ * only specifies C++17. This script detects the failure and retries the
+ * build with the correct flag.
+ *
+ * See: https://github.com/truecourse-ai/truecourse/issues/22
+ */
+
+try {
+  require('tree-sitter');
+} catch {
+  const { execSync } = require('child_process');
+  const packages = [
+    'tree-sitter',
+    'tree-sitter-typescript',
+    'tree-sitter-javascript',
+    'tree-sitter-python',
+  ].join(' ');
+
+  console.log('[TrueCourse] tree-sitter native module not found, rebuilding with C++20...');
+
+  try {
+    execSync(`CXXFLAGS="-std=c++20" npm rebuild ${packages}`, {
+      stdio: 'inherit',
+      env: { ...process.env, CXXFLAGS: '-std=c++20' },
+    });
+    console.log('[TrueCourse] tree-sitter rebuilt successfully.');
+  } catch {
+    console.error(
+      '\n[TrueCourse] Failed to rebuild tree-sitter.\n\n' +
+      'Fix: set the C++20 flag manually and reinstall:\n' +
+      '  export CXXFLAGS="-std=c++20"\n' +
+      '  npx truecourse\n\n' +
+      'See: https://github.com/truecourse-ai/truecourse/issues/22\n'
+    );
+  }
+}

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.2.4",
+  "version": "0.3.1",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from "commander";
 import * as p from "@clack/prompts";
+import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -16,11 +17,14 @@ import { getPlatform } from "./commands/service/platform.js";
 import { readTelemetryConfig, writeTelemetryConfig } from "./telemetry.js";
 import { runHooksInstall, runHooksUninstall, runHooksStatus, runHooksRun } from "./commands/hooks.js";
 
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json");
+
 const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.2.2")
+  .version(version)
   .description("TrueCourse CLI - Setup and manage your TrueCourse instance");
 
 program


### PR DESCRIPTION
## Summary
- Add postinstall script that automatically rebuilds tree-sitter with `CXXFLAGS="-std=c++20"` when native bindings fail to compile on Node 24+
- Consolidate version to single source of truth in `tools/cli/package.json`
- Document background service, git hooks, rules, and telemetry commands in README

Closes #22

## Test plan
- [x] All 3,379 tests pass
- [x] `truecourse --version` reads version from package.json
- [ ] Verify postinstall rebuilds tree-sitter on Node 24 when bindings are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)