### PR TITLE
Bump to v0.4.5

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/server",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -25,7 +25,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.4.4")
+  .version("0.4.5")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## Summary
- Version bump only (0.4.4 → 0.4.5) in the three required places (tools/cli/package.json, apps/server/package.json, tools/cli/src/index.ts).
- Purpose: publish a new version so the upgrade-path failure can be reproduced on a machine that has 0.4.4 cached in ~/.npm/_npx/, and the real install log can be captured before designing the postinstall fix.

## Test plan
- [ ] Merge → tag v0.4.5 from main → publish workflow runs → `npm view truecourse version` shows 0.4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)