### PR TITLE
Fix postinstall: exit 0 on rebuild failure

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -30,12 +30,14 @@ try {
     });
     console.log('[TrueCourse] tree-sitter rebuilt successfully.');
   } catch {
-    console.error(
-      '\n[TrueCourse] Failed to rebuild tree-sitter.\n\n' +
+    console.warn(
+      '\n[TrueCourse] Could not rebuild tree-sitter automatically.\n' +
       'Fix: set the C++20 flag manually and reinstall:\n' +
       '  export CXXFLAGS="-std=c++20"\n' +
       '  npx truecourse\n\n' +
       'See: https://github.com/truecourse-ai/truecourse/issues/22\n'
     );
+    // Exit 0 — don't fail the install
+    process.exit(0);
   }
 }


### PR DESCRIPTION
## Summary
- Postinstall script was crashing `npm install` during `build:dist` in CI
- The rebuild attempt fails because tree-sitter isn't compiled yet mid-install
- Now exits with code 0 and prints a warning instead of failing the install

🤖 Generated with [Claude Code](https://claude.com/claude-code)