### PR TITLE
Fix tree-sitter disappearing between npx runs: use npm rebuild, bump 0.4.2

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -42,30 +42,26 @@ try {
 
   const { execSync } = require('child_process');
 
-  // Read versions from our own package.json to pin exact ranges
-  let packages;
-  try {
-    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf-8'));
-    const opt = pkg.optionalDependencies || {};
-    packages = ['tree-sitter', 'tree-sitter-typescript', 'tree-sitter-javascript', 'tree-sitter-python']
-      .map(name => opt[name] ? `${name}@"${opt[name]}"` : name)
-      .join(' ');
-  } catch {
-    packages = 'tree-sitter tree-sitter-typescript tree-sitter-javascript tree-sitter-python';
-  }
+  // The optional-dep install already extracted tree-sitter's source into
+  // node_modules/tree-sitter/ — only its native .node binary failed to build
+  // (Node 24 needs C++20, default is C++17). `npm rebuild` runs the build
+  // scripts on the existing install with our CXXFLAGS, leaving manifests
+  // untouched so the install survives later `npm exec` integrity passes
+  // that would prune an `npm install --no-save` addition as extraneous.
+  const packages = ['tree-sitter', 'tree-sitter-typescript', 'tree-sitter-javascript', 'tree-sitter-python'];
 
-  log('Installing tree-sitter with CXXFLAGS="-std=c++20"...');
+  log('Rebuilding tree-sitter with CXXFLAGS="-std=c++20"...');
 
   try {
-    execSync(`npm install --no-save ${packages}`, {
+    execSync(`npm rebuild ${packages.join(' ')}`, {
       stdio: 'inherit',
       env: { ...process.env, CXXFLAGS: '-std=c++20' },
     });
-    log('tree-sitter: installed OK');
+    log('tree-sitter: rebuilt OK');
   } catch {
-    log('tree-sitter: install failed');
+    log('tree-sitter: rebuild failed');
     console.warn(
-      '\n[TrueCourse] Could not install tree-sitter automatically.\n' +
+      '\n[TrueCourse] Could not rebuild tree-sitter automatically.\n' +
       'Fix: set the C++20 flag manually and reinstall:\n' +
       '  export CXXFLAGS="-std=c++20"\n' +
       '  npx truecourse\n\n' +

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -29,7 +29,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.4.1")
+  .version("0.4.2")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## Root cause

0.4.1's first `npx truecourse <cmd>` worked, every subsequent invocation crashed with:

```
Cannot find package 'tree-sitter' imported from .../truecourse/cli.mjs
```

Postinstall only runs on install — not on cache reuse — so something was removing tree-sitter between runs.

The culprit is `npm install --no-save` inside `postinstall.cjs`. It adds tree-sitter to `node_modules` without touching any manifest or lockfile. When npx reuses the cached install, it calls `npm exec` which runs an integrity pass that sees tree-sitter as extraneous (not in any manifest) and prunes it. Next invocation can't resolve tree-sitter and the CLI fails at module load before any command code runs.

## Fix

Tree-sitter's optional-dep install still extracts the source tarball into `node_modules/tree-sitter/` even when its native build fails (Node 24 needs C++20, gyp defaults to C++17). So we can use `npm rebuild` instead of `npm install --no-save`:

```diff
- execSync(`npm install --no-save ${packages}`, { env: { ...process.env, CXXFLAGS: '-std=c++20' } })
+ execSync(`npm rebuild ${packages.join(' ')}`, { env: { ...process.env, CXXFLAGS: '-std=c++20' } })
```

`npm rebuild` operates on the existing optional-extracted package, runs its build scripts with our env vars, and doesn't create any manifest/lockfile drift. The package stays "tracked as optional" and survives subsequent integrity passes.

## Version

Bumped to **0.4.2** in the three sites per CLAUDE.md.

## Test plan

- [ ] `rm -rf ~/.npm/_npx && npx truecourse@0.4.2 analyze` → works
- [ ] `npx truecourse@0.4.2 dashboard` → works without re-running postinstall
- [ ] `npx truecourse@0.4.2 analyze` again → still works (no tree-sitter prune)

🤖 Generated with [Claude Code](https://claude.com/claude-code)