### PR TITLE
Add `truecourse auto` mode: re-analyze on post-merge of the trigger branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,11 @@ pre-commit:
 Auto mode keeps `LATEST.json` fresh by re-running analyze whenever your trigger branch advances locally:
 
 ```bash
-truecourse auto enable                # Prompts for the trigger branch (default detected)
-truecourse auto enable --branch main  # Skip the prompt and bake in a branch
-truecourse auto disable               # Remove the hooks
-truecourse auto status                # Show installation status + trigger branch
+truecourse auto enable                          # Prompts for the trigger branch (default detected)
+truecourse auto enable --branch main            # Skip the prompt and bake in a branch
+truecourse auto enable --branch main --commit   # Also commit LATEST.json (no push)
+truecourse auto disable                         # Remove the hooks
+truecourse auto status                          # Show installation status + trigger branch + commit mode
 ```
 
 `auto enable` asks (or you pass `--branch`) which branch the hook should fire on, and bakes that name into the hook script. Auto-detection prefills the prompt from `origin/HEAD`, falling back to `main` then `master`. Teams using `develop`, `trunk`, or any other convention pass `--branch <name>`.
@@ -173,6 +174,14 @@ truecourse auto status                # Show installation status + trigger branc
 Once enabled, every `git pull` (or `git pull --rebase`) that lands new commits on the trigger branch runs `truecourse analyze --no-llm --no-stash` in the background — your `git` command returns immediately, and the analysis writes to `.truecourse/LATEST.json` and logs to `.truecourse/logs/auto.log`. Pulls on other branches are unaffected, and the hook no-ops when another analyze is already running so concurrent pulls won't pile up.
 
 The typical PR workflow: open a PR from a feature branch → merge on GitHub → switch to the trigger branch locally and `git pull` → auto mode re-analyzes. No LLM tokens are spent and your working tree isn't stashed.
