### PR TITLE
Fix dashboard URL, list shouldn't need server, add --reconfigure (0.4.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ truecourse add                        # Register repo without analyzing
 
 # Dashboard (web UI)
 truecourse dashboard                  # Start + open the dashboard
+truecourse dashboard --reconfigure    # Re-prompt for console vs background service mode
 truecourse dashboard stop             # Stop the dashboard
 truecourse dashboard status           # Show dashboard status
 truecourse dashboard logs             # Tail dashboard logs (service mode only)

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -35,6 +35,10 @@
     "./lib/analysis-store": {
       "types": "./dist/lib/analysis-store.d.ts",
       "import": "./dist/lib/analysis-store.js"
+    },
+    "./services/violation-query": {
+      "types": "./dist/services/violation-query.service.d.ts",
+      "import": "./dist/services/violation-query.service.js"
     }
   },
   "scripts": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/server",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "exports": {
@@ -31,6 +31,10 @@
     "./lib/logger": {
       "types": "./dist/lib/logger.d.ts",
       "import": "./dist/lib/logger.js"
+    },
+    "./lib/analysis-store": {
+      "types": "./dist/lib/analysis-store.d.ts",
+      "import": "./dist/lib/analysis-store.js"
     }
   },
   "scripts": {

--- a/apps/server/src/routes/analysis.ts
+++ b/apps/server/src/routes/analysis.ts
@@ -33,6 +33,7 @@ import {
   removeFromHistory,
   writeLatest,
 } from '../lib/analysis-store.js';
+import { getDiffResult } from '../services/violation-query.service.js';
 
 const router: Router = Router();
 
@@ -552,13 +553,12 @@ router.get(
     try {
       const id = req.params.id as string;
       const repo = resolveProjectForRequest(id);
-      const diff = readDiff(repo.path);
-      if (!diff) {
+      const result = getDiffResult(repo.path);
+      if (!result) {
         res.json(null);
         return;
       }
-      const latest = readLatest(repo.path);
-      const isStale = latest ? latest.analysis.id !== diff.baseAnalysisId : false;
+      const { diff, isStale } = result;
 
       res.json({
         resolvedViolations: diff.resolvedViolations,

--- a/apps/server/src/routes/violations.ts
+++ b/apps/server/src/routes/violations.ts
@@ -1,21 +1,13 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
 import { resolveProjectForRequest } from '../config/current-project.js';
 import { readAnalysis, readLatest } from '../lib/analysis-store.js';
-import type { ViolationStatus, ViolationWithNames } from '../types/snapshot.js';
+import { listViolations } from '../services/violation-query.service.js';
 
 const router: Router = Router();
 
-const SEVERITY_ORDER: Record<string, number> = {
-  critical: 0,
-  high: 1,
-  medium: 2,
-  low: 3,
-  info: 4,
-};
-
 // ---------------------------------------------------------------------------
 // GET /api/repos/:id/violations
-// Filter + sort + paginate the active LATEST violation set in JS.
+// Filter + sort + paginate lives in violation-query.service (shared with CLI).
 // ---------------------------------------------------------------------------
 
 router.get(
@@ -25,69 +17,24 @@ router.get(
       const id = req.params.id as string;
       const repo = resolveProjectForRequest(id);
 
-      const analysisIdParam = req.query.analysisId as string | undefined;
-      const fileParam = req.query.file as string | undefined;
-      const statusParam = req.query.status as string | undefined;
       const limitParam = parseInt(req.query.limit as string) || 0;
       const offsetParam = parseInt(req.query.offset as string) || 0;
+      const statusParam = req.query.status as string | undefined;
+      const status =
+        statusParam === 'resolved' ? 'resolved' : statusParam === 'all' ? 'all' : 'active';
 
-      let violations: ViolationWithNames[];
-
-      if (analysisIdParam) {
-        const latest = readLatest(repo.path);
-        if (latest && latest.analysis.id === analysisIdParam) {
-          violations = latest.violations;
-        } else {
-          res.json(limitParam > 0 ? { violations: [], total: 0 } : []);
-          return;
-        }
-      } else {
-        const latest = readLatest(repo.path);
-        if (!latest) {
-          res.json(limitParam > 0 ? { violations: [], total: 0 } : []);
-          return;
-        }
-        violations = latest.violations;
-      }
-
-      // Status filter — default to active (new + unchanged)
-      let filtered: ViolationWithNames[];
-      if (statusParam === 'resolved') {
-        filtered = violations.filter((v) => v.status === 'resolved');
-      } else if (statusParam === 'all') {
-        filtered = violations;
-      } else {
-        const active: ViolationStatus[] = ['new', 'unchanged'];
-        filtered = violations.filter((v) => active.includes(v.status));
-      }
-
-      // Optional file filter (accepts absolute or relative). Scoped to code
-      // violations only — arch-AST rows (type module/function/service) can
-      // also carry a filePath for graph linkage, but the per-file code view
-      // is for line-anchored findings.
-      if (fileParam) {
-        const absPath = fileParam.startsWith('/') ? fileParam : `${repo.path}/${fileParam}`;
-        filtered = filtered.filter(
-          (v) => v.type === 'code' && (v.filePath === absPath || v.filePath === fileParam),
-        );
-      }
-
-      // Severity order → createdAt desc
-      filtered.sort((a, b) => {
-        const sa = SEVERITY_ORDER[a.severity] ?? 5;
-        const sb = SEVERITY_ORDER[b.severity] ?? 5;
-        if (sa !== sb) return sa - sb;
-        return b.createdAt.localeCompare(a.createdAt);
+      const { violations, total } = listViolations(repo.path, {
+        analysisId: req.query.analysisId as string | undefined,
+        filePath: req.query.file as string | undefined,
+        status,
+        limit: limitParam,
+        offset: offsetParam,
       });
 
-      const total = filtered.length;
-
-      const paged = limitParam > 0 ? filtered.slice(offsetParam, offsetParam + limitParam) : filtered;
-
       if (limitParam > 0 || offsetParam > 0) {
-        res.json({ violations: paged, total });
+        res.json({ violations, total });
       } else {
-        res.json(paged);
+        res.json(violations);
       }
     } catch (error) {
       next(error);

--- a/apps/server/src/services/violation-query.service.ts
+++ b/apps/server/src/services/violation-query.service.ts
@@ -1,0 +1,103 @@
+/**
+ * Query helpers over the stored violation set.
+ *
+ * Used by:
+ *   - `GET /api/repos/:id/violations`  (dashboard HTTP route)
+ *   - `truecourse list` / `list --diff` (CLI)
+ *
+ * Filter, sort, and paginate live here so both callers stay consistent.
+ * Reads from `LATEST.json` / `diff.json` via analysis-store.
+ */
+
+import type { DiffSnapshot, ViolationStatus, ViolationWithNames } from '../types/snapshot.js';
+import { readDiff, readLatest } from '../lib/analysis-store.js';
+
+export const SEVERITY_ORDER: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  info: 4,
+};
+
+export interface ListViolationsOptions {
+  /** Scope to a specific analysis id; if it doesn't match LATEST, returns empty. */
+  analysisId?: string;
+  /** `active` (default) = new + unchanged. `resolved` = only resolved. `all` = no status filter. */
+  status?: 'active' | 'resolved' | 'all';
+  /** File path filter (absolute or repo-relative). Scoped to `type === 'code'`. */
+  filePath?: string;
+  /** 0 = no pagination, just full list. */
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListViolationsResult {
+  violations: ViolationWithNames[];
+  /** Size of the filtered set before pagination. */
+  total: number;
+}
+
+/**
+ * Filter + sort + paginate the active LATEST violation set. Returns an empty
+ * result if LATEST doesn't exist or `analysisId` is set and doesn't match.
+ */
+export function listViolations(
+  repoPath: string,
+  options: ListViolationsOptions = {},
+): ListViolationsResult {
+  const latest = readLatest(repoPath);
+  if (!latest) return { violations: [], total: 0 };
+  if (options.analysisId && latest.analysis.id !== options.analysisId) {
+    return { violations: [], total: 0 };
+  }
+
+  const statusMode = options.status ?? 'active';
+  let filtered: ViolationWithNames[];
+  if (statusMode === 'resolved') {
+    filtered = latest.violations.filter((v) => v.status === 'resolved');
+  } else if (statusMode === 'all') {
+    filtered = latest.violations;
+  } else {
+    const active: ViolationStatus[] = ['new', 'unchanged'];
+    filtered = latest.violations.filter((v) => active.includes(v.status));
+  }
+
+  if (options.filePath) {
+    const absPath = options.filePath.startsWith('/')
+      ? options.filePath
+      : `${repoPath}/${options.filePath}`;
+    filtered = filtered.filter(
+      (v) => v.type === 'code' && (v.filePath === absPath || v.filePath === options.filePath),
+    );
+  }
+
+  filtered.sort((a, b) => {
+    const sa = SEVERITY_ORDER[a.severity] ?? 5;
+    const sb = SEVERITY_ORDER[b.severity] ?? 5;
+    if (sa !== sb) return sa - sb;
+    return b.createdAt.localeCompare(a.createdAt);
+  });
+
+  const total = filtered.length;
+  const limit = options.limit ?? 0;
+  const offset = options.offset ?? 0;
+  const paged = limit > 0 ? filtered.slice(offset, offset + limit) : filtered;
+
+  return { violations: paged, total };
+}
+
+export interface DiffResultWithStale {
+  diff: DiffSnapshot;
+  /** True when the diff's baseAnalysisId no longer matches current LATEST. */
+  isStale: boolean;
+}
+
+/** Read the current diff snapshot and compute stale-vs-LATEST. */
+export function getDiffResult(repoPath: string): DiffResultWithStale | null {
+  const diff = readDiff(repoPath);
+  if (!diff) return null;
+  const latest = readLatest(repoPath);
+  const isStale = latest ? latest.analysis.id !== diff.baseAnalysisId : false;
+  return { diff, isStale };
+}

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/commands/dashboard.ts
+++ b/tools/cli/src/commands/dashboard.ts
@@ -46,7 +46,7 @@ function targetUrlFor(baseUrl: string): string {
   const repoDir = resolveRepoDir(process.cwd());
   if (!repoDir) return baseUrl;
   const entry = getProjectByPath(repoDir) ?? registerProject(repoDir);
-  return `${baseUrl}/projects/${entry.slug}`;
+  return `${baseUrl}/repos/${entry.slug}`;
 }
 
 async function promptRunMode(): Promise<TrueCourseConfig["runMode"]> {
@@ -135,7 +135,7 @@ async function runServiceMode(serverEntry: string): Promise<void> {
   p.log.info("Stop the dashboard with: truecourse dashboard stop");
 }
 
-export async function runDashboard(): Promise<void> {
+export async function runDashboard(options: { reconfigure?: boolean } = {}): Promise<void> {
   p.intro("Opening TrueCourse dashboard");
 
   const serverEntry = resolveServerEntry();
@@ -147,8 +147,9 @@ export async function runDashboard(): Promise<void> {
   }
 
   const configured = fs.existsSync(getConfigPath());
-  const runMode = configured ? readConfig().runMode : await promptRunMode();
-  if (!configured) writeConfig({ runMode });
+  const shouldPrompt = !configured || options.reconfigure;
+  const runMode = shouldPrompt ? await promptRunMode() : readConfig().runMode;
+  if (shouldPrompt) writeConfig({ runMode });
 
   if (runMode === "service") {
     try {

--- a/tools/cli/src/commands/helpers.ts
+++ b/tools/cli/src/commands/helpers.ts
@@ -47,21 +47,6 @@ export function getServerUrl(): string {
   return `http://localhost:${port}`;
 }
 
-/** Fail fast if the dashboard server isn't responding. */
-export async function requireDashboard(): Promise<void> {
-  const url = getServerUrl();
-  try {
-    const res = await fetch(`${url}/api/health`);
-    if (!res.ok) throw new Error();
-  } catch {
-    p.log.error(
-      `TrueCourse dashboard is not running at ${url}.\n` +
-        `Start it first with: truecourse dashboard`,
-    );
-    process.exit(1);
-  }
-}
-
 /**
  * Resolve the current directory's registered project from the local registry.
  * Registers the repo on first use. Exits if no `.truecourse/` is found.

--- a/tools/cli/src/commands/list.ts
+++ b/tools/cli/src/commands/list.ts
@@ -1,68 +1,45 @@
 import * as p from "@clack/prompts";
-import { readLatest, readDiff } from "@truecourse/server/lib/analysis-store";
-import type { Violation, DiffResult } from "./helpers.js";
 import {
-  requireRegisteredRepo,
-  renderViolations,
-  renderDiffResults,
-} from "./helpers.js";
-
-const SEVERITY_ORDER: Record<string, number> = {
-  critical: 0,
-  high: 1,
-  medium: 2,
-  low: 3,
-  info: 4,
-};
+  listViolations,
+  getDiffResult,
+} from "@truecourse/server/services/violation-query";
+import type { Violation, DiffResult } from "./helpers.js";
+import { requireRegisteredRepo, renderViolations, renderDiffResults } from "./helpers.js";
 
 export async function runList({ limit = 20, offset = 0 } = {}): Promise<void> {
   p.intro("Violations");
 
   const repo = requireRegisteredRepo();
-  const latest = readLatest(repo.path);
+  const { violations, total } = listViolations(repo.path, {
+    limit: isFinite(limit) ? limit : 0,
+    offset,
+  });
 
-  if (!latest) {
-    p.log.info("No analysis found. Run `truecourse analyze` first.");
+  if (total === 0 && violations.length === 0) {
+    p.log.info("No violations. Run `truecourse analyze` if you haven't yet.");
     return;
   }
 
-  // Active set: new + unchanged. Matches the default filter on
-  // GET /api/repos/:id/violations so CLI and dashboard agree.
-  const active = latest.violations
-    .filter((v) => v.status === "new" || v.status === "unchanged")
-    .sort((a, b) => {
-      const sa = SEVERITY_ORDER[a.severity] ?? 5;
-      const sb = SEVERITY_ORDER[b.severity] ?? 5;
-      if (sa !== sb) return sa - sb;
-      return b.createdAt.localeCompare(a.createdAt);
-    });
-
-  const total = active.length;
-  const showAll = !isFinite(limit);
-  const paged = showAll ? active : active.slice(offset, offset + limit);
-
-  renderViolations(paged as unknown as Violation[], { total, offset });
+  renderViolations(violations as unknown as Violation[], { total, offset });
 }
 
 export async function runListDiff(): Promise<void> {
   p.intro("Diff check results");
 
   const repo = requireRegisteredRepo();
-  const diff = readDiff(repo.path);
+  const result = getDiffResult(repo.path);
 
-  if (!diff) {
+  if (!result) {
     p.log.info("No diff check found. Run `truecourse analyze --diff` first.");
     return;
   }
 
-  const latest = readLatest(repo.path);
-  const isStale = latest ? latest.analysis.id !== diff.baseAnalysisId : false;
-
+  const { diff, isStale } = result;
   if (isStale) {
     p.log.warn("Results may be stale — baseline analysis has changed.");
   }
 
-  const result: DiffResult = {
+  const rendered: DiffResult = {
     isStale,
     changedFiles: diff.changedFiles,
     newViolations: diff.newViolations as unknown as DiffResult["newViolations"],
@@ -70,5 +47,5 @@ export async function runListDiff(): Promise<void> {
     summary: { newCount: diff.summary.newCount, resolvedCount: diff.summary.resolvedCount },
   };
 
-  renderDiffResults(result);
+  renderDiffResults(rendered);
 }

--- a/tools/cli/src/commands/list.ts
+++ b/tools/cli/src/commands/list.ts
@@ -1,71 +1,74 @@
 import * as p from "@clack/prompts";
+import { readLatest, readDiff } from "@truecourse/server/lib/analysis-store";
 import type { Violation, DiffResult } from "./helpers.js";
 import {
-  requireDashboard,
   requireRegisteredRepo,
-  getServerUrl,
   renderViolations,
   renderDiffResults,
 } from "./helpers.js";
 
+const SEVERITY_ORDER: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  info: 4,
+};
+
 export async function runList({ limit = 20, offset = 0 } = {}): Promise<void> {
   p.intro("Violations");
 
-  await requireDashboard();
   const repo = requireRegisteredRepo();
+  const latest = readLatest(repo.path);
 
-  const serverUrl = getServerUrl();
+  if (!latest) {
+    p.log.info("No analysis found. Run `truecourse analyze` first.");
+    return;
+  }
+
+  // Active set: new + unchanged. Matches the default filter on
+  // GET /api/repos/:id/violations so CLI and dashboard agree.
+  const active = latest.violations
+    .filter((v) => v.status === "new" || v.status === "unchanged")
+    .sort((a, b) => {
+      const sa = SEVERITY_ORDER[a.severity] ?? 5;
+      const sb = SEVERITY_ORDER[b.severity] ?? 5;
+      if (sa !== sb) return sa - sb;
+      return b.createdAt.localeCompare(a.createdAt);
+    });
+
+  const total = active.length;
   const showAll = !isFinite(limit);
+  const paged = showAll ? active : active.slice(offset, offset + limit);
 
-  const params = new URLSearchParams();
-  if (!showAll) {
-    params.set("limit", String(limit));
-    params.set("offset", String(offset));
-  }
-
-  const url = `${serverUrl}/api/repos/${repo.id}/violations${params.toString() ? `?${params}` : ""}`;
-  const res = await fetch(url);
-
-  if (!res.ok) {
-    p.log.error(`Failed to fetch violations: ${res.status}`);
-    process.exit(1);
-  }
-
-  const body = await res.json();
-
-  // Server returns { violations, total } when paginated, or array when not
-  if (Array.isArray(body)) {
-    renderViolations(body, { total: body.length });
-  } else {
-    const { violations, total } = body as { violations: Violation[]; total: number };
-    renderViolations(violations, { total, offset });
-  }
+  renderViolations(paged as unknown as Violation[], { total, offset });
 }
 
 export async function runListDiff(): Promise<void> {
   p.intro("Diff check results");
 
-  await requireDashboard();
   const repo = requireRegisteredRepo();
+  const diff = readDiff(repo.path);
 
-  const serverUrl = getServerUrl();
-  const res = await fetch(`${serverUrl}/api/repos/${repo.id}/diff-check`);
-
-  if (!res.ok) {
-    p.log.error(`Failed to fetch diff check results: ${res.status}`);
-    process.exit(1);
-  }
-
-  const result = (await res.json()) as DiffResult | null;
-
-  if (!result) {
+  if (!diff) {
     p.log.info("No diff check found. Run `truecourse analyze --diff` first.");
     return;
   }
 
-  if (result.isStale) {
+  const latest = readLatest(repo.path);
+  const isStale = latest ? latest.analysis.id !== diff.baseAnalysisId : false;
+
+  if (isStale) {
     p.log.warn("Results may be stale — baseline analysis has changed.");
   }
+
+  const result: DiffResult = {
+    isStale,
+    changedFiles: diff.changedFiles,
+    newViolations: diff.newViolations as unknown as DiffResult["newViolations"],
+    resolvedViolations: diff.resolvedViolations as unknown as DiffResult["resolvedViolations"],
+    summary: { newCount: diff.summary.newCount, resolvedCount: diff.summary.resolvedCount },
+  };
 
   renderDiffResults(result);
 }

--- a/tools/cli/src/commands/rules.ts
+++ b/tools/cli/src/commands/rules.ts
@@ -1,0 +1,96 @@
+import * as p from "@clack/prompts";
+import { DOMAIN_ORDER } from "@truecourse/shared";
+import {
+  readProjectConfig,
+  updateProjectConfig,
+} from "@truecourse/server/config/project-config";
+import { requireRegisteredRepo } from "./helpers.js";
+
+const ALL_CATEGORIES = [...DOMAIN_ORDER] as string[];
+
+export interface RulesCategoriesOptions {
+  enable?: string;
+  disable?: string;
+  reset?: boolean;
+}
+
+export async function runRulesCategories(options: RulesCategoriesOptions): Promise<void> {
+  const repo = requireRegisteredRepo();
+
+  if (options.reset) {
+    updateProjectConfig(repo.path, { enabledCategories: null });
+    p.log.success("Reset to global default categories.");
+    return;
+  }
+
+  if (options.enable || options.disable) {
+    const cat = options.enable ?? options.disable!;
+    if (!ALL_CATEGORIES.includes(cat)) {
+      p.log.error(`Invalid category: ${cat}. Valid: ${ALL_CATEGORIES.join(", ")}`);
+      process.exit(1);
+    }
+
+    const config = readProjectConfig(repo.path);
+    const hasOverride = config.enabledCategories != null;
+    const current = new Set<string>(hasOverride ? config.enabledCategories! : ALL_CATEGORIES);
+
+    if (options.enable) current.add(cat);
+    else current.delete(cat);
+
+    updateProjectConfig(repo.path, { enabledCategories: [...current] });
+    p.log.success(`${options.enable ? "Enabled" : "Disabled"} ${cat} rules for ${repo.name}.`);
+    return;
+  }
+
+  const config = readProjectConfig(repo.path);
+  const isOverride = config.enabledCategories != null;
+  const enabled = new Set<string>(isOverride ? config.enabledCategories! : ALL_CATEGORIES);
+
+  const status = (cat: string) =>
+    enabled.has(cat) ? "\x1b[32menabled\x1b[0m" : "\x1b[31mdisabled\x1b[0m";
+
+  p.log.info(
+    `Rule categories for ${repo.name}${isOverride ? " (per-repo override)" : " (global default)"}:`,
+  );
+  for (const cat of ALL_CATEGORIES) {
+    console.log(`  ${cat.padEnd(14)} ${status(cat)}`);
+  }
+  console.log("");
+  if (!isOverride) {
+    p.log.info("Override with: truecourse rules categories --enable/--disable <name>");
+  }
+}
+
+export interface RulesLlmOptions {
+  enable?: boolean;
+  disable?: boolean;
+  reset?: boolean;
+}
+
+export async function runRulesLlm(options: RulesLlmOptions): Promise<void> {
+  const repo = requireRegisteredRepo();
+
+  if (options.reset) {
+    updateProjectConfig(repo.path, { enableLlmRules: null });
+    p.log.success("Reset LLM rules to global default.");
+    return;
+  }
+
+  if (options.enable || options.disable) {
+    const enabled = !!options.enable;
+    updateProjectConfig(repo.path, { enableLlmRules: enabled });
+    p.log.success(`LLM rules ${enabled ? "enabled" : "disabled"} for ${repo.name}.`);
+    return;
+  }
+
+  const config = readProjectConfig(repo.path);
+  const isOverride = config.enableLlmRules != null;
+  const effective = isOverride ? config.enableLlmRules! : true;
+  const status = effective ? "\x1b[32menabled\x1b[0m" : "\x1b[31mdisabled\x1b[0m";
+  p.log.info(
+    `LLM rules for ${repo.name}${isOverride ? " (per-repo override)" : " (global default)"}: ${status}`,
+  );
+  if (!isOverride) {
+    p.log.info("Override with: truecourse rules llm --enable/--disable");
+  }
+}

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -12,11 +12,7 @@ import {
   runDashboardUninstall,
 } from "./commands/dashboard.js";
 import { runList, runListDiff } from "./commands/list.js";
-import {
-  getServerUrl,
-  requireDashboard,
-  requireRegisteredRepo,
-} from "./commands/helpers.js";
+import { runRulesCategories, runRulesLlm } from "./commands/rules.js";
 import { readTelemetryConfig, writeTelemetryConfig } from "./telemetry.js";
 import {
   runHooksInstall,
@@ -105,7 +101,7 @@ program
     }
   });
 
-// Rules management — talks to the dashboard API.
+// Rules management — reads/writes per-repo config.json directly. No server needed.
 const rulesCmd = program
   .command("rules")
   .description("Manage analysis rules");
@@ -117,71 +113,7 @@ rulesCmd
   .option("--disable <category>", "Disable a category")
   .option("--reset", "Reset to global default")
   .action(async (options) => {
-    await requireDashboard();
-    const repo = requireRegisteredRepo();
-    const serverUrl = getServerUrl();
-
-    const { DOMAIN_ORDER } = await import("@truecourse/shared");
-    const allCategories = [...DOMAIN_ORDER] as string[];
-
-    if (options.reset) {
-      await fetch(`${serverUrl}/api/repos/${repo.id}/categories`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enabledCategories: null }),
-      });
-      p.log.success("Reset to global default categories.");
-      return;
-    }
-
-    if (options.enable || options.disable) {
-      const cat = options.enable || options.disable;
-      if (!allCategories.includes(cat)) {
-        p.log.error(`Invalid category: ${cat}. Valid: ${allCategories.join(", ")}`);
-        process.exit(1);
-      }
-
-      const repoRes = await fetch(`${serverUrl}/api/repos/${repo.id}`);
-      const repoData = (await repoRes.json()) as { enabledCategories?: string[] | null };
-      const hasOverride =
-        repoData.enabledCategories !== null && repoData.enabledCategories !== undefined;
-      const current = new Set<string>(
-        hasOverride ? repoData.enabledCategories! : allCategories,
-      );
-
-      if (options.enable) current.add(cat);
-      else current.delete(cat);
-
-      await fetch(`${serverUrl}/api/repos/${repo.id}/categories`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enabledCategories: [...current] }),
-      });
-      p.log.success(`${options.enable ? "Enabled" : "Disabled"} ${cat} rules for ${repo.name}.`);
-      return;
-    }
-
-    const repoRes = await fetch(`${serverUrl}/api/repos/${repo.id}`);
-    const repoData = (await repoRes.json()) as { enabledCategories?: string[] | null };
-    const isOverride =
-      repoData.enabledCategories !== null && repoData.enabledCategories !== undefined;
-    const enabled = new Set<string>(
-      isOverride ? repoData.enabledCategories! : allCategories,
-    );
-
-    const status = (cat: string) =>
-      enabled.has(cat) ? "\x1b[32menabled\x1b[0m" : "\x1b[31mdisabled\x1b[0m";
-
-    p.log.info(
-      `Rule categories for ${repo.name}${isOverride ? " (per-repo override)" : " (global default)"}:`,
-    );
-    for (const cat of allCategories) {
-      console.log(`  ${cat.padEnd(14)} ${status(cat)}`);
-    }
-    console.log("");
-    if (!isOverride) {
-      p.log.info("Override with: truecourse rules categories --enable/--disable <name>");
-    }
+    await runRulesCategories(options);
   });
 
 rulesCmd
@@ -191,43 +123,7 @@ rulesCmd
   .option("--disable", "Disable LLM rules")
   .option("--reset", "Reset to global default")
   .action(async (options) => {
-    await requireDashboard();
-    const repo = requireRegisteredRepo();
-    const serverUrl = getServerUrl();
-
-    if (options.reset) {
-      await fetch(`${serverUrl}/api/repos/${repo.id}/llm`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enableLlmRules: null }),
-      });
-      p.log.success("Reset LLM rules to global default.");
-      return;
-    }
-
-    if (options.enable || options.disable) {
-      const enabled = !!options.enable;
-      await fetch(`${serverUrl}/api/repos/${repo.id}/llm`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enableLlmRules: enabled }),
-      });
-      p.log.success(`LLM rules ${enabled ? "enabled" : "disabled"} for ${repo.name}.`);
-      return;
-    }
-
-    const repoRes = await fetch(`${serverUrl}/api/repos/${repo.id}`);
-    const repoData = (await repoRes.json()) as { enableLlmRules?: boolean | null };
-    const isOverride =
-      repoData.enableLlmRules !== null && repoData.enableLlmRules !== undefined;
-    const effective = isOverride ? repoData.enableLlmRules! : true;
-    const status = effective ? "\x1b[32menabled\x1b[0m" : "\x1b[31mdisabled\x1b[0m";
-    p.log.info(
-      `LLM rules for ${repo.name}${isOverride ? " (per-repo override)" : " (global default)"}: ${status}`,
-    );
-    if (!isOverride) {
-      p.log.info("Override with: truecourse rules llm --enable/--disable");
-    }
+    await runRulesLlm(options);
   });
 
 // Telemetry management

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -29,14 +29,15 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.4.2")
+  .version("0.4.3")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program
   .command("dashboard")
   .description("Start the TrueCourse dashboard and open it in your browser")
-  .action(async () => {
-    await runDashboard();
+  .option("--reconfigure", "Re-prompt for console vs background service mode")
+  .action(async (options) => {
+    await runDashboard({ reconfigure: options.reconfigure });
   });
 
 dashboardCmd


### PR DESCRIPTION
## Three fixes

**1. Dashboard URL bug** — `truecourse dashboard` was opening `http://localhost:3001/projects/<slug>`, but the web app routes `/repos/:repoId`. Land page loaded the wrong URL. Fixed to `/repos/<slug>`.

**2. `truecourse list` required the dashboard to be running** and fetched violations over HTTP — inappropriate now that we have a file-based store. Exports `analysis-store` from `@truecourse/server` and reads `LATEST.json` / `diff.json` directly in the CLI. Keeps the same default filter (active = new + unchanged) and severity sort as the HTTP endpoint so CLI and dashboard agree.

**3. Console-vs-service mode was sticky** — once you chose one, subsequent `truecourse dashboard` skipped the prompt forever. Added `--reconfigure` to re-prompt and overwrite the saved choice. Documented in README.

## Version

Bumped to **0.4.3** in all three sites per CLAUDE.md.

## Test plan

- [ ] `npx truecourse@0.4.3 analyze` on a fresh repo → creates `.truecourse/LATEST.json`
- [ ] `npx truecourse@0.4.3 list` → shows violations **without** needing dashboard running
- [ ] `npx truecourse@0.4.3 list --diff` → works against `diff.json` directly
- [ ] `npx truecourse@0.4.3 dashboard` → opens `http://localhost:3001/repos/<slug>`
- [ ] `npx truecourse@0.4.3 dashboard --reconfigure` → re-prompts for mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)