### PR TITLE
Cap concurrent LLM CLI spawns and unify progress format (v0.5.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,28 @@ The first `truecourse analyze` (or `truecourse add`) in a fresh repo asks whethe
 - Node.js >= 20
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI on your PATH. Deterministic rules run without it, LLM-powered rules need it.
 
+## Configuration
+
+TrueCourse talks to Claude Code via the `claude` CLI. You can tune how that interaction behaves — which binary to invoke, which model to pass, timeouts, retries, and how many `claude` processes to run in parallel — through environment variables.
+
+For packaged installs (`npx truecourse` or `npm install -g truecourse`), the simplest place to set them is `~/.truecourse/.env`. The file is loaded automatically on every invocation:
+
+```
+CLAUDE_CODE_BINARY=claude             # override the `claude` binary on PATH
+CLAUDE_CODE_MODEL=                    # Claude Code --model flag (empty = default)
+CLAUDE_CODE_TIMEOUT_MS=120000         # per-call timeout (ms)
+CLAUDE_CODE_MAX_RETRIES=2             # retry attempts on parse/validation failure
+CLAUDE_CODE_MAX_CONCURRENCY=10        # max concurrent `claude` processes per run
+```
+
+**`CLAUDE_CODE_MAX_CONCURRENCY`** caps how many Claude CLI processes TrueCourse spawns in parallel during a single analyze. Default `10`. Raise it on CI runners with spare headroom; lower it on resource-constrained machines (e.g. 8 GB laptops, shared VMs) to avoid OOM on large repos. Must be a positive integer.
+
+For a one-off override, prefix the command:
+
+```bash
+CLAUDE_CODE_MAX_CONCURRENCY=2 truecourse analyze
+```
+
 ## Development
 
 ```bash

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/server",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "type": "module",
   "exports": {
@@ -55,6 +55,7 @@
     "dagre": "^0.8.5",
     "dotenv": "^16.4.0",
     "express": "^4.21.0",
+    "p-limit": "^7.3.0",
     "posthog-node": "^4.0.0",
     "simple-git": "^3.27.0",
     "socket.io": "^4.8.0",

--- a/apps/server/src/commands/analyze-in-process.ts
+++ b/apps/server/src/commands/analyze-in-process.ts
@@ -11,6 +11,8 @@ import type { LLMProvider } from '../services/llm/provider.js';
 import type { StepTracker } from '../socket/handlers.js';
 import { analyzeCore, type LlmEstimate } from './analyze-core.js';
 import { persistFullAnalysis, type PersistFullResult } from './analyze-persist.js';
+import { config } from '../config/index.js';
+import { log } from '../lib/logger.js';
 
 export type { LlmEstimate };
 
@@ -36,6 +38,9 @@ export async function analyzeInProcess(
   options: AnalyzeInProcessOptions = {},
 ): Promise<AnalyzeInProcessResult> {
   const startedAt = Date.now();
+  log.info(
+    `[LLM] Provider: claude-code, model: ${config.claudeCodeModel || 'default'}, maxConcurrency: ${config.claudeCodeMaxConcurrency}`,
+  );
   const core = await analyzeCore(project, { ...options, mode: 'full' });
   return persistFullAnalysis(project, core, startedAt);
 }

--- a/apps/server/src/config/index.ts
+++ b/apps/server/src/config/index.ts
@@ -1,5 +1,14 @@
 import './env.js';
 
+function parsePositiveInt(envVar: string, raw: string | undefined, defaultValue: number): number {
+  if (raw === undefined || raw === '') return defaultValue;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${envVar} must be a positive integer, got "${raw}"`);
+  }
+  return parsed;
+}
+
 export const config = {
   port: parseInt(process.env.PORT || '3001', 10),
   llmProvider: 'claude-code' as const,
@@ -8,4 +17,9 @@ export const config = {
   claudeCodeModel: process.env.CLAUDE_CODE_MODEL || '',
   claudeCodeTimeoutMs: parseInt(process.env.CLAUDE_CODE_TIMEOUT_MS || '120000', 10),
   claudeCodeMaxRetries: parseInt(process.env.CLAUDE_CODE_MAX_RETRIES || '2', 10),
+  claudeCodeMaxConcurrency: parsePositiveInt(
+    'CLAUDE_CODE_MAX_CONCURRENCY',
+    process.env.CLAUDE_CODE_MAX_CONCURRENCY,
+    10,
+  ),
 } as const;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -38,8 +38,6 @@ async function main() {
     log.info('[Storage] Legacy Postgres data wiped. Re-analyze to repopulate.');
   }
 
-  log.info(`[LLM] Provider: claude-code, model: ${config.claudeCodeModel || 'default'}`);
-
   // 2. Setup Express app
   const app: express.Express = express();
   const httpServer = createServer(app);

--- a/apps/server/src/services/llm/cli-provider.ts
+++ b/apps/server/src/services/llm/cli-provider.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { log } from '../../lib/logger.js';
+import pLimit, { type LimitFunction } from 'p-limit';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { registerChildProcess, unregisterChildProcess } from '../analysis-registry.js';
@@ -62,6 +63,8 @@ interface SpawnOptions {
   timeoutMs?: number;
   /** Extra CLI args appended after base args */
   extraArgs?: string[];
+  /** Fires once the concurrency limiter grants a slot, before spawnCLI runs. */
+  onStart?: () => void;
 }
 
 interface CLIUsage {
@@ -79,6 +82,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
   abstract get modelFlag(): string[];
 
   private maxRetries = config.claudeCodeMaxRetries ?? 2;
+  private limit: LimitFunction = pLimit(config.claudeCodeMaxConcurrency);
   private debugDir: string | null = null;
   private callCounter = 0;
   private _analysisId: string | null = null;
@@ -296,39 +300,52 @@ export abstract class BaseCLIProvider implements LLMProvider {
     schema: ZodType<T>,
     opts?: SpawnOptions & { label?: string },
   ): Promise<{ data: T; usage?: CLIUsage }> {
-    const jsonSchemaStr = this.toJsonSchema(schema);
-    const label = opts?.label ?? 'call';
-    let lastError: Error | null = null;
+    // Cap concurrent CLI spawns across all callers on this provider.
+    // The limit runs the inner fn only when a slot is free, so timeout
+    // timers (inside spawnCLI) can't start while the task is queued.
+    return this.limit(async () => {
+      if (this._abortSignal?.aborted) {
+        throw this._abortSignal.reason ?? new DOMException('Analysis cancelled', 'AbortError');
+      }
+      opts?.onStart?.();
 
-    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
-      try {
-        const raw = await this.spawnCLI(prompt, jsonSchemaStr, opts);
-        this.dumpDebug(label, prompt, raw, jsonSchemaStr);
-        return this.parseAndValidate(raw, schema);
-      } catch (err) {
-        lastError = err as Error;
-        if (this._abortSignal?.aborted) throw lastError; // don't retry on cancel
-        if (attempt < this.maxRetries) {
-          log.warn(`[CLI] Attempt ${attempt + 1} failed, retrying... (${lastError.message})`);
+      const jsonSchemaStr = this.toJsonSchema(schema);
+      const label = opts?.label ?? 'call';
+      let lastError: Error | null = null;
+
+      for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+        try {
+          const raw = await this.spawnCLI(prompt, jsonSchemaStr, opts);
+          this.dumpDebug(label, prompt, raw, jsonSchemaStr);
+          return this.parseAndValidate(raw, schema);
+        } catch (err) {
+          lastError = err as Error;
+          if (this._abortSignal?.aborted) throw lastError; // don't retry on cancel
+          if (attempt < this.maxRetries) {
+            log.warn(`[CLI] Attempt ${attempt + 1} failed, retrying... (${lastError.message})`);
+          }
         }
       }
-    }
 
-    throw lastError!;
+      throw lastError!;
+    });
   }
 
   // ---------------------------------------------------------------------------
   // LLMProvider implementation
   // ---------------------------------------------------------------------------
 
-  async generateServiceViolations(context: ServiceViolationContext): Promise<ServiceViolationsResult> {
+  async generateServiceViolations(
+    context: ServiceViolationContext,
+    opts?: { onStart?: () => void },
+  ): Promise<ServiceViolationsResult> {
     const { vars, idMap } = buildServiceTemplateVars(context);
     const prompt = getPrompt('violations-service', vars);
 
     log.info('[CLI] Service violations call starting...');
     const t0 = Date.now();
     const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, ServiceViolationOutputSchema, {
-      extraArgs: ['--tools', ''], label: 'service',
+      extraArgs: ['--tools', ''], label: 'service', onStart: opts?.onStart,
     });
     const dur = Date.now() - t0;
     log.info(`[CLI] Service violations call done in ${dur}ms — ${object.violations.length} violations`);
@@ -353,14 +370,17 @@ export abstract class BaseCLIProvider implements LLMProvider {
     };
   }
 
-  async generateDatabaseViolations(context: DatabaseViolationContext): Promise<DatabaseViolationsResult> {
+  async generateDatabaseViolations(
+    context: DatabaseViolationContext,
+    opts?: { onStart?: () => void },
+  ): Promise<DatabaseViolationsResult> {
     const { vars, idMap } = buildDatabaseTemplateVars(context);
     const prompt = getPrompt('violations-database', vars);
 
     log.info('[CLI] Database violations call starting...');
     const t0 = Date.now();
     const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, DatabaseViolationOutputSchema, {
-      extraArgs: ['--tools', ''], label: 'database',
+      extraArgs: ['--tools', ''], label: 'database', onStart: opts?.onStart,
     });
     const dur = Date.now() - t0;
     log.info(`[CLI] Database violations call done in ${dur}ms — ${object.violations.length} violations`);
@@ -382,7 +402,10 @@ export abstract class BaseCLIProvider implements LLMProvider {
     };
   }
 
-  async generateModuleViolations(context: ModuleViolationContext): Promise<ModuleViolationsResult> {
+  async generateModuleViolations(
+    context: ModuleViolationContext,
+    opts?: { onStart?: () => void },
+  ): Promise<ModuleViolationsResult> {
     const { vars, idMap } = buildModuleTemplateVars(context);
     const prompt = getPrompt('violations-module', vars);
 
@@ -396,7 +419,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
     // to avoid losing cross-module dependency edges
     const moduleTimeoutMs = 300_000; // 5 minutes
     const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, ModuleViolationOutputSchema, {
-      extraArgs: ['--tools', ''], label: 'module', timeoutMs: moduleTimeoutMs,
+      extraArgs: ['--tools', ''], label: 'module', timeoutMs: moduleTimeoutMs, onStart: opts?.onStart,
     });
     const dur = Date.now() - t0;
     log.info(`[CLI] Module violations call done in ${dur}ms — ${object.violations.length} violations`);
@@ -425,16 +448,24 @@ export abstract class BaseCLIProvider implements LLMProvider {
 
   async generateAllViolations(contexts: AllViolationsInput): Promise<AllViolationsResult> {
     const onStepComplete = contexts.onStepComplete;
+    const onCallStart = contexts.onCallStart;
+    const onCallDone = contexts.onCallDone;
     const promises: [string, Promise<unknown>][] = [];
 
     if (contexts.service) {
-      promises.push(['service', this.generateServiceViolations(contexts.service)]);
+      promises.push(['service', this.generateServiceViolations(contexts.service, {
+        onStart: () => onCallStart?.('service'),
+      })]);
     }
     if (contexts.database) {
-      promises.push(['database', this.generateDatabaseViolations(contexts.database)]);
+      promises.push(['database', this.generateDatabaseViolations(contexts.database, {
+        onStart: () => onCallStart?.('database'),
+      })]);
     }
     if (contexts.module) {
-      promises.push(['module', this.generateModuleViolations(contexts.module)]);
+      promises.push(['module', this.generateModuleViolations(contexts.module, {
+        onStart: () => onCallStart?.('module'),
+      })]);
     }
 
     const stepLabels: Record<string, string> = {
@@ -444,7 +475,10 @@ export abstract class BaseCLIProvider implements LLMProvider {
     };
 
     const settled = await Promise.allSettled(promises.map(([key, p]) =>
-      p.then((v) => { onStepComplete?.(stepLabels[key] || `${key} done`); return v; })
+      p.then(
+        (v) => { onStepComplete?.(stepLabels[key] || `${key} done`); onCallDone?.(key as 'service' | 'database' | 'module', true); return v; },
+        (err) => { onCallDone?.(key as 'service' | 'database' | 'module', false); throw err; },
+      )
     ));
 
     const result: AllViolationsResult = {};
@@ -465,6 +499,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
     contexts: AllViolationsInput,
     onStepComplete?: (step: string) => void,
   ): Promise<AllViolationsLifecycleResult> {
+    const onCallStart = contexts.onCallStart;
     const allResolved: string[] = [];
     const allNew: DiffViolationItem[] = [];
     let serviceDescriptions: ServiceDescription[] = [];
@@ -483,7 +518,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
           log.info('[CLI] Lifecycle service call starting...');
           const t0 = Date.now();
           const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, LifecycleServiceOutputSchema, {
-            extraArgs: ['--tools', ''], label: 'service-lifecycle',
+            extraArgs: ['--tools', ''], label: 'service-lifecycle', onStart: () => onCallStart?.('service'),
           });
           const dur = Date.now() - t0;
           log.info(`[CLI] Lifecycle service call done in ${dur}ms — resolved: ${object.resolvedViolationIds.length}, new: ${object.newViolations.length}`);
@@ -491,7 +526,9 @@ export abstract class BaseCLIProvider implements LLMProvider {
           return object;
         })()]);
       } else {
-        promises.push(['service-normal', this.generateServiceViolations(ctx)]);
+        promises.push(['service-normal', this.generateServiceViolations(ctx, {
+          onStart: () => onCallStart?.('service'),
+        })]);
       }
     }
 