+
+**`--commit` mode (opt-in).** With `--commit`, after analyze finishes the hook also commits the updated `.truecourse/LATEST.json` on the trigger branch — but **only** when:
+
+- you're still on the trigger branch when analyze finishes,
+- `HEAD` still equals `origin/<branch>` (no local divergence since the pull),
+- and `LATEST.json` actually changed.
+
+It never pushes; that stays manual. The `HEAD == origin/<branch>` gate is the race protection — if multiple teammates pulled main near the same instant, only the first one whose hook finishes will produce a commit; everyone else's gate fails safely on next pull, so you don't end up with conflicting local-main commits.
 
 If you later rename your main branch, re-run `truecourse auto enable` to update the baked-in name. `auto enable` also refuses to overwrite an existing non-TrueCourse hook — it prints the conflicting paths so you can fold the snippet into your hook manually.
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,25 @@ pre-commit:
   llm: false                   # run LLM rules on every commit (tokens per commit)
 ```
 
+### Auto Mode
+
+Auto mode keeps `LATEST.json` fresh by re-running analyze whenever your trigger branch advances locally:
+
+```bash
+truecourse auto enable                # Prompts for the trigger branch (default detected)
+truecourse auto enable --branch main  # Skip the prompt and bake in a branch
+truecourse auto disable               # Remove the hooks
+truecourse auto status                # Show installation status + trigger branch
+```
+
+`auto enable` asks (or you pass `--branch`) which branch the hook should fire on, and bakes that name into the hook script. Auto-detection prefills the prompt from `origin/HEAD`, falling back to `main` then `master`. Teams using `develop`, `trunk`, or any other convention pass `--branch <name>`.
+
+Once enabled, every `git pull` (or `git pull --rebase`) that lands new commits on the trigger branch runs `truecourse analyze --no-llm --no-stash` in the background — your `git` command returns immediately, and the analysis writes to `.truecourse/LATEST.json` and logs to `.truecourse/logs/auto.log`. Pulls on other branches are unaffected, and the hook no-ops when another analyze is already running so concurrent pulls won't pile up.
+
+The typical PR workflow: open a PR from a feature branch → merge on GitHub → switch to the trigger branch locally and `git pull` → auto mode re-analyzes. No LLM tokens are spent and your working tree isn't stashed.
+
+If you later rename your main branch, re-run `truecourse auto enable` to update the baked-in name. `auto enable` also refuses to overwrite an existing non-TrueCourse hook — it prints the conflicting paths so you can fold the snippet into your hook manually.
+
 ### Telemetry
 
 TrueCourse collects anonymous usage data to improve the product. It is automatically disabled in CI environments.

--- a/tests/cli/auto.test.ts
+++ b/tests/cli/auto.test.ts
@@ -13,6 +13,7 @@ import {
 const HOOK_NAMES = ['post-merge', 'post-rewrite'] as const;
 const IDENTIFIER = '# TrueCourse auto-mode hook';
 const BRANCH_MARKER = '# truecourse-branch:';
+const COMMIT_MARKER = '# truecourse-commit:';
 
 function initRepo(dir: string): void {
   execSync('git init -q', { cwd: dir });
@@ -182,13 +183,13 @@ describe('truecourse auto', () => {
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('not enabled'));
   });
 
-  it('status surfaces the configured branch when enabled', async () => {
+  it('status surfaces the configured branch and commit mode when enabled', async () => {
     initRepo(repoDir);
     await runAutoEnable({ branch: 'develop' });
     logSpy.mockClear();
     runAutoStatus();
     expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining('TrueCourse auto mode: enabled (branch: develop)'),
+      expect.stringContaining('branch: develop, commit: no'),
     );
   });
 
@@ -267,6 +268,168 @@ describe('truecourse auto', () => {
       // bounded poll
     }
     expect(fs.existsSync(marker)).toBe(true);
+
+    fs.rmSync(stubDir, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // --commit mode
+  // -------------------------------------------------------------------------
+
+  /**
+   * Set up a repo with a fake `origin` remote pointing at itself, both main
+   * branches at the same SHA, and an initial committed `LATEST.json`. That
+   * gives the hook's commit gate (`HEAD == origin/main`) a defined baseline
+   * we can advance or diverge in each test.
+   */
+  function seedRepoWithOrigin(dir: string): void {
+    initRepo(dir);
+    fs.mkdirSync(path.join(dir, '.truecourse'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.truecourse', 'LATEST.json'), '{"v": 1}');
+    fs.writeFileSync(path.join(dir, 'README'), 'hello');
+    execSync('git add README .truecourse/LATEST.json', { cwd: dir });
+    execSync('git commit -q -m initial', { cwd: dir });
+    execSync('git branch -M main', { cwd: dir });
+    // Fake an origin/main ref pointing at HEAD by writing the packed ref
+    // directly. This lets `git rev-parse origin/main` resolve without an
+    // actual remote round-trip.
+    const sha = execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf-8' }).trim();
+    const remotesDir = path.join(dir, '.git', 'refs', 'remotes', 'origin');
+    fs.mkdirSync(remotesDir, { recursive: true });
+    fs.writeFileSync(path.join(remotesDir, 'main'), sha + '\n');
+  }
+
+  /**
+   * Build a stub `truecourse` that mutates LATEST.json (so a commit becomes
+   * possible) and a stub `npx` that just exits. We shadow both via PATH so
+   * the hook never reaches a real CLI.
+   */
+  function makeStubs(repoDir: string, mutateLatest: boolean): {
+    stubDir: string;
+    env: NodeJS.ProcessEnv;
+  } {
+    const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-auto-stub-'));
+    const truecourseStub = mutateLatest
+      ? `#!/bin/sh\nmkdir -p "${repoDir}/.truecourse"\necho "{\\"v\\": 2}" > "${repoDir}/.truecourse/LATEST.json"\nexit 0\n`
+      : `#!/bin/sh\nexit 0\n`;
+    fs.writeFileSync(path.join(stubDir, 'truecourse'), truecourseStub, { mode: 0o755 });
+    fs.writeFileSync(path.join(stubDir, 'npx'), `#!/bin/sh\nexit 0\n`, { mode: 0o755 });
+    const env = { ...process.env, PATH: `${stubDir}:${process.env.PATH}` };
+    return { stubDir, env };
+  }
+
+  /** Wait until the hook's background subshell finishes (analyze + commit). */
+  function awaitBackgroundDone(repoDir: string, deadlineMs = 3000): void {
+    const deadline = Date.now() + deadlineMs;
+    // The background subshell appends to auto.log; once HEAD advances or the
+    // log mentions completion we're done. Simpler: just poll for HEAD to
+    // change, with a short ceiling so we don't hang on a no-op test.
+    const startHead = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    while (Date.now() < deadline) {
+      const cur = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+      if (cur !== startHead) return;
+    }
+  }
+
+  it('enable --commit bakes the commit marker into the hook', async () => {
+    initRepo(repoDir);
+    await runAutoEnable({ branch: 'main', commit: true });
+    const content = fs.readFileSync(hookPath('post-merge'), 'utf-8');
+    expect(content).toContain(`${COMMIT_MARKER} yes`);
+    expect(content).toContain('git commit -q -m "chore: refresh LATEST.json [truecourse auto]"');
+  });
+
+  it('enable without --commit bakes commit:no and omits the commit block', async () => {
+    initRepo(repoDir);
+    await runAutoEnable({ branch: 'main' });
+    const content = fs.readFileSync(hookPath('post-merge'), 'utf-8');
+    expect(content).toContain(`${COMMIT_MARKER} no`);
+    expect(content).not.toContain('git commit');
+  });
+
+  it('status reports the commit mode', async () => {
+    initRepo(repoDir);
+    await runAutoEnable({ branch: 'main', commit: true });
+    logSpy.mockClear();
+    runAutoStatus();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('commit: yes'),
+    );
+  });
+
+  it('hook commits LATEST.json when HEAD == origin/main and the file changed', async () => {
+    seedRepoWithOrigin(repoDir);
+    await runAutoEnable({ branch: 'main', commit: true });
+
+    const startHead = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    const { stubDir, env } = makeStubs(repoDir, /* mutateLatest */ true);
+
+    execSync(`sh ${hookPath('post-merge')}`, { cwd: repoDir, env });
+    awaitBackgroundDone(repoDir);
+
+    const endHead = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    expect(endHead).not.toBe(startHead);
+    const lastMsg = execSync('git log -1 --pretty=%s', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    expect(lastMsg).toContain('refresh LATEST.json');
+
+    fs.rmSync(stubDir, { recursive: true, force: true });
+  });
+
+  it('hook skips commit when HEAD has diverged from origin/main', async () => {
+    seedRepoWithOrigin(repoDir);
+    await runAutoEnable({ branch: 'main', commit: true });
+
+    // Add a local commit so HEAD advances past origin/main — the gate must skip.
+    fs.writeFileSync(path.join(repoDir, 'extra.txt'), 'local');
+    execSync('git add extra.txt && git commit -q -m local', { cwd: repoDir });
+    const headBefore = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+
+    const { stubDir, env } = makeStubs(repoDir, /* mutateLatest */ true);
+    execSync(`sh ${hookPath('post-merge')}`, { cwd: repoDir, env });
+    // Give the background process time to either commit (bug) or skip (correct).
+    const deadline = Date.now() + 1500;
+    while (Date.now() < deadline) { /* settle */ }
+
+    const headAfter = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    expect(headAfter).toBe(headBefore);
+
+    fs.rmSync(stubDir, { recursive: true, force: true });
+  });
+
+  it('hook skips commit when LATEST.json did not change', async () => {
+    seedRepoWithOrigin(repoDir);
+    await runAutoEnable({ branch: 'main', commit: true });
+
+    const headBefore = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    const { stubDir, env } = makeStubs(repoDir, /* mutateLatest */ false);
+
+    execSync(`sh ${hookPath('post-merge')}`, { cwd: repoDir, env });
+    const deadline = Date.now() + 1500;
+    while (Date.now() < deadline) { /* settle */ }
+
+    const headAfter = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    expect(headAfter).toBe(headBefore);
+
+    fs.rmSync(stubDir, { recursive: true, force: true });
+  });
+
+  it('hook skips commit when origin/<branch> ref is missing', async () => {
+    initRepo(repoDir);
+    seedMain(repoDir); // no origin remote at all
+    await runAutoEnable({ branch: 'main', commit: true });
+
+    fs.mkdirSync(path.join(repoDir, '.truecourse'), { recursive: true });
+    fs.writeFileSync(path.join(repoDir, '.truecourse', 'LATEST.json'), '{"v": 1}');
+    execSync('git add .truecourse/LATEST.json && git commit -q -m baseline', { cwd: repoDir });
+    const headBefore = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+
+    const { stubDir, env } = makeStubs(repoDir, /* mutateLatest */ true);
+    execSync(`sh ${hookPath('post-merge')}`, { cwd: repoDir, env });
+    const deadline = Date.now() + 1500;
+    while (Date.now() < deadline) { /* settle */ }
+
+    const headAfter = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    expect(headAfter).toBe(headBefore);
 
     fs.rmSync(stubDir, { recursive: true, force: true });
   });

--- a/tests/cli/auto.test.ts
+++ b/tests/cli/auto.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+import {
+  runAutoEnable,
+  runAutoDisable,
+  runAutoStatus,
+} from '../../tools/cli/src/commands/auto';
+
+const HOOK_NAMES = ['post-merge', 'post-rewrite'] as const;
+const IDENTIFIER = '# TrueCourse auto-mode hook';
+const BRANCH_MARKER = '# truecourse-branch:';
+
+function initRepo(dir: string): void {
+  execSync('git init -q', { cwd: dir });
+  execSync('git config user.email test@example.com', { cwd: dir });
+  execSync('git config user.name test', { cwd: dir });
+}
+
+/**
+ * Create main with one commit so detectMainBranch() can find it. Without
+ * a commit, `git show-ref refs/heads/main` returns nothing.
+ */
+function seedMain(dir: string): void {
+  fs.writeFileSync(path.join(dir, 'README'), 'hello');
+  execSync('git add README && git commit -q -m init', { cwd: dir });
+  execSync('git branch -M main', { cwd: dir });
+}
+
+describe('truecourse auto', () => {
+  let repoDir: string;
+  let originalCwd: string;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-auto-'));
+    originalCwd = process.cwd();
+    process.chdir(repoDir);
+
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  function hookPath(name: string): string {
+    return path.join(repoDir, '.git', 'hooks', name);
+  }
+
+  it('exits with an error when not in a git repository', async () => {
+    await expect(runAutoEnable({ branch: 'main' })).rejects.toThrow('process.exit(1)');
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Not a git repository'),
+    );
+  });
+
+  it('enable bakes the explicit --branch into both hooks and marks them executable', async () => {
+    initRepo(repoDir);
+    await runAutoEnable({ branch: 'develop' });
+
+    for (const name of HOOK_NAMES) {
+      const p = hookPath(name);
+      expect(fs.existsSync(p), `${name} should exist`).toBe(true);
+      const content = fs.readFileSync(p, 'utf-8');
+      expect(content).toContain(IDENTIFIER);
+      expect(content).toContain(`${BRANCH_MARKER} develop`);
+      expect(content).toContain('"$current_branch" = "develop"');
+      expect(content).toMatch(/--no-llm/);
+      expect(content).toMatch(/--no-stash/);
+      const mode = fs.statSync(p).mode & 0o777;
+      expect(mode & 0o100).toBe(0o100);
+    }
+  });
+
+  it('enable rejects branch names with invalid characters', async () => {
+    initRepo(repoDir);
+    await expect(runAutoEnable({ branch: 'evil; rm -rf /' })).rejects.toThrow(
+      'process.exit(1)',
+    );
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('invalid branch name'));
+    expect(fs.existsSync(hookPath('post-merge'))).toBe(false);
+  });
+
+  it('enable auto-detects from a local main branch in non-interactive mode', async () => {
+    initRepo(repoDir);
+    seedMain(repoDir);
+
+    const wasTty = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    try {
+      await runAutoEnable({});
+    } finally {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: wasTty,
+        configurable: true,
+      });
+    }
+
+    const content = fs.readFileSync(hookPath('post-merge'), 'utf-8');
+    expect(content).toContain(`${BRANCH_MARKER} main`);
+    expect(content).toContain('"$current_branch" = "main"');
+  });
+
+  it('enable errors in non-interactive mode when no branch can be detected', async () => {
+    initRepo(repoDir); // no commit, no branch yet
+
+    const wasTty = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    try {
+      await expect(runAutoEnable({})).rejects.toThrow('process.exit(1)');
+    } finally {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: wasTty,
+        configurable: true,
+      });
+    }
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('could not detect a main branch'),
+    );
+  });
+
+  it('enable is idempotent: re-running with same branch overwrites our hooks identically', async () => {
+    initRepo(repoDir);
+    await runAutoEnable({ branch: 'main' });
+    const before = fs.readFileSync(hookPath('post-merge'), 'utf-8');
+    await runAutoEnable({ branch: 'main' });
+    const after = fs.readFileSync(hookPath('post-merge'), 'utf-8');
+    expect(after).toBe(before);
+  });
+
+  it('enable can change the trigger branch on rerun', async () => {
+    initRepo(repoDir);
+    await runAutoEnable({ branch: 'main' });
+    await runAutoEnable({ branch: 'trunk' });
+    const content = fs.readFileSync(hookPath('post-merge'), 'utf-8');
+    expect(content).toContain(`${BRANCH_MARKER} trunk`);
+    expect(content).toContain('"$current_branch" = "trunk"');
+    expect(content).not.toContain(`${BRANCH_MARKER} main`);
+  });
+
+  it('enable refuses to clobber a foreign hook and exits 1', async () => {
+    initRepo(repoDir);
+    const foreignBody = '#!/bin/sh\necho "my custom hook"\n';
+    fs.mkdirSync(path.join(repoDir, '.git', 'hooks'), { recursive: true });
+    fs.writeFileSync(hookPath('post-merge'), foreignBody, { mode: 0o755 });
+
+    await expect(runAutoEnable({ branch: 'main' })).rejects.toThrow('process.exit(1)');
+    expect(fs.readFileSync(hookPath('post-merge'), 'utf-8')).toBe(foreignBody);
+    expect(fs.existsSync(hookPath('post-rewrite'))).toBe(false);
+  });
+
+  it('disable removes only our hooks, leaves foreign ones', async () => {
+    initRepo(repoDir);
+    await runAutoEnable({ branch: 'main' });
+
+    const foreign = '#!/bin/sh\necho hi\n';
+    fs.writeFileSync(hookPath('post-rewrite'), foreign, { mode: 0o755 });
+
+    runAutoDisable();
+
+    expect(fs.existsSync(hookPath('post-merge'))).toBe(false);
+    expect(fs.readFileSync(hookPath('post-rewrite'), 'utf-8')).toBe(foreign);
+  });
+
+  it('disable is a no-op (no error) when nothing is installed', () => {
+    initRepo(repoDir);
+    expect(() => runAutoDisable()).not.toThrow();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('not enabled'));
+  });
+
+  it('status surfaces the configured branch when enabled', async () => {
+    initRepo(repoDir);
+    await runAutoEnable({ branch: 'develop' });
+    logSpy.mockClear();
+    runAutoStatus();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('TrueCourse auto mode: enabled (branch: develop)'),
+    );
+  });
+
+  it('status detects an inconsistent half-installed state', async () => {
+    initRepo(repoDir);
+    await runAutoEnable({ branch: 'main' });
+    // Replace just one hook with a different-branch script to simulate a
+    // partial reinstall (e.g. user interrupted mid-rerun).
+    const wonky = fs
+      .readFileSync(hookPath('post-merge'), 'utf-8')
+      .replace(`${BRANCH_MARKER} main`, `${BRANCH_MARKER} trunk`)
+      .replace('"$current_branch" = "main"', '"$current_branch" = "trunk"');
+    fs.writeFileSync(hookPath('post-rewrite'), wonky);
+
+    logSpy.mockClear();
+    runAutoStatus();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('inconsistent'),
+    );
+  });
+
+  it('hook script gates on the configured branch (feature branch skips, main fires)', async () => {
+    initRepo(repoDir);
+    seedMain(repoDir);
+    await runAutoEnable({ branch: 'main' });
+
+    // Stub `truecourse` and `npx` in PATH so the hook's analyze call just
+    // touches a marker file — we don't want a real analyze in tests.
+    const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-auto-stub-'));
+    const marker = path.join(repoDir, 'analyze-was-called');
+    const stub = `#!/bin/sh\ntouch "${marker}"\nexit 0\n`;
+    fs.writeFileSync(path.join(stubDir, 'truecourse'), stub, { mode: 0o755 });
+    fs.writeFileSync(path.join(stubDir, 'npx'), stub, { mode: 0o755 });
+    const env = { ...process.env, PATH: `${stubDir}:${process.env.PATH}` };
+
+    // Feature branch → gate skips, marker stays absent.
+    execSync('git checkout -q -b feature', { cwd: repoDir });
+    execSync(`sh ${hookPath('post-merge')}`, { cwd: repoDir, env });
+    expect(fs.existsSync(marker)).toBe(false);
+
+    // Main → gate fires, background analyze stub touches the marker.
+    execSync('git checkout -q main', { cwd: repoDir });
+    execSync(`sh ${hookPath('post-merge')}`, { cwd: repoDir, env });
+    const deadline = Date.now() + 2000;
+    while (!fs.existsSync(marker) && Date.now() < deadline) {
+      // bounded poll
+    }
+    expect(fs.existsSync(marker)).toBe(true);
+
+    fs.rmSync(stubDir, { recursive: true, force: true });
+  });
+
+  it('hook script honours a non-default trigger branch (develop)', async () => {
+    initRepo(repoDir);
+    seedMain(repoDir);
+    execSync('git checkout -q -b develop', { cwd: repoDir });
+    await runAutoEnable({ branch: 'develop' });
+
+    const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-auto-stub-'));
+    const marker = path.join(repoDir, 'analyze-was-called');
+    const stub = `#!/bin/sh\ntouch "${marker}"\nexit 0\n`;
+    fs.writeFileSync(path.join(stubDir, 'truecourse'), stub, { mode: 0o755 });
+    fs.writeFileSync(path.join(stubDir, 'npx'), stub, { mode: 0o755 });
+    const env = { ...process.env, PATH: `${stubDir}:${process.env.PATH}` };
+
+    // On main: gate skips (we configured 'develop' as the trigger).
+    execSync('git checkout -q main', { cwd: repoDir });
+    execSync(`sh ${hookPath('post-merge')}`, { cwd: repoDir, env });
+    expect(fs.existsSync(marker)).toBe(false);
+
+    // On develop: gate fires.
+    execSync('git checkout -q develop', { cwd: repoDir });
+    execSync(`sh ${hookPath('post-merge')}`, { cwd: repoDir, env });
+    const deadline = Date.now() + 2000;
+    while (!fs.existsSync(marker) && Date.now() < deadline) {
+      // bounded poll
+    }
+    expect(fs.existsSync(marker)).toBe(true);
+
+    fs.rmSync(stubDir, { recursive: true, force: true });
+  });
+
+  it('hook script skips when an analyze lock exists', async () => {
+    initRepo(repoDir);
+    seedMain(repoDir);
+    await runAutoEnable({ branch: 'main' });
+
+    fs.mkdirSync(path.join(repoDir, '.truecourse'), { recursive: true });
+    fs.writeFileSync(path.join(repoDir, '.truecourse', '.analyze.lock'), '');
+
+    const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-auto-stub-'));
+    const marker = path.join(repoDir, 'analyze-was-called');
+    const stub = `#!/bin/sh\ntouch "${marker}"\nexit 0\n`;
+    fs.writeFileSync(path.join(stubDir, 'truecourse'), stub, { mode: 0o755 });
+    fs.writeFileSync(path.join(stubDir, 'npx'), stub, { mode: 0o755 });
+    const env = { ...process.env, PATH: `${stubDir}:${process.env.PATH}` };
+
+    execSync(`sh ${hookPath('post-merge')}`, { cwd: repoDir, env });
+    const deadline = Date.now() + 500;
+    while (Date.now() < deadline) {
+      // brief settle for any background process
+    }
+    expect(fs.existsSync(marker)).toBe(false);
+
+    fs.rmSync(stubDir, { recursive: true, force: true });
+  });
+});

