### PR TITLE
Fix v0.4.0 publish workflow and README dashboard section

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build packages
+        run: pnpm build
+
       - name: Run tests
         run: pnpm test
 

--- a/README.md
+++ b/README.md
@@ -107,17 +107,6 @@ truecourse telemetry disable          # Opt out of anonymous telemetry
 truecourse telemetry enable           # Opt back in
 ```
 
-## Web Dashboard
-
-Run `truecourse dashboard` to open the web UI:
-
-- **Home** — Analytics (violation trends, hotspots, category breakdowns) and a browser for all 1,180+ rules enabled on this repo
-- **Dependency graph** — Interactive service/module/method visualization with React Flow
-- **Code viewer** — Inline violations with severity markers and fix suggestions
-- **Flow tracing** — End-to-end request flows across service boundaries
-- **Database ER diagrams** — Auto-detected from ORM usage (Prisma, Drizzle, SQLAlchemy, etc.)
-- **Diff mode** — See which violations your uncommitted changes introduce or fix
-
 ## Analysis Rules
 
 TrueCourse ships with **1,200+ deterministic rules** and **100 LLM rules** across 8 categories:

--- a/README.md
+++ b/README.md
@@ -111,13 +111,12 @@ truecourse telemetry enable           # Opt back in
 
 Run `truecourse dashboard` to open the web UI:
 
+- **Home** — Analytics (violation trends, hotspots, category breakdowns) and a browser for all 1,180+ rules enabled on this repo
 - **Dependency graph** — Interactive service/module/method visualization with React Flow
 - **Code viewer** — Inline violations with severity markers and fix suggestions
 - **Flow tracing** — End-to-end request flows across service boundaries
 - **Database ER diagrams** — Auto-detected from ORM usage (Prisma, Drizzle, SQLAlchemy, etc.)
-- **Analytics** — Violation trends over time, code hotspots, category breakdowns
 - **Diff mode** — See which violations your uncommitted changes introduce or fix
-- **Rules browser** — View all 1,300+ rules with descriptions and categories
 
 ## Analysis Rules
 


### PR DESCRIPTION
## Summary

- Publish workflow was missing `pnpm build` before `pnpm test`, so workspace packages had no `dist/` when vitest ran — v0.4.0 publish failed at the test step with `Failed to resolve entry for package "@truecourse/analyzer"`. Add the build step to match `test.yml`.
- README dashboard section listed Analytics + Rules browser as separate pages — both have been consolidated onto Home. Collapse into one Home bullet and correct the stale rule count.

## Test plan

- [ ] Merge, then re-tag v0.4.0 at the new main HEAD so the Publish workflow re-runs with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)