@@ -506,7 +543,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
           log.info('[CLI] Lifecycle database call starting...');
           const t0 = Date.now();
           const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, DiffViolationOutputSchema, {
-            extraArgs: ['--tools', ''], label: 'database-lifecycle',
+            extraArgs: ['--tools', ''], label: 'database-lifecycle', onStart: () => onCallStart?.('database'),
           });
           const dur = Date.now() - t0;
           log.info(`[CLI] Lifecycle database call done in ${dur}ms — resolved: ${object.resolvedViolationIds.length}, new: ${object.newViolations.length}`);
@@ -514,7 +551,9 @@ export abstract class BaseCLIProvider implements LLMProvider {
           return object;
         })()]);
       } else {
-        promises.push(['database-normal', this.generateDatabaseViolations(ctx)]);
+        promises.push(['database-normal', this.generateDatabaseViolations(ctx, {
+          onStart: () => onCallStart?.('database'),
+        })]);
       }
     }
 
@@ -532,7 +571,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
           log.info('[CLI] Lifecycle module call starting...');
           const t0 = Date.now();
           const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, DiffViolationOutputSchema, {
-            extraArgs: ['--tools', ''], label: 'module-lifecycle',
+            extraArgs: ['--tools', ''], label: 'module-lifecycle', onStart: () => onCallStart?.('module'),
           });
           const dur = Date.now() - t0;
           log.info(`[CLI] Lifecycle module call done in ${dur}ms — resolved: ${object.resolvedViolationIds.length}, new: ${object.newViolations.length}`);