--- a/tools/cli/src/commands/auto.ts
+++ b/tools/cli/src/commands/auto.ts
@@ -1,0 +1,350 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import * as p from "@clack/prompts";
+import { isInteractive } from "./helpers.js";
+
+// ---------------------------------------------------------------------------
+// Hook identifier + script template
+// ---------------------------------------------------------------------------
+
+const HOOK_IDENTIFIER = "# TrueCourse auto-mode hook";
+const BRANCH_MARKER = "# truecourse-branch:";
+
+// `post-merge` covers `git pull` (default merge mode) and local merges.
+// `post-rewrite` covers `git pull --rebase` and `pull.rebase=true`. Both
+// gate on "current branch is the configured main branch", so installing
+// both gives full coverage regardless of the team's pull strategy.
+const HOOK_NAMES = ["post-merge", "post-rewrite"] as const;
+type HookName = (typeof HOOK_NAMES)[number];
+
+/**
+ * Build the hook script with the branch name baked in. Baking it in (vs.
+ * detecting at runtime via `origin/HEAD`) keeps the hook short and avoids
+ * surprises when `origin/HEAD` is stale or unset. The trade-off is that
+ * renaming the main branch later requires re-running `truecourse auto enable`.
+ */
+function buildHookScript(branch: string): string {
+  return `#!/bin/sh
+${HOOK_IDENTIFIER}
+${BRANCH_MARKER} ${branch}
+# Installed by: truecourse auto enable
+# Disable with: truecourse auto disable
+#
+# After merges/rebases that land on the configured main branch, runs
+# \`truecourse analyze --no-llm --no-stash\` detached so git returns instantly.
+# Skips when another analyze is already in progress.
+
+repo_root=\$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+current_branch=\$(git -C "\$repo_root" symbolic-ref --quiet --short HEAD 2>/dev/null) || exit 0
+[ "\$current_branch" = "${branch}" ] || exit 0
+
+[ -f "\$repo_root/.truecourse/.analyze.lock" ] && exit 0
+
+if command -v truecourse >/dev/null 2>&1; then
+  cmd=truecourse
+else
+  cmd="npx -y truecourse"
+fi
+
+mkdir -p "\$repo_root/.truecourse/logs"
+( cd "\$repo_root" && nohup \$cmd analyze --no-llm --no-stash >> "\$repo_root/.truecourse/logs/auto.log" 2>&1 < /dev/null & )
+
+exit 0
+`;
+}
+
+/**
+ * Extract the branch name baked into a hook script. Returns null if the
+ * file isn't ours, or if it predates the branch marker.
+ */
+function readHookBranch(content: string): string | null {
+  if (!content.includes(HOOK_IDENTIFIER)) return null;
+  const match = content.match(new RegExp(`^${BRANCH_MARKER} (.+)$`, "m"));
+  return match ? match[1].trim() : null;
+}
+
+// ---------------------------------------------------------------------------
+// Git directory resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the directory holding `hooks/` for the current repo. For a regular
+ * checkout this is `<repo>/.git`. For a worktree, `.git` is a file pointing
+ * at the worktree's gitdir; we then read `commondir` to land in the shared
+ * git dir (hooks live there, not per-worktree).
+ */
+function findGitDir(from: string): string | null {
+  let dir = from;
+  while (true) {
+    const gitPath = path.join(dir, ".git");
+    if (fs.existsSync(gitPath)) {
+      const stat = fs.statSync(gitPath);
+      if (stat.isDirectory()) return gitPath;
+      if (stat.isFile()) {
+        const content = fs.readFileSync(gitPath, "utf-8").trim();
+        const match = content.match(/^gitdir:\s*(.+)$/);
+        if (match) {
+          const worktreeGitDir = path.resolve(dir, match[1]);
+          const commondirFile = path.join(worktreeGitDir, "commondir");
+          if (fs.existsSync(commondirFile)) {
+            const commondir = fs.readFileSync(commondirFile, "utf-8").trim();
+            return path.resolve(worktreeGitDir, commondir);
+          }
+          return worktreeGitDir;
+        }
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function findRepoRoot(from: string): string | null {
+  let dir = from;
+  while (true) {
+    if (fs.existsSync(path.join(dir, ".git"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function requireGitDir(): { gitDir: string; repoRoot: string } {
+  const repoRoot = findRepoRoot(process.cwd());
+  const gitDir = findGitDir(process.cwd());
+  if (!gitDir || !repoRoot) {
+    console.error("Error: Not a git repository.");
+    process.exit(1);
+  }
+  return { gitDir, repoRoot };
+}
+
+// ---------------------------------------------------------------------------
+// Branch detection + resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Try to determine the repo's main branch. Returns the first hit:
+ *   1. `origin/HEAD` symbolic ref (set by `git clone` / `git remote set-head`)
+ *   2. Local `main` branch
+ *   3. Local `master` branch
+ * Returns null if none of these exist.
+ */
+function detectMainBranch(repoRoot: string): string | null {
+  try {
+    const ref = execSync(
+      "git symbolic-ref --quiet refs/remotes/origin/HEAD",
+      { cwd: repoRoot, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim();
+    if (ref.startsWith("refs/remotes/origin/")) {
+      return ref.slice("refs/remotes/origin/".length);
+    }
+  } catch {
+    // origin/HEAD not set — fall through
+  }
+  for (const candidate of ["main", "master"]) {
+    try {
+      execSync(`git show-ref --verify --quiet refs/heads/${candidate}`, {
+        cwd: repoRoot,
+        stdio: "ignore",
+      });
+      return candidate;
+    } catch {
+      // not present — try next
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve which branch to bake into the hook. Priority:
+ *   1. `--branch` flag (always wins, no prompt)
+ *   2. interactive: prompt with auto-detected default
+ *   3. non-interactive: use auto-detected silently; error if none
+ */
+async function resolveBranch(
+  repoRoot: string,
+  explicit: string | undefined,
+): Promise<string> {
+  if (explicit) {
+    if (!/^[A-Za-z0-9._/-]+$/.test(explicit)) {
+      console.error(
+        `Error: invalid branch name "${explicit}". Use only letters, digits, dot, underscore, slash, or dash.`,
+      );
+      process.exit(1);
+    }
+    return explicit;
+  }
+
+  const detected = detectMainBranch(repoRoot);
+
+  if (!isInteractive()) {
+    if (detected) return detected;
+    console.error(
+      "Error: could not detect a main branch (no `origin/HEAD`, `main`, or `master`).\n" +
+        "Pass --branch <name> to specify the branch the hook should fire on.",
+    );
+    process.exit(1);
+  }
+
+  const answer = await p.text({
+    message: "Which branch should auto-mode trigger on?",
+    placeholder: detected ?? "main",
+    initialValue: detected ?? "",
+    validate: (value) => {
+      const v = (value ?? "").trim();
+      if (!v) return "Branch name is required.";
+      if (!/^[A-Za-z0-9._/-]+$/.test(v))
+        return "Use only letters, digits, dot, underscore, slash, or dash.";
+      return undefined;
+    },
+  });
+  if (p.isCancel(answer)) {
+    p.cancel("Cancelled.");
+    process.exit(0);
+  }
+  return (answer as string).trim();
+}
+
+// ---------------------------------------------------------------------------
+// Hook state inspection
+// ---------------------------------------------------------------------------
+
+interface HookState {
+  name: HookName;
+  path: string;
+  exists: boolean;
+  ours: boolean;
+  branch: string | null;
+}
+
+function inspectHooks(gitDir: string): HookState[] {
+  const hooksDir = path.join(gitDir, "hooks");
+  return HOOK_NAMES.map((name) => {
+    const hookPath = path.join(hooksDir, name);
+    const exists = fs.existsSync(hookPath);
+    if (!exists) {
+      return { name, path: hookPath, exists, ours: false, branch: null };
+    }
+    const content = fs.readFileSync(hookPath, "utf-8");
+    const ours = content.includes(HOOK_IDENTIFIER);
+    return {
+      name,
+      path: hookPath,
+      exists,
+      ours,
+      branch: ours ? readHookBranch(content) : null,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// enable / disable / status
+// ---------------------------------------------------------------------------
+
+interface AutoEnableOptions {
+  branch?: string;
+}
+
+export async function runAutoEnable(options: AutoEnableOptions = {}): Promise<void> {
+  const { gitDir, repoRoot } = requireGitDir();
+  const hooksDir = path.join(gitDir, "hooks");
+  fs.mkdirSync(hooksDir, { recursive: true });
+
+  const states = inspectHooks(gitDir);
+
+  // Refuse to overwrite hooks we didn't write — a user's existing post-merge
+  // hook may be load-bearing (e.g. submodule sync, asset rebuild). Tell them
+  // and bail rather than clobber.
+  const conflicts = states.filter((s) => s.exists && !s.ours);
+  if (conflicts.length > 0) {
+    console.error(
+      "Error: existing non-TrueCourse hooks would be overwritten:",
+    );
+    for (const c of conflicts) console.error(`  ${c.path}`);
+    console.error(
+      "\nMove or remove them (or fold the TrueCourse snippet into yours), then\n" +
+        "re-run `truecourse auto enable`.",
+    );
+    process.exit(1);
+  }
+
+  const branch = await resolveBranch(repoRoot, options.branch);
+  const script = buildHookScript(branch);
+
+  for (const state of states) {
+    fs.writeFileSync(state.path, script, { mode: 0o755 });
+  }
+
+  p.log.success(`TrueCourse auto mode enabled (trigger branch: ${branch}).`);
+  for (const s of states) console.log(`  ${s.path}`);
+  console.log(
+    `\nWhen "${branch}" advances locally (merge or rebase), TrueCourse will run\n` +
+      "`analyze --no-llm --no-stash` in the background.\n" +
+      "Logs: .truecourse/logs/auto.log",
+  );
+}
+
+export function runAutoDisable(): void {
+  const { gitDir } = requireGitDir();
+  const states = inspectHooks(gitDir);
+  const ours = states.filter((s) => s.ours);
+
+  if (ours.length === 0) {
+    console.log("Auto mode is not enabled (no TrueCourse hooks found).");
+    return;
+  }
+
+  for (const state of ours) {
+    fs.unlinkSync(state.path);
+    console.log(`Removed ${state.path}`);
+  }
+  p.log.success("TrueCourse auto mode disabled.");
+}
+
+export function runAutoStatus(): void {
+  const { gitDir } = requireGitDir();
+  const states = inspectHooks(gitDir);
+
+  const ourCount = states.filter((s) => s.ours).length;
+  const branches = new Set(
+    states.filter((s) => s.ours && s.branch).map((s) => s.branch as string),
+  );
+
+  if (ourCount === states.length) {
+    if (branches.size === 1) {
+      console.log(`TrueCourse auto mode: enabled (branch: ${[...branches][0]})`);
+    } else if (branches.size > 1) {
+      // Hooks pointing at different branches — half-installed state from a
+      // partial reinstall. Show both so the user can fix.
+      console.log(
+        `TrueCourse auto mode: enabled but inconsistent (branches: ${[...branches].join(", ")})`,
+      );
+      console.log("  Re-run `truecourse auto enable` to resync.");
+    } else {
+      console.log("TrueCourse auto mode: enabled (no branch recorded)");
+      console.log("  Re-run `truecourse auto enable` to record the trigger branch.");
+    }
+  } else if (ourCount > 0) {
+    console.log("TrueCourse auto mode: partially enabled");
+  } else {
+    console.log("TrueCourse auto mode: disabled");
+    console.log('  Run "truecourse auto enable" to set up.');
+  }
+
+  for (const s of states) {
+    let tag: string;
+    if (s.ours) {
+      tag = s.branch ? `TrueCourse (branch: ${s.branch})` : "TrueCourse";
+    } else if (s.exists) {
+      tag = "non-TrueCourse (will not be touched)";
+    } else {
+      tag = "not installed";
+    }
+    console.log(`  ${s.name}: ${tag}`);
+    if (s.exists) console.log(`    ${s.path}`);
+  }
+}

--- a/tools/cli/src/commands/auto.ts
+++ b/tools/cli/src/commands/auto.ts
@@ -10,6 +10,7 @@ import { isInteractive } from "./helpers.js";
 
 const HOOK_IDENTIFIER = "# TrueCourse auto-mode hook";
 const BRANCH_MARKER = "# truecourse-branch:";
+const COMMIT_MARKER = "# truecourse-commit:";
 
 // `post-merge` covers `git pull` (default merge mode) and local merges.
 // `post-rewrite` covers `git pull --rebase` and `pull.rebase=true`. Both
@@ -23,11 +24,34 @@ type HookName = (typeof HOOK_NAMES)[number];
  * detecting at runtime via `origin/HEAD`) keeps the hook short and avoids
  * surprises when `origin/HEAD` is stale or unset. The trade-off is that
  * renaming the main branch later requires re-running `truecourse auto enable`.
+ *
+ * When `commit` is true, after analyze finishes the hook also tries to
+ * commit `.truecourse/LATEST.json` on the trigger branch — but only if
+ * `HEAD == origin/<branch>` (no local divergence) and the file actually
+ * changed. It never pushes; the user does that manually. This gating
+ * keeps a 3-dev race ("everyone pulled main at once") from producing
+ * conflicting local-main commits: first dev's commit advances HEAD past
+ * origin, and the others' gates fail safely on next pull.
  */
-function buildHookScript(branch: string): string {
+function buildHookScript(branch: string, commit: boolean): string {
+  const commitBlock = commit
+    ? `
+  cur=\$(git symbolic-ref --quiet --short HEAD 2>/dev/null) || exit 0
+  [ "\$cur" = "${branch}" ] || exit 0
+  head_sha=\$(git rev-parse HEAD 2>/dev/null) || exit 0
+  upstream_sha=\$(git rev-parse "origin/${branch}" 2>/dev/null) || exit 0
+  [ "\$head_sha" = "\$upstream_sha" ] || exit 0
+  git add .truecourse/LATEST.json 2>/dev/null || exit 0
+  if git diff --cached --quiet -- .truecourse/LATEST.json 2>/dev/null; then
+    exit 0
+  fi
+  git commit -q -m "chore: refresh LATEST.json [truecourse auto]" -- .truecourse/LATEST.json 2>/dev/null || true`
+    : "";
+
   return `#!/bin/sh
 ${HOOK_IDENTIFIER}
 ${BRANCH_MARKER} ${branch}
+${COMMIT_MARKER} ${commit ? "yes" : "no"}
 # Installed by: truecourse auto enable
 # Disable with: truecourse auto disable
 #
@@ -49,7 +73,10 @@ else
 fi
 
 mkdir -p "\$repo_root/.truecourse/logs"
-( cd "\$repo_root" && nohup \$cmd analyze --no-llm --no-stash >> "\$repo_root/.truecourse/logs/auto.log" 2>&1 < /dev/null & )
+(
+  cd "\$repo_root" || exit 0
+  \$cmd analyze --no-llm --no-stash${commitBlock}
+) >> "\$repo_root/.truecourse/logs/auto.log" 2>&1 </dev/null &
 
 exit 0
 `;
@@ -63,6 +90,13 @@ function readHookBranch(content: string): string | null {
   if (!content.includes(HOOK_IDENTIFIER)) return null;
   const match = content.match(new RegExp(`^${BRANCH_MARKER} (.+)$`, "m"));
   return match ? match[1].trim() : null;
+}
+
+function readHookCommit(content: string): boolean | null {
+  if (!content.includes(HOOK_IDENTIFIER)) return null;
+  const match = content.match(new RegExp(`^${COMMIT_MARKER} (yes|no)$`, "m"));
+  if (!match) return null;
+  return match[1] === "yes";
 }
 
 // ---------------------------------------------------------------------------
@@ -219,6 +253,7 @@ interface HookState {
   exists: boolean;
   ours: boolean;
   branch: string | null;
+  commit: boolean | null;
 }
 
 function inspectHooks(gitDir: string): HookState[] {
@@ -227,7 +262,7 @@ function inspectHooks(gitDir: string): HookState[] {
     const hookPath = path.join(hooksDir, name);
     const exists = fs.existsSync(hookPath);
     if (!exists) {
-      return { name, path: hookPath, exists, ours: false, branch: null };
+      return { name, path: hookPath, exists, ours: false, branch: null, commit: null };
     }
     const content = fs.readFileSync(hookPath, "utf-8");
     const ours = content.includes(HOOK_IDENTIFIER);
@@ -237,6 +272,7 @@ function inspectHooks(gitDir: string): HookState[] {
       exists,
       ours,
       branch: ours ? readHookBranch(content) : null,
+      commit: ours ? readHookCommit(content) : null,
     };
   });
 }
@@ -247,6 +283,7 @@ function inspectHooks(gitDir: string): HookState[] {
 
 interface AutoEnableOptions {
   branch?: string;
+  commit?: boolean;
 }
 
 export async function runAutoEnable(options: AutoEnableOptions = {}): Promise<void> {
@@ -273,19 +310,29 @@ export async function runAutoEnable(options: AutoEnableOptions = {}): Promise<vo
   }
 
   const branch = await resolveBranch(repoRoot, options.branch);
-  const script = buildHookScript(branch);
+  const commit = options.commit === true;
+  const script = buildHookScript(branch, commit);
 
   for (const state of states) {
     fs.writeFileSync(state.path, script, { mode: 0o755 });
   }
 
-  p.log.success(`TrueCourse auto mode enabled (trigger branch: ${branch}).`);
+  p.log.success(
+    `TrueCourse auto mode enabled (trigger branch: ${branch}, commit: ${commit ? "yes" : "no"}).`,
+  );
   for (const s of states) console.log(`  ${s.path}`);
   console.log(
     `\nWhen "${branch}" advances locally (merge or rebase), TrueCourse will run\n` +
       "`analyze --no-llm --no-stash` in the background.\n" +
       "Logs: .truecourse/logs/auto.log",
   );
+  if (commit) {
+    console.log(
+      "\nCommit mode is on — after analyze, the hook will commit\n" +
+        `\`.truecourse/LATEST.json\` on ${branch} if HEAD still equals origin/${branch}\n` +
+        "and the file actually changed. It does NOT push; that stays manual.",
+    );
+  }
 }
 
 export function runAutoDisable(): void {
@@ -313,10 +360,17 @@ export function runAutoStatus(): void {
   const branches = new Set(
     states.filter((s) => s.ours && s.branch).map((s) => s.branch as string),
   );
+  const commits = new Set(
+    states.filter((s) => s.ours && s.commit !== null).map((s) => s.commit as boolean),
+  );
+  const commitMode =
+    commits.size === 1 ? ([...commits][0] ? "yes" : "no") : "?";
 
   if (ourCount === states.length) {
     if (branches.size === 1) {
-      console.log(`TrueCourse auto mode: enabled (branch: ${[...branches][0]})`);
+      console.log(
+        `TrueCourse auto mode: enabled (branch: ${[...branches][0]}, commit: ${commitMode})`,
+      );
     } else if (branches.size > 1) {
       // Hooks pointing at different branches — half-installed state from a
       // partial reinstall. Show both so the user can fix.
@@ -338,7 +392,10 @@ export function runAutoStatus(): void {
   for (const s of states) {
     let tag: string;
     if (s.ours) {
-      tag = s.branch ? `TrueCourse (branch: ${s.branch})` : "TrueCourse";
+      const parts: string[] = [];
+      if (s.branch) parts.push(`branch: ${s.branch}`);
+      if (s.commit !== null) parts.push(`commit: ${s.commit ? "yes" : "no"}`);
+      tag = parts.length ? `TrueCourse (${parts.join(", ")})` : "TrueCourse";
     } else if (s.exists) {
       tag = "non-TrueCourse (will not be touched)";
     } else {

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -27,6 +27,11 @@ import {
   runHooksStatus,
   runHooksRun,
 } from "./commands/hooks.js";
+import {
+  runAutoEnable,
+  runAutoDisable,
+  runAutoStatus,
+} from "./commands/auto.js";
 
 const program = new Command();
 
@@ -275,6 +280,36 @@ hooksCmd
   .description("Run pre-commit checks (called by the hook)")
   .action(async () => {
     await runHooksRun();
+  });
+
+// Auto mode — re-analyze in the background after merges/rebases land on main
+const autoCmd = program
+  .command("auto")
+  .description("Auto mode: re-run analyze on the main branch after merges");
+
+autoCmd
+  .command("enable")
+  .description("Install post-merge and post-rewrite hooks")
+  .option(
+    "--branch <name>",
+    "Branch the hook should fire on (auto-detects from origin/HEAD if omitted)",
+  )
+  .action(async (options: { branch?: string }) => {
+    await runAutoEnable({ branch: options.branch });
+  });
+
+autoCmd
+  .command("disable")
+  .description("Remove TrueCourse auto-mode hooks")
+  .action(() => {
+    runAutoDisable();
+  });
+
+autoCmd
+  .command("status")
+  .description("Show auto-mode hook status")
+  .action(() => {
+    runAutoStatus();
   });
 
 program.action(() => {

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -294,8 +294,12 @@ autoCmd
     "--branch <name>",
     "Branch the hook should fire on (auto-detects from origin/HEAD if omitted)",
   )
-  .action(async (options: { branch?: string }) => {
-    await runAutoEnable({ branch: options.branch });
+  .option(
+    "--commit",
+    "After analyze, also commit .truecourse/LATEST.json on the trigger branch (no push). Skips when HEAD has diverged from origin/<branch>",
+  )
+  .action(async (options: { branch?: string; commit?: boolean }) => {
+    await runAutoEnable({ branch: options.branch, commit: options.commit });
   });
 
 autoCmd


### PR DESCRIPTION
## Summary
- New `truecourse auto enable | disable | status` command that installs `post-merge` and `post-rewrite` git hooks. After the configured branch advances locally (e.g. `git pull` after a PR merge), the hook runs `truecourse analyze --no-llm --no-stash` detached so `git` returns instantly. Logs go to `.truecourse/logs/auto.log`.
- `auto enable` accepts `--branch <name>`; without it, an interactive prompt is prefilled from `origin/HEAD` (falling back to `main` then `master`). The chosen name is **baked into the hook script** so the gate is a single string compare. Trade-off: renaming the main branch later means re-running `auto enable`.
- Hook no-ops while another analyze holds `.truecourse/.analyze.lock`, so concurrent pulls don't stack. `auto enable` refuses to clobber a non-TrueCourse hook; `auto disable` removes only our own.
- `auto status` reports the configured branch and flags a half-installed inconsistent state (post-merge says X, post-rewrite says Y) suggesting a re-run.

## Why this exists
Keeps `LATEST.json` fresh through the typical PR workflow — feature branch → PR merged on GitHub → developer pulls main locally → auto mode re-analyzes — without ever touching LLM tokens or stashing the working tree. Sibling to the existing `truecourse hooks` (pre-commit gate); concerns are deliberately split since pre-commit *blocks* commits while auto-mode just *records* state.

## Test plan
- [x] `pnpm test tests/cli/auto.test.ts` — 15 tests cover: not-a-git-repo error; explicit `--branch` baked in; branch-name validation rejecting shell metacharacters; non-interactive auto-detect; non-interactive failure when nothing detectable; idempotent re-run; branch-change on rerun; foreign-hook conflict refusal; selective disable; no-op disable; status shows branch; status detects inconsistent half-install; hook gates correctly on `main` vs feature branch; hook honours a non-default trigger (`develop`); hook skips when `.analyze.lock` exists.
- [x] Smoke-test the rendered hook script with `sh -n` (syntax-clean) and confirmed it launches a stubbed `truecourse` only on the configured branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)