### PR TITLE
Install skills at .claude/skills/<name>/ (flat), not nested under truecourse/

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/server",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/commands/helpers.ts
+++ b/tools/cli/src/commands/helpers.ts
@@ -369,11 +369,17 @@ function resolveSkillsSrcDir(): string | null {
   return existsSync(candidate) ? candidate : null;
 }
 
-function skillDestDir(repoPath: string): string {
-  return resolve(repoPath, ".claude", "skills", "truecourse");
+/**
+ * Where skills live in the consumer repo. Claude Code's canonical layout
+ * is flat: each skill at `<repo>/.claude/skills/<skill-name>/SKILL.md`.
+ * Don't nest under a `truecourse/` namespace folder — the docs call that
+ * out as non-standard and it won't be discovered by some tooling.
+ */
+function skillsParentDir(repoPath: string): string {
+  return resolve(repoPath, ".claude", "skills");
 }
 
-/** Subdirectory names under a skills root — each entry is one skill. */
+/** Subdirectory names immediately under `root`. */
 function listSkillDirs(root: string): string[] {
   if (!existsSync(root)) return [];
   return readdirSync(root, { withFileTypes: true })
@@ -383,27 +389,45 @@ function listSkillDirs(root: string): string[] {
 }
 
 /**
- * Names of shipped skills not yet present in the user's repo. First-time
- * install returns the full list; upgrades after a new skill ships return
- * only the new one(s).
+ * Names of shipped skills not yet present in the user's repo. We only
+ * consider truecourse-owned names — other tools' skills sitting in the
+ * same `.claude/skills/` are ignored.
  */
 function computeMissingSkills(repoPath: string): string[] {
   const src = resolveSkillsSrcDir();
   if (!src) return [];
-  const shipped = new Set(listSkillDirs(src));
-  const installed = new Set(listSkillDirs(skillDestDir(repoPath)));
-  return [...shipped].filter((name) => !installed.has(name));
+  const shipped = listSkillDirs(src);
+  const parent = skillsParentDir(repoPath);
+  return shipped.filter((name) => !existsSync(resolve(parent, name)));
 }
 
-/** True when every shipped skill is already present in the repo. */
+/** True when every shipped skill is already present (at the flat layout). */
 export function hasInstalledSkills(repoPath: string): boolean {
   return computeMissingSkills(repoPath).length === 0;
 }
 
 /**
- * Copy each named skill from the bundled source dir into the repo. Never
- * overwrites an existing skill — user customizations are preserved; the
- * "missing" list already excludes anything already installed.
+ * Pre-0.5.3 installs sometimes ended up with a wrapper folder at
+ * `.claude/skills/truecourse/<skill-name>/`. That's not a layout Claude
+ * Code discovers cleanly. Warn the user once on install so they can
+ * delete it — we don't remove anything automatically.
+ */
+function warnAboutLegacyWrapper(repoPath: string): void {
+  const legacy = resolve(skillsParentDir(repoPath), "truecourse");
+  if (!existsSync(legacy)) return;
+  const nestedSkills = listSkillDirs(legacy);
+  if (nestedSkills.length === 0) return;
+  p.log.warn(
+    `Found legacy nested skills at ${legacy}. The current layout is flat ` +
+      `(\`.claude/skills/<skill>/\`), so that directory is now unused and ` +
+      `can be deleted: \`rm -rf ${legacy}\`.`,
+  );
+}
+
+/**
+ * Copy each named skill from the bundled source dir into the repo at the
+ * flat layout. Never overwrites an existing skill — user customizations
+ * are preserved; the "missing" list already excludes anything present.
  */
 function copySkills(repoPath: string, skillNames: string[]): void {
   const src = resolveSkillsSrcDir();
@@ -412,12 +436,12 @@ function copySkills(repoPath: string, skillNames: string[]): void {
     return;
   }
 
-  const destParent = skillDestDir(repoPath);
-  mkdirSync(destParent, { recursive: true });
+  const parent = skillsParentDir(repoPath);
+  mkdirSync(parent, { recursive: true });
 
   for (const name of skillNames) {
     const skillSrc = resolve(src, name);
-    const skillDest = resolve(destParent, name);
+    const skillDest = resolve(parent, name);
     if (existsSync(skillDest)) continue; // belt-and-suspenders
     cpSync(skillSrc, skillDest, { recursive: true });
   }
@@ -426,6 +450,8 @@ function copySkills(repoPath: string, skillNames: string[]): void {
     `Installed ${skillNames.length} Claude Code skill${skillNames.length === 1 ? "" : "s"}:`,
   );
   for (const name of skillNames) p.log.message(`  - ${name}`);
+
+  warnAboutLegacyWrapper(repoPath);
 }
 
 /**
@@ -459,9 +485,13 @@ export async function promptInstallSkills(
 
   // First-time install vs upgrade phrasing — the latter names the new
   // skill(s) so the user can decide whether they want that specific
-  // capability rather than being asked a generic yes/no.
-  const isUpgrade = existsSync(skillDestDir(repoPath));
-  const message = isUpgrade
+  // capability rather than being asked a generic yes/no. "Upgrade" means
+  // at least one of our shipped skills is already present in the repo.
+  const src = resolveSkillsSrcDir();
+  const shipped = src ? listSkillDirs(src) : [];
+  const parent = skillsParentDir(repoPath);
+  const alreadyInstalled = shipped.some((name) => existsSync(resolve(parent, name)));
+  const message = alreadyInstalled
     ? `New Claude Code skill${missing.length === 1 ? "" : "s"} available: ${missing.join(", ")}. Install?`
     : "Would you like to install Claude Code skills?";
 

--- a/tools/cli/src/commands/helpers.ts
+++ b/tools/cli/src/commands/helpers.ts
@@ -407,24 +407,6 @@ export function hasInstalledSkills(repoPath: string): boolean {
 }
 
 /**
- * Pre-0.5.3 installs sometimes ended up with a wrapper folder at
- * `.claude/skills/truecourse/<skill-name>/`. That's not a layout Claude
- * Code discovers cleanly. Warn the user once on install so they can
- * delete it — we don't remove anything automatically.
- */
-function warnAboutLegacyWrapper(repoPath: string): void {
-  const legacy = resolve(skillsParentDir(repoPath), "truecourse");
-  if (!existsSync(legacy)) return;
-  const nestedSkills = listSkillDirs(legacy);
-  if (nestedSkills.length === 0) return;
-  p.log.warn(
-    `Found legacy nested skills at ${legacy}. The current layout is flat ` +
-      `(\`.claude/skills/<skill>/\`), so that directory is now unused and ` +
-      `can be deleted: \`rm -rf ${legacy}\`.`,
-  );
-}
-
-/**
  * Copy each named skill from the bundled source dir into the repo at the
  * flat layout. Never overwrites an existing skill — user customizations
  * are preserved; the "missing" list already excludes anything present.
@@ -450,8 +432,6 @@ function copySkills(repoPath: string, skillNames: string[]): void {
     `Installed ${skillNames.length} Claude Code skill${skillNames.length === 1 ? "" : "s"}:`,
   );
   for (const name of skillNames) p.log.message(`  - ${name}`);
-
-  warnAboutLegacyWrapper(repoPath);
 }
 
 /**

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -25,7 +25,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.5.3")
+  .version("0.5.4")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## Problem

PR #59's per-skill sync shipped the skills into a wrapper folder:

```
.claude/skills/truecourse/truecourse-analyze/
.claude/skills/truecourse/truecourse-fix/
...
```

Claude Code's canonical layout is **flat** — one skill per top-level directory directly under `.claude/skills/`. The `truecourse/` wrapper isn't discovered cleanly by Claude Code's skill loader.

## Fix

Move back to the flat layout. Each shipped skill goes directly at `.claude/skills/<skill-name>/`.

- `skillsParentDir(repoPath)` now returns `.claude/skills` (no `truecourse/` inside).
- `computeMissingSkills` diffs shipped names against whether each sits directly under that parent.
- `alreadyInstalled` (controls first-time vs upgrade prompt phrasing) checks the same way.

No migration code for users who hit the 0.5.3 nested layout — the affected population is the author alone, who will clean up manually.

## Verification

- [x] `pnpm test` — 3378 passing, 1 skipped
- [x] Scratch repos:
  - Fresh → all 4 skills at flat layout
  - Flat with 3 skills → only new `truecourse-hooks` installed, others untouched

Reference: Claude Code's [custom skills documentation](https://code.claude.com/docs/en/custom-skills.md) — "Where skills live" describes the flat layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)