### PR TITLE
Add public landing site (apps/landing) with teams waitlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ dist/
 .next/
 .turbo/
 .env
+.env.local
+.env.development.local
+.env.production.local
+.vercel/
 *.log
 .DS_Store
 coverage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 
 - `apps/dashboard/client/` — Vite + React Router frontend (React Flow graph, Tailwind CSS, dark mode)
 - `apps/dashboard/server/` — Express + Socket.io HTTP layer that serves the dashboard. Thin adapter over `@truecourse/core`; contains routes, sockets, middleware, and dashboard-only services (analytics, watcher, telemetry).
+- `apps/landing/` — Public marketing site (Vite + React + Tailwind v4). Standalone, deployed separately from the local dashboard. `pnpm --filter @truecourse/landing dev` runs it on port 3100. Sample OSS analysis reports live in `apps/landing/src/data/analyses.ts`.
 - `packages/core/` — Framework-agnostic analysis engine: pipeline, graph/flow services, LLM providers, persistence (analysis-store), config, logger, errors. Consumed by both the CLI and the dashboard server.
 - `packages/analyzer/` — Tree-sitter (WASM via `web-tree-sitter`) + TypeScript Compiler analysis engine (TS/JS/Python)
 - `packages/shared/` — Shared Zod schemas and TypeScript types

--- a/apps/landing/.env.example
+++ b/apps/landing/.env.example
@@ -1,0 +1,15 @@
+# Vercel/Netlify env vars consumed by api/waitlist.ts
+# Copy to .env.local for local dev (with `vercel dev`), or set in your host's project settings.
+# Never commit real values.
+
+# Personal access token from https://airtable.com/create/tokens
+# Required scopes: data.records:write
+# Required base access: TrueCourse Founder CRM (appGuf6PL5dDfYK3f)
+AIRTABLE_API_KEY=patXXXXXXXXXXXXXX.YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+
+# Optional. Defaults are baked into api/waitlist.ts:
+#   AIRTABLE_BASE_ID = appGuf6PL5dDfYK3f  (TrueCourse Founder CRM)
+#   AIRTABLE_TABLE   = Waitlist
+# Override only if you move bases or rename the table.
+# AIRTABLE_BASE_ID=appGuf6PL5dDfYK3f
+# AIRTABLE_TABLE=Waitlist

--- a/apps/landing/api/waitlist.ts
+++ b/apps/landing/api/waitlist.ts
@@ -1,0 +1,147 @@
+/**
+ * Vercel serverless function: POST /api/waitlist
+ *
+ * Forwards waitlist submissions to the Airtable "Waitlist" table in the
+ * "TrueCourse Founder CRM" base. All credentials are server-only env vars —
+ * the browser never sees the API key.
+ *
+ * Required env vars (set in Vercel project settings):
+ *   AIRTABLE_API_KEY  Personal access token with `data.records:write` scope
+ *                     for the target base. Create at airtable.com/create/tokens
+ *   AIRTABLE_BASE_ID  Defaults to the TrueCourse Founder CRM base
+ *                     (appGuf6PL5dDfYK3f). Override only if you move bases.
+ *
+ * Optional:
+ *   AIRTABLE_TABLE    Table name. Defaults to "Waitlist".
+ *
+ * Wired against the real schema as of 2026-05-08:
+ *   Email                singleLineText (primary)
+ *   Company Name         singleLineText
+ *   Company Size Range   singleSelect — see SIZE_TO_AIRTABLE map
+ *   Submitted Date       dateTime (ISO timestamp)
+ *   Source               singleLineText  (we tag every submission with the page)
+ */
+
+type Req = {
+  method?: string;
+  body?: unknown;
+  headers?: Record<string, string | string[] | undefined>;
+};
+
+type Res = {
+  status(code: number): Res;
+  json(body: unknown): void;
+  setHeader(name: string, value: string): void;
+};
+
+type Body = {
+  email?: unknown;
+  company?: unknown;
+  size?: unknown;
+  // Honeypot — humans never see/fill this. Bots usually do.
+  website?: unknown;
+};
+
+/**
+ * Form values (left) → exact Airtable single-select option names (right).
+ * These must match the strings configured in the "Company Size Range" field
+ * exactly (en-dash vs hyphen matters in Airtable).
+ */
+const SIZE_TO_AIRTABLE: Record<string, string> = {
+  '1-10': '1 – 10 engineers',
+  '11-50': '11 – 50',
+  '51-200': '51 – 200',
+  '200+': '200+',
+};
+
+const ALLOWED_SIZES = new Set([...Object.keys(SIZE_TO_AIRTABLE), '']);
+
+const DEFAULT_BASE_ID = 'appGuf6PL5dDfYK3f';
+const DEFAULT_TABLE = 'Waitlist';
+
+export default async function handler(req: Req, res: Res): Promise<void> {
+  res.setHeader('content-type', 'application/json');
+
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const body = parseBody(req.body);
+
+  // Honeypot: bots fill hidden fields, real users don't. Quietly succeed
+  // without writing anything so spam goes nowhere.
+  if (typeof body.website === 'string' && body.website.trim() !== '') {
+    res.status(200).json({ ok: true });
+    return;
+  }
+
+  const email = typeof body.email === 'string' ? body.email.trim() : '';
+  const company = typeof body.company === 'string' ? body.company.trim().slice(0, 200) : '';
+  const size = typeof body.size === 'string' ? body.size.trim() : '';
+
+  if (!email || email.length > 254 || !email.includes('@') || email.includes(' ')) {
+    res.status(400).json({ error: 'Valid email required' });
+    return;
+  }
+  if (!ALLOWED_SIZES.has(size)) {
+    res.status(400).json({ error: 'Invalid team size' });
+    return;
+  }
+
+  const apiKey = process.env.AIRTABLE_API_KEY;
+  const baseId = process.env.AIRTABLE_BASE_ID ?? DEFAULT_BASE_ID;
+  const table = process.env.AIRTABLE_TABLE ?? DEFAULT_TABLE;
+
+  if (!apiKey) {
+    console.error('waitlist: missing AIRTABLE_API_KEY');
+    res.status(500).json({ error: 'Server misconfigured' });
+    return;
+  }
+
+  const url = `https://api.airtable.com/v0/${encodeURIComponent(baseId)}/${encodeURIComponent(table)}`;
+
+  const fields: Record<string, string> = {
+    Email: email,
+    Source: 'truecourse.dev/teams',
+    'Submitted Date': new Date().toISOString(),
+  };
+  if (company) fields['Company Name'] = company;
+  if (size) fields['Company Size Range'] = SIZE_TO_AIRTABLE[size];
+
+  try {
+    const ar = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ fields, typecast: true }),
+    });
+
+    if (!ar.ok) {
+      const text = await ar.text().catch(() => '');
+      console.error('waitlist: airtable error', ar.status, text.slice(0, 500));
+      res.status(502).json({ error: 'Could not save submission' });
+      return;
+    }
+
+    res.status(200).json({ ok: true });
+  } catch (err) {
+    console.error('waitlist: airtable fetch threw', err);
+    res.status(502).json({ error: 'Could not reach Airtable' });
+  }
+}
+
+function parseBody(raw: unknown): Body {
+  if (!raw) return {};
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw) as Body;
+    } catch {
+      return {};
+    }
+  }
+  if (typeof raw === 'object') return raw as Body;
+  return {};
+}

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TrueCourse · Validate the code your AI generates</title>
+    <meta
+      name="description"
+      content="TrueCourse is the validation layer for AI-generated code. It cross-checks every change against your business logic and your codebase, catching hallucinated APIs, fabricated calls, and silent intent drift before they ship. Open source CLI for TS, JS, Python."
+    />
+    <meta property="og:title" content="TrueCourse · Validate the code your AI generates" />
+    <meta property="og:description" content="The validation layer for AI-generated code. Catch hallucinated APIs, fabricated calls, and business-logic drift before they ship. Open source CLI + dashboard." />
+    <meta property="og:type" content="website" />
+    <link rel="icon" href="/logo.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@400..700&family=Inter:wght@400..700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="font-sans antialiased">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@truecourse/landing",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite --port 3100",
+    "build": "vite build",
+    "preview": "vite preview",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.468.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.1.0",
+    "tailwind-merge": "^3.5.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.0.0",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/landing/postcss.config.mjs
+++ b/apps/landing/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};

--- a/apps/landing/public/icon.svg
+++ b/apps/landing/public/icon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- Background -->
+  <rect width="512" height="512" rx="80" fill="#0f172a"/>
+
+  <!-- Sail -->
+  <polygon points="256,110 256,310 170,310" fill="#3b82f6"/>
+
+  <!-- Mast -->
+  <line x1="256" y1="95" x2="256" y2="330" stroke="#e2e8f0" stroke-width="6" stroke-linecap="round"/>
+
+  <!-- Crow's nest -->
+  <rect x="238" y="95" width="36" height="20" rx="4" fill="#e2e8f0"/>
+  <line x1="256" y1="95" x2="256" y2="85" stroke="#e2e8f0" stroke-width="5" stroke-linecap="round"/>
+
+  <!-- Hull -->
+  <path d="M 140,330 L 370,330 L 345,380 L 165,380 Z" fill="#e2e8f0"/>
+
+  <!-- Hull accent -->
+  <path d="M 150,348 L 360,348 L 350,372 L 160,372 Z" fill="#3b82f6" opacity="0.35"/>
+</svg>

--- a/apps/landing/public/logo.svg
+++ b/apps/landing/public/logo.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 320" width="400" height="320">
+  <!-- Sail -->
+  <polygon points="200,30 200,190 130,190" fill="#3b82f6" opacity="0.9"/>
+
+  <!-- Mast -->
+  <line x1="200" y1="20" x2="200" y2="210" stroke="#1e3a5f" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Crow's nest -->
+  <rect x="185" y="20" width="30" height="16" rx="3" fill="#1e3a5f"/>
+  <line x1="200" y1="20" x2="200" y2="12" stroke="#1e3a5f" stroke-width="3" stroke-linecap="round"/>
+
+  <!-- Hull -->
+  <path d="M 100,210 L 300,210 L 280,250 L 120,250 Z" fill="#1e3a5f"/>
+
+  <!-- Hull accent stripe -->
+  <path d="M 108,225 L 292,225 L 284,245 L 116,245 Z" fill="#2563eb" opacity="0.4"/>
+
+  <!-- Bow detail -->
+  <path d="M 280,210 L 310,210 L 280,250 Z" fill="#163050"/>
+
+  <!-- Waves -->
+  <path d="M 60,260 Q 90,248 120,260 Q 150,272 180,260 Q 210,248 240,260 Q 270,272 300,260 Q 330,248 360,260"
+        fill="none" stroke="#3b82f6" stroke-width="3" opacity="0.6" stroke-linecap="round"/>
+  <path d="M 50,275 Q 80,263 110,275 Q 140,287 170,275 Q 200,263 230,275 Q 260,287 290,275 Q 320,263 350,275"
+        fill="none" stroke="#3b82f6" stroke-width="2.5" opacity="0.35" stroke-linecap="round"/>
+
+  <!-- TrueCourse text -->
+  <text x="200" y="310" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="700" fill="#1e3a5f" letter-spacing="3">TRUECOURSE</text>
+</svg>

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -1,0 +1,18 @@
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { Layout } from '@/components/Layout';
+import HomePage from '@/pages/HomePage';
+import TeamsPage from '@/pages/TeamsPage';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Layout>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/teams" element={<TeamsPage />} />
+          <Route path="*" element={<HomePage />} />
+        </Routes>
+      </Layout>
+    </BrowserRouter>
+  );
+}