@@ -553,7 +592,9 @@ export abstract class BaseCLIProvider implements LLMProvider {
           };
         })()]);
       } else {
-        promises.push(['module-normal', this.generateModuleViolations(ctx)]);
+        promises.push(['module-normal', this.generateModuleViolations(ctx, {
+          onStart: () => onCallStart?.('module'),
+        })]);
       }
     }
 
@@ -565,9 +606,14 @@ export abstract class BaseCLIProvider implements LLMProvider {
       module: 'Module checks done',
       'module-normal': 'Module checks done',
     };
+    const baseKey = (key: string) => key.replace('-normal', '') as 'service' | 'database' | 'module';
+    const onCallDone = contexts.onCallDone;
 
     const settled = await Promise.allSettled(promises.map(([key, p]) =>
-      p.then((v) => { onStepComplete?.(stepLabels[key] || `${key} done`); return v; })
+      p.then(
+        (v) => { onStepComplete?.(stepLabels[key] || `${key} done`); onCallDone?.(baseKey(key), true); return v; },
+        (err) => { onCallDone?.(baseKey(key), false); throw err; },
+      )
     ));
 
     for (let i = 0; i < promises.length; i++) {
@@ -651,7 +697,10 @@ export abstract class BaseCLIProvider implements LLMProvider {
     return { resolvedViolationIds: allResolved, newViolations: allNew, serviceDescriptions };
   }
 
-  async generateCodeViolations(context: CodeViolationContext): Promise<CodeViolationsResult> {
+  async generateCodeViolations(
+    context: CodeViolationContext,
+    opts?: { onStart?: () => void },
+  ): Promise<CodeViolationsResult> {
     const hasExisting = context.existingViolations && context.existingViolations.length > 0;
     let promptName: Parameters<typeof getPrompt>[0];
     if (context.tier === 'metadata') {
@@ -677,7 +726,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
 
     if (hasExisting) {
       const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, CodeViolationLifecycleOutputSchema, {
-        extraArgs: codeExtraArgs, label: 'code-lifecycle', timeoutMs: codeTimeoutMs,
+        extraArgs: codeExtraArgs, label: 'code-lifecycle', timeoutMs: codeTimeoutMs, onStart: opts?.onStart,
       });
       const dur = Date.now() - t0;
       log.info(`[CLI] Code violations call done in ${dur}ms — new: ${object.newViolations.length}, resolved: ${object.resolvedViolationIds.length}, unchanged: ${object.unchangedViolationIds.length}`);
@@ -700,7 +749,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
     }
 
     const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, CodeViolationOutputSchema, {
-      extraArgs: codeExtraArgs, label: 'code', timeoutMs: codeTimeoutMs,
+      extraArgs: codeExtraArgs, label: 'code', timeoutMs: codeTimeoutMs, onStart: opts?.onStart,
     });
     const dur = Date.now() - t0;
     log.info(`[CLI] Code violations call done in ${dur}ms — ${object.violations.length} violations`);

--- a/apps/server/src/services/llm/provider.ts
+++ b/apps/server/src/services/llm/provider.ts
@@ -190,6 +190,10 @@ export interface AllViolationsInput {
   database?: DatabaseViolationContext;
   module?: ModuleViolationContext;
   onStepComplete?: (step: string) => void;
+  /** Fires when each sub-call's limiter slot is acquired (before the CLI spawns). */
+  onCallStart?: (key: 'service' | 'database' | 'module') => void;
+  /** Fires when each sub-call settles (fulfilled or rejected). */
+  onCallDone?: (key: 'service' | 'database' | 'module', ok: boolean) => void;
 }
 
 export interface AllViolationsResult {
@@ -224,12 +228,24 @@ export interface UsageRecord {
 }
 
 export interface LLMProvider {
-  generateServiceViolations(context: ServiceViolationContext): Promise<ServiceViolationsResult>;
-  generateDatabaseViolations(context: DatabaseViolationContext): Promise<DatabaseViolationsResult>;
-  generateModuleViolations(context: ModuleViolationContext): Promise<ModuleViolationsResult>;
+  generateServiceViolations(
+    context: ServiceViolationContext,
+    opts?: { onStart?: () => void },
+  ): Promise<ServiceViolationsResult>;
+  generateDatabaseViolations(
+    context: DatabaseViolationContext,
+    opts?: { onStart?: () => void },
+  ): Promise<DatabaseViolationsResult>;
+  generateModuleViolations(
+    context: ModuleViolationContext,
+    opts?: { onStart?: () => void },
+  ): Promise<ModuleViolationsResult>;
   generateAllViolations(contexts: AllViolationsInput): Promise<AllViolationsResult>;
   generateAllViolationsWithLifecycle(contexts: AllViolationsInput, onStepComplete?: (step: string) => void): Promise<AllViolationsLifecycleResult>;
-  generateCodeViolations(context: CodeViolationContext): Promise<CodeViolationsResult>;
+  generateCodeViolations(
+    context: CodeViolationContext,
+    opts?: { onStart?: () => void },
+  ): Promise<CodeViolationsResult>;
   generateAllCodeViolations(batches: CodeViolationContext[]): Promise<CodeViolationsResult>;
   enrichFlow(context: FlowEnrichmentContext): Promise<FlowEnrichmentResult>;
   setAnalysisId(id: string): void;

--- a/apps/server/src/services/violation-pipeline.service.ts
+++ b/apps/server/src/services/violation-pipeline.service.ts
@@ -23,6 +23,62 @@ function throwIfAborted(signal?: AbortSignal) {
   if (signal?.aborted) throw new DOMException('Analysis cancelled', 'AbortError');
 }
 
+/** Format an elapsed duration as "Ns" under a minute, "Nm Ns" otherwise. */
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return min === 0 ? `${sec}s` : `${min}m ${sec}s`;
+}
+
+/**
+ * Unified LLM-phase detail string used across all domains.
+ * Format: `{N det · }LLM {done}/{total}{ · M running}{ · elapsed}`.
+ * `det` is shown only when > 0; `running` only when > 0; elapsed only after 1s.
+ */
+function renderLlmDetail(s: {
+  detCount: number;
+  total: number;
+  done: number;
+  running: number;
+  elapsedMs: number;
+}): string {
+  const parts: string[] = [];
+  if (s.detCount > 0) parts.push(`${s.detCount} det`);
+  parts.push(`LLM ${s.done}/${s.total}`);
+  if (s.running > 0) parts.push(`${s.running} running`);
+  if (s.elapsedMs >= 1000) parts.push(formatElapsed(s.elapsedMs));
+  return parts.join(' · ');
+}
+
+/**
+ * Per-domain LLM progress tracker. Owns a running/done counter, a start
+ * timestamp, and refreshes tracker.detail on every state transition.
+ * Call onCallStart when a call's limiter slot is granted; call onCallDone
+ * when the call settles (pass whether onCallStart had fired — tasks that
+ * abort while still queued never fire onCallStart, so we must not decrement
+ * `running` for them).
+ */
+function createLlmTracker(
+  tracker: import('../socket/handlers.js').StepTracker | undefined,
+  domain: string,
+  detCount: number,
+  total: number,
+) {
+  let done = 0;
+  let running = 0;
+  const t0 = Date.now();
+  const render = () => tracker?.detail(domain, renderLlmDetail({
+    detCount, total, done, running, elapsedMs: Date.now() - t0,
+  }));
+
+  return {
+    initialDetail: renderLlmDetail({ detCount, total, done: 0, running: 0, elapsedMs: 0 }),
+    onCallStart: () => { running++; render(); },
+    onCallDone: (started: boolean) => { if (started) running--; done++; render(); },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -554,11 +610,8 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
   const allResolvedLlmIds: string[] = [];
 
   const hasArchLlm = enableLlmRules !== false && !llmSkipped;
-  if (hasArchLlm) tracker?.start('architecture', 'Running LLM analysis...');
-  for (const [domain] of domainCodeBatches) {
-    const detCount = violationsByDomain.get(domain) ?? 0;
-    tracker?.start(domain, detCount > 0 ? `${detCount} det, running LLM...` : 'Running LLM...');
-  }
+  // tracker.start for LLM steps fires later, once dbSchemaContext and
+  // violationInput are known — see the "build LLM trackers" block below.
 
   const previousDetForComparison = previousDetViolations.map((v) => ({
     ruleKey: v.ruleKey,
@@ -813,6 +866,36 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
     existingModuleViolations: hasLlmOnlyExistingViolations ? existingModuleViolations : undefined,
   };
 
+  // ---------- Build LLM trackers (one shared instance per tracker key) ----------
+  // Every LLM-phase detail string goes through createLlmTracker so the format
+  // is identical across code-batch, schema, and architecture paths.
+  const llmTrackers = new Map<string, ReturnType<typeof createLlmTracker>>();
+
+  for (const [domain, batches] of domainCodeBatches) {
+    const detCount = violationsByDomain.get(domain) ?? 0;
+    const ll = createLlmTracker(tracker, domain, detCount, batches.length);
+    llmTrackers.set(domain, ll);
+    tracker?.start(domain, ll.initialDetail);
+  }
+  // Schema-only case: database has no code batches but does have a schema call.
+  // When both exist, the code-batch tracker dominates (schema runs silently —
+  // a pre-existing aggregation limitation we preserve for now).
+  if (dbSchemaContext && !llmSkipped && !domainCodeBatches.has('database')) {
+    const detCount = violationsByDomain.get('database') ?? 0;
+    const ll = createLlmTracker(tracker, 'database', detCount, 1);
+    llmTrackers.set('database', ll);
+    tracker?.start('database', ll.initialDetail);
+  }
+  if (hasArchLlm) {
+    const detCount = violationsByDomain.get('architecture') ?? 0;
+    // generateViolations calls: 1 (service, always) + 1 (module, if any).
+    // The pipeline passes `databases: undefined` to arch, so db sub-call never fires.
+    const archTotal = 1 + (violationModules && violationModules.length > 0 ? 1 : 0);
+    const ll = createLlmTracker(tracker, 'architecture', detCount, archTotal);
+    llmTrackers.set('architecture', ll);
+    tracker?.start('architecture', ll.initialDetail);
+  }
+
   type DomainLlmResult = { domain: string; violations: CodeViolation[]; resolvedIds: string[]; unchangedIds: string[] };
   const domainLlmPromises: Promise<DomainLlmResult>[] = [];
 
@@ -821,9 +904,15 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
       const detCount = violationsByDomain.get(domain) ?? 0;
       log.info(`[LLM] ${domain}: starting (${batches.length} code batches)`);
       const t0 = Date.now();
+      const ll = llmTrackers.get(domain)!;
 
       const codeResults = await Promise.allSettled(
-        batches.map((b) => provider.generateCodeViolations(b)),
+        batches.map((b) => {
+          let started = false;
+          return provider.generateCodeViolations(b, {
+            onStart: () => { started = true; ll.onCallStart(); },
+          }).finally(() => ll.onCallDone(started));
+        }),
       );
 
       const rawViolations: CodeViolationRaw[] = [];
@@ -853,16 +942,20 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
   // Database schema LLM (separate from code batches)
   let dbSchemaViolations: ViolationRecord[] = [];
   if (dbSchemaContext && !llmSkipped) {
-    if (!domainCodeBatches.has('database')) {
-      const detCount = violationsByDomain.get('database') ?? 0;
-      tracker?.start('database', detCount > 0 ? `${detCount} det, running LLM...` : 'Running LLM...');
-    }
+    // Shared tracker exists only when schema is the sole database LLM path.
+    // When code batches also exist, the code-batch tracker dominates and
+    // schema runs silently (pre-existing aggregation limitation).
+    const schemaLl = domainCodeBatches.has('database') ? undefined : llmTrackers.get('database');
 
     domainLlmPromises.push((async (): Promise<DomainLlmResult> => {
       log.info(`[LLM] database-schema: starting`);
       const t0 = Date.now();
+      let started = false;
       try {
-        const dbResult = await provider.generateDatabaseViolations(dbSchemaContext);
+        const dbResult = await provider.generateDatabaseViolations(dbSchemaContext, {
+          onStart: () => { started = true; schemaLl?.onCallStart(); },
+        });
+        schemaLl?.onCallDone(started);
         const dur = Date.now() - t0;
         log.info(`[LLM] database-schema: done in ${dur}ms — ${dbResult.violations.length} violations`);
 
@@ -905,6 +998,7 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
 
         return { domain: 'database-schema', violations: [], resolvedIds: [], unchangedIds: [] };
       } catch (err) {
+        schemaLl?.onCallDone(started);
         const dur = Date.now() - t0;
         log.warn(`[LLM] database-schema: failed in ${dur}ms — ${err instanceof Error ? err.message : String(err)}`);
         if (!domainCodeBatches.has('database')) tracker?.error('database', `Schema LLM failed`);
@@ -919,11 +1013,24 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
 
   const llmRulePromise = (async () => {
     if (enableLlmRules === false || llmSkipped) return;
+    const archLl = llmTrackers.get('architecture');
+    // Mirror sub-call lifecycle events into the architecture tracker so
+    // `LLM X/Y · M running · elapsed` refreshes per sub-call, not all-at-end.
+    const archStarted = new Set<string>();
+    const archOnCallStart = (key: 'service' | 'database' | 'module') => {
+      archStarted.add(key);
+      archLl?.onCallStart();
+    };
+    const archOnCallDone = (key: 'service' | 'database' | 'module') => {
+      archLl?.onCallDone(archStarted.has(key));
+    };
     if (hasLlmOnlyExistingViolations) {
       const archResult = await generateViolationsWithLifecycle(
         violationInput,
-        (step) => tracker?.detail('architecture', step),
+        undefined,
         provider,
+        archOnCallStart,
+        archOnCallDone,
       );
       serviceDescriptions = archResult.serviceDescriptions;
       allResolvedLlmIds.push(...archResult.resolvedViolationIds);
@@ -954,8 +1061,10 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
     } else {
       const archResult = await generateViolations(
         violationInput,
-        (step) => tracker?.detail('architecture', step),
+        undefined,
         provider,
+        archOnCallStart,
+        archOnCallDone,
       );
       serviceDescriptions = archResult.serviceDescriptions;
 

--- a/apps/server/src/services/violation.service.ts
+++ b/apps/server/src/services/violation.service.ts
@@ -93,6 +93,8 @@ export async function generateViolations(
   input: ViolationGenerationInput,
   onProgress?: (step: string) => void,
   externalProvider?: LLMProvider,
+  onCallStart?: (key: 'service' | 'database' | 'module') => void,
+  onCallDone?: (key: 'service' | 'database' | 'module', ok: boolean) => void,
 ): Promise<ViolationsResult> {
   const provider = externalProvider ?? createLLMProvider();
 
@@ -156,6 +158,8 @@ export async function generateViolations(
     database: dbContext,
     module: moduleContext,
     onStepComplete: onProgress,
+    onCallStart,
+    onCallDone,
   });
 
   // --- Merge results ---
@@ -210,6 +214,8 @@ export async function generateViolationsWithLifecycle(
   input: ViolationGenerationInput,
   onProgress?: (step: string) => void,
   externalProvider?: LLMProvider,
+  onCallStart?: (key: 'service' | 'database' | 'module') => void,
+  onCallDone?: (key: 'service' | 'database' | 'module', ok: boolean) => void,
 ): Promise<AllViolationsLifecycleResult> {
   const provider = externalProvider ?? createLLMProvider();
 
@@ -264,6 +270,8 @@ export async function generateViolationsWithLifecycle(
     service: serviceContext,
     database: dbContext,
     module: moduleContext,
+    onCallStart,
+    onCallDone,
   }, (step) => {
     onProgress?.(step);
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       express:
         specifier: ^4.21.0
         version: 4.22.1
+      p-limit:
+        specifier: ^7.3.0
+        version: 7.3.0
       posthog-node:
         specifier: ^4.0.0
         version: 4.18.0
@@ -2880,6 +2883,10 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
+  p-limit@7.3.0:
+    resolution: {integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==}
+    engines: {node: '>=20'}
+
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
@@ -3750,6 +3757,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
@@ -6379,6 +6390,10 @@ snapshots:
 
   outvariant@1.4.3: {}
 
+  p-limit@7.3.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   package-manager-detector@1.6.0: {}
 
   parent-module@1.0.1:
@@ -7348,6 +7363,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yocto-queue@1.2.2: {}
 
   yoctocolors-cjs@2.1.3: {}
 

--- a/tests/server/cli-provider-concurrency.test.ts
+++ b/tests/server/cli-provider-concurrency.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { BaseCLIProvider } from '../../apps/server/src/services/llm/cli-provider.js';
+import { ServiceViolationOutputSchema } from '../../apps/server/src/services/llm/schemas.js';
+import { config } from '../../apps/server/src/config/index.js';
+
+/**
+ * Test subclass: bypasses real process spawning. Each spawnCLI call
+ * resolves to a fixed JSON envelope after a configurable delay, while
+ * tracking in-flight count so tests can assert peak concurrency.
+ */
+class CountingProvider extends BaseCLIProvider {
+  get binaryName() { return 'test-binary'; }
+  get baseArgs() { return []; }
+  get modelFlag() { return []; }
+
+  public inFlight = 0;
+  public peak = 0;
+  public calls = 0;
+  public delayMs = 20;
+
+  protected async spawnCLI(): Promise<string> {
+    this.calls++;
+    this.inFlight++;
+    this.peak = Math.max(this.peak, this.inFlight);
+    try {
+      await new Promise((r) => setTimeout(r, this.delayMs));
+      return JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        structured_output: { violations: [], serviceDescriptions: [] },
+      });
+    } finally {
+      this.inFlight--;
+    }
+  }
+
+  async runTask(onStart?: () => void) {
+    return (this as unknown as {
+      spawnAndParse: (
+        p: string,
+        s: typeof ServiceViolationOutputSchema,
+        opts?: { onStart?: () => void },
+      ) => Promise<unknown>;
+    }).spawnAndParse('prompt', ServiceViolationOutputSchema, { onStart });
+  }
+}
+
+describe('BaseCLIProvider concurrency cap', () => {
+  it('never exceeds config.claudeCodeMaxConcurrency across concurrent spawnAndParse calls', async () => {
+    const provider = new CountingProvider();
+    const cap = config.claudeCodeMaxConcurrency;
+    const total = cap * 3 + 2;
+
+    const results = await Promise.all(
+      Array.from({ length: total }, () => provider.runTask()),
+    );
+
+    expect(results).toHaveLength(total);
+    expect(provider.calls).toBe(total);
+    expect(provider.peak).toBeLessThanOrEqual(cap);
+    expect(provider.peak).toBe(cap); // saturates under load
+  });
+
+  it('queues tasks rather than dropping them when the cap is hit', async () => {
+    const provider = new CountingProvider();
+    provider.delayMs = 50;
+    const cap = config.claudeCodeMaxConcurrency;
+    const total = cap * 2;
+
+    const t0 = Date.now();
+    await Promise.all(
+      Array.from({ length: total }, () => provider.runTask()),
+    );
+    const elapsed = Date.now() - t0;
+
+    // With a hard cap, total runtime must be at least 2 waves.
+    // Allow loose lower bound to stay robust under CI timing jitter.
+    expect(elapsed).toBeGreaterThanOrEqual(provider.delayMs * 2 * 0.75);
+    expect(provider.calls).toBe(total);
+  });
+
+  it('fires onStart only after the limiter grants a slot, not at submission', async () => {
+    const provider = new CountingProvider();
+    const cap = config.claudeCodeMaxConcurrency;
+    provider.delayMs = 60;
+
+    // Fill every slot with blockers; none carry an onStart callback.
+    const blockers = Array.from({ length: cap }, () => provider.runTask());
+
+    let queuedStarted = false;
+    const queued = provider.runTask(() => { queuedStarted = true; });
+
+    // Immediately after submission the onStart for the queued task
+    // must NOT have fired — it's still waiting behind the blockers.
+    await new Promise((r) => setImmediate(r));
+    expect(queuedStarted).toBe(false);
+
+    await Promise.all([queued, ...blockers]);
+    expect(queuedStarted).toBe(true);
+  });
+
+  it('defers spawnCLI until a slot is acquired (timer starts after acquire)', async () => {
+    // Core invariant: spawnAndParse must acquire the semaphore BEFORE calling
+    // spawnCLI, so a queued task's timeout timer (which lives inside spawnCLI)
+    // does not start counting while it waits.
+    const provider = new CountingProvider();
+    const cap = config.claudeCodeMaxConcurrency;
+    provider.delayMs = 80;
+
+    // Fill every slot.
+    const blockers = Array.from({ length: cap }, () => provider.runTask());
+
+    // One more task — must be queued, not yet in spawnCLI.
+    const queuedPromise = provider.runTask();
+    await new Promise((r) => setImmediate(r));
+    expect(provider.calls).toBe(cap); // N+1'th task has NOT spawned yet
+
+    await Promise.all([queuedPromise, ...blockers]);
+    expect(provider.calls).toBe(cap + 1); // ran after a slot freed up
+  });
+});

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -25,7 +25,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.5.4")
+  .version("0.5.5")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## Summary

Fixes https://github.com/truecourse-ai/truecourse/issues/57 — uncontrolled `Promise.allSettled` over every LLM batch + domain could spawn 50+ concurrent `claude` processes during a single `truecourse analyze`, freezing shared dev machines and OOMing CI runners.

- Caps concurrent `claude` CLI spawns per run. `p-limit` wraps `BaseCLIProvider.spawnAndParse` so every LLM call path — code batches, architecture sub-calls, database-schema — shares one bound.
- Adds `CLAUDE_CODE_MAX_CONCURRENCY` env var (default `10`, validated `>= 1` at startup, clear error on invalid).
- Timeout timer lives inside `spawnCLI`, so it only starts after the limiter grants a slot — queued tasks no longer eat their own budget.
- Unifies per-domain progress display with a single format: `{N det · }LLM {done}/{total}{ · M running}{ · elapsed}`. Replaces the old three-way split between code-batch, architecture, and database-schema paths.
- Moves the `[LLM] Provider: ... maxConcurrency: ...` log line from dashboard boot to the start of each analyze so it lands in `<repo>/.truecourse/logs/analyze.log`, not `dashboard.log`.
- Adds a top-level `## Configuration` section to the README explaining the env vars and `~/.truecourse/.env` mechanism.

Bumps to v0.5.5.

## Test plan

- [ ] `pnpm test` — full suite green (3382 passed / 1 skipped).
- [ ] New `tests/server/cli-provider-concurrency.test.ts`: cap saturates, queues instead of drops, defers `spawnCLI` until slot is acquired, `onStart` fires only after slot grant.
- [ ] Manual smoke: `CLAUDE_CODE_MAX_CONCURRENCY=2 truecourse analyze` — verify at most 2 overlapping `[CLI] ... call starting` lines in `analyze.log`.
- [ ] Manual smoke: `CLAUDE_CODE_MAX_CONCURRENCY=0 truecourse analyze` — startup throws clear error, not a hang.
- [ ] Manual smoke: run analyze with LLM enabled on a multi-domain repo — verify the unified progress format appears across architecture, code batches, and database schema.
- [ ] Check that `[LLM] Provider: claude-code, model: ..., maxConcurrency: N` now shows up in `<repo>/.truecourse/logs/analyze.log` at the top of each analyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)