### PR TITLE
Inject toolVersion into bundled CLI/server (0.5.11)

### DIFF
--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/src/services/telemetry.service.ts
+++ b/packages/core/src/services/telemetry.service.ts
@@ -158,10 +158,19 @@ export function detectLanguages(result: AnalysisResult): string[] {
 // System info
 // ---------------------------------------------------------------------------
 
+// Set by esbuild --define when building the published bundle (see
+// scripts/build.ts). Workspace/dev runs have no replacement, so the
+// `typeof` guard falls through to the file walk below.
+declare const __TRUECOURSE_VERSION__: string;
+
 let cachedVersion: string | null = null;
 
 function readToolVersion(): string {
   if (cachedVersion) return cachedVersion;
+  if (typeof __TRUECOURSE_VERSION__ !== 'undefined') {
+    cachedVersion = __TRUECOURSE_VERSION__;
+    return cachedVersion;
+  }
   try {
     const here = fileURLToPath(import.meta.url);
     const pkgPath = path.resolve(path.dirname(here), '..', '..', 'package.json');

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -67,6 +67,10 @@ run('pnpm --filter @truecourse/dashboard-client build');
 // stay external so their package metadata (and asset files like the WASM
 // runtime) can be resolved at runtime from installed node_modules.
 console.log('\n=== Bundling dashboard server ===');
+const cliPkgForVersion = JSON.parse(
+  fs.readFileSync(path.join(ROOT, 'tools/cli/package.json'), 'utf-8'),
+);
+const versionDefine = `--define:__TRUECOURSE_VERSION__=${JSON.stringify(JSON.stringify(cliPkgForVersion.version))}`;
 run(
   [
     'npx esbuild apps/dashboard/server/src/index.ts',
@@ -78,6 +82,7 @@ run(
     '--external:web-tree-sitter',
     '--external:pyright',
     '--external:typescript',
+    versionDefine,
     '--banner:js="import { createRequire } from \'node:module\'; const require = createRequire(import.meta.url);"',
   ].join(' '),
 );
@@ -102,6 +107,7 @@ run(
     '--external:web-tree-sitter',
     '--external:pyright',
     '--external:typescript',
+    versionDefine,
     '--banner:js="import { createRequire as __cR } from \'node:module\'; const require = __cR(import.meta.url);"',
   ].join(' '),
 );

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -32,7 +32,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.5.10")
+  .version("0.5.11")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## Summary

Telemetry was reporting `toolVersion: '0.0.0'` for npx-installed CLI runs (and bundled dashboard server), while running from unbundled `dist/` in dev worked. The published CLI ships as a single bundled `cli.mjs` at the package root, but the version-reading logic walked up two dirs from `import.meta.url` looking for `package.json` — which works for `packages/core/dist/services/telemetry.service.js` but lands in the wrong place from `<package>/cli.mjs`.

**Fix:** inject the version at bundle time via esbuild `--define:__TRUECOURSE_VERSION__=...` for both CLI and dashboard-server bundles. Keep the `package.json` walk as a workspace/dev fallback for non-bundled execution.

Bumps to `0.5.11` (patch — telemetry payload fix).

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm build:dist` clean; `grep __TRUECOURSE_VERSION__ dist/{cli,server}.mjs` returns 0 occurrences (literal was replaced)
- [x] `node dist/cli.mjs --version` prints `0.5.11`
- [ ] After merge + tag, verify a fresh `npx truecourse@0.5.11 analyze` lands a PostHog event with `toolVersion: "0.5.11"` (not `0.0.0`)

Note: 3 pre-existing analyzer test failures (`tests/analyzer/{js,python}-negative.test.ts`) are present on plain `origin/main` and are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)