### PR TITLE
Lift telemetry into core; auto-emit source from CLI + dashboard

### DIFF
--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -15,7 +15,6 @@
     "chokidar": "^4.0.0",
     "cors": "^2.8.5",
     "express": "^4.21.0",
-    "posthog-node": "^4.0.0",
     "socket.io": "^4.8.0"
   },
   "devDependencies": {

--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/dashboard/server/src/routes/analyses.ts
+++ b/apps/dashboard/server/src/routes/analyses.ts
@@ -37,7 +37,6 @@ import {
   unregisterAnalysis,
 } from '@truecourse/core/services/analysis-registry';
 import { createLLMProvider, type LLMProvider } from '@truecourse/core/services/llm/provider';
-import { trackEvent, bucketFileCount, bucketDuration } from '../services/telemetry.service.js';
 import { getDiffResult } from '@truecourse/core/services/violation-query';
 import {
   deleteAnalysis as deleteAnalysisFile,
@@ -330,25 +329,19 @@ async function runFullAnalyze(id: string, repo: RegistryEntry, opts: StartRunOpt
     tracker: opts.tracker,
     signal: opts.signal,
     provider,
+    source: 'dashboard',
     onLlmEstimate: createSocketLlmEstimateHandler(id),
   });
 
   emitViolationsReady(id, outcome.analysisId);
   emitAnalysisComplete(id, outcome.analysisId);
-
-  trackEvent('analyze', {
-    serviceCount: outcome.serviceCount,
-    fileCountRange: bucketFileCount(outcome.fileCount),
-    languages: [],
-    architecture: outcome.architecture,
-    durationRange: bucketDuration(outcome.durationMs),
-  });
 }
 
 async function runDiffAnalyze(id: string, repo: RegistryEntry, opts: Pick<StartRunOptions, 'tracker' | 'signal'>): Promise<void> {
   const { diff } = await diffInProcess(repo, {
     tracker: opts.tracker,
     signal: opts.signal,
+    source: 'dashboard',
     onLlmEstimate: createSocketLlmEstimateHandler(id),
   });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,6 +100,10 @@
       "types": "./dist/services/llm/provider.d.ts",
       "import": "./dist/services/llm/provider.js"
     },
+    "./services/telemetry": {
+      "types": "./dist/services/telemetry.service.d.ts",
+      "import": "./dist/services/telemetry.service.js"
+    },
     "./types/snapshot": {
       "types": "./dist/types/snapshot.d.ts",
       "import": "./dist/types/snapshot.js"
@@ -116,6 +120,7 @@
     "dagre": "^0.8.5",
     "dotenv": "^16.4.0",
     "p-limit": "^7.3.0",
+    "posthog-node": "^4.0.0",
     "simple-git": "^3.27.0",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.25.1"

--- a/packages/core/src/commands/analyze-in-process.ts
+++ b/packages/core/src/commands/analyze-in-process.ts
@@ -13,6 +13,13 @@ import { analyzeCore, type LlmEstimate } from './analyze-core.js';
 import { persistFullAnalysis, type PersistFullResult } from './analyze-persist.js';
 import { config } from '../config/index.js';
 import { log } from '../lib/logger.js';
+import {
+  bucketDuration,
+  bucketFileCount,
+  detectLanguages,
+  trackEvent,
+  type TelemetrySource,
+} from '../services/telemetry.service.js';
 
 export type { LlmEstimate };
 
@@ -35,6 +42,11 @@ export interface AnalyzeInProcessOptions {
   onLlmResolved?: (proceed: boolean) => void;
   provider?: LLMProvider;
   signal?: AbortSignal;
+  /**
+   * Adapter that triggered this run. Auto-emitted in the telemetry payload so
+   * we can attribute analyses to CLI vs dashboard. Omit to skip telemetry.
+   */
+  source?: TelemetrySource;
 }
 
 export type AnalyzeInProcessResult = PersistFullResult;
@@ -48,7 +60,21 @@ export async function analyzeInProcess(
     `[LLM] Provider: claude-code, model: ${config.claudeCodeModel || 'default'}, maxConcurrency: ${config.claudeCodeMaxConcurrency}`,
   );
   const core = await analyzeCore(project, { ...options, mode: 'full' });
-  return persistFullAnalysis(project, core, startedAt);
+  const result = persistFullAnalysis(project, core, startedAt);
+
+  if (options.source) {
+    await trackEvent('analyze', {
+      source: options.source,
+      mode: 'full',
+      serviceCount: result.serviceCount,
+      fileCountRange: bucketFileCount(result.fileCount),
+      languages: detectLanguages(core.analysisResult),
+      architecture: result.architecture,
+      durationRange: bucketDuration(result.durationMs),
+    });
+  }
+
+  return result;
 }
 
 // Re-export so the route can detect and remove a specific analysis's history entry.

