### PR TITLE
Fix typed-catch false positives in catch rules

### DIFF
--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unknown-catch-variable.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unknown-catch-variable.ts
@@ -9,7 +9,7 @@ export const unknownCatchVariableVisitor: CodeRuleVisitor = {
     const param = node.childForFieldName('parameter')
     if (!param) return null
 
-    const typeAnnotation = param.namedChildren.find((c) => c.type === 'type_annotation')
+    const typeAnnotation = node.childForFieldName('type')
     if (typeAnnotation) return null
 
     const paramName = param.text

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/catch-without-error-type.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/catch-without-error-type.ts
@@ -19,9 +19,7 @@ export const catchWithoutErrorTypeVisitor: CodeRuleVisitor = {
     const bodyText = body.text
     if (bodyText.includes('instanceof') || bodyText.includes('typeof')) return null
 
-    // Check for type annotation on the parameter (TS catch(e: SomeType))
-    // In tree-sitter, a typed catch param has a type_annotation child
-    const hasTypeAnnotation = param.namedChildren.some((c) => c.type === 'type_annotation')
+    const hasTypeAnnotation = node.childForFieldName('type') !== null
     if (hasTypeAnnotation) return null
 
     return makeViolation(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/analyzer/code-quality-rules.test.ts
+++ b/tests/analyzer/code-quality-rules.test.ts
@@ -356,6 +356,43 @@ describe('code-quality/deterministic/no-var-declaration', () => {
   });
 });
 
+describe('code-quality/deterministic/unknown-catch-variable', () => {
+  const ruleKey = 'code-quality/deterministic/unknown-catch-variable';
+
+  it('detects untyped catch parameter', () => {
+    const violations = check(`
+try {
+  doSomething();
+} catch (e) {
+  console.error(e);
+}
+`);
+    expect(violations.filter((v) => v.ruleKey === ruleKey)).toHaveLength(1);
+  });
+
+  it('does not flag catch typed as unknown', () => {
+    const violations = check(`
+try {
+  doSomething();
+} catch (e: unknown) {
+  console.error(e);
+}
+`);
+    expect(violations.filter((v) => v.ruleKey === ruleKey)).toHaveLength(0);
+  });
+
+  it('does not flag catch typed as Error', () => {
+    const violations = check(`
+try {
+  doSomething();
+} catch (e: Error) {
+  console.error(e.message);
+}
+`);
+    expect(violations.filter((v) => v.ruleKey === ruleKey)).toHaveLength(0);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Integration
 // ---------------------------------------------------------------------------

--- a/tests/analyzer/reliability-rules.test.ts
+++ b/tests/analyzer/reliability-rules.test.ts
@@ -55,6 +55,28 @@ try {
 `);
     expect(violations.filter((v) => v.ruleKey === ruleKey)).toHaveLength(0);
   });
+
+  it('does not flag typed catch parameter (Error)', () => {
+    const violations = check(`
+try {
+  doSomething();
+} catch (e: Error) {
+  console.error(e.message);
+}
+`);
+    expect(violations.filter((v) => v.ruleKey === ruleKey)).toHaveLength(0);
+  });
+
+  it('does not flag typed catch parameter (unknown)', () => {
+    const violations = check(`
+try {
+  doSomething();
+} catch (e: unknown) {
+  console.error(e);
+}
+`);
+    expect(violations.filter((v) => v.ruleKey === ruleKey)).toHaveLength(0);
+  });
 });
 
 // ===========================================================================

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -25,7 +25,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.5.5")
+  .version("0.5.6")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## Summary

- Fixes #67. Two rules (`code-quality/deterministic/unknown-catch-variable` and `reliability/deterministic/catch-without-error-type`) looked for `type_annotation` as a child of the catch parameter identifier. In tree-sitter-typescript's grammar, `type_annotation` is a *sibling* of the identifier under `catch_clause`, reachable as `node.childForFieldName('type')`. The result was a false positive on every TypeScript-typed catch like `catch (e: unknown)` or `catch (e: Error)`.
- Both rules now read the type via the field-name accessor on the `catch_clause` node, matching the pattern already used (and noted) in `bugs/deterministic/error-type-any`.
- Added regression tests covering typed-catch shapes for both rules.

## Test plan

- [x] `pnpm test tests/analyzer/reliability-rules.test.ts tests/analyzer/code-quality-rules.test.ts` — 997 tests passing, including the four new typed-catch cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)