### PR TITLE
Rework pre-commit hook to reuse the analyzer pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,26 @@ truecourse rules llm --disable                 # Disable LLM rules
 
 ### Git Hooks
 
-TrueCourse can install a pre-commit hook that blocks commits with critical violations:
+TrueCourse can install a pre-commit hook that blocks commits introducing new violations at or above a configured severity:
 
 ```bash
 truecourse hooks install              # Install pre-commit hook
 truecourse hooks uninstall            # Remove pre-commit hook
-truecourse hooks status               # Show hook installation status
+truecourse hooks status               # Show hook status + config
+```
+
+On every commit the hook runs `truecourse analyze --diff` against the repo's last full analysis and blocks if any newly-introduced violation matches the configured block severities. **Commits will take as long as a full diff analysis** — on large repos that can be tens of seconds per commit. `truecourse hooks install` warns you and requires confirmation before writing the hook.
+
+**First-time setup:** run `truecourse analyze` once to establish a baseline. Without it the hook can't diff.
+
+**Bypass:** `git commit --no-verify` (standard git).
+
+**Configuration** — `hooks install` seeds `<repo>/.truecourse/hooks.yaml` with starter defaults; commit the file so your team shares one policy. The hook reads only from this file — if you delete it, the hook warns and passes every commit (no hidden code-level defaults). Current shape:
+
+```yaml
+pre-commit:
+  block-on: [critical, high]   # severities. Valid: info|low|medium|high|critical
+  llm: false                   # run LLM rules on every commit (tokens per commit)
 ```
 
 ### Telemetry
@@ -131,7 +145,7 @@ TrueCourse ships with **1,200+ deterministic rules** and **100 LLM rules** acros
 
 TrueCourse includes [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) for conversational analysis from within Claude Code.
 
-Run `truecourse add` to install skills to `.claude/skills/truecourse/` in your project.
+The first `truecourse analyze` (or `truecourse add`) in a fresh repo asks whether to install skills into `.claude/skills/truecourse/`. Re-runs skip the prompt if skills are already present. Pass `--install-skills` / `--no-skills` to bypass the prompt explicitly.
 
 | Skill | What it does |
 |---|---|
@@ -171,6 +185,10 @@ pnpm build              # Build all packages
 ## Telemetry
 
 TrueCourse collects anonymous usage data (event type, language, file count range, OS). No source code, file paths, or violation details are collected. Opt out with `truecourse telemetry disable` or `TRUECOURSE_TELEMETRY=0`.
+
+## Contact
+
+Questions, feedback, or security reports: **Mushegh Gevorgyan** — [mushegh@truecourse.dev](mailto:mushegh@truecourse.dev).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The first `truecourse analyze` (or `truecourse add`) in a fresh repo asks whethe
 | `/truecourse-analyze` | Runs analysis or diff check, summarizes results |
 | `/truecourse-list` | Shows full violation details |
 | `/truecourse-fix` | Lists fixable violations, applies changes |
+| `/truecourse-hooks` | Installs, configures, or removes the pre-commit hook |
 
 ## Language Support
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -169,6 +169,10 @@ const publishPkg = {
     'node-windows': '^1.0.0-beta.8',
   },
   license: 'MIT',
