### PR TITLE
Fix npx truecourse crash: externalize typescript, bump to 0.4.1

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -60,13 +60,16 @@ run(
     '--target=node20',
     '--format=esm',
     '--outfile=dist/server.mjs',
-    // Only externalize native/binary deps that can't be bundled
+    // Externalize native/binary deps that can't be bundled, plus typescript —
+    // it relies on CJS-only `__filename` in its bundled internals and works
+    // cleanly when resolved from node_modules at runtime.
     '--external:tree-sitter',
     '--external:tree-sitter-typescript',
     '--external:tree-sitter-javascript',
     '--external:tree-sitter-python',
     '--external:pyright',
-    '--banner:js="import { createRequire } from \'node:module\'; import { fileURLToPath as __esm_fileURLToPath } from \'node:url\'; import { dirname as __esm_dirname } from \'node:path\'; const require = createRequire(import.meta.url); const __filename = __esm_fileURLToPath(import.meta.url); const __dirname = __esm_dirname(__filename);"',
+    '--external:typescript',
+    '--banner:js="import { createRequire } from \'node:module\'; const require = createRequire(import.meta.url);"',
   ].join(' '),
 );
 
@@ -92,6 +95,7 @@ run(
     '--external:tree-sitter-javascript',
     '--external:tree-sitter-python',
     '--external:pyright',
+    '--external:typescript',
     '--banner:js="import { createRequire as __cR } from \'node:module\'; const require = __cR(import.meta.url);"',
   ].join(' '),
 );
@@ -139,6 +143,7 @@ const publishPkg = {
     'dotenv': serverPkg.dependencies['dotenv'],
     'commander': cliPkg.dependencies['commander'],
     '@clack/prompts': cliPkg.dependencies['@clack/prompts'],
+    'typescript': analyzerPkg.dependencies['typescript'],
   },
   optionalDependencies: {
     // tree-sitter is optional so npm continues if native compilation fails

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -29,7 +29,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.4.0")
+  .version("0.4.1")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## Summary

v0.4.0 crashes on first analyzer-touching command:

```
ReferenceError: __filename is not defined in ES module scope
    at isFileSystemCaseSensitive (node_modules/truecourse/cli.mjs:19338:41)
    at getNodeSystem (node_modules/truecourse/cli.mjs:19131:46)
```

The `typescript` npm package references the CommonJS `__filename` global in its internals. Bundling it into our ESM CLI left those references dangling at runtime — the prior build masked this with a `__filename`/`__dirname` banner shim, but that's a workaround.

## Root-cause fix

Mark `typescript` as `--external` in both CLI and server bundles (same treatment as `tree-sitter`, `pyright`, `node-windows`) and add it to the published package's runtime `dependencies`. Node resolves it from `node_modules` as CJS at runtime, where `__filename` works natively.

Banner shrunk from `createRequire + fileURLToPath + dirname` to just `createRequire` (still needed because bundled CJS modules call `require()` directly). CLI bundle size dropped ~45% (246K → 130K lines).

## Version

Bumped to **0.4.1** in the three sites specified in CLAUDE.md:
- `tools/cli/package.json`
- `apps/server/package.json`
- `tools/cli/src/index.ts` (`.version(…)`)

## Test plan

- [x] `pnpm build:dist` + `node dist/cli.mjs --version` → `0.4.1`
- [x] `node dist/cli.mjs analyze --help` → loads the analyzer without crashing
- [x] Remaining `__filename` references in `dist/cli.mjs` are all harmless (JSDoc, a string literal, our own pyright.js which self-initializes via `fileURLToPath(import.meta.url)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)