--- a/packages/core/src/commands/diff-in-process.ts
+++ b/packages/core/src/commands/diff-in-process.ts
@@ -10,6 +10,12 @@ import type { RegistryEntry } from '../config/registry.js';
 import type { StepTracker } from '../progress.js';
 import { analyzeCore, type LlmEstimate } from './analyze-core.js';
 import { persistDiffAnalysis, type PersistDiffResult } from './analyze-persist.js';
+import {
+  bucketDuration,
+  detectLanguages,
+  trackEvent,
+  type TelemetrySource,
+} from '../services/telemetry.service.js';
 
 export interface DiffInProcessOptions {
   tracker?: StepTracker;
@@ -26,6 +32,11 @@ export interface DiffInProcessOptions {
   /** Pre-flight prompt hook — same contract as `analyzeInProcess`. */
   onLlmEstimate?: (estimate: LlmEstimate) => Promise<boolean>;
   onLlmResolved?: (proceed: boolean) => void;
+  /**
+   * Adapter that triggered this run. Auto-emitted in the telemetry payload so
+   * we can attribute diff runs to CLI vs dashboard. Omit to skip telemetry.
+   */
+  source?: TelemetrySource;
 }
 
 export type DiffInProcessResult = PersistDiffResult;
@@ -34,6 +45,21 @@ export async function diffInProcess(
   project: RegistryEntry,
   options: DiffInProcessOptions = {},
 ): Promise<DiffInProcessResult> {
+  const startedAt = Date.now();
   const core = await analyzeCore(project, { ...options, mode: 'diff' });
-  return persistDiffAnalysis(project, core);
+  const result = persistDiffAnalysis(project, core);
+
+  if (options.source) {
+    await trackEvent('analyze', {
+      source: options.source,
+      mode: 'diff',
+      languages: detectLanguages(core.analysisResult),
+      changedFileCount: result.diff.changedFiles.length,
+      newViolations: result.diff.summary.newCount,
+      resolvedViolations: result.diff.summary.resolvedCount,
+      durationRange: bucketDuration(Date.now() - startedAt),
+    });
+  }
+
+  return result;
 }

--- a/packages/core/src/services/telemetry.service.ts
+++ b/packages/core/src/services/telemetry.service.ts
@@ -1,26 +1,42 @@
+/**
+ * Anonymous usage telemetry — single source of truth.
+ *
+ * Used automatically by `analyzeInProcess` / `diffInProcess`, so every adapter
+ * (CLI, dashboard server, future hooks) reports without having to wire its own
+ * call. Adapters only pass `source: 'cli' | 'dashboard'` so the event includes
+ * the surface that triggered it.
+ *
+ * Config lives at `~/.truecourse/telemetry.json`. Set `TRUECOURSE_TELEMETRY=0`
+ * or `CI=true` to disable for a process. `truecourse telemetry disable`
+ * persists the opt-out.
+ */
+
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 import { PostHog } from 'posthog-node';
-import type { AnalysisResult } from '@truecourse/core/services/analyzer';
+import type { AnalysisResult } from './analyzer.service.js';
 
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
 
-interface TelemetryConfig {
+export interface TelemetryConfig {
   enabled: boolean;
   anonymousId: string;
+  /** CLI-only — tracks whether the first-run notice has been printed. */
+  noticeShown: boolean;
 }
 
 const DEFAULT_CONFIG: TelemetryConfig = {
   enabled: true,
   anonymousId: '',
+  noticeShown: false,
 };
 
 const POSTHOG_API_KEY = 'phc_ys9Ykf49KmNqAC3fhq3jugTejc4BDqyKqRS8qRoYZYew';
-const TOOL_VERSION = '0.2.2';
 
 function getTelemetryConfigPath(): string {
   return path.join(os.homedir(), '.truecourse', 'telemetry.json');
@@ -32,17 +48,16 @@ export function readTelemetryConfig(): TelemetryConfig {
     const raw = fs.readFileSync(configPath, 'utf-8');
     const parsed = JSON.parse(raw);
     const config = { ...DEFAULT_CONFIG, ...parsed };
-    // Ensure anonymousId is always set
     if (!config.anonymousId) {
       config.anonymousId = crypto.randomUUID();
       writeTelemetryConfig(config);
     }
     return config;
   } catch {
-    // First time — generate config with new anonymous ID
     const config: TelemetryConfig = {
       enabled: true,
       anonymousId: crypto.randomUUID(),
+      noticeShown: false,
     };
     writeTelemetryConfig(config);
     return config;
@@ -67,7 +82,7 @@ export function writeTelemetryConfig(partial: Partial<TelemetryConfig>): void {
 }
 
 // ---------------------------------------------------------------------------
-// Telemetry state
+// PostHog client
 // ---------------------------------------------------------------------------
 
 let posthogClient: PostHog | null = null;
@@ -143,10 +158,25 @@ export function detectLanguages(result: AnalysisResult): string[] {
 // System info
 // ---------------------------------------------------------------------------
 
+let cachedVersion: string | null = null;
+
+function readToolVersion(): string {
+  if (cachedVersion) return cachedVersion;
+  try {
+    const here = fileURLToPath(import.meta.url);
+    const pkgPath = path.resolve(path.dirname(here), '..', '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    cachedVersion = String(pkg.version ?? '0.0.0');
+  } catch {
+    cachedVersion = '0.0.0';
+  }
+  return cachedVersion;
+}
+
 export function getSystemInfo(): { os: string; version: string } {
   return {
     os: `${process.platform}-${process.arch}`,
-    version: TOOL_VERSION,
+    version: readToolVersion(),
   };
 }
 
@@ -154,7 +184,12 @@ export function getSystemInfo(): { os: string; version: string } {
 // Event tracking
 // ---------------------------------------------------------------------------
 
-export function trackEvent(event: string, properties: Record<string, unknown>): void {
+export type TelemetrySource = 'cli' | 'dashboard';
+
+export async function trackEvent(
+  event: string,
+  properties: Record<string, unknown>,
+): Promise<void> {
   try {
     if (!isTelemetryEnabled()) return;
 
@@ -171,7 +206,20 @@ export function trackEvent(event: string, properties: Record<string, unknown>): 
         os: systemInfo.os,
       },
     });
+    // PostHog buffers + flushes async; await flush so short-lived CLI
+    // processes don't exit before the event hits the wire.
+    await client.flush();
   } catch {
-    // Silently ignore — telemetry must never break the app
+    // Silently ignore — telemetry must never break the app.
   }
+}
+
+export async function shutdownTelemetry(): Promise<void> {
+  if (!posthogClient) return;
+  try {
+    await posthogClient.shutdown();
+  } catch {
+    // ignore
+  }
+  posthogClient = null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,9 +159,6 @@ importers:
       express:
         specifier: ^4.21.0
         version: 4.22.1
-      posthog-node:
-        specifier: ^4.0.0
-        version: 4.18.0
       socket.io:
         specifier: ^4.8.0
         version: 4.8.3
@@ -239,6 +236,9 @@ importers:
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
+      posthog-node:
+        specifier: ^4.0.0
+        version: 4.18.0
       simple-git:
         specifier: ^3.27.0
         version: 3.33.0

--- a/tests/core/telemetry.service.test.ts
+++ b/tests/core/telemetry.service.test.ts
@@ -9,7 +9,7 @@ import {
   bucketDuration,
   detectLanguages,
   getSystemInfo,
-} from '../../apps/dashboard/server/src/services/telemetry.service';
+} from '../../packages/core/src/services/telemetry.service';
 import type { AnalysisResult } from '../../packages/core/src/services/analyzer.service';
 
 let tmpDir: string;

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/commands/analyze.ts
+++ b/tools/cli/src/commands/analyze.ts
@@ -292,6 +292,7 @@ export async function runAnalyze(options: AnalyzeOptions = {}): Promise<void> {
       skipStash: stashDecision.skipStash,
       enabledCategoriesOverride: enabledCategories,
       enableLlmRulesOverride: enableLlmRules,
+      source: "cli",
       onLlmEstimate: async (estimate) => {
         stopSpinner();
         const proceed = await promptLlmEstimate(estimate, {
@@ -383,6 +384,7 @@ export async function runAnalyzeDiff(options: AnalyzeOptions = {}): Promise<void
       signal: abortController.signal,
       enabledCategoriesOverride: enabledCategories,
       enableLlmRulesOverride: enableLlmRules,
+      source: "cli",
       onLlmEstimate: async (estimate) => {
         stopSpinner();
         const proceed = await promptLlmEstimate(estimate, {

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -32,7 +32,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.5.9")
+  .version("0.5.10")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program

--- a/tools/cli/src/telemetry.ts
+++ b/tools/cli/src/telemetry.ts
@@ -1,71 +1,19 @@
+/**
+ * CLI telemetry surface — config + first-run notice.
+ *
+ * Event capture itself lives in `@truecourse/core/services/telemetry`; this
+ * file just re-exports the config helpers (so `truecourse telemetry
+ * enable/disable/status` keep working) and prints the one-time notice.
+ */
+
 import * as p from "@clack/prompts";
-import fs from "node:fs";
-import path from "node:path";
-import os from "node:os";
-import crypto from "node:crypto";
+import {
+  readTelemetryConfig,
+  writeTelemetryConfig,
+  type TelemetryConfig,
+} from "@truecourse/core/services/telemetry";
 
-// ---------------------------------------------------------------------------
-// Config
-// ---------------------------------------------------------------------------
-
-interface TelemetryConfig {
-  enabled: boolean;
-  anonymousId: string;
-  noticeShown: boolean;
-}
-
-const DEFAULT_CONFIG: TelemetryConfig = {
-  enabled: true,
-  anonymousId: "",
-  noticeShown: false,
-};
-
-function getTelemetryConfigPath(): string {
-  return path.join(os.homedir(), ".truecourse", "telemetry.json");
-}
-
-export function readTelemetryConfig(): TelemetryConfig {
-  const configPath = getTelemetryConfigPath();
-  try {
-    const raw = fs.readFileSync(configPath, "utf-8");
-    const parsed = JSON.parse(raw);
-    const config = { ...DEFAULT_CONFIG, ...parsed };
-    if (!config.anonymousId) {
-      config.anonymousId = crypto.randomUUID();
-      writeTelemetryConfig(config);
-    }
-    return config;
-  } catch {
-    const config: TelemetryConfig = {
-      enabled: true,
-      anonymousId: crypto.randomUUID(),
-      noticeShown: false,
-    };
-    writeTelemetryConfig(config);
-    return config;
-  }
-}
-
-export function writeTelemetryConfig(partial: Partial<TelemetryConfig>): void {
-  const configPath = getTelemetryConfigPath();
-  const dir = path.dirname(configPath);
-  fs.mkdirSync(dir, { recursive: true });
-
-  let current: TelemetryConfig;
-  try {
-    const raw = fs.readFileSync(configPath, "utf-8");
-    current = { ...DEFAULT_CONFIG, ...JSON.parse(raw) };
-  } catch {
-    current = { ...DEFAULT_CONFIG };
-  }
-
-  const merged = { ...current, ...partial };
-  fs.writeFileSync(configPath, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-}
-
-// ---------------------------------------------------------------------------
-// First-run notice
-// ---------------------------------------------------------------------------
+export { readTelemetryConfig, writeTelemetryConfig, type TelemetryConfig };
 
 export function showFirstRunNotice(): void {
   try {


### PR DESCRIPTION
## Summary

- Move the PostHog client + config helpers from `apps/dashboard/server` into `@truecourse/core` (`services/telemetry`), so there's a single source of truth.
- Have `analyzeInProcess` / `diffInProcess` emit the `analyze` event themselves. Adapters now just pass `source: 'cli' | 'dashboard'` and every analyze gets reported automatically — CLI runs were silently missing from telemetry before.
- Wire real `languages` / `durationRange` into the diff event and read the tool version from `package.json` instead of the stale hardcoded `0.2.2`.
- Collapse the duplicated CLI/dashboard telemetry config modules into one; CLI's `tools/cli/src/telemetry.ts` shrinks to a thin re-export + first-run notice. `posthog-node` moves from the dashboard server's deps into core's.

## Test plan

- [x] `pnpm build` clean across all packages
- [x] `pnpm test` — 3453/3453 passing (telemetry tests now under `tests/core/telemetry.service.test.ts`, dashboard-only test file removed)
- [ ] Manually verify a `truecourse analyze` from the CLI reports an event with `source: 'cli'`
- [ ] Manually verify a dashboard-triggered analyze reports `source: 'dashboard'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)