+  author: {
+    name: 'Mushegh Gevorgyan',
+    email: 'mushegh@truecourse.dev',
+  },
   repository: {
     type: 'git',
     url: 'https://github.com/truecourse-ai/truecourse',

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/skills/truecourse/truecourse-analyze/SKILL.md
+++ b/tools/cli/skills/truecourse/truecourse-analyze/SKILL.md
@@ -18,7 +18,7 @@ Run architecture analysis on the current repository using TrueCourse.
 - **Full analysis** stashes any uncommitted changes, analyzes the clean working tree, then unstashes. The user's uncommitted work is preserved.
 - **Diff check** analyzes the full working tree (including uncommitted changes — it does NOT stash) and compares the result against the last full analysis baseline. The report lists violations newly introduced and violations resolved since that baseline. Prefer diff for in-progress work where the user is iterating on changes.
 - **Always invoke via `npx -y`** — without `-y`, npx will hang on the "Ok to proceed?" prompt whenever the user hasn't cached the latest `truecourse` version (which happens every time we publish a new release).
-- **LLM rules cost real money.** Never pass `--llm` without first relaying the cost estimate to the user and getting approval. See the LLM flow below.
+- **LLM rules cost tokens.** Never pass `--llm` without first relaying the token estimate to the user and getting approval. See the LLM flow below.
 
 ## Instructions
 
@@ -30,7 +30,7 @@ Ask the user whether they want a **full analysis** or a **diff check**. If they 
 
 ### 2. Decide on LLM rules
 
-LLM rules add higher-value insights but cost money per run. Ask the user one question: **"Run LLM-powered rules this time?"** If the user is unsure, offer to run deterministic-only first (free, fast) and add LLM later.
+LLM rules add higher-value insights but cost tokens per run. Ask the user one question: **"Run LLM-powered rules this time?"** If the user is unsure, offer to run deterministic-only first (no tokens, fast) and add LLM later.
 
 - If **user approves LLM**: append `--llm` to the command.
 - If **user declines LLM or wants a free run**: append `--no-llm`.

--- a/tools/cli/skills/truecourse/truecourse-hooks/SKILL.md
+++ b/tools/cli/skills/truecourse/truecourse-hooks/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: truecourse-hooks
+description: Install, configure, or remove the TrueCourse pre-commit hook
+user_invocable: true
+triggers:
+  - install the pre-commit hook
+  - set up truecourse hooks
+  - enable truecourse hook
+  - check hook status
+  - remove pre-commit hook
+  - change what the hook blocks
+  - edit hook config
+---
+
+# TrueCourse Hooks
+
+Install, configure, and manage the pre-commit hook that blocks new violations before they land in git.
+
+## Important
+
+- **Always invoke via `npx -y`** — without `-y`, npx will hang on the "Ok to proceed?" prompt whenever the user hasn't cached the latest `truecourse` version.
+- **The hook makes commits slower.** Every commit runs `truecourse analyze --diff`. On large repos that can be tens of seconds per commit. Make sure the user knows before you install.
+- **Baseline required.** The hook needs a `truecourse analyze` to have run at least once in the repo — otherwise every commit is blocked with "run analyze first". If the user hasn't, suggest running `/truecourse-analyze` first (or `npx -y truecourse analyze`).
+- **`hooks.yaml` is the single source of truth.** Installation creates `<repo>/.truecourse/hooks.yaml` with defaults; edit it to change policy. The file is meant to be committed so the whole team shares one hook config.
+
+## Instructions
+
+### 1. Figure out what the user wants
+
+- "install", "set up", "enable" → **Install flow**
+- "status", "is the hook active", "what does it block" → **Status flow**
+- "uninstall", "remove", "disable" → **Uninstall flow**
+- "change what blocks", "make it stricter/looser", "add/remove severities", "enable LLM" → **Configure flow**
+
+### 2. Install flow
+
+1. Tell the user the tradeoff upfront: commits will be slower; this repo needs a `truecourse analyze` baseline; policy lives in `.truecourse/hooks.yaml` which they should commit.
+2. Run:
+   ```
+   npx -y truecourse hooks install
+   ```
+3. Relay the output. Two files get created:
+   - `.git/hooks/pre-commit` (the script git invokes)
+   - `.truecourse/hooks.yaml` (starter policy, blocks `critical` and `high` by default, LLM off)
+4. If the user hasn't run a full analysis in this repo, suggest `/truecourse-analyze` — without it, every commit will be blocked with "no baseline" until they do.
+
+### 3. Status flow
+
+Run:
+```
+npx -y truecourse hooks status
+```
+Relay the output. It reports whether the hook is installed, the config path, the block severities, and whether LLM is on.
+
+### 4. Uninstall flow
+
+Run:
+```
+npx -y truecourse hooks uninstall
+```
+Only removes the git hook script. `hooks.yaml` is preserved (it's team policy, not install state).
+
+### 5. Configure flow
+
+The config lives at `<repo>/.truecourse/hooks.yaml`. Use the Read and Edit tools — do not shell out through `truecourse` for edits.
+
+Schema:
+```yaml
+pre-commit:
+  block-on: [critical, high]   # valid: info, low, medium, high, critical
+  llm: false                   # true = LLM rules on every commit (tokens per commit)
+```
+
+Common edits the user might ask for:
+- **Stricter** ("block medium too"): `block-on: [critical, high, medium]`
+- **Permissive** ("only block criticals"): `block-on: [critical]`
+- **Enable LLM** ("run full checks on commit"): set `llm: true`. Warn the user this spends tokens on every commit — confirm before flipping it.
+
+After editing, run `npx -y truecourse hooks status` so they can verify the parsed values match their intent.
+
+### 6. When the user hits a blocked commit
+
+If a user comes to you saying "my commit got blocked" or similar:
+- The hook's stdout already listed the blocking violations (file, line, title, severity).
+- Offer to run `/truecourse-fix` to apply fix suggestions to those violations.
+- If they want to ship anyway, remind them of `git commit --no-verify` (standard git bypass).

--- a/tools/cli/src/commands/hooks.ts
+++ b/tools/cli/src/commands/hooks.ts
@@ -2,37 +2,80 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import yaml from "js-yaml";
-import { severityIcon, severityColor } from "./helpers.js";
+import * as p from "@clack/prompts";
+import { resolveRepoDir } from "@truecourse/server/config/paths";
+import { getProjectByPath, registerProject } from "@truecourse/server/config/registry";
+import { readLatest } from "@truecourse/server/lib/analysis-store";
+import { diffInProcess } from "@truecourse/server/diff";
+import { isInteractive, severityIcon, severityColor } from "./helpers.js";
+
+// ---------------------------------------------------------------------------
+// Hook script + identifier
+// ---------------------------------------------------------------------------
 
 const HOOK_IDENTIFIER = "# TrueCourse pre-commit hook";
 
+// `npx -y` works whether or not the user has truecourse installed globally:
+//   * globally installed  → npx exec's the local binary with no download
+//   * cached npx install  → npx runs it from the cache
+//   * nothing cached      → npx fetches the latest and runs it
+// `-y` silences the "Need to install… Ok to proceed?" prompt, which would
+// otherwise hang the git-commit flow. A bare `exec truecourse` fails with
+// "command not found" on machines that only use truecourse via npx.
 const HOOK_SCRIPT = `#!/bin/sh
 ${HOOK_IDENTIFIER}
 # Installed by: truecourse hooks install
 # Bypass with: git commit --no-verify
 
-exec truecourse hooks run
+exec npx -y truecourse hooks run
 `;
 
-type BlockRule =
-  | string // rule key like "hardcoded-secret" or "security/deterministic/hardcoded-secret"
-  | { severity: string };
+// ---------------------------------------------------------------------------
+// Config: severity-only block list + optional LLM toggle
+// ---------------------------------------------------------------------------
 
-type HooksConfig = {
+const SEVERITIES = ["info", "low", "medium", "high", "critical"] as const;
+type Severity = (typeof SEVERITIES)[number];
+
+interface HooksConfig {
   "pre-commit"?: {
-    "block-on"?: BlockRule[];
-    timeout?: string;
+    "block-on"?: Severity[];
+    llm?: boolean;
   };
-};
+}
 
-const DEFAULT_BLOCK_ON: BlockRule[] = [
-  "security/deterministic/hardcoded-secret",
-  { severity: "critical" },
-];
+// `[critical, high]` because the hook only gates on *newly-introduced*
+// violations via diff — it never surfaces existing debt. Blocking on new
+// criticals and new highs catches things like SQL injection, unhandled
+// async exceptions, race conditions, missing input validation. Medium
+// and below (style, complexity) aren't worth friction on every commit.
+// Users wanting stricter or more permissive override via hooks.yaml.
+/**
+ * Template written to `.truecourse/hooks.yaml` on `hooks install` when the
+ * file doesn't already exist. **This is the only place default values
+ * live.** At runtime the hook reads `hooks.yaml` and nothing else — no
+ * code-level fallback. If the file is gone, the hook can't know what to
+ * enforce, so it warns and passes.
+ */
+const HOOKS_YAML_TEMPLATE = `# TrueCourse pre-commit hook config.
+# Commit this file — it's the team-shared policy for what blocks a commit.
+# Check the live values with \`truecourse hooks status\`.
+pre-commit:
+  # Severities that block a commit when the diff surfaces NEW violations
+  # at that level. Valid: info, low, medium, high, critical.
+  block-on:
+    - critical
+    - high
 
-const DEFAULT_TIMEOUT_MS = 30_000;
+  # Run LLM-powered rules on every commit? Off by default (no tokens per
+  # commit). Set to true for deeper semantic checks at the commit gate —
+  # each commit will then cost tokens.
+  llm: false
+`;
 
-// --- Git directory resolution ---
+// ---------------------------------------------------------------------------
+// Git directory resolution
+// ---------------------------------------------------------------------------
 
 function findGitDir(from: string): string | null {
   let dir = from;
@@ -40,17 +83,12 @@ function findGitDir(from: string): string | null {
     const gitPath = path.join(dir, ".git");
     if (fs.existsSync(gitPath)) {
       const stat = fs.statSync(gitPath);
-      if (stat.isDirectory()) {
-        return gitPath;
-      }
+      if (stat.isDirectory()) return gitPath;
       // Worktree: .git is a file containing "gitdir: <path>"
       if (stat.isFile()) {
         const content = fs.readFileSync(gitPath, "utf-8").trim();
         const match = content.match(/^gitdir:\s*(.+)$/);
-        if (match) {
-          const resolved = path.resolve(dir, match[1]);
-          return resolved;
-        }
+        if (match) return path.resolve(dir, match[1]);
       }
     }
     const parent = path.dirname(dir);
@@ -62,60 +100,106 @@ function findGitDir(from: string): string | null {
 function findProjectRoot(from: string): string | null {
   let dir = from;
   while (true) {
-    if (fs.existsSync(path.join(dir, ".git"))) {
-      return dir;
-    }
+    if (fs.existsSync(path.join(dir, ".git"))) return dir;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
     dir = parent;
   }
 }
 
-// --- Config loading ---
+// ---------------------------------------------------------------------------
+// Config loading + validation
+// ---------------------------------------------------------------------------
 
-function parseTimeout(value: string): number {
-  const match = value.match(/^(\d+)\s*(s|ms|m)?$/);
-  if (!match) return DEFAULT_TIMEOUT_MS;
-  const num = parseInt(match[1], 10);
-  const unit = match[2] || "s";
-  if (unit === "ms") return num;
-  if (unit === "m") return num * 60_000;
-  return num * 1_000;
+interface LoadedHooksConfig {
+  blockOn: readonly Severity[];
+  llm: boolean;
+  configPath: string;
 }
 
-function loadConfig(projectRoot: string): HooksConfig {
+/**
+ * Load `.truecourse/hooks.yaml`. Returns `null` when the file doesn't
+ * exist — callers decide what to do (the hook runner warns and passes;
+ * status reports "no config"). A malformed file exits 1 with a clear
+ * message; we never silently accept garbage.
+ */
+function loadConfig(projectRoot: string): LoadedHooksConfig | null {
   const configPath = path.join(projectRoot, ".truecourse", "hooks.yaml");
-  if (!fs.existsSync(configPath)) return {};
+  if (!fs.existsSync(configPath)) return null;
 
+  let parsed: HooksConfig;
   try {
     const raw = fs.readFileSync(configPath, "utf-8");
-    return (yaml.load(raw) as HooksConfig) || {};
-  } catch {
-    return {};
+    parsed = (yaml.load(raw) as HooksConfig) || {};
+  } catch (err) {
+    console.error(`Error parsing ${configPath}: ${(err as Error).message}`);
+    process.exit(1);
   }
+
+  const preCommit = parsed["pre-commit"] ?? {};
+  const rawBlockOn = preCommit["block-on"];
+  if (!Array.isArray(rawBlockOn)) {
+    console.error(
+      `Invalid ${configPath}: \`pre-commit.block-on\` must be an array of severity names.`,
+    );
+    console.error(`  Valid severities: ${SEVERITIES.join(", ")}`);
+    process.exit(1);
+  }
+  const invalid = rawBlockOn.filter(
+    (s) => typeof s !== "string" || !(SEVERITIES as readonly string[]).includes(s),
+  );
+  if (invalid.length > 0) {
+    console.error(
+      `Invalid ${configPath}: unknown value(s) in \`pre-commit.block-on\`: ${invalid
+        .map((v) => JSON.stringify(v))
+        .join(", ")}`,
+    );
+    console.error(`  Valid severities: ${SEVERITIES.join(", ")}`);
+    process.exit(1);
+  }
+
+  return {
+    blockOn: rawBlockOn as Severity[],
+    llm: preCommit.llm === true,
+    configPath,
+  };
 }
 
-function getBlockRules(config: HooksConfig): BlockRule[] {
-  return config["pre-commit"]?.["block-on"] ?? DEFAULT_BLOCK_ON;
-}
+// ---------------------------------------------------------------------------
+// Install / Uninstall / Status
+// ---------------------------------------------------------------------------
 
-function getTimeoutMs(config: HooksConfig): number {
-  const raw = config["pre-commit"]?.timeout;
-  return raw ? parseTimeout(raw) : DEFAULT_TIMEOUT_MS;
-}
+const INSTALL_WARNING =
+  "The pre-commit hook runs `truecourse analyze --diff` on every commit.\n" +
+  "Commits will take as long as a full diff analysis of this repo —\n" +
+  "on large repos that can be tens of seconds per commit.";
 
-// --- Install / Uninstall / Status ---
-
-export function runHooksInstall(): void {
+export async function runHooksInstall(): Promise<void> {
   const gitDir = findGitDir(process.cwd());
   if (!gitDir) {
     console.error("Error: Not a git repository.");
     process.exit(1);
   }
 
+  // Warn about commit latency. In a TTY, require explicit confirmation;
+  // non-interactive installs (CI, devcontainer setup) get the notice and
+  // proceed — they're intentional and shouldn't hang.
+  if (isInteractive()) {
+    p.log.warn(INSTALL_WARNING);
+    const proceed = await p.confirm({
+      message: "Install the pre-commit hook?",
+      initialValue: false,
+    });
+    if (p.isCancel(proceed) || !proceed) {
+      p.cancel("Install cancelled.");
+      process.exit(0);
+    }
+  } else {
+    console.log(INSTALL_WARNING);
+  }
+
   const hooksDir = path.join(gitDir, "hooks");
   fs.mkdirSync(hooksDir, { recursive: true });
-
   const hookPath = path.join(hooksDir, "pre-commit");
 
   if (fs.existsSync(hookPath)) {
@@ -134,6 +218,19 @@ export function runHooksInstall(): void {
   fs.writeFileSync(hookPath, HOOK_SCRIPT, { mode: 0o755 });
   console.log("TrueCourse pre-commit hook installed.");
   console.log(`  ${hookPath}`);
+
+  // Seed the team-shared policy file on first install. We never overwrite
+  // an existing hooks.yaml — that's the user's config.
+  const projectRoot = findProjectRoot(process.cwd());
+  if (projectRoot) {
+    const cfgDir = path.join(projectRoot, ".truecourse");
+    const cfgPath = path.join(cfgDir, "hooks.yaml");
+    if (!fs.existsSync(cfgPath)) {
+      fs.mkdirSync(cfgDir, { recursive: true });
+      fs.writeFileSync(cfgPath, HOOKS_YAML_TEMPLATE);
+      console.log(`  ${cfgPath} (starter config — edit to customize, commit to share with the team)`);
+    }
+  }
 }
 
 export function runHooksUninstall(): void {
@@ -182,65 +279,30 @@ export function runHooksStatus(): void {
 
   const projectRoot = findProjectRoot(process.cwd());
   if (projectRoot) {
-    const configPath = path.join(projectRoot, ".truecourse", "hooks.yaml");
-    if (fs.existsSync(configPath)) {
-      console.log(`\nConfig: ${configPath}`);
-      const config = loadConfig(projectRoot);
-      const blockRules = getBlockRules(config);
-      console.log("Block on:");
-      for (const rule of blockRules) {
-        if (typeof rule === "string") {
-          console.log(`  - ${rule}`);
-        } else {
-          console.log(`  - severity: ${rule.severity}`);
-        }
-      }
-      const timeoutMs = getTimeoutMs(config);
-      console.log(`Timeout: ${timeoutMs / 1000}s`);
+    const cfg = loadConfig(projectRoot);
+    if (!cfg) {
+      console.log(
+        "\nNo `.truecourse/hooks.yaml` — hook has no policy. Run `truecourse hooks install` to generate one.",
+      );
     } else {
-      console.log("\nNo config file. Using defaults (block on: security/deterministic/hardcoded-secret, severity: critical).");
+      console.log(`\nConfig: ${cfg.configPath}`);
+      console.log(`Block on severities: ${cfg.blockOn.join(", ")}`);
+      console.log(`LLM rules on commit: ${cfg.llm ? "enabled (tokens per commit)" : "disabled"}`);
     }
   }
 }
 
-// --- Run (called by the hook) ---
+// ---------------------------------------------------------------------------
+// Run (called by the hook script)
+// ---------------------------------------------------------------------------
 
-type CodeViolation = {
-  ruleKey: string;
-  filePath: string;
-  lineStart: number;
-  lineEnd: number;
-  columnStart: number;
-  columnEnd: number;
-  severity: string;
-  title: string;
-  content: string;
-  snippet: string;
-  fixPrompt?: string;
-};
-
-function shouldBlock(violation: CodeViolation, blockRules: BlockRule[]): boolean {
-  for (const rule of blockRules) {
-    if (typeof rule === "string") {
-      // Match by rule key — support both short name ("hardcoded-secret") and full key
-      if (
-        violation.ruleKey === rule ||
-        violation.ruleKey.endsWith(`/${rule}`)
-      ) {
-        return true;
-      }
-    } else if (rule.severity) {
-      if (violation.severity.toLowerCase() === rule.severity.toLowerCase()) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
+/**
+ * The hook runs the same `analyze --diff` pipeline the user would get from
+ * `truecourse analyze --diff`, then filters new violations by severity. No
+ * custom per-file parse loop — one pipeline keeps the hook aligned with the
+ * dashboard and with `truecourse list --diff`.
+ */
 export async function runHooksRun(): Promise<void> {
-  const startTime = Date.now();
-
   process.stdout.write("TrueCourse pre-commit check...");
 
   const projectRoot = findProjectRoot(process.cwd());
@@ -249,107 +311,102 @@ export async function runHooksRun(): Promise<void> {
     process.exit(0);
   }
 
-  const config = loadConfig(projectRoot);
-  const blockRules = getBlockRules(config);
-  const timeoutMs = getTimeoutMs(config);
-
-  // Get staged files (Added, Copied, Modified — skip Deleted)
-  let stagedFiles: string[];
+  // Any staged files at all? No staged content → nothing to check.
+  let hasStaged = false;
   try {
     const output = execSync("git diff --cached --name-only --diff-filter=ACM", {
       encoding: "utf-8",
       cwd: projectRoot,
     }).trim();
-    stagedFiles = output ? output.split("\n") : [];
+    hasStaged = output.length > 0;
   } catch {
     console.log(" skipped (git error)");
     process.exit(0);
   }
-
-  if (stagedFiles.length === 0) {
+  if (!hasStaged) {
     console.log(" \u2714 passed (no staged files)");
     process.exit(0);
   }
 
-  // Import analyzer dynamically to avoid loading tree-sitter when not needed
-  let parseCode: typeof import("@truecourse/analyzer").parseCode;
-  let detectLanguage: typeof import("@truecourse/analyzer").detectLanguage;
-  let checkCodeRules: typeof import("@truecourse/analyzer").checkCodeRules;
-  let CODE_RULES: typeof import("@truecourse/analyzer").CODE_RULES;
+  // hooks.yaml is the single source of truth. If it's gone, the hook
+  // has no policy to enforce — warn and pass. Users who want the hook
+  // active can recreate the file with `truecourse hooks install`.
+  const cfg = loadConfig(projectRoot);
+  if (!cfg) {
+    console.log(" skipped");
+    console.error(
+      "No `.truecourse/hooks.yaml` found. The pre-commit hook has no policy to\n" +
+        "enforce — run `truecourse hooks install` to generate one.",
+    );
+    process.exit(0);
+  }
 
+  // The diff pipeline compares against the last full analysis. Without
+  // a `.truecourse/` dir or a LATEST snapshot, there's nothing to diff
+  // against — block with a clear message rather than letting commits
+  // silently pass (a silent-pass hook is worse than no hook: the user
+  // would think they were protected when they aren't).
+  const repoDir = resolveRepoDir(process.cwd());
+  const project = repoDir
+    ? (getProjectByPath(repoDir) ?? registerProject(repoDir))
+    : null;
+  if (!project || !readLatest(project.path)) {
+    console.log("");
+    console.error(
+      "No baseline analysis yet. Run `truecourse analyze` once in this repo before\n" +
+        "the pre-commit hook can block new violations. Or bypass this commit with\n" +
+        "`git commit --no-verify`.",
+    );
+    process.exit(1);
+  }
+
+  // Ctrl-C during a long commit should cancel the diff cleanly.
+  const abortController = new AbortController();
+  const onSigint = () => abortController.abort();
+  process.on("SIGINT", onSigint);
+
+  process.stdout.write(" running analysis...");
+
+  let newViolations: Awaited<ReturnType<typeof diffInProcess>>["diff"]["newViolations"];
   try {
-    const analyzer = await import("@truecourse/analyzer");
-    parseCode = analyzer.parseCode;
-    detectLanguage = analyzer.detectLanguage;
-    checkCodeRules = analyzer.checkCodeRules;
-    CODE_RULES = analyzer.CODE_RULES;
-    // WASM parsers need one-time async init before any parseCode call.
-    await analyzer.initParsers();
-  } catch {
-    console.log(" skipped (analyzer not available)");
-    process.exit(0);
+    const { diff } = await diffInProcess(project, {
+      signal: abortController.signal,
+      enableLlmRulesOverride: cfg.llm,
+      // Pre-approved: the user opted into LLM-in-hook by setting llm: true
+      // in hooks.yaml, so we don't re-prompt for the token cost estimate.
+      onLlmEstimate: async () => true,
+    });
+    newViolations = diff.newViolations;
+  } catch (err) {
+    console.log("");
+    if (err instanceof DOMException && err.name === "AbortError") {
+      console.error("Pre-commit check cancelled.");
+      process.exit(130);
+    }
+    console.error(`Pre-commit check failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  } finally {
+    process.removeListener("SIGINT", onSigint);
   }
 
-  // Filter to supported languages
-  const supportedFiles = stagedFiles.filter((f) => detectLanguage(f) !== null);
-
-  if (supportedFiles.length === 0) {
-    console.log(" \u2714 passed");
-    process.exit(0);
-  }
-
-  const allViolations: CodeViolation[] = [];
-
-  for (const filePath of supportedFiles) {
-    // Check timeout
-    if (Date.now() - startTime > timeoutMs) {
-      console.log("\n  Warning: timeout reached, skipping remaining files.");
-      break;
-    }
-
-    const language = detectLanguage(filePath);
-    if (!language) continue;
-
-    // Read staged content (not working copy)
-    let content: string;
-    try {
-      content = execSync(`git show ":${filePath}"`, {
-        encoding: "utf-8",
-        cwd: projectRoot,
-        maxBuffer: 5 * 1024 * 1024, // 5MB
-      });
-    } catch {
-      // File might be binary or inaccessible
-      continue;
-    }
-
-    // Parse and check
-    try {
-      const tree = parseCode(content, language);
-      const violations = checkCodeRules(tree, filePath, content, CODE_RULES, language);
-      allViolations.push(...violations);
-    } catch {
-      // Skip files that fail to parse
-      continue;
-    }
-  }
-
-  // Filter to blocking violations
-  const blocking = allViolations.filter((v) => shouldBlock(v, blockRules));
+  const blockSet = new Set<string>(cfg.blockOn);
+  const blocking = newViolations.filter((v) => blockSet.has(v.severity.toLowerCase()));
 
   if (blocking.length === 0) {
-    console.log(" \u2714 passed");
+    console.log(` \u2714 passed (${newViolations.length} new violations, none at or above ${cfg.blockOn.join("/")})`);
     process.exit(0);
   }
 
-  // Print blocking violations
   console.log("\n");
-
   for (const v of blocking) {
     const icon = severityIcon(v.severity);
     const color = severityColor(v.severity);
+    const location = v.filePath
+      ? `${v.filePath}${v.lineStart ? `:${v.lineStart}` : ""}`
+      : "(no file)";
     console.log(` ${color(`${icon} BLOCKED`)}: ${v.title}`);
-    console.log(`   ${v.filePath}:${v.lineStart} \u2014 ${v.content}`);
+    console.log(`   ${location} \u2014 ${v.content}`);
+    if (v.fixPrompt) console.log(`   Fix: ${v.fixPrompt}`);
     console.log("");
   }
 

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -210,8 +210,8 @@ const hooksCmd = program
 hooksCmd
   .command("install")
   .description("Install pre-commit hook")
-  .action(() => {
-    runHooksInstall();
+  .action(async () => {
+    await runHooksInstall();
   });
 
 hooksCmd

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -25,7 +25,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.5.1")
+  .version("0.5.2")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## Problem

`truecourse hooks run` had its own custom implementation: parse staged files with tree-sitter, call `checkCodeRules` directly, hand-rolled `shouldBlock()`. That was a duplicated + **partial** version of the analyzer — only per-file AST visitors, missing everything graph-aware (cross-file taint, architecture, service/module context). The hook's output disagreed with the dashboard.

Block-list config was also overcomplicated: rule keys + severity objects, with a partially-redundant default (`hardcoded-secret` is already `critical`).

## Solution

Hook now runs the same `analyze --diff` pipeline the dashboard and `truecourse analyze --diff` use (`diffInProcess`), reads `newViolations` from the returned snapshot, filters by severity, blocks on match.

### `hooks.yaml` is the single source of truth

- No hardcoded defaults in code. Missing file at runtime → warn + pass (never silently "enforce" unknown policy).
- `hooks install` seeds a starter `.truecourse/hooks.yaml` with `block-on: [critical, high]`, `llm: false`. Never overwrites existing user edits.
- `block-on` is now a list of severity names only. Valid: `info | low | medium | high | critical`. Invalid entries exit 1 with a listing of valid values.
- `hooks uninstall` never touches `hooks.yaml` — that's team policy, stays put.

### Install-time cost warning

Commits will take as long as a full diff analysis. In a TTY, `hooks install` prints the warning and requires explicit confirmation. Non-TTY installs (CI / devcontainer setup) print the notice and proceed without prompting.

### Hook-script bug fix

Old script: `exec truecourse hooks run` — fails with "command not found" for users who only use truecourse via npx. New script: `exec npx -y truecourse hooks run` — works with global install, cached npx, or cold npx.

### Runtime guards

- No `.truecourse/` or no `LATEST.json` → block with "run `truecourse analyze` first". Silent-pass would be worse than no hook.
- SIGINT during a long commit propagates through AbortSignal → clean cancel, exit 130.
- `llm: true` in config → pre-approves the cost estimate; hook does not prompt mid-commit.

## Drive-by fixes (same branch)

- `README.md`: hook section rewritten; skills paragraph updated to match PR #56; new Contact section pointing at `mushegh@truecourse.dev`.
- `scripts/build.ts`: `author` field in the generated `dist/package.json` so the npm registry shows the author + email.
- `truecourse-analyze/SKILL.md`: "cost money" → "cost tokens" (x2).

## Verification

- [x] `pnpm test` — 3378 passing, 1 skipped
- [x] `tsc --noEmit` — clean
- [x] `pnpm build:dist` — clean; packed and smoke-tested locally
- [x] Scratch-repo smoke tests:
  - No `hooks.yaml` → hook prints warning + exits 0 + commit proceeds
  - Invalid `block-on` entry (`[banana]`) → exit 1 with valid-severity listing
  - No `.truecourse/` or no `LATEST.json` → exit 1 with "run analyze first"
  - `hooks install` seeds `hooks.yaml` with the template; re-install preserves user edits
  - `hooks status` reports "no config" when file missing, parsed values when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)