--- a/apps/landing/src/components/AnalysisReports.tsx
+++ b/apps/landing/src/components/AnalysisReports.tsx
@@ -1,0 +1,285 @@
+import { useMemo, useState } from 'react';
+import { ArrowUpRight, FileText, Github, Star } from 'lucide-react';
+import { ANALYSIS_REPORTS, type AnalysisReport, type Severity } from '@/data/analyses';
+import { cn } from '@/lib/cn';
+import { useReveal } from '@/lib/useReveal';
+
+const FILTERS = ['All', 'TypeScript', 'JavaScript', 'Python'] as const;
+type Filter = (typeof FILTERS)[number];
+
+export function AnalysisReports() {
+  const [filter, setFilter] = useState<Filter>('All');
+
+  const reports = useMemo(() => {
+    if (filter === 'All') return ANALYSIS_REPORTS;
+    return ANALYSIS_REPORTS.filter((r) => r.language === filter);
+  }, [filter]);
+
+  return (
+    <section id="reports" className="relative border-b border-border py-24 sm:py-32">
+      <div className="bg-radial-glow absolute inset-x-0 top-0 -z-10 h-96 opacity-40" />
+
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="flex flex-col items-start justify-between gap-6 sm:flex-row sm:items-end">
+          <div className="max-w-2xl">
+            <p className="text-xs font-medium uppercase tracking-[0.18em] text-accent">
+              Field reports
+            </p>
+            <h2 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+              We pointed TrueCourse at the OSS world.
+              <span className="block text-muted-foreground">Here&apos;s what it found.</span>
+            </h2>
+            <p className="mt-4 text-pretty text-base leading-relaxed text-muted-foreground sm:text-lg">
+              Real codebases. No synthetic fixtures, no cherry-picked snippets. The same
+              checks we run on AI-generated changes, run end-to-end against repositories
+              you already know.
+            </p>
+          </div>
+
+          {/* Filter pills */}
+          <div className="flex flex-wrap items-center gap-1.5 rounded-xl border border-border bg-card/60 p-1 backdrop-blur-md">
+            {FILTERS.map((f) => (
+              <button
+                key={f}
+                type="button"
+                onClick={() => setFilter(f)}
+                className={cn(
+                  'rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+                  filter === f
+                    ? 'bg-foreground text-background'
+                    : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+                )}
+              >
+                {f}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-12 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {reports.map((report, i) => (
+            <ReportCard key={report.slug} report={report} delayMs={(i % 3) * 80} />
+          ))}
+        </div>
+
+        <div className="mt-10 flex items-center justify-center">
+          <a
+            href="https://github.com/truecourse-ai/truecourse"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-2 rounded-full border border-border bg-card/60 px-4 py-2 text-sm text-muted-foreground transition-colors hover:border-border-strong hover:text-foreground"
+          >
+            Want us to analyze your favorite OSS repo? Open an issue
+            <ArrowUpRight className="h-3.5 w-3.5" />
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ReportCard({ report, delayMs }: { report: AnalysisReport; delayMs: number }) {
+  const total =
+    report.totals.critical + report.totals.high + report.totals.medium + report.totals.low;
+  const { ref, visible } = useReveal<HTMLElement>();
+
+  return (
+    <article
+      ref={ref}
+      style={{ ['--delay' as string]: `${delayMs}ms` }}
+      className={cn(
+        'reveal surface surface-hover group relative flex flex-col rounded-2xl border border-border p-5',
+        report.featured && 'glow-border',
+        visible && 'visible',
+      )}
+    >
+      {report.featured && (
+        <span className="absolute right-4 top-4 rounded-full border border-accent/40 bg-accent/15 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-accent">
+          Featured
+        </span>
+      )}
+
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border bg-background/60">
+          <Github className="h-4.5 w-4.5 text-muted-foreground" />
+        </span>
+        <div className="min-w-0">
+          <a
+            href={report.repoUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="truncate font-mono text-sm font-medium hover:text-accent"
+          >
+            {report.repo}
+          </a>
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            {report.description}
+          </p>
+        </div>
+      </div>
+
+      {/* Meta row */}
+      <div className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[11px] text-muted-foreground">
+        <Meta icon={Star}>{report.stars}</Meta>
+        <Dot />
+        <span>{report.language}</span>
+        <Dot />
+        <span>{report.files.toLocaleString()} files</span>
+        <Dot />
+        <span>{report.loc} LOC</span>
+      </div>
+
+      {/* Severity bar */}
+      <div className="mt-5">
+        <div className="flex items-baseline justify-between">
+          <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            Findings
+          </span>
+          <span className="font-mono text-sm">
+            {total.toLocaleString()}
+            <span className="ml-1 text-muted-foreground">total</span>
+          </span>
+        </div>
+        <SeverityBar totals={report.totals} animateIn={visible} />
+        <div className="mt-2 grid grid-cols-4 gap-2 text-[10px] text-muted-foreground">
+          <Tally tone="rose" label="critical" value={report.totals.critical} />
+          <Tally tone="amber" label="high" value={report.totals.high} />
+          <Tally tone="sky" label="medium" value={report.totals.medium} />
+          <Tally tone="slate" label="low" value={report.totals.low} />
+        </div>
+      </div>
+
+      {/* Top findings */}
+      <div className="mt-5 flex-1">
+        <p className="text-[11px] uppercase tracking-wider text-muted-foreground">
+          Top findings
+        </p>
+        <ul className="mt-2 space-y-1.5">
+          {report.topFindings.slice(0, 4).map((f) => (
+            <li
+              key={f.rule}
+              className="flex items-center justify-between rounded-md border border-border bg-background/40 px-2.5 py-1.5"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <SeverityDot severity={f.severity} />
+                <span className="truncate font-mono text-xs">{f.rule}</span>
+              </div>
+              <span className="font-mono text-xs text-muted-foreground">{f.count}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Summary */}
+      <p className="mt-5 text-pretty text-sm leading-relaxed text-muted-foreground">
+        {report.summary}
+      </p>
+
+      {/* Footer */}
+      <div className="mt-5 flex items-center justify-between border-t border-border pt-4">
+        <span className="text-[11px] text-muted-foreground">
+          Analyzed{' '}
+          {new Date(report.analyzedAt).toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+          })}{' '}
+          · {report.duration}
+        </span>
+        <a
+          href={report.reportUrl ?? report.repoUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs font-medium text-foreground transition-colors hover:text-accent"
+        >
+          <FileText className="h-3.5 w-3.5" />
+          View report
+          <ArrowUpRight className="h-3.5 w-3.5" />
+        </a>
+      </div>
+    </article>
+  );
+}
+
+function Meta({ icon: Icon, children }: { icon: typeof Star; children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <Icon className="h-3 w-3" />
+      {children}
+    </span>
+  );
+}
+
+function Dot() {
+  return <span className="text-muted-foreground/60">·</span>;
+}
+
+function SeverityBar({
+  totals,
+  animateIn,
+}: {
+  totals: AnalysisReport['totals'];
+  animateIn: boolean;
+}) {
+  const total = totals.critical + totals.high + totals.medium + totals.low || 1;
+  const pct = (n: number) => (n / total) * 100;
+  const segments = [
+    { color: 'bg-rose-500', value: totals.critical },
+    { color: 'bg-amber-500', value: totals.high },
+    { color: 'bg-sky-500', value: totals.medium },
+    { color: 'bg-slate-500', value: totals.low },
+  ].filter((s) => s.value > 0);
+
+  return (
+    <div className="mt-2 flex h-1.5 w-full overflow-hidden rounded-full bg-muted/40">
+      {segments.map((seg, i) => (
+        <span
+          key={i}
+          className={cn('severity-fill h-full', seg.color)}
+          style={{
+            width: animateIn ? `${pct(seg.value)}%` : '0%',
+            ['--delay' as string]: `${250 + i * 110}ms`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Tally({
+  tone,
+  label,
+  value,
+}: {
+  tone: 'rose' | 'amber' | 'sky' | 'slate';
+  label: string;
+  value: number;
+}) {
+  const dot = {
+    rose: 'bg-rose-500',
+    amber: 'bg-amber-500',
+    sky: 'bg-sky-500',
+    slate: 'bg-slate-500',
+  }[tone];
+  return (
+    <span className="inline-flex items-center gap-1.5 truncate">
+      <span className={cn('h-1.5 w-1.5 rounded-full', dot)} />
+      <span className="truncate">
+        <span className="font-mono text-foreground">{value}</span> {label}
+      </span>
+    </span>
+  );
+}
+
+function SeverityDot({ severity }: { severity: Severity }) {
+  const tone =
+    severity === 'critical'
+      ? 'bg-rose-500 ring-rose-500/30'
+      : severity === 'high'
+        ? 'bg-amber-500 ring-amber-500/30'
+        : severity === 'medium'
+          ? 'bg-sky-500 ring-sky-500/30'
+          : 'bg-slate-500 ring-slate-500/30';
+  return <span className={cn('h-1.5 w-1.5 rounded-full ring-2', tone)} />;
+}

--- a/apps/landing/src/components/Capabilities.tsx
+++ b/apps/landing/src/components/Capabilities.tsx
@@ -1,0 +1,136 @@
+import {
+  Bug,
+  Compass,
+  Database,
+  Gauge,
+  Lock,
+  Network,
+  ShieldCheck,
+  Sparkles,
+  Wrench,
+} from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { useReveal } from '@/lib/useReveal';
+
+type Category = {
+  icon: typeof Network;
+  title: string;
+  blurb: string;
+  tag?: string;
+};
+
+const CATEGORIES: Category[] = [
+  {
+    icon: Compass,
+    title: 'Drift',
+    blurb:
+      'Business-logic drift, hallucinated APIs, fabricated imports, intent mismatch — the things AI gets confidently wrong.',
+    tag: 'Preview',
+  },
+  {
+    icon: Network,
+    title: 'Architecture',
+    blurb:
+      'Circular dependencies, layer violations, god modules, dead modules, tight coupling, cross-service imports.',
+  },
+  {
+    icon: Lock,
+    title: 'Security',
+    blurb:
+      'SQL injection, hardcoded secrets, eval usage, insecure random, XSS, path traversal, unsafe deserialization.',
+  },
+  {
+    icon: Bug,
+    title: 'Bugs',
+    blurb:
+      'Race conditions, type mismatches, mutable defaults, implicit optional, off-by-one, unchecked returns.',
+  },
+  {
+    icon: Wrench,
+    title: 'Code Quality',
+    blurb:
+      'Cognitive complexity, magic numbers, large functions, dead code, missing type hints, unused exports.',
+  },
+  {
+    icon: Gauge,
+    title: 'Performance',
+    blurb:
+      'N+1 queries, O(n²) loops, sync I/O in async paths, unnecessary allocations, missing pagination.',
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Reliability',
+    blurb:
+      'Unhandled promises, resource leaks, missing timeouts, swallowed exceptions, unsafe error handling.',
+  },
+  {
+    icon: Database,
+    title: 'Database',
+    blurb:
+      'Missing indexes, missing transactions, lazy loading in loops, raw SQL bypassing the ORM, schema drift.',
+  },
+  {
+    icon: Sparkles,
+    title: 'Style',
+    blurb:
+      'Import ordering, naming conventions, docstring completeness, formatting preferences.',
+  },
+];
+
+export function Capabilities() {
+  return (
+    <section id="capabilities" className="relative border-b border-border py-24 sm:py-32">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="max-w-2xl">
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-accent">
+            What we catch
+          </p>
+          <h2 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+            The bugs your AI is shipping every day.
+          </h2>
+          <p className="mt-4 text-pretty text-base leading-relaxed text-muted-foreground sm:text-lg">
+            <span className="text-foreground">1,200+ deterministic checks</span> running
+            in milliseconds.{' '}
+            <span className="text-foreground">100 LLM-powered checks</span> for the
+            semantic depth pattern-matchers can&apos;t reach: intent matching,
+            business-logic drift, reasoning about side effects. Whether the change came
+            from a human or a model, TrueCourse holds it to the same standard.
+          </p>
+        </div>
+
+        <div className="mt-12 grid grid-cols-1 gap-px overflow-hidden rounded-2xl border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
+          {CATEGORIES.map((cat, i) => (
+            <CategoryCard key={cat.title} cat={cat} delayMs={i * 60} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CategoryCard({ cat, delayMs }: { cat: Category; delayMs: number }) {
+  const { ref, visible } = useReveal<HTMLDivElement>();
+  return (
+    <div
+      ref={ref}
+      style={{ ['--delay' as string]: `${delayMs}ms` }}
+      className={cn(
+        'reveal group relative bg-background p-6 transition-colors hover:bg-card',
+        visible && 'visible',
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-card text-accent transition-transform group-hover:scale-110">
+          <cat.icon className="h-4.5 w-4.5" />
+        </span>
+        {cat.tag && (
+          <span className="rounded-full border border-accent/40 bg-accent/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-accent">
+            {cat.tag}
+          </span>
+        )}
+      </div>
+      <h3 className="mt-4 text-base font-semibold">{cat.title}</h3>
+      <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{cat.blurb}</p>
+    </div>
+  );
+}

--- a/apps/landing/src/components/Commercial.tsx
+++ b/apps/landing/src/components/Commercial.tsx
@@ -1,0 +1,260 @@
+import { useState } from 'react';
+import { ArrowRight, Check, Github, Loader2, ShieldCheck, Sparkles, Users } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { cn } from '@/lib/cn';
+
+const PERKS = [
+  {
+    icon: Github,
+    title: 'GitHub-native PR review',
+    body: 'Install the GitHub App once. Every PR gets reviewed automatically with line-by-line comments on hallucinations, fabricated APIs, and drift. Merge-blocking on critical findings, optional.',
+  },
+  {
+    icon: Users,
+    title: 'Team &amp; per-engineer insights',
+    body: 'See who&apos;s shipping, what&apos;s drifting, and where each engineer needs support. AI-generated ratio, drift caught at PR, findings escaped to main &mdash; per engineer, per team.',
+  },
+  {
+    icon: Sparkles,
+    title: 'Business-logic drift baselines',
+    body: 'Encode your specs once. Every AI-generated change is checked against them automatically. Drift gets surfaced before it lands.',
+  },
+  {
+    icon: ShieldCheck,
+    title: 'SSO &amp; audit logs',
+    body: 'SAML, SCIM, RBAC. The compliance controls you need to put TrueCourse on the path of every AI-written commit.',
+  },
+];
+
+export function Commercial() {
+  const [email, setEmail] = useState('');
+  const [company, setCompany] = useState('');
+  const [size, setSize] = useState<string>('');
+  // Honeypot — humans never see/touch this; bots usually fill any text input.
+  const [website, setWebsite] = useState('');
+  const [state, setState] = useState<'idle' | 'submitting' | 'done' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!email.trim() || !email.includes('@')) {
+      setError('Please enter a valid work email.');
+      return;
+    }
+    setState('submitting');
+    try {
+      const res = await fetch('/api/waitlist', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email, company, size, website }),
+      });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      setState('done');
+    } catch {
+      setState('error');
+      setError('Could not submit right now. Try again in a moment.');
+    }
+  };
+
+  return (
+    <section id="waitlist" className="relative scroll-mt-24 border-b border-border py-24 sm:py-32">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="grid gap-12 lg:grid-cols-[1.1fr_1fr] lg:gap-16">
+          {/* Left: pitch + perks */}
+          <div>
+            <p className="text-xs font-medium uppercase tracking-[0.18em] text-accent">
+              The teams plan
+            </p>
+            <h2 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+              Validate every line your AI ships.
+              <span className="block text-muted-foreground">Across every repo, every PR.</span>
+            </h2>
+            <p className="mt-5 text-pretty text-base leading-relaxed text-muted-foreground sm:text-lg">
+              PR review for AI-generated changes, business-logic drift baselines, org-wide
+              dashboards, SSO, audit logs, and a hosted control plane you don&apos;t have
+              to babysit. Drop your details and we&apos;ll be in touch when a slot opens.
+            </p>
+
+            <div className="mt-8 grid gap-4 sm:grid-cols-2">
+              {PERKS.map((p) => (
+                <div
+                  key={p.title}
+                  className="surface rounded-xl border border-border p-4 transition-colors hover:border-border-strong"
+                >
+                  <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-background/60 text-accent">
+                    <p.icon className="h-4 w-4" />
+                  </span>
+                  <h3
+                    className="mt-3 text-sm font-semibold"
+                    dangerouslySetInnerHTML={{ __html: p.title }}
+                  />
+                  <p
+                    className="mt-1.5 text-xs leading-relaxed text-muted-foreground"
+                    dangerouslySetInnerHTML={{ __html: p.body }}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Right: waitlist form */}
+          <div className="lg:sticky lg:top-24 lg:self-start">
+            <div className="glow-border surface rounded-2xl border border-border p-6 shadow-2xl shadow-black/40 sm:p-8">
+              {state === 'done' ? (
+                <SuccessState email={email} />
+              ) : (
+                <>
+                  <h3 className="text-xl font-semibold">Join the waitlist</h3>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    We&apos;re onboarding teams in waves. Drop your details and we&apos;ll
+                    be in touch when a slot opens.
+                  </p>
+
+                  <form onSubmit={onSubmit} className="mt-6 space-y-4">
+                    {/* Honeypot — hidden from users, attractive to spam bots */}
+                    <div
+                      aria-hidden
+                      style={{
+                        position: 'absolute',
+                        left: '-10000px',
+                        width: '1px',
+                        height: '1px',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <label htmlFor="website">Website (leave empty)</label>
+                      <input
+                        id="website"
+                        name="website"
+                        type="text"
+                        tabIndex={-1}
+                        autoComplete="off"
+                        value={website}
+                        onChange={(e) => setWebsite(e.target.value)}
+                      />
+                    </div>
+
+                    <Field label="Work email" htmlFor="email">
+                      <input
+                        id="email"
+                        type="email"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="you@company.com"
+                        autoComplete="email"
+                        className="block w-full rounded-lg border border-border bg-background/60 px-3.5 py-2.5 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-accent focus:ring-2 focus:ring-accent/30"
+                      />
+                    </Field>
+                    <Field label="Company" htmlFor="company">
+                      <input
+                        id="company"
+                        type="text"
+                        value={company}
+                        onChange={(e) => setCompany(e.target.value)}
+                        placeholder="Acme Inc."
+                        autoComplete="organization"
+                        className="block w-full rounded-lg border border-border bg-background/60 px-3.5 py-2.5 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-accent focus:ring-2 focus:ring-accent/30"
+                      />
+                    </Field>
+                    <Field label="Team size" htmlFor="size">
+                      <select
+                        id="size"
+                        value={size}
+                        onChange={(e) => setSize(e.target.value)}
+                        className="block w-full rounded-lg border border-border bg-background/60 px-3.5 py-2.5 text-sm outline-none transition-colors focus:border-accent focus:ring-2 focus:ring-accent/30"
+                      >
+                        <option value="">Select…</option>
+                        <option value="1-10">1 – 10 engineers</option>
+                        <option value="11-50">11 – 50</option>
+                        <option value="51-200">51 – 200</option>
+                        <option value="200+">200+</option>
+                      </select>
+                    </Field>
+
+                    {error && (
+                      <p className="rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
+                        {error}
+                      </p>
+                    )}
+
+                    <button
+                      type="submit"
+                      disabled={state === 'submitting'}
+                      className={cn(
+                        'inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg border border-accent/40 bg-accent/15 px-4 text-sm font-medium text-foreground transition-all hover:border-accent/60 hover:bg-accent/25',
+                        state === 'submitting'
+                          ? 'cursor-not-allowed opacity-70'
+                          : 'hover:-translate-y-0.5',
+                      )}
+                    >
+                      {state === 'submitting' ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          Submitting…
+                        </>
+                      ) : (
+                        <>
+                          Request access
+                          <ArrowRight className="h-4 w-4" />
+                        </>
+                      )}
+                    </button>
+                    <p className="text-center text-[11px] text-muted-foreground">
+                      We&apos;ll only use your email to talk about TrueCourse. No newsletters.
+                    </p>
+                  </form>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label htmlFor={htmlFor} className="block">
+      <span className="mb-1.5 block text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function SuccessState({ email }: { email: string }) {
+  return (
+    <div className="text-center">
+      <div className="mx-auto inline-flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-300">
+        <Check className="h-6 w-6" />
+      </div>
+      <h3 className="mt-4 text-xl font-semibold">You&apos;re on the list</h3>
+      <p className="mt-2 text-sm text-muted-foreground">
+        We&apos;ll reach out to{' '}
+        <span className="font-medium text-foreground">{email}</span> as soon as a slot opens
+        in the next onboarding wave. In the meantime, the open source CLI is yours to use today.
+      </p>
+      <Link
+        to="/#open-source"
+        className="mt-6 inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm transition-colors hover:border-border-strong"
+      >
+        Try the open source CLI
+        <ArrowRight className="h-4 w-4" />
+      </Link>
+    </div>
+  );
+}

--- a/apps/landing/src/components/Comparison.tsx
+++ b/apps/landing/src/components/Comparison.tsx
@@ -1,0 +1,119 @@
+import { Check, Minus } from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { useReveal } from '@/lib/useReveal';
+
+type Cell = boolean | string;
+type Row = { feature: string; oss: Cell; teams: Cell; hint?: string };
+
+const ROWS: Row[] = [
+  { feature: '1,200+ deterministic checks', oss: true, teams: true },
+  { feature: '100 LLM-powered checks', oss: true, teams: true },
+  { feature: 'Local CLI &amp; dashboard', oss: true, teams: true },
+  { feature: 'Diff mode (review only AI-changed lines)', oss: true, teams: true },
+  { feature: 'Pre-commit hook', oss: true, teams: true },
+  { feature: 'TS / JS / Python support', oss: true, teams: true },
+  { feature: 'Per-repo config in git', oss: true, teams: true },
+  { feature: 'Hallucinated-API &amp; fabricated-import detection', oss: true, teams: true },
+  { feature: 'Business-logic drift detection', oss: 'CLI preview', teams: 'PR + dashboard' },
+  { feature: 'GitHub App (auto-review every PR)', oss: false, teams: true },
+  { feature: 'Inline PR comments on findings', oss: false, teams: true },
+  { feature: 'Merge-blocking on critical findings', oss: false, teams: true },
+  { feature: 'Org &amp; team visibility dashboard', oss: false, teams: true },
+  { feature: 'Per-engineer insights (PRs, drift, AI ratio)', oss: false, teams: true },
+  { feature: 'Hosted control plane', oss: false, teams: true },
+  { feature: 'SSO (SAML, SCIM)', oss: false, teams: true },
+  { feature: 'Role-based access control', oss: false, teams: true },
+  { feature: 'Audit logs', oss: false, teams: true },
+  { feature: 'Custom rules &amp; LLM tuning', oss: false, teams: 'With our team' },
+  { feature: 'Priority support &amp; SLAs', oss: 'Community', teams: 'Email + Slack' },
+];
+
+export function Comparison() {
+  const table = useReveal<HTMLDivElement>({ threshold: 0.05 });
+  return (
+    <section className="relative border-b border-border py-24 sm:py-32">
+      <div className="mx-auto max-w-5xl px-4 sm:px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-accent">
+            What changes
+          </p>
+          <h2 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+            Open source vs. teams.
+          </h2>
+          <p className="mt-4 text-pretty text-base leading-relaxed text-muted-foreground sm:text-lg">
+            The CLI stays open source forever. Teams adds the org-level surface area
+            engineering leaders need, without forcing your code into a SaaS.
+          </p>
+        </div>
+
+        <div
+          ref={table.ref}
+          className={cn(
+            'surface reveal mt-12 overflow-hidden rounded-2xl border border-border',
+            table.visible && 'visible',
+          )}
+        >
+          {/* Header row */}
+          <div className="grid grid-cols-[1.4fr_1fr_1fr] border-b border-border bg-background/30">
+            <div className="px-5 py-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              Feature
+            </div>
+            <div className="border-l border-border px-5 py-4">
+              <div className="text-sm font-semibold">Open source</div>
+              <div className="text-[11px] text-muted-foreground">Free forever &middot; MIT</div>
+            </div>
+            <div className="border-l border-border px-5 py-4">
+              <div className="text-sm font-semibold text-gradient-accent inline-block">
+                Teams
+              </div>
+              <div className="text-[11px] text-muted-foreground">Closed beta</div>
+            </div>
+          </div>
+
+          {/* Rows */}
+          {ROWS.map((row, i) => (
+            <div
+              key={row.feature}
+              className={cn(
+                'grid grid-cols-[1.4fr_1fr_1fr] items-center text-sm transition-colors hover:bg-muted/20',
+                i !== ROWS.length - 1 && 'border-b border-border',
+              )}
+            >
+              <div
+                className="px-5 py-3.5 text-foreground/90"
+                dangerouslySetInnerHTML={{ __html: row.feature }}
+              />
+              <CellView value={row.oss} />
+              <CellView value={row.teams} highlight />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CellView({ value, highlight }: { value: Cell; highlight?: boolean }) {
+  return (
+    <div className="border-l border-border px-5 py-3.5">
+      {value === true ? (
+        <span
+          className={cn(
+            'inline-flex h-5 w-5 items-center justify-center rounded-full',
+            highlight
+              ? 'bg-accent/15 text-accent ring-1 ring-inset ring-accent/30'
+              : 'bg-emerald-500/15 text-emerald-300 ring-1 ring-inset ring-emerald-500/25',
+          )}
+        >
+          <Check className="h-3 w-3" />
+        </span>
+      ) : value === false ? (
+        <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted/40 text-muted-foreground ring-1 ring-inset ring-border">
+          <Minus className="h-3 w-3" />
+        </span>
+      ) : (
+        <span className="text-xs text-muted-foreground">{value}</span>
+      )}
+    </div>
+  );
+}

--- a/apps/landing/src/components/Footer.tsx
+++ b/apps/landing/src/components/Footer.tsx
@@ -1,0 +1,134 @@
+import { Github, Mail } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+export function Footer() {
+  return (
+    <footer className="relative overflow-hidden">
+      <div className="bg-radial-glow absolute inset-x-0 -top-32 -z-10 h-64 opacity-50" />
+      <div className="mx-auto max-w-6xl px-4 py-16 sm:px-6">
+        <div className="grid gap-10 md:grid-cols-[1.4fr_1fr_1fr_1fr]">
+          <div>
+            <div className="flex items-center gap-2.5">
+              <img src="/logo.svg" alt="" className="h-7 w-7" />
+              <span className="text-base font-semibold tracking-tight">TrueCourse</span>
+            </div>
+            <p className="mt-4 max-w-sm text-sm leading-relaxed text-muted-foreground">
+              The validation layer for AI-generated code. Open source, local-first, and
+              built for the speed your models code at.
+            </p>
+            <div className="mt-5 flex items-center gap-2">
+              <a
+                href="https://github.com/truecourse-ai/truecourse"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:border-border-strong hover:text-foreground"
+                aria-label="GitHub"
+              >
+                <Github className="h-4 w-4" />
+              </a>
+              <a
+                href="mailto:mushegh@truecourse.dev"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:border-border-strong hover:text-foreground"
+                aria-label="Email"
+              >
+                <Mail className="h-4 w-4" />
+              </a>
+            </div>
+          </div>
+
+          <Column
+            title="Product"
+            links={[
+              { href: '/#open-source', label: 'Open source' },
+              { href: '/teams', label: 'For teams' },
+              { href: '/#capabilities', label: 'What it catches' },
+              // Hidden until we have real OSS analysis reports — see HomePage.tsx for the matching toggle.
+              // { href: '/#reports', label: 'Field reports' },
+            ]}
+          />
+          <Column
+            title="Resources"
+            links={[
+              { href: 'https://github.com/truecourse-ai/truecourse', label: 'GitHub' },
+              { href: 'https://www.npmjs.com/package/truecourse', label: 'npm' },
+              {
+                href: 'https://github.com/truecourse-ai/truecourse#readme',
+                label: 'Documentation',
+              },
+              { href: 'mailto:mushegh@truecourse.dev', label: 'Contact' },
+            ]}
+          />
+          <Column
+            title="Legal"
+            links={[
+              {
+                href: 'https://github.com/truecourse-ai/truecourse/blob/main/LICENSE',
+                label: 'License (MIT)',
+              },
+              {
+                href: 'https://github.com/truecourse-ai/truecourse/blob/main/CODE_OF_CONDUCT.md',
+                label: 'Code of conduct',
+              },
+            ]}
+          />
+        </div>
+
+        <div className="mt-12 flex flex-col items-start justify-between gap-4 border-t border-border pt-6 sm:flex-row sm:items-center">
+          <div className="text-xs text-muted-foreground">
+            <p>
+              © {new Date().getFullYear()} TrueCourse AI, Inc. &middot; MIT licensed.
+            </p>
+            <p className="mt-1">
+              2261 Market Street STE 88087, San Francisco, CA 94114 US
+            </p>
+          </div>
+          <p className="text-xs text-muted-foreground sm:text-right">
+            Built with TypeScript and tree-sitter.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function Column({
+  title,
+  links,
+}: {
+  title: string;
+  links: { href: string; label: string }[];
+}) {
+  return (
+    <div>
+      <h4 className="text-[11px] font-medium uppercase tracking-wider text-foreground">
+        {title}
+      </h4>
+      <ul className="mt-4 space-y-2.5">
+        {links.map((l) => {
+          const className =
+            'text-sm text-muted-foreground transition-colors hover:text-foreground';
+          const isInternal = l.href.startsWith('/');
+          return (
+            <li key={l.href}>
+              {isInternal ? (
+                <Link to={l.href} className={className}>
+                  {l.label}
+                </Link>
+              ) : (
+                <a
+                  href={l.href}
+                  className={className}
+                  {...(l.href.startsWith('http')
+                    ? { target: '_blank', rel: 'noreferrer' }
+                    : {})}
+                >
+                  {l.label}
+                </a>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/landing/src/components/Header.tsx
+++ b/apps/landing/src/components/Header.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react';
+import { Github, Menu, X } from 'lucide-react';
+import { Link, useLocation } from 'react-router-dom';
+import { cn } from '@/lib/cn';
+
+type NavItem = { href: string; label: string; external?: boolean };
+
+const NAV: NavItem[] = [
+  { href: '/#open-source', label: 'Open Source' },
+  // Hidden until we have real OSS analysis reports — see HomePage.tsx for the matching toggle.
+  // { href: '/#reports', label: 'Reports' },
+  { href: '/#capabilities', label: 'What it catches' },
+  { href: '/teams', label: 'For teams' },
+];
+
+export function Header() {
+  const [scrolled, setScrolled] = useState(false);
+  const [open, setOpen] = useState(false);
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 8);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  return (
+    <header
+      className={cn(
+        'fixed inset-x-0 top-0 z-50 transition-all duration-300',
+        scrolled
+          ? 'border-b border-border bg-background/70 backdrop-blur-xl'
+          : 'border-b border-transparent',
+      )}
+    >
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6">
+        <Link
+          to="/"
+          onClick={(e) => {
+            // Same-page click: react-router won't re-mount, so no Layout effect fires.
+            // Prevent default and scroll explicitly. On a different page, let the
+            // Link navigate normally; Layout's pathname effect handles the scroll.
+            if (pathname === '/') {
+              e.preventDefault();
+              window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+            }
+          }}
+          className="flex items-center gap-2.5"
+        >
+          <img src="/logo.svg" alt="" className="h-7 w-7" />
+          <span className="text-base font-semibold tracking-tight">TrueCourse</span>
+          <span className="ml-1 hidden rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[10px] font-medium tracking-wider text-muted-foreground sm:inline-block">
+            BETA
+          </span>
+        </Link>
+
+        <nav className="hidden items-center gap-1 md:flex">
+          {NAV.map((item) => (
+            <NavLink key={item.href} item={item} />
+          ))}
+        </nav>
+
+        <div className="flex items-center gap-2">
+          <a
+            href="https://github.com/truecourse-ai/truecourse"
+            target="_blank"
+            rel="noreferrer"
+            className="hidden h-9 items-center gap-2 rounded-md border border-border px-3 text-sm text-muted-foreground transition-colors hover:border-border-strong hover:text-foreground sm:inline-flex"
+          >
+            <Github className="h-4 w-4" />
+            GitHub
+          </a>
+          <Link
+            to="/teams#waitlist"
+            className="hidden h-9 items-center rounded-md bg-foreground px-3.5 text-sm font-medium text-background transition-opacity hover:opacity-90 sm:inline-flex"
+          >
+            Join waitlist
+          </Link>
+          <button
+            type="button"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border md:hidden"
+            onClick={() => setOpen((v) => !v)}
+            aria-label="Menu"
+          >
+            {open ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+          </button>
+        </div>
+      </div>
+
+      {open && (
+        <div className="border-t border-border bg-background/95 backdrop-blur-xl md:hidden">
+          <nav className="mx-auto flex max-w-6xl flex-col px-4 py-3 sm:px-6">
+            {NAV.map((item) => (
+              <NavLink key={item.href} item={item} mobile onNavigate={() => setOpen(false)} />
+            ))}
+            <a
+              href="https://github.com/truecourse-ai/truecourse"
+              target="_blank"
+              rel="noreferrer"
+              className="mt-1 flex items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+            >
+              <Github className="h-4 w-4" />
+              GitHub
+            </a>
+          </nav>
+        </div>
+      )}
+    </header>
+  );
+}
+
+function NavLink({
+  item,
+  mobile,
+  onNavigate,
+}: {
+  item: NavItem;
+  mobile?: boolean;
+  onNavigate?: () => void;
+}) {
+  const cls = cn(
+    'rounded-md text-sm transition-colors',
+    mobile
+      ? 'px-3 py-2 text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+      : 'px-3 py-1.5 text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+  );
+
+  // Hash links to home page sections — let react-router handle them so the
+  // Layout's scroll-to-hash effect runs on navigation.
+  if (item.href.startsWith('/#')) {
+    return (
+      <Link to={item.href} onClick={onNavigate} className={cls}>
+        {item.label}
+      </Link>
+    );
+  }
+
+  return (
+    <Link to={item.href} onClick={onNavigate} className={cls}>
+      {item.label}
+    </Link>
+  );
+}

--- a/apps/landing/src/components/Hero.tsx
+++ b/apps/landing/src/components/Hero.tsx
@@ -1,0 +1,362 @@
+import { useState } from 'react';
+import { ArrowRight, Check, Copy, Sparkles, Terminal } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { cn } from '@/lib/cn';
+
+const INSTALL = 'npx truecourse analyze';
+
+export function Hero() {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard?.writeText(INSTALL).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    });
+  };
+
+  return (
+    <section
+      id="top"
+      className="relative isolate overflow-hidden border-b border-border pt-32 pb-24 sm:pt-40 sm:pb-32"
+    >
+      <div className="bg-radial-glow absolute inset-0 -z-10" />
+      <div className="bg-grid absolute inset-0 -z-10" />
+
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="mx-auto max-w-3xl text-center">
+          <Link
+            to="/#capabilities"
+            style={{ ['--delay' as string]: '0ms' }}
+            className="animate-fade-up animate-pulse-ring mx-auto inline-flex items-center gap-2 rounded-full border border-border bg-card/60 px-3 py-1 text-xs text-muted-foreground backdrop-blur-md transition-colors hover:border-border-strong hover:text-foreground"
+          >
+            <Sparkles className="h-3 w-3 text-accent" />
+            New &middot; business-logic drift detection (preview)
+            <ArrowRight className="h-3 w-3" />
+          </Link>
+
+          <h1
+            style={{ ['--delay' as string]: '80ms' }}
+            className="animate-fade-up mt-6 text-balance text-5xl font-semibold leading-[1.05] tracking-tight sm:text-6xl md:text-7xl"
+          >
+            <span className="text-gradient">AI writes the code.</span>
+            <br />
+            <span className="text-gradient-accent">We catch what it gets wrong.</span>
+          </h1>
+
+          <p
+            style={{ ['--delay' as string]: '200ms' }}
+            className="animate-fade-up mx-auto mt-6 max-w-2xl text-pretty text-lg leading-relaxed text-muted-foreground sm:text-xl"
+          >
+            Hallucinated APIs. Fabricated function calls. Plausible-looking logic that
+            quietly drifts from what you actually asked for. TrueCourse is the validation
+            layer for AI-generated code. It cross-checks every change against your
+            business logic and your codebase{' '}
+            <span className="text-foreground/80">before it ships</span>, not after the
+            on-call page.
+          </p>
+
+          {/* Install / CTA */}
+          <div
+            style={{ ['--delay' as string]: '320ms' }}
+            className="animate-fade-up mx-auto mt-10 flex max-w-2xl flex-col items-center gap-4 sm:flex-row sm:justify-center"
+          >
+            <button
+              type="button"
+              onClick={copy}
+              className={cn(
+                'glow-border group relative flex h-12 w-full max-w-md items-center gap-3 rounded-xl border border-border bg-card/80 px-4 text-left font-mono text-sm shadow-2xl shadow-black/40 backdrop-blur-md transition-all sm:w-auto',
+                'hover:border-border-strong',
+              )}
+            >
+              <Terminal className="h-4 w-4 shrink-0 text-accent" />
+              <span className="flex-1 truncate">
+                <span className="text-muted-foreground">$ </span>
+                {INSTALL}
+              </span>
+              <span
+                className={cn(
+                  'inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-background/60 text-muted-foreground transition-colors',
+                  copied && 'border-emerald-500/40 text-emerald-400',
+                )}
+                aria-hidden
+              >
+                {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+              </span>
+            </button>
+
+            <Link
+              to="/teams#waitlist"
+              className="group inline-flex h-12 items-center gap-2 rounded-xl border border-accent/40 bg-accent/15 px-5 text-sm font-medium text-foreground backdrop-blur-md transition-all hover:-translate-y-0.5 hover:border-accent/60 hover:bg-accent/25"
+            >
+              Join the teams waitlist
+              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+            </Link>
+          </div>
+
+          <p
+            style={{ ['--delay' as string]: '420ms' }}
+            className="animate-fade-up mt-4 text-xs text-muted-foreground"
+          >
+            Open source MIT &middot; Works on TypeScript, JavaScript, Python &middot; Zero config
+          </p>
+        </div>
+
+        {/* Hero preview */}
+        <div style={{ ['--delay' as string]: '520ms' }} className="animate-fade-up">
+          <HeroPreview />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function HeroPreview() {
+  return (
+    <div className="relative mx-auto mt-16 max-w-5xl">
+      {/* Halo */}
+      <div className="bg-radial-glow absolute -inset-x-12 -top-10 -bottom-10 -z-10 opacity-60 blur-3xl" />
+
+      <div className="glow-border overflow-hidden rounded-2xl border border-border bg-card/80 shadow-2xl shadow-black/50 backdrop-blur-md">
+        {/* Window chrome */}
+        <div className="flex items-center justify-between border-b border-border bg-background/40 px-4 py-2.5">
+          <div className="flex items-center gap-1.5">
+            <span className="h-2.5 w-2.5 rounded-full bg-red-500/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-yellow-500/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-emerald-500/70" />
+          </div>
+          <div className="font-mono text-xs text-muted-foreground">
+            ~/projects/sample-project · truecourse analyze
+          </div>
+          <div className="w-12" />
+        </div>
+
+        <div className="grid gap-0 md:grid-cols-[1.1fr_1fr]">
+          {/* Terminal — matches the real clack-formatted CLI output */}
+          <ClackTerminal />
+
+          {/* Top findings panel — what `truecourse list` would surface */}
+          <div className="bg-background/40 p-5">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-medium">Top findings &middot; sample-project</h3>
+              <span className="rounded-full bg-rose-500/10 px-2 py-0.5 text-[10px] font-medium text-rose-300">
+                197 TOTAL
+              </span>
+            </div>
+            <ul className="mt-3 space-y-2.5">
+              <Finding
+                severity="critical"
+                rule="business-logic-drift"
+                file="billing/refund.ts"
+                category="Drift"
+              />
+              <Finding
+                severity="high"
+                rule="hardcoded-secret"
+                file="auth/jwt.ts"
+                category="Security"
+              />
+              <Finding
+                severity="high"
+                rule="circular-dependency"
+                file="billing/usage.ts"
+                category="Architecture"
+              />
+              <Finding
+                severity="high"
+                rule="unhandled-promise"
+                file="workers/cron.ts"
+                category="Reliability"
+              />
+            </ul>
+            <div className="mt-4 rounded-lg border border-border bg-card/60 px-3 py-2 text-[11px] text-muted-foreground">
+              <span className="text-foreground">Tip:</span> install the pre-commit hook
+              so new high-severity findings never reach main.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Condensed render of the real `truecourse analyze` clack-formatted output.
+ * Frame glyphs, strings, and indentation match the actual CLI; interactive
+ * prompts are stripped so the preview stays scannable for visitors.
+ */
+function ClackTerminal() {
+  return (
+    <div className="border-b border-border p-5 font-mono text-[12.5px] leading-[1.55] md:border-b-0 md:border-r">
+      {/* Prompt */}
+      <div className="flex">
+        <span className="text-muted-foreground">$&nbsp;</span>
+        <span className="text-foreground">npx truecourse analyze</span>
+      </div>
+
+      <div className="mt-1.5">
+        {/* Intro */}
+        <FrameLine glyph="┌">
+          <span className="text-foreground">Analyzing repository</span>
+        </FrameLine>
+        <FrameLine glyph="│" />
+
+        {/* Repo */}
+        <FrameLine glyph="◇">
+          <span className="text-muted-foreground">Repository:</span>{' '}
+          <span className="text-foreground">sample-project</span>
+        </FrameLine>
+        <FrameLine glyph="│" />
+
+        {/* Inline progress: parse + scan */}
+        <ProgressLine label="Parsing repository" value="3 services, 20 files" />
+        <ProgressLine label="Scanning files" value="20 files" />
+        <FrameLine glyph="│" />
+
+        {/* Category checks (incl. business-logic drift preview) */}
+        <ProgressLine label="Security checks" value="3 violations" tone="warn" />
+        <ProgressLine label="Bugs checks" value="2 violations" tone="warn" />
+        <ProgressLine label="Architecture checks" value="24 violations" tone="warn" />
+        <ProgressLine label="Performance checks" value="Clean" tone="ok" />
+        <ProgressLine label="Reliability checks" value="5 violations" tone="warn" />
+        <ProgressLine label="Code quality checks" value="156 violations" tone="warn" />
+        <ProgressLine label="Database checks" value="1 violation" tone="warn" />
+        <ProgressLine label="Style checks" value="2 violations" tone="warn" />
+        <ProgressLine label="Business-logic drift" value="4 violations" tone="warn" />
+        <ProgressLine label="Saving results" value="Done" tone="ok" />
+
+        <FrameLine glyph="│" />
+
+        {/* Final success */}
+        <FrameLine glyph="◆">
+          <span className="text-foreground">Analysis complete</span>
+        </FrameLine>
+        <RawLine />
+        <RawLine>
+          <span className="text-foreground">197 violations</span>{' '}
+          <span className="text-muted-foreground">(</span>
+          <span className="text-rose-500">1 critical</span>
+          <span className="text-muted-foreground">, </span>
+          <span className="text-rose-400">6 high</span>
+          <span className="text-muted-foreground">, </span>
+          <span className="text-amber-400">114 medium</span>
+          <span className="text-muted-foreground">, </span>
+          <span className="text-amber-300">76 low</span>
+          <span className="text-muted-foreground">)</span>
+        </RawLine>
+        <RawLine />
+
+        <FrameLine glyph="│" />
+        <FrameLine glyph="●" glyphClass="text-sky-400">
+          <span className="text-muted-foreground">Run</span>{' '}
+          <span className="text-foreground">`truecourse list`</span>{' '}
+          <span className="text-muted-foreground">to see full details.</span>
+        </FrameLine>
+        <FrameLine glyph="│" />
+        <FrameLine glyph="└">
+          <span className="text-muted-foreground">
+            Analysis complete — view results with:
+          </span>{' '}
+          <span className="text-foreground">truecourse dashboard</span>
+        </FrameLine>
+      </div>
+
+      {/* Blinking prompt */}
+      <div className="mt-2 flex items-center">
+        <span className="text-muted-foreground">$&nbsp;</span>
+        <span
+          className="animate-blink ml-0.5 inline-block h-3 w-1.5 translate-y-0.5 bg-emerald-400"
+          aria-hidden
+        />
+      </div>
+    </div>
+  );
+}
+
+function FrameLine({
+  glyph,
+  glyphClass = 'text-cyan-400/80',
+  children,
+}: {
+  glyph: string;
+  glyphClass?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="flex">
+      <span className={cn('w-5 shrink-0', glyphClass)}>{glyph}</span>
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+    </div>
+  );
+}
+
+function RawLine({ children }: { children?: React.ReactNode }) {
+  return (
+    <div className="flex">
+      <span className="w-5 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+    </div>
+  );
+}
+
+/** Progress line with the inline ● bullet and a `label — value` body. */
+function ProgressLine({
+  label,
+  value,
+  tone = 'ok',
+}: {
+  label: string;
+  value: string;
+  tone?: 'ok' | 'warn';
+}) {
+  return (
+    <div className="flex">
+      <span className="w-5 shrink-0 pl-2 text-muted-foreground/70">●</span>
+      <span className="min-w-0 flex-1 truncate">
+        <span className="text-foreground">{label}</span>{' '}
+        <span className="text-muted-foreground">—</span>{' '}
+        <span className={tone === 'warn' ? 'text-amber-200' : 'text-emerald-300'}>
+          {value}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function Finding({
+  severity,
+  rule,
+  file,
+  category,
+}: {
+  severity: 'critical' | 'high' | 'medium' | 'low';
+  rule: string;
+  file: string;
+  category: string;
+}) {
+  const tone =
+    severity === 'critical'
+      ? 'bg-rose-600/20 text-rose-200 ring-rose-500/40'
+      : severity === 'high'
+        ? 'bg-rose-500/15 text-rose-300 ring-rose-500/25'
+        : severity === 'medium'
+          ? 'bg-amber-500/15 text-amber-200 ring-amber-500/25'
+          : 'bg-sky-500/15 text-sky-300 ring-sky-500/25';
+  return (
+    <li className="rounded-lg border border-border bg-card/40 p-2.5 transition-colors hover:border-border-strong">
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className={cn(
+            'rounded px-1.5 py-0.5 text-[10px] font-medium uppercase ring-1 ring-inset',
+            tone,
+          )}
+        >
+          {severity}
+        </span>
+        <span className="font-mono text-[11px] text-muted-foreground">{category}</span>
+      </div>
+      <div className="mt-1.5 font-mono text-[12.5px]">{rule}</div>
+      <div className="font-mono text-[11px] text-muted-foreground">{file}</div>
+    </li>
+  );
+}

--- a/apps/landing/src/components/Layout.tsx
+++ b/apps/landing/src/components/Layout.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { Header } from '@/components/Header';
+import { Footer } from '@/components/Footer';
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  const { pathname, hash } = useLocation();
+
+  useEffect(() => {
+    if (hash) {
+      const el = document.getElementById(hash.slice(1));
+      if (el) {
+        el.scrollIntoView({ behavior: 'instant', block: 'start' });
+        return;
+      }
+    }
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+  }, [pathname, hash]);
+
+  return (
+    <div className="relative min-h-screen bg-background text-foreground">
+      <Header />
+      <main>{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/landing/src/components/OpenSource.tsx
+++ b/apps/landing/src/components/OpenSource.tsx
@@ -1,0 +1,174 @@
+import {
+  ArrowRight,
+  Check,
+  FileCode2,
+  GitPullRequest,
+  Github,
+  Server,
+  Star,
+  Terminal,
+} from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { useReveal } from '@/lib/useReveal';
+
+const FEATURES = [
+  'CLI: analyze, list, diff, hooks, rules',
+  'Diff mode that scopes review to the lines AI just changed',
+  'Pre-commit hook that blocks new high-severity findings',
+  'Per-repo rule toggles committed in .truecourse/config.json',
+  'Tree-sitter AST + Claude Code LLM-powered checks',
+  'Business-logic drift detection (preview)',
+  'TypeScript, JavaScript, Python (more languages coming)',
+  'Claude Code Skills for conversational review',
+];
+
+export function OpenSource() {
+  const left = useReveal<HTMLDivElement>();
+  const right = useReveal<HTMLDivElement>();
+  return (
+    <section id="open-source" className="relative border-b border-border py-24 sm:py-32">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="grid gap-12 lg:grid-cols-[1fr_1.05fr] lg:gap-16">
+          {/* Left: pitch */}
+          <div ref={left.ref} className={cn('reveal', left.visible && 'visible')}>
+            <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-3 py-1 text-xs font-medium text-emerald-200">
+              <Check className="h-3 w-3" />
+              Free forever &middot; MIT license
+            </div>
+            <h2 className="mt-4 text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+              The open source CLI &amp; dashboard.
+              <span className="block text-gradient-accent">Yours to run, fork, ship.</span>
+            </h2>
+            <p className="mt-5 text-pretty text-base leading-relaxed text-muted-foreground sm:text-lg">
+              Everything you need to validate a codebase end-to-end is on npm. The CLI
+              runs locally and the dashboard runs locally. Your code, your prompts, and
+              your business-logic specs never leave your machine unless you explicitly
+              enable LLM checks.
+            </p>
+
+            {/* Install */}
+            <div className="mt-8 space-y-3">
+              <CommandRow
+                label="One-shot analyze"
+                cmd="npx truecourse analyze"
+              />
+              <CommandRow label="Open the dashboard" cmd="npx truecourse dashboard" />
+              <CommandRow label="Install the pre-commit hook" cmd="truecourse hooks install" />
+            </div>
+
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <a
+                href="https://github.com/truecourse-ai/truecourse"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex h-11 items-center gap-2 rounded-lg border border-border bg-card px-4 text-sm font-medium transition-colors hover:border-border-strong"
+              >
+                <Github className="h-4 w-4" />
+                Star on GitHub
+                <span className="ml-1 inline-flex items-center gap-1 rounded-md border border-border bg-background/50 px-1.5 py-0.5 text-xs text-muted-foreground">
+                  <Star className="h-3 w-3" />
+                  ★
+                </span>
+              </a>
+              <a
+                href="https://www.npmjs.com/package/truecourse"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex h-11 items-center gap-2 rounded-lg border border-accent/40 bg-accent/15 px-4 text-sm font-medium text-foreground transition-all hover:-translate-y-0.5 hover:border-accent/60 hover:bg-accent/25"
+              >
+                View on npm
+                <ArrowRight className="h-4 w-4" />
+              </a>
+            </div>
+          </div>
+
+          {/* Right: feature checklist + stats card */}
+          <div
+            ref={right.ref}
+            style={{ ['--delay' as string]: '120ms' }}
+            className={cn('reveal grid gap-4', right.visible && 'visible')}
+          >
+            <div className="surface rounded-2xl border border-border p-6">
+              <div className="grid grid-cols-3 gap-4">
+                <Stat icon={FileCode2} label="Files / sec" value="~300" />
+                <Stat icon={Server} label="No backend" value="Local" />
+                <Stat icon={GitPullRequest} label="PR-aware" value="Diff" />
+              </div>
+
+              <div className="mt-6 grid gap-2.5 sm:grid-cols-2">
+                {FEATURES.map((line) => (
+                  <div
+                    key={line}
+                    className="flex items-start gap-2.5 rounded-lg border border-border bg-background/40 p-3 text-sm text-muted-foreground transition-colors hover:border-border-strong"
+                  >
+                    <span className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-300">
+                      <Check className="h-2.5 w-2.5" />
+                    </span>
+                    <span>{line}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="surface flex items-start gap-3 rounded-2xl border border-border p-5">
+              <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-card text-accent">
+                <Terminal className="h-4 w-4" />
+              </span>
+              <div className="text-sm leading-relaxed text-muted-foreground">
+                <p className="font-medium text-foreground">Designed for the terminal first.</p>
+                <p className="mt-1">
+                  The dashboard is optional. <code className="font-mono text-xs text-foreground">truecourse list</code>{' '}
+                  prints findings the way <code className="font-mono text-xs text-foreground">grep</code> would:
+                  fast, scriptable, CI-friendly.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CommandRow({ label, cmd }: { label: string; cmd: string }) {
+  return (
+    <div className="surface group flex items-center justify-between gap-4 rounded-xl border border-border px-4 py-3">
+      <div>
+        <div className="text-[11px] uppercase tracking-wider text-muted-foreground">
+          {label}
+        </div>
+        <div className="mt-0.5 font-mono text-sm">
+          <span className="text-muted-foreground">$ </span>
+          {cmd}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => navigator.clipboard?.writeText(cmd)}
+        className="rounded-md border border-border px-2 py-1 text-[11px] text-muted-foreground transition-colors group-hover:border-border-strong group-hover:text-foreground"
+      >
+        Copy
+      </button>
+    </div>
+  );
+}
+
+function Stat({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof FileCode2;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-background/40 p-4">
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <Icon className="h-4 w-4" />
+        <span className="text-[11px] uppercase tracking-wider">{label}</span>
+      </div>
+      <div className="mt-2 font-mono text-xl font-medium">{value}</div>
+    </div>
+  );
+}

--- a/apps/landing/src/components/TeamInsights.tsx
+++ b/apps/landing/src/components/TeamInsights.tsx
@@ -1,0 +1,289 @@
+import {
+  Activity,
+  ArrowDownRight,
+  ArrowUpRight,
+  Github,
+  Minus,
+  Users,
+} from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { useReveal } from '@/lib/useReveal';
+
+type Trend = 'up' | 'down' | 'flat';
+
+type Engineer = {
+  handle: string;
+  prs: number;
+  caught: number;
+  escaped: number;
+  aiPct: number;
+  trend: Trend;
+};
+
+const ENGINEERS: Engineer[] = [
+  { handle: 'jhonny.l', prs: 31, caught: 19, escaped: 2, aiPct: 81, trend: 'up' },
+  { handle: 'ari.k', prs: 24, caught: 12, escaped: 0, aiPct: 68, trend: 'up' },
+  { handle: 'maya.r', prs: 18, caught: 7, escaped: 1, aiPct: 52, trend: 'flat' },
+  { handle: 'sam.p', prs: 14, caught: 4, escaped: 0, aiPct: 41, trend: 'down' },
+  { handle: 'priya.v', prs: 22, caught: 9, escaped: 1, aiPct: 58, trend: 'up' },
+  { handle: 'tom.w', prs: 11, caught: 3, escaped: 0, aiPct: 47, trend: 'flat' },
+];
+
+const REPOS = [
+  { name: 'web-app', prs: 48, caught: 22 },
+  { name: 'api-gateway', prs: 31, caught: 14 },
+  { name: 'billing-service', prs: 19, caught: 8 },
+  { name: 'data-pipeline', prs: 24, caught: 11 },
+  { name: 'mobile', prs: 16, caught: 5 },
+  { name: 'docs', prs: 4, caught: 0 },
+];
+
+export function TeamInsights() {
+  const left = useReveal<HTMLDivElement>();
+  const right = useReveal<HTMLDivElement>();
+
+  return (
+    <section className="relative border-b border-border py-24 sm:py-32">
+      <div className="bg-radial-glow absolute inset-x-0 top-0 -z-10 h-72 opacity-30" />
+
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="grid gap-12 lg:grid-cols-[1fr_1.4fr] lg:gap-16">
+          {/* Left: pitch */}
+          <div ref={left.ref} className={cn('reveal', left.visible && 'visible')}>
+            <p className="text-xs font-medium uppercase tracking-[0.18em] text-accent">
+              Team visibility
+            </p>
+            <h2 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+              See who&apos;s shipping. What&apos;s drifting.
+              <span className="block text-muted-foreground">Where to focus.</span>
+            </h2>
+            <p className="mt-5 text-pretty text-base leading-relaxed text-muted-foreground sm:text-lg">
+              Install the GitHub App, point it at your org, and TrueCourse starts
+              reviewing every PR in every repo. The dashboard rolls the findings into
+              views your engineering leads actually use: by team, by repo, and by engineer.
+            </p>
+
+            <ul className="mt-8 space-y-4">
+              <Bullet
+                icon={Github}
+                title="Native GitHub App"
+                body="Reviews every PR. Posts inline comments on hallucinated APIs, fabricated calls, and business-logic drift. Optional merge-blocking on critical findings."
+              />
+              <Bullet
+                icon={Users}
+                title="Per-engineer insights"
+                body="See AI-generated ratio, drift caught at PR, and findings escaped to main, per engineer. Surface who needs support, not who to blame."
+              />
+              <Bullet
+                icon={Activity}
+                title="Org &amp; team trends"
+                body="Track AI usage and drift rate over time. Spot regressions early, ship safer."
+              />
+            </ul>
+          </div>
+
+          {/* Right: dashboard mock */}
+          <div
+            ref={right.ref}
+            style={{ ['--delay' as string]: '120ms' }}
+            className={cn('reveal', right.visible && 'visible')}
+          >
+            <DashboardMock />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Bullet({
+  icon: Icon,
+  title,
+  body,
+}: {
+  icon: typeof Github;
+  title: string;
+  body: string;
+}) {
+  return (
+    <li className="flex items-start gap-3">
+      <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-card text-accent">
+        <Icon className="h-4 w-4" />
+      </span>
+      <div>
+        <h3
+          className="text-sm font-semibold"
+          dangerouslySetInnerHTML={{ __html: title }}
+        />
+        <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{body}</p>
+      </div>
+    </li>
+  );
+}
+
+function DashboardMock() {
+  return (
+    <div className="glow-border surface overflow-hidden rounded-2xl border border-border shadow-2xl shadow-black/40">
+      {/* Window chrome */}
+      <div className="flex items-center justify-between border-b border-border bg-background/40 px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <Github className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="font-mono text-xs text-muted-foreground">
+            acme-corp · TrueCourse
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-full bg-emerald-400/80" />
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            live
+          </span>
+        </div>
+      </div>
+
+      {/* Top metrics */}
+      <div className="grid grid-cols-2 gap-px bg-border sm:grid-cols-4">
+        <Metric label="Repos" value="8" />
+        <Metric label="Engineers" value="24" />
+        <Metric label="PRs / wk" value="142" trend="up" trendValue="+18%" />
+        <Metric label="Block rate" value="96%" trend="up" trendValue="+2 pp" />
+      </div>
+
+      {/* Engineer leaderboard */}
+      <div className="border-b border-border p-5">
+        <div className="flex items-baseline justify-between">
+          <h4 className="text-sm font-semibold">Engineers</h4>
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            last 30 days
+          </span>
+        </div>
+
+        {/* Header row */}
+        <div className="mt-3 grid grid-cols-[1.4fr_repeat(4,1fr)_28px] gap-3 px-2 pb-1.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+          <div>Engineer</div>
+          <div className="text-right">PRs</div>
+          <div className="text-right">Caught</div>
+          <div className="text-right">Escaped</div>
+          <div className="text-right">AI ratio</div>
+          <div />
+        </div>
+
+        <ul className="space-y-1">
+          {ENGINEERS.map((e) => (
+            <li
+              key={e.handle}
+              className="grid grid-cols-[1.4fr_repeat(4,1fr)_28px] items-center gap-3 rounded-md px-2 py-2 text-sm transition-colors hover:bg-muted/30"
+            >
+              <div className="flex items-center gap-2 truncate">
+                <span
+                  className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent/15 font-mono text-[10px] font-medium text-accent ring-1 ring-inset ring-accent/30"
+                  aria-hidden
+                >
+                  {e.handle[0]?.toUpperCase()}
+                </span>
+                <span className="truncate font-mono text-[12.5px]">{e.handle}</span>
+              </div>
+              <div className="text-right font-mono text-[12.5px] tabular-nums">
+                {e.prs}
+              </div>
+              <div className="text-right font-mono text-[12.5px] tabular-nums text-emerald-300">
+                {e.caught}
+              </div>
+              <div
+                className={cn(
+                  'text-right font-mono text-[12.5px] tabular-nums',
+                  e.escaped === 0 ? 'text-muted-foreground' : 'text-rose-300',
+                )}
+              >
+                {e.escaped}
+              </div>
+              <div className="flex items-center justify-end gap-1.5 font-mono text-[12.5px] tabular-nums">
+                <span>{e.aiPct}%</span>
+                <span className="relative inline-block h-1.5 w-10 overflow-hidden rounded-full bg-muted/50">
+                  <span
+                    className="absolute inset-y-0 left-0 bg-accent"
+                    style={{ width: `${e.aiPct}%` }}
+                  />
+                </span>
+              </div>
+              <div className="flex justify-end">
+                <TrendArrow trend={e.trend} />
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Repos strip */}
+      <div className="p-5">
+        <div className="flex items-baseline justify-between">
+          <h4 className="text-sm font-semibold">Repos</h4>
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            this week
+          </span>
+        </div>
+        <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {REPOS.map((r) => (
+            <div
+              key={r.name}
+              className="rounded-md border border-border bg-background/40 px-3 py-2"
+            >
+              <div className="font-mono text-[12.5px]">{r.name}</div>
+              <div className="mt-1 flex items-baseline justify-between text-[10.5px] text-muted-foreground">
+                <span>
+                  <span className="text-foreground">{r.prs}</span> PRs
+                </span>
+                <span className="text-emerald-300">{r.caught} caught</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  trend,
+  trendValue,
+}: {
+  label: string;
+  value: string;
+  trend?: Trend;
+  trendValue?: string;
+}) {
+  return (
+    <div className="bg-background/30 px-4 py-4">
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1.5 flex items-baseline gap-2">
+        <span className="font-mono text-2xl font-medium tabular-nums">{value}</span>
+        {trend && trendValue && (
+          <span
+            className={cn(
+              'inline-flex items-center gap-0.5 font-mono text-[11px]',
+              trend === 'up' && 'text-emerald-300',
+              trend === 'down' && 'text-rose-300',
+              trend === 'flat' && 'text-muted-foreground',
+            )}
+          >
+            <TrendArrow trend={trend} small />
+            {trendValue}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TrendArrow({ trend, small }: { trend: Trend; small?: boolean }) {
+  const cls = small ? 'h-3 w-3' : 'h-3.5 w-3.5';
+  if (trend === 'up')
+    return <ArrowUpRight className={cn(cls, 'text-emerald-400')} aria-label="up" />;
+  if (trend === 'down')
+    return <ArrowDownRight className={cn(cls, 'text-rose-400')} aria-label="down" />;
+  return <Minus className={cn(cls, 'text-muted-foreground')} aria-label="flat" />;
+}
+

--- a/apps/landing/src/components/TeamsHero.tsx
+++ b/apps/landing/src/components/TeamsHero.tsx
@@ -1,0 +1,58 @@
+import { ArrowRight, Sparkles } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+export function TeamsHero() {
+  return (
+    <section className="relative isolate overflow-hidden border-b border-border pt-32 pb-16 sm:pt-40 sm:pb-24">
+      <div className="bg-radial-glow absolute inset-0 -z-10" />
+      <div className="bg-grid absolute inset-0 -z-10" />
+
+      <div className="mx-auto max-w-4xl px-4 text-center sm:px-6">
+        <Link
+          to="/"
+          style={{ ['--delay' as string]: '0ms' }}
+          className="animate-fade-up animate-pulse-ring mx-auto inline-flex items-center gap-2 rounded-full border border-accent/40 bg-accent/10 px-3 py-1 text-xs font-medium text-accent backdrop-blur-md transition-colors hover:bg-accent/15"
+        >
+          <Sparkles className="h-3 w-3" />
+          Coming soon &middot; Closed beta
+        </Link>
+
+        <h1
+          style={{ ['--delay' as string]: '80ms' }}
+          className="animate-fade-up mt-6 text-balance text-5xl font-semibold leading-[1.05] tracking-tight sm:text-6xl"
+        >
+          <span className="text-gradient">TrueCourse</span>{' '}
+          <span className="text-gradient-accent">for teams.</span>
+        </h1>
+
+        <p
+          style={{ ['--delay' as string]: '200ms' }}
+          className="animate-fade-up mx-auto mt-6 max-w-2xl text-pretty text-lg leading-relaxed text-muted-foreground sm:text-xl"
+        >
+          Runs on top of GitHub. Reviews every PR, blocks the drift, and rolls the
+          findings into a dashboard your engineering leads actually want: who&apos;s
+          shipping, what&apos;s drifting, where each engineer needs support.
+        </p>
+
+        <div
+          style={{ ['--delay' as string]: '320ms' }}
+          className="animate-fade-up mt-9 flex flex-wrap items-center justify-center gap-3"
+        >
+          <a
+            href="#waitlist"
+            className="group inline-flex h-12 items-center gap-2 rounded-xl border border-accent/40 bg-accent/15 px-5 text-sm font-medium text-foreground backdrop-blur-md transition-all hover:-translate-y-0.5 hover:border-accent/60 hover:bg-accent/25"
+          >
+            Request access
+            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+          </a>
+          <Link
+            to="/#open-source"
+            className="inline-flex h-12 items-center gap-2 rounded-xl border border-border bg-card/60 px-5 text-sm font-medium backdrop-blur-md transition-colors hover:border-border-strong"
+          >
+            Try the open source CLI
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/landing/src/data/analyses.ts
+++ b/apps/landing/src/data/analyses.ts
@@ -1,0 +1,167 @@
+export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+export type Finding = {
+  rule: string;
+  category: string;
+  count: number;
+  severity: Severity;
+};
+
+export type AnalysisReport = {
+  slug: string;
+  repo: string;
+  repoUrl: string;
+  description: string;
+  language: 'TypeScript' | 'JavaScript' | 'Python' | 'Mixed';
+  stars: string;
+  analyzedAt: string;
+  files: number;
+  loc: string;
+  duration: string;
+  totals: {
+    critical: number;
+    high: number;
+    medium: number;
+    low: number;
+  };
+  topFindings: Finding[];
+  summary: string;
+  reportUrl?: string;
+  featured?: boolean;
+};
+
+/**
+ * Sample analysis reports — replace these with real results once you've
+ * run `truecourse analyze` against each repository. Keep entries short:
+ * the cards on the landing page show a 3-line summary + top 4 findings.
+ */
+export const ANALYSIS_REPORTS: AnalysisReport[] = [
+  {
+    slug: 'react',
+    repo: 'facebook/react',
+    repoUrl: 'https://github.com/facebook/react',
+    description: 'The library for web and native user interfaces.',
+    language: 'JavaScript',
+    stars: '230k',
+    analyzedAt: '2026-04-22',
+    files: 4218,
+    loc: '512k',
+    duration: '2m 14s',
+    totals: { critical: 0, high: 7, medium: 142, low: 318 },
+    topFindings: [
+      { rule: 'cognitive-complexity', category: 'code-quality', count: 64, severity: 'medium' },
+      { rule: 'magic-numbers', category: 'code-quality', count: 38, severity: 'low' },
+      { rule: 'large-function', category: 'code-quality', count: 22, severity: 'medium' },
+      { rule: 'cross-package-import', category: 'architecture', count: 7, severity: 'high' },
+    ],
+    summary:
+      'Surprisingly clean for its size. Most findings are deliberate choices in the reconciler: long functions sitting at the hot path. Zero criticals.',
+    featured: true,
+  },
+  {
+    slug: 'vite',
+    repo: 'vitejs/vite',
+    repoUrl: 'https://github.com/vitejs/vite',
+    description: 'Next-generation frontend tooling.',
+    language: 'TypeScript',
+    stars: '74k',
+    analyzedAt: '2026-04-24',
+    files: 1062,
+    loc: '128k',
+    duration: '38s',
+    totals: { critical: 0, high: 3, medium: 71, low: 184 },
+    topFindings: [
+      { rule: 'unhandled-promise', category: 'reliability', count: 18, severity: 'medium' },
+      { rule: 'console-log', category: 'code-quality', count: 14, severity: 'low' },
+      { rule: 'missing-await', category: 'bugs', count: 9, severity: 'medium' },
+      { rule: 'tight-coupling', category: 'architecture', count: 3, severity: 'high' },
+    ],
+    summary:
+      'Three high-severity coupling issues between the dev-server and plugin host. Likely candidates for a layer extraction. Otherwise tidy.',
+    featured: true,
+  },
+  {
+    slug: 'fastapi',
+    repo: 'tiangolo/fastapi',
+    repoUrl: 'https://github.com/tiangolo/fastapi',
+    description: 'Modern, fast web framework for building APIs with Python.',
+    language: 'Python',
+    stars: '79k',
+    analyzedAt: '2026-04-26',
+    files: 612,
+    loc: '94k',
+    duration: '24s',
+    totals: { critical: 1, high: 4, medium: 53, low: 122 },
+    topFindings: [
+      { rule: 'mutable-default-argument', category: 'bugs', count: 6, severity: 'high' },
+      { rule: 'missing-type-hints', category: 'code-quality', count: 41, severity: 'low' },
+      { rule: 'broad-exception-catch', category: 'reliability', count: 12, severity: 'medium' },
+      { rule: 'sync-io-in-async', category: 'performance', count: 1, severity: 'critical' },
+    ],
+    summary:
+      'One blocking sync call inside an async path. A real latency tax under load. Mutable defaults appear in test scaffolding only.',
+  },
+  {
+    slug: 'next',
+    repo: 'vercel/next.js',
+    repoUrl: 'https://github.com/vercel/next.js',
+    description: 'The React framework for production.',
+    language: 'TypeScript',
+    stars: '128k',
+    analyzedAt: '2026-04-28',
+    files: 5871,
+    loc: '742k',
+    duration: '4m 02s',
+    totals: { critical: 0, high: 12, medium: 218, low: 487 },
+    topFindings: [
+      { rule: 'circular-dependency', category: 'architecture', count: 9, severity: 'high' },
+      { rule: 'cognitive-complexity', category: 'code-quality', count: 96, severity: 'medium' },
+      { rule: 'unused-export', category: 'code-quality', count: 71, severity: 'low' },
+      { rule: 'race-condition', category: 'bugs', count: 3, severity: 'high' },
+    ],
+    summary:
+      'Nine circular dependency clusters, all between the app router and the build pipeline. Three suspected race conditions worth a closer look.',
+  },
+  {
+    slug: 'astro',
+    repo: 'withastro/astro',
+    repoUrl: 'https://github.com/withastro/astro',
+    description: 'The web framework for content-driven websites.',
+    language: 'TypeScript',
+    stars: '47k',
+    analyzedAt: '2026-04-30',
+    files: 1944,
+    loc: '218k',
+    duration: '1m 08s',
+    totals: { critical: 0, high: 2, medium: 88, low: 211 },
+    topFindings: [
+      { rule: 'large-file', category: 'code-quality', count: 28, severity: 'low' },
+      { rule: 'unhandled-promise', category: 'reliability', count: 11, severity: 'medium' },
+      { rule: 'missing-error-boundary', category: 'reliability', count: 6, severity: 'medium' },
+      { rule: 'layer-violation', category: 'architecture', count: 2, severity: 'high' },
+    ],
+    summary:
+      'Two layer violations crossing the build / runtime boundary. Small but worth tightening before they spread.',
+  },
+  {
+    slug: 'tailwindcss',
+    repo: 'tailwindlabs/tailwindcss',
+    repoUrl: 'https://github.com/tailwindlabs/tailwindcss',
+    description: 'A utility-first CSS framework.',
+    language: 'TypeScript',
+    stars: '83k',
+    analyzedAt: '2026-05-02',
+    files: 482,
+    loc: '64k',
+    duration: '18s',
+    totals: { critical: 0, high: 1, medium: 27, low: 88 },
+    topFindings: [
+      { rule: 'cognitive-complexity', category: 'code-quality', count: 14, severity: 'medium' },
+      { rule: 'magic-numbers', category: 'code-quality', count: 22, severity: 'low' },
+      { rule: 'tight-coupling', category: 'architecture', count: 1, severity: 'high' },
+      { rule: 'unused-import', category: 'code-quality', count: 9, severity: 'low' },
+    ],
+    summary:
+      'Almost spotless. The single high finding is a tight coupling between the parser and the candidate engine. Likely intentional.',
+  },
+];

--- a/apps/landing/src/globals.css
+++ b/apps/landing/src/globals.css
@@ -1,0 +1,272 @@
+@import 'tailwindcss';
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  color-scheme: dark;
+
+  --background: oklch(0.115 0.025 255);
+  --background-deep: oklch(0.085 0.025 258);
+  --background-soft: oklch(0.16 0.03 255);
+  --foreground: oklch(0.97 0.005 90);
+  --muted: oklch(0.20 0.025 255);
+  --muted-foreground: oklch(0.66 0.02 250);
+  --border: oklch(1 0 0 / 7%);
+  --border-strong: oklch(1 0 0 / 14%);
+  --card: oklch(0.145 0.028 255 / 75%);
+  --card-foreground: oklch(0.97 0.005 90);
+  --primary: oklch(0.78 0.10 245);
+  --primary-foreground: oklch(0.10 0.02 250);
+  --accent: oklch(0.80 0.09 245);
+  --ring: oklch(0.78 0.10 245);
+}
+
+@theme inline {
+  --font-sans: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-accent: var(--accent);
+  --color-ring: var(--ring);
+
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-2xl: 1.25rem;
+  --radius-3xl: 1.75rem;
+}
+
+@layer base {
+  * {
+    border-color: var(--border);
+  }
+  html,
+  body {
+    background: var(--background);
+    color: var(--foreground);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+  }
+  ::selection {
+    background: oklch(0.78 0.10 245 / 35%);
+    color: var(--foreground);
+  }
+}
+
+/* ----- Background grid + glow (monochrome blue, matches palette) ----- */
+.bg-grid {
+  background-image:
+    linear-gradient(to right, oklch(1 0 0 / 4%) 1px, transparent 1px),
+    linear-gradient(to bottom, oklch(1 0 0 / 4%) 1px, transparent 1px);
+  background-size: 56px 56px;
+  background-position: -1px -1px;
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 30%, transparent 80%);
+}
+
+.bg-radial-glow {
+  background:
+    radial-gradient(ellipse 80% 50% at 50% -10%, oklch(0.55 0.15 245 / 38%), transparent 70%),
+    radial-gradient(ellipse 60% 40% at 80% 30%, oklch(0.50 0.10 240 / 18%), transparent 70%),
+    radial-gradient(ellipse 50% 40% at 10% 40%, oklch(0.50 0.10 255 / 14%), transparent 70%);
+}
+
+/* ----- Gradient text (monochrome blue family) ----- */
+.text-gradient {
+  background: linear-gradient(
+    180deg,
+    oklch(0.99 0 0) 0%,
+    oklch(0.99 0 0) 40%,
+    oklch(0.78 0.05 245) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+.text-gradient-accent {
+  background: linear-gradient(
+    90deg,
+    oklch(0.86 0.10 235) 0%,
+    oklch(0.78 0.10 245) 50%,
+    oklch(0.70 0.12 255) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+/* ----- Glow border (shimmering accent ring) ----- */
+.glow-border {
+  position: relative;
+}
+.glow-border::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    oklch(0.78 0.10 245 / 45%),
+    oklch(0.78 0.10 245 / 18%) 35%,
+    transparent 65%
+  );
+  z-index: -1;
+  pointer-events: none;
+}
+
+/* ----- Card surface ----- */
+.surface {
+  background:
+    linear-gradient(180deg, oklch(1 0 0 / 3%), oklch(1 0 0 / 0%)),
+    var(--card);
+  backdrop-filter: blur(8px);
+}
+
+.surface-hover {
+  transition:
+    border-color 200ms ease,
+    transform 200ms ease,
+    background 200ms ease;
+}
+.surface-hover:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-2px);
+  background:
+    linear-gradient(180deg, oklch(1 0 0 / 5%), oklch(1 0 0 / 0%)),
+    var(--card);
+}
+
+/* ----- Entrance animations ----- */
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.animate-fade-up {
+  opacity: 0;
+  animation: fade-up 720ms cubic-bezier(0.16, 0.84, 0.3, 1) forwards;
+  animation-delay: var(--delay, 0ms);
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.animate-fade-in {
+  opacity: 0;
+  animation: fade-in 900ms ease forwards;
+  animation-delay: var(--delay, 0ms);
+}
+
+/* Reveal-on-scroll: hidden by default, .visible class triggers transition */
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition:
+    opacity 700ms cubic-bezier(0.16, 0.84, 0.3, 1),
+    transform 700ms cubic-bezier(0.16, 0.84, 0.3, 1);
+  transition-delay: var(--delay, 0ms);
+  will-change: opacity, transform;
+}
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Blinking caret for terminal mock */
+@keyframes blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+.animate-blink {
+  animation: blink 1s steps(2, start) infinite;
+}
+
+/* Subtle pulsing ring for "new" pill */
+@keyframes pulse-ring {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 0 oklch(0.78 0.10 245 / 0%),
+      0 0 0 0 oklch(0.78 0.10 245 / 0%);
+  }
+  50% {
+    box-shadow:
+      0 0 0 5px oklch(0.78 0.10 245 / 14%),
+      0 0 22px 0 oklch(0.78 0.10 245 / 22%);
+  }
+}
+.animate-pulse-ring {
+  animation: pulse-ring 3s ease-in-out infinite;
+}
+
+/* Severity bar fill */
+.severity-fill {
+  width: 0;
+  transition: width 900ms cubic-bezier(0.16, 0.84, 0.3, 1);
+  transition-delay: var(--delay, 0ms);
+}
+
+/* ----- Scrollbar ----- */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: oklch(1 0 0 / 8%);
+  border-radius: 5px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: oklch(1 0 0 / 18%);
+}
+
+/* ----- Reduced motion ----- */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-up,
+  .animate-fade-in {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+  .reveal {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
+  .animate-blink,
+  .animate-pulse-ring,
+  .severity-fill {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/apps/landing/src/lib/cn.ts
+++ b/apps/landing/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/landing/src/lib/useReveal.ts
+++ b/apps/landing/src/lib/useReveal.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Adds the `visible` class to the returned ref's element once it scrolls into view.
+ * Pair with `.reveal` in globals.css to fade-up the element. Triggers once.
+ */
+export function useReveal<T extends HTMLElement = HTMLDivElement>(opts?: {
+  rootMargin?: string;
+  threshold?: number;
+}) {
+  const ref = useRef<T | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setVisible(true);
+      return;
+    }
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setVisible(true);
+            obs.unobserve(entry.target);
+          }
+        }
+      },
+      {
+        rootMargin: opts?.rootMargin ?? '0px 0px -10% 0px',
+        threshold: opts?.threshold ?? 0.12,
+      },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [opts?.rootMargin, opts?.threshold]);
+
+  return { ref, visible };
+}
+

--- a/apps/landing/src/main.tsx
+++ b/apps/landing/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './globals.css';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/landing/src/pages/HomePage.tsx
+++ b/apps/landing/src/pages/HomePage.tsx
@@ -1,0 +1,20 @@
+import { Hero } from '@/components/Hero';
+import { Capabilities } from '@/components/Capabilities';
+import { OpenSource } from '@/components/OpenSource';
+// Reports section is hidden until we have real OSS analysis results to publish.
+// Sample data still lives in `src/data/analyses.ts`; uncomment the import + the
+// <AnalysisReports /> block below to bring it back. When you re-enable, also
+// restore the "Reports" nav entry in Header.tsx and the "Field reports" link in
+// Footer.tsx (both currently commented next to this same flag).
+// import { AnalysisReports } from '@/components/AnalysisReports';
+
+export default function HomePage() {
+  return (
+    <>
+      <Hero />
+      <Capabilities />
+      <OpenSource />
+      {/* <AnalysisReports /> */}
+    </>
+  );
+}

--- a/apps/landing/src/pages/TeamsPage.tsx
+++ b/apps/landing/src/pages/TeamsPage.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { TeamsHero } from '@/components/TeamsHero';
+import { TeamInsights } from '@/components/TeamInsights';
+import { Comparison } from '@/components/Comparison';
+import { Commercial } from '@/components/Commercial';
+
+export default function TeamsPage() {
+  useEffect(() => {
+    const prev = document.title;
+    document.title = 'TrueCourse for teams · join the waitlist';
+    return () => {
+      document.title = prev;
+    };
+  }, []);
+
+  return (
+    <>
+      <TeamsHero />
+      <TeamInsights />
+      <Comparison />
+      <Commercial />
+    </>
+  );
+}

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  build: {
+    outDir: 'dist',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,55 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  apps/landing:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.468.0
+        version: 0.468.0(react@19.2.4)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      react-router-dom:
+        specifier: ^7.1.0
+        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.0.0
+        version: 4.2.1
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      postcss:
+        specifier: ^8.4.0
+        version: 8.5.8
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.2.1
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/analyzer:
     dependencies:
       '@truecourse/shared':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
   - "apps/dashboard/*"
+  - "apps/landing"
   - "packages/*"
   - "tools/*"


### PR DESCRIPTION
## Summary

- New \`apps/landing\` workspace: Vite + React + Tailwind v4 marketing site, deploys standalone (no dashboard-server dependency).
- Two routes: \`/\` (hero with real CLI clack output, 9-category capabilities, OSS pitch) and \`/teams\` (teams hero, engineer-insights dashboard mock, OSS-vs-Teams comparison, waitlist).
- \`POST /api/waitlist\` Vercel function writes submissions to the Airtable \`Waitlist\` table in TrueCourse Founder CRM, with honeypot anti-spam and server-side select-option mapping.

## What's in apps/landing

- **Hero** — \`AI writes the code. We catch what it gets wrong.\` with the real \`truecourse analyze\` clack-formatted preview (clack frame glyphs, severity colors, business-logic-drift category line included).
- **Capabilities** — 9 cards (Drift preview + Architecture, Security, Bugs, Code Quality, Performance, Reliability, Database, Style).
- **OpenSource** — install commands, GitHub/npm CTAs, feature checklist.
- **TeamsHero + TeamInsights + Comparison + Commercial** on /teams. The dashboard mock shows GitHub-native PR review, per-engineer leaderboard, repos breakdown.
- **AnalysisReports** is built but commented out in HomePage.tsx until we have real OSS analysis output to publish (sample data lives in \`src/data/analyses.ts\`; toggle markers in HomePage.tsx, Header.tsx, Footer.tsx).

## Waitlist wiring

- Frontend: \`apps/landing/src/components/Commercial.tsx\` POSTs \`{ email, company, size, website }\` to \`/api/waitlist\`. Honeypot input is offscreen at \`left: -10000px\`.
- Backend: \`apps/landing/api/waitlist.ts\` validates input, maps the form's \`1-10\`/\`11-50\`/etc. → Airtable's en-dash select option names, and POSTs to Airtable.
- Default base/table baked in (\`appGuf6PL5dDfYK3f\` / \`Waitlist\`); only env var to set is \`AIRTABLE_API_KEY\`. See \`apps/landing/.env.example\`.

## Deploy

1. Vercel → Import \`truecourse-ai/truecourse\` → set Root Directory = \`apps/landing\` (auto-detects Vite, leaves install command blank for pnpm workspaces).
2. Add env var \`AIRTABLE_API_KEY\` (PAT from airtable.com/create/tokens, scope \`data.records:write\`, base = TrueCourse Founder CRM).
3. Deploy. Submission test should appear as a row in the Waitlist table with \`Source = truecourse.dev/teams\`.

## Test plan

- [ ] \`cd apps/landing && pnpm install && pnpm build\` succeeds.
- [ ] \`pnpm --filter @truecourse/landing dev\` serves at http://localhost:3100; \`/\` and \`/teams\` render.
- [ ] Header logo click on \`/\` smooth-scrolls to top; on other routes navigates to \`/\` (Layout effect handles scroll).
- [ ] \`Join waitlist\` in header / hero scrolls directly to the form via \`/teams#waitlist\`.
- [ ] After Vercel deploy: form submission produces an Airtable row in Waitlist with mapped size, ISO timestamp, source.
- [ ] Form errors fail loud (network failure → red error message instead of silent success).
- [ ] Honeypot: filling the hidden \`website\` input causes a 200 with no Airtable row written.

## Other changes

- \`pnpm-workspace.yaml\` includes \`apps/landing\`.
- \`.gitignore\`: ignore \`.env.local\`, \`.vercel/\`, \`.env.*.local\`.
- \`CLAUDE.md\`: project-layout entry for apps/landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)