### PR TITLE
Delegate file discovery to git for full gitignore semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,23 @@ For a one-off override, prefix the command:
 CLAUDE_CODE_MAX_CONCURRENCY=2 truecourse analyze
 ```
 
+### Excluding files from analysis
+
+TrueCourse honors `.gitignore` automatically (including nested `.gitignore` files, `.git/info/exclude`, and your configured global excludes file).
+
+For paths you want tracked in git but not analyzed — generated code, vendored snapshots, large fixtures — add a `.truecourseignore` at the repo root. Same syntax as `.gitignore`:
+
+```
+# generated
+src/generated/
+# vendored
+third_party/
+# specific files
+scripts/ingest-epub.js
+```
+
+Patterns are anchored to the file's location, so `src/generated/` matches the top-level directory only; use `**/generated/` to match at any depth.
+
 ## Development
 
 ```bash

--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/analyzer/src/file-discovery.ts
+++ b/packages/analyzer/src/file-discovery.ts
@@ -1,12 +1,87 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs'
+import { execFileSync } from 'child_process'
 import { join, relative, resolve } from 'path'
 import ignore from 'ignore'
 import { detectLanguage, getAllIgnorePatterns, getAllTestPatterns } from './language-config.js'
 
-/**
- * Find all .gitignore files from startDir up to root
- * Returns array of {path, dir} objects, ordered from root to startDir
- */
+function isInsideGitWorkTree(dir: string): boolean {
+  try {
+    const out = execFileSync('git', ['-C', dir, 'rev-parse', '--is-inside-work-tree'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return out.toString('utf8').trim() === 'true'
+  } catch {
+    return false
+  }
+}
+
+// Build the post-git filter: .truecourseignore + language test/ignore patterns
+// + .git. Rooted at `dir` so .truecourseignore patterns are anchored correctly.
+function buildPostGitFilter(dir: string): ReturnType<typeof ignore> {
+  const ig = ignore()
+  const tcPath = join(dir, '.truecourseignore')
+  if (existsSync(tcPath)) ig.add(readFileSync(tcPath, 'utf8'))
+  ig.add('.git')
+  for (const p of getAllTestPatterns()) ig.add(p)
+  for (const p of getAllIgnorePatterns()) ig.add(p)
+  return ig
+}
+
+// Use git for full gitignore semantics: nested .gitignore, .git/info/exclude,
+// the configured global excludes file, and the repo boundary. Returns null
+// when `dir` is not in a git work tree or git is unavailable.
+function discoverFilesViaGit(dir: string): string[] | null {
+  if (!isInsideGitWorkTree(dir)) return null
+
+  let stdout: Buffer
+  try {
+    stdout = execFileSync(
+      'git',
+      ['-C', dir, 'ls-files', '--cached', '--others', '--exclude-standard', '-z', '--', '.'],
+      { maxBuffer: 256 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] },
+    ) as Buffer
+  } catch {
+    return null
+  }
+
+  const relPaths = stdout.toString('utf8').split('\0').filter(Boolean)
+  // git emits a flat lexicographic order; the walker emits depth-first per-
+  // directory order. They diverge when a directory and a sibling file share
+  // a prefix (e.g. `foo/` and `foo.ts`). Downstream service/layer detection
+  // is order-sensitive, so re-sort to match the walker.
+  relPaths.sort(compareDepthFirst)
+  const ig = buildPostGitFilter(dir)
+
+  const out: string[] = []
+  for (const rel of relPaths) {
+    if (ig.ignores(rel)) continue
+    const abs = join(dir, rel)
+    let isFile = false
+    try {
+      isFile = statSync(abs).isFile()
+    } catch {
+      continue
+    }
+    if (!isFile) continue
+    if (detectLanguage(abs)) out.push(abs)
+  }
+  return out
+}
+
+function compareDepthFirst(a: string, b: string): number {
+  const ap = a.split('/')
+  const bp = b.split('/')
+  const len = Math.min(ap.length, bp.length)
+  for (let i = 0; i < len; i++) {
+    const x = ap[i]!
+    const y = bp[i]!
+    if (x !== y) return x < y ? -1 : 1
+  }
+  return ap.length - bp.length
+}
+
+// Find all .gitignore files from startDir up to root.
+// Returns array of {path, dir} objects, ordered from root to startDir.
 function findAllGitignores(startDir: string): Array<{ path: string; dir: string }> {
   const gitignores: Array<{ path: string; dir: string }> = []
   let currentDir = resolve(startDir)
@@ -18,10 +93,7 @@ function findAllGitignores(startDir: string): Array<{ path: string; dir: string 
     }
 
     const parentDir = resolve(currentDir, '..')
-    // Reached root directory (on both Unix and Windows)
-    if (parentDir === currentDir) {
-      break
-    }
+    if (parentDir === currentDir) break
     currentDir = parentDir
   }
 
@@ -58,24 +130,16 @@ function reanchorTruecourseignore(content: string, prefix: string): string {
     .join('\n')
 }
 
-/**
- * Load ignore patterns from .gitignore and .truecourseignore files
- * Returns ignore instance and the root directory (where topmost .gitignore is)
- */
 function loadIgnorePatterns(baseDir: string): { ig: ReturnType<typeof ignore>; rootDir: string } {
   const ig = ignore()
 
-  // Find all .gitignore files in parent hierarchy
   const gitignores = findAllGitignores(baseDir)
   const rootDir = gitignores.length > 0 && gitignores[0] ? gitignores[0].dir : baseDir
 
-  // Load all .gitignore files (from root down to baseDir)
   for (const { path: gitignorePath } of gitignores) {
-    const content = readFileSync(gitignorePath, 'utf8')
-    ig.add(content)
+    ig.add(readFileSync(gitignorePath, 'utf8'))
   }
 
-  // Load .truecourseignore (tool-specific ignore rules, only from baseDir)
   const truecourseignorePath = join(baseDir, '.truecourseignore')
   if (existsSync(truecourseignorePath)) {
     const content = readFileSync(truecourseignorePath, 'utf8')
@@ -83,60 +147,59 @@ function loadIgnorePatterns(baseDir: string): { ig: ReturnType<typeof ignore>; r
     ig.add(reanchorTruecourseignore(content, prefix))
   }
 
-  // Always ignore .git directory (never analyze git internals)
   ig.add('.git')
 
-  // Ignore test files and language-specific directories (from language configs)
   for (const pattern of getAllTestPatterns()) ig.add(pattern)
   for (const pattern of getAllIgnorePatterns()) ig.add(pattern)
 
   return { ig, rootDir }
 }
 
-/**
- * Discover all supported source files in a directory
- * Respects .gitignore and .truecourseignore patterns
- */
-export function discoverFiles(dir: string): string[] {
+// Manual walker — used when `dir` is not in a git work tree (e.g. test temp
+// dirs without git init). git delegation is preferred when available because
+// it gets nested-.gitignore anchoring, .git/info/exclude, the global excludes
+// file, and the repo boundary right.
+function discoverFilesViaWalker(dir: string): string[] {
   const files: string[] = []
   const { ig, rootDir } = loadIgnorePatterns(dir)
 
   function traverse(currentPath: string) {
     try {
-      // Sort so traversal order is deterministic across filesystems — ext4
-      // returns entries in creation order, APFS in insertion/alphabetical
-      // order. Downstream steps (service detection, layer classification)
-      // have order-sensitive decisions, so leaving this unsorted gives
-      // different results on macOS vs Linux CI.
+      // Sort for deterministic traversal — APFS and ext4 return entries in
+      // different orders, and downstream service/layer detection is order-
+      // sensitive.
       const entries = readdirSync(currentPath).sort()
 
       for (const entry of entries) {
         const fullPath = join(currentPath, entry)
-        // Calculate path relative to the root where .gitignore is located
         const relativePath = relative(rootDir, fullPath)
         const stat = statSync(fullPath)
 
-        // Check if path should be ignored
-        // For directories, add trailing slash for proper gitignore matching
         const pathToCheck = stat.isDirectory() ? relativePath + '/' : relativePath
-        if (ig.ignores(pathToCheck)) {
-          continue
-        }
+        if (ig.ignores(pathToCheck)) continue
 
         if (stat.isDirectory()) {
           traverse(fullPath)
         } else if (stat.isFile()) {
-          // Use detectLanguage to check if file is supported
-          if (detectLanguage(fullPath)) {
-            files.push(fullPath)
-          }
+          if (detectLanguage(fullPath)) files.push(fullPath)
         }
       }
-    } catch (error) {
-      // Skip directories we can't read
+    } catch {
+      // Skip directories we can't read.
     }
   }
 
   traverse(dir)
   return files
+}
+
+/**
+ * Discover all supported source files in a directory.
+ * Respects .gitignore (incl. nested), .git/info/exclude, the configured
+ * global excludes file, and .truecourseignore.
+ */
+export function discoverFiles(dir: string): string[] {
+  const viaGit = discoverFilesViaGit(dir)
+  if (viaGit !== null) return viaGit
+  return discoverFilesViaWalker(dir)
 }

--- a/packages/analyzer/src/file-discovery.ts
+++ b/packages/analyzer/src/file-discovery.ts
@@ -28,6 +28,36 @@ function findAllGitignores(startDir: string): Array<{ path: string; dir: string 
   return gitignores
 }
 
+// Re-anchor leading-/internal-slash patterns to baseDir so they still match
+// when a parent .gitignore makes rootDir an ancestor of baseDir.
+function reanchorTruecourseignore(content: string, prefix: string): string {
+  if (prefix === '' || prefix === '.') return content
+
+  return content
+    .split('\n')
+    .map((line) => {
+      const raw = line
+      const trimmed = raw.trim()
+      if (trimmed === '' || trimmed.startsWith('#')) return raw
+
+      const negate = trimmed.startsWith('!')
+      const body = negate ? trimmed.slice(1) : trimmed
+
+      if (body.startsWith('**/')) return raw
+
+      const hasLeadingSlash = body.startsWith('/')
+      const withoutTrailing = body.endsWith('/') ? body.slice(0, -1) : body
+      const inner = hasLeadingSlash ? withoutTrailing.slice(1) : withoutTrailing
+      const hasInternalSlash = inner.includes('/')
+
+      if (!hasLeadingSlash && !hasInternalSlash) return raw
+
+      const stripped = hasLeadingSlash ? body.slice(1) : body
+      return `${negate ? '!' : ''}${prefix}/${stripped}`
+    })
+    .join('\n')
+}
+
 /**
  * Load ignore patterns from .gitignore and .truecourseignore files
  * Returns ignore instance and the root directory (where topmost .gitignore is)
@@ -49,7 +79,8 @@ function loadIgnorePatterns(baseDir: string): { ig: ReturnType<typeof ignore>; r
   const truecourseignorePath = join(baseDir, '.truecourseignore')
   if (existsSync(truecourseignorePath)) {
     const content = readFileSync(truecourseignorePath, 'utf8')
-    ig.add(content)
+    const prefix = relative(rootDir, baseDir).replace(/\\/g, '/')
+    ig.add(reanchorTruecourseignore(content, prefix))
   }
 
   // Always ignore .git directory (never analyze git internals)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/analyzer/file-discovery.test.ts
+++ b/tests/analyzer/file-discovery.test.ts
@@ -93,3 +93,103 @@ describe('discoverFiles with gitignore patterns', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 });
+
+describe('.truecourseignore with parent .gitignore', () => {
+  const tempDirs: string[] = [];
+  let repoDir: string;
+
+  afterAll(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function setup(truecourseignore: string): void {
+    const tempDir = mkdtempSync(join(tmpdir(), 'truecourse-anchored-'));
+    tempDirs.push(tempDir);
+    const parentDir = join(tempDir, 'parent');
+    repoDir = join(parentDir, 'repo');
+
+    // Parent .gitignore — its presence is what triggers the bug; content is
+    // intentionally generic.
+    mkdirSync(parentDir, { recursive: true });
+    writeFileSync(join(parentDir, '.gitignore'), 'node_modules/\n');
+
+    // Repo layout.
+    const srcDir = join(repoDir, 'src');
+    const extensionsDir = join(repoDir, 'extensions');
+    const scriptsDir = join(repoDir, 'scripts');
+    const booksDir = join(repoDir, 'BOOKS');
+    const nestedExt = join(repoDir, 'src', 'extensions');
+    mkdirSync(srcDir, { recursive: true });
+    mkdirSync(extensionsDir, { recursive: true });
+    mkdirSync(scriptsDir, { recursive: true });
+    mkdirSync(booksDir, { recursive: true });
+    mkdirSync(nestedExt, { recursive: true });
+
+    writeFileSync(join(srcDir, 'app.ts'), 'export const x = 1;');
+    writeFileSync(join(extensionsDir, 'plugin.ts'), 'export const p = 1;');
+    writeFileSync(join(extensionsDir, 'keep.ts'), 'export const k = 1;');
+    writeFileSync(join(scriptsDir, 'ingest-epub.js'), 'module.exports = {};');
+    writeFileSync(join(scriptsDir, 'other.js'), 'module.exports = {};');
+    writeFileSync(join(booksDir, 'reader.ts'), 'export const b = 1;');
+    writeFileSync(join(repoDir, 'secret.txt'), 'shh');
+    writeFileSync(join(nestedExt, 'inner.ts'), 'export const i = 1;');
+
+    writeFileSync(join(repoDir, '.truecourseignore'), truecourseignore);
+  }
+
+  it('honors leading-slash anchored pattern in .truecourseignore', () => {
+    setup('/extensions/\n');
+
+    const files = discoverFiles(repoDir);
+
+    // Top-level extensions/ is excluded (anchored).
+    expect(files.some((f) => f === join(repoDir, 'extensions', 'plugin.ts'))).toBe(false);
+    // src/ files unaffected.
+    expect(files.some((f) => f === join(repoDir, 'src', 'app.ts'))).toBe(true);
+    // Leading-slash anchors only the top level — nested src/extensions/ is NOT
+    // matched.
+    expect(files.some((f) => f === join(repoDir, 'src', 'extensions', 'inner.ts'))).toBe(true);
+  });
+
+  it('honors internal-slash anchored pattern in .truecourseignore', () => {
+    setup('scripts/ingest-epub.js\n');
+
+    const files = discoverFiles(repoDir);
+
+    // Specific anchored file is excluded.
+    expect(files.some((f) => f === join(repoDir, 'scripts', 'ingest-epub.js'))).toBe(false);
+    // Sibling in same directory is preserved.
+    expect(files.some((f) => f === join(repoDir, 'scripts', 'other.js'))).toBe(true);
+  });
+
+  it('preserves non-anchored patterns (trailing-slash and bare name)', () => {
+    // BOOKS/ is non-anchored (trailing-slash only) so it must match at any
+    // depth. plugin.ts is a bare-name match — non-anchored, matches anywhere.
+    setup('BOOKS/\nplugin.ts\n');
+
+    const files = discoverFiles(repoDir);
+
+    // Trailing-slash pattern excludes BOOKS/ at top level.
+    expect(files.some((f) => f === join(repoDir, 'BOOKS', 'reader.ts'))).toBe(false);
+    // Bare-name pattern excludes plugin.ts wherever it appears.
+    expect(files.some((f) => f.endsWith('plugin.ts'))).toBe(false);
+    // Other source files still discovered.
+    expect(files.some((f) => f === join(repoDir, 'src', 'app.ts'))).toBe(true);
+    expect(files.some((f) => f === join(repoDir, 'extensions', 'keep.ts'))).toBe(true);
+  });
+
+  it('honors negation in .truecourseignore', () => {
+    // Ignore specific anchored files, then re-include one. The directory
+    // itself stays traversable because we use file-level patterns.
+    setup('extensions/plugin.ts\nextensions/keep.ts\n!extensions/keep.ts\n');
+
+    const files = discoverFiles(repoDir);
+
+    // Anchored ignore still applies to plugin.ts.
+    expect(files.some((f) => f === join(repoDir, 'extensions', 'plugin.ts'))).toBe(false);
+    // Negation re-includes extensions/keep.ts after re-anchoring.
+    expect(files.some((f) => f === join(repoDir, 'extensions', 'keep.ts'))).toBe(true);
+  });
+});

--- a/tests/analyzer/file-discovery.test.ts
+++ b/tests/analyzer/file-discovery.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect, afterAll } from 'vitest';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { discoverFiles } from '../../packages/analyzer/src/file-discovery';
+
+function gitInit(dir: string): void {
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+}
 
 const FIXTURE_PATH = new URL('../fixtures/sample-js-project-negative', import.meta.url).pathname;
 
@@ -191,5 +199,89 @@ describe('.truecourseignore with parent .gitignore', () => {
     expect(files.some((f) => f === join(repoDir, 'extensions', 'plugin.ts'))).toBe(false);
     // Negation re-includes extensions/keep.ts after re-anchoring.
     expect(files.some((f) => f === join(repoDir, 'extensions', 'keep.ts'))).toBe(true);
+  });
+});
+
+// These exercise gitignore semantics that the manual walker can't get right.
+// They require an actual git repo so the implementation can delegate to
+// `git ls-files --exclude-standard`.
+describe('discoverFiles in a git repo (gitignore semantics)', () => {
+  const tempDirs: string[] = [];
+
+  afterAll(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeRepo(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'truecourse-gitrepo-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('honors anchored patterns in nested .gitignore files', () => {
+    // A nested .gitignore at repo/sub/.gitignore with an internal-slash
+    // pattern is anchored to repo/sub/, not the repo root. The single-matcher
+    // walker conflates the two roots and silently misses anchored rules in
+    // nested .gitignore files.
+    const repo = makeRepo();
+    gitInit(repo);
+
+    mkdirSync(join(repo, 'sub', 'internal'), { recursive: true });
+    mkdirSync(join(repo, 'internal'), { recursive: true });
+
+    writeFileSync(join(repo, 'sub', '.gitignore'), 'internal/secret.ts\n');
+    writeFileSync(join(repo, 'sub', 'internal', 'secret.ts'), 'export const s = 1;');
+    writeFileSync(join(repo, 'sub', 'internal', 'public.ts'), 'export const p = 1;');
+    // Decoy at the repo root — the nested rule must not anchor here.
+    writeFileSync(join(repo, 'internal', 'secret.ts'), 'export const r = 1;');
+
+    const files = discoverFiles(repo);
+
+    // The nested rule should anchor to repo/sub/.
+    expect(files.some((f) => f === join(repo, 'sub', 'internal', 'secret.ts'))).toBe(false);
+    expect(files.some((f) => f === join(repo, 'sub', 'internal', 'public.ts'))).toBe(true);
+    // Repo-root file is unrelated to the nested rule.
+    expect(files.some((f) => f === join(repo, 'internal', 'secret.ts'))).toBe(true);
+  });
+
+  it('honors .git/info/exclude', () => {
+    // git's per-repo non-shared excludes file. The walker never reads it.
+    const repo = makeRepo();
+    gitInit(repo);
+
+    writeFileSync(join(repo, '.git', 'info', 'exclude'), 'private.ts\n');
+    writeFileSync(join(repo, 'private.ts'), 'export const p = 1;');
+    writeFileSync(join(repo, 'public.ts'), 'export const q = 1;');
+
+    const files = discoverFiles(repo);
+
+    expect(files.some((f) => f === join(repo, 'private.ts'))).toBe(false);
+    expect(files.some((f) => f === join(repo, 'public.ts'))).toBe(true);
+  });
+
+  it('does not apply .gitignore from outside the git repo boundary', () => {
+    // The walker climbs to the filesystem root collecting every ancestor
+    // .gitignore. A .gitignore in a directory that is not part of the git
+    // repo (e.g. ~/.gitignore) must not influence files inside the repo —
+    // git itself ignores it.
+    const tempDir = mkdtempSync(join(tmpdir(), 'truecourse-boundary-'));
+    tempDirs.push(tempDir);
+
+    const outside = join(tempDir, 'outside');
+    mkdirSync(outside, { recursive: true });
+    // This .gitignore lives outside any git repo; it must not leak in.
+    writeFileSync(join(outside, '.gitignore'), 'should-be-included.ts\n');
+
+    const repo = join(outside, 'repo');
+    mkdirSync(repo, { recursive: true });
+    gitInit(repo);
+
+    writeFileSync(join(repo, 'should-be-included.ts'), 'export const x = 1;');
+
+    const files = discoverFiles(repo);
+
+    expect(files.some((f) => f === join(repo, 'should-be-included.ts'))).toBe(true);
   });
 });

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -25,7 +25,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.5.6")
+  .version("0.5.7")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## Summary

Fixes #66.

After the original fix landed (re-anchoring `.truecourseignore` patterns), the same anchoring bug still affects nested `.gitignore` files inside the repo, and the walker also misses `.git/info/exclude`, the configured global excludes file, and the repo boundary. Reimplementing all of that correctly is a losing battle; this commit delegates to git when possible.

When `dir` is inside a git work tree, discovery uses
`git ls-files --cached --others --exclude-standard -z -- .` and applies
`.truecourseignore` + language test/ignore filters on top, rooted at `dir` so anchoring is correct by construction. The walker (with the prior re-anchor fix) remains as the fallback for non-git directories — useful for test temp dirs.

Git emits a flat lexicographic order while downstream service/layer detection is order-sensitive (the walker has a comment about this). The two diverge when a directory and a sibling file share a prefix, so git's output is re-sorted to match the walker's depth-first per-directory order.

Bumps version to `0.5.7`.

## Test plan

- [x] Three new test cases in `tests/analyzer/file-discovery.test.ts` that fail without this change and pass with it:
  - nested `.gitignore` with an anchored pattern (`internal/secret.ts` inside `repo/sub/.gitignore`)
  - `.git/info/exclude`
  - ancestor `.gitignore` outside the repo boundary should not leak in
- [x] Existing `.truecourseignore` re-anchor tests still pass (walker fallback).
- [x] Full `pnpm test` on a clean checkout: all 3353 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)