### PR TITLE
Fix landing waitlist function ESM loading + add diagnostic logs

### DIFF
--- a/apps/landing/api/waitlist.ts
+++ b/apps/landing/api/waitlist.ts
@@ -2,51 +2,24 @@
  * Vercel serverless function: POST /api/waitlist
  *
  * Forwards waitlist submissions to the Airtable "Waitlist" table in the
- * "TrueCourse Founder CRM" base. All credentials are server-only env vars —
- * the browser never sees the API key.
+ * "TrueCourse Founder CRM" base. All credentials are server-only env vars.
  *
- * Required env vars (set in Vercel project settings):
+ * Required env vars (Vercel project settings):
  *   AIRTABLE_API_KEY  Personal access token with `data.records:write` scope
- *                     for the target base. Create at airtable.com/create/tokens
- *   AIRTABLE_BASE_ID  Defaults to the TrueCourse Founder CRM base
- *                     (appGuf6PL5dDfYK3f). Override only if you move bases.
+ *                     for the target base. airtable.com/create/tokens
  *
- * Optional:
- *   AIRTABLE_TABLE    Table name. Defaults to "Waitlist".
+ * Optional (defaults baked in below):
+ *   AIRTABLE_BASE_ID  Defaults to appGuf6PL5dDfYK3f
+ *   AIRTABLE_TABLE    Defaults to "Waitlist"
  *
- * Wired against the real schema as of 2026-05-08:
+ * Schema (verified 2026-05-08):
  *   Email                singleLineText (primary)
  *   Company Name         singleLineText
- *   Company Size Range   singleSelect — see SIZE_TO_AIRTABLE map
- *   Submitted Date       dateTime (ISO timestamp)
- *   Source               singleLineText  (we tag every submission with the page)
+ *   Company Size Range   singleSelect — see SIZE_TO_AIRTABLE
+ *   Submitted Date       dateTime
+ *   Source               singleLineText
  */
 
-type Req = {
-  method?: string;
-  body?: unknown;
-  headers?: Record<string, string | string[] | undefined>;
-};
-
-type Res = {
-  status(code: number): Res;
-  json(body: unknown): void;
-  setHeader(name: string, value: string): void;
-};
-
-type Body = {
-  email?: unknown;
-  company?: unknown;
-  size?: unknown;
-  // Honeypot — humans never see/fill this. Bots usually do.
-  website?: unknown;
-};
-
-/**
- * Form values (left) → exact Airtable single-select option names (right).
- * These must match the strings configured in the "Company Size Range" field
- * exactly (en-dash vs hyphen matters in Airtable).
- */
 const SIZE_TO_AIRTABLE: Record<string, string> = {
   '1-10': '1 – 10 engineers',
   '11-50': '11 – 50',
@@ -59,89 +32,117 @@ const ALLOWED_SIZES = new Set([...Object.keys(SIZE_TO_AIRTABLE), '']);
 const DEFAULT_BASE_ID = 'appGuf6PL5dDfYK3f';
 const DEFAULT_TABLE = 'Waitlist';
 
-export default async function handler(req: Req, res: Res): Promise<void> {
-  res.setHeader('content-type', 'application/json');
-
-  if (req.method !== 'POST') {
-    res.status(405).json({ error: 'Method not allowed' });
-    return;
-  }
-
-  const body = parseBody(req.body);
-
-  // Honeypot: bots fill hidden fields, real users don't. Quietly succeed
-  // without writing anything so spam goes nowhere.
-  if (typeof body.website === 'string' && body.website.trim() !== '') {
-    res.status(200).json({ ok: true });
-    return;
-  }
-
-  const email = typeof body.email === 'string' ? body.email.trim() : '';
-  const company = typeof body.company === 'string' ? body.company.trim().slice(0, 200) : '';
-  const size = typeof body.size === 'string' ? body.size.trim() : '';
-
-  if (!email || email.length > 254 || !email.includes('@') || email.includes(' ')) {
-    res.status(400).json({ error: 'Valid email required' });
-    return;
-  }
-  if (!ALLOWED_SIZES.has(size)) {
-    res.status(400).json({ error: 'Invalid team size' });
-    return;
-  }
-
-  const apiKey = process.env.AIRTABLE_API_KEY;
-  const baseId = process.env.AIRTABLE_BASE_ID ?? DEFAULT_BASE_ID;
-  const table = process.env.AIRTABLE_TABLE ?? DEFAULT_TABLE;
-
-  if (!apiKey) {
-    console.error('waitlist: missing AIRTABLE_API_KEY');
-    res.status(500).json({ error: 'Server misconfigured' });
-    return;
-  }
-
-  const url = `https://api.airtable.com/v0/${encodeURIComponent(baseId)}/${encodeURIComponent(table)}`;
-
-  const fields: Record<string, string> = {
-    Email: email,
-    Source: 'truecourse.dev/teams',
-    'Submitted Date': new Date().toISOString(),
-  };
-  if (company) fields['Company Name'] = company;
-  if (size) fields['Company Size Range'] = SIZE_TO_AIRTABLE[size];
+// Vercel injects Node IncomingMessage / ServerResponse augmented with `body`,
+// `status`, `json`, `send`. Use `any` so the bundler doesn't get tripped up
+// by structural type mismatches.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default async function handler(req: any, res: any): Promise<void> {
+  console.log('waitlist: invoked', { method: req?.method });
 
   try {
-    const ar = await fetch(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({ fields, typecast: true }),
-    });
+    if (req.method !== 'POST') {
+      res.status(405).json({ error: 'Method not allowed' });
+      return;
+    }
+
+    const body = parseBody(req.body);
+    console.log('waitlist: body keys', Object.keys(body));
+
+    // Honeypot
+    if (typeof body.website === 'string' && body.website.trim() !== '') {
+      res.status(200).json({ ok: true });
+      return;
+    }
+
+    const email = typeof body.email === 'string' ? body.email.trim() : '';
+    const company = typeof body.company === 'string' ? body.company.trim().slice(0, 200) : '';
+    const size = typeof body.size === 'string' ? body.size.trim() : '';
+
+    if (!email || email.length > 254 || !email.includes('@') || email.includes(' ')) {
+      res.status(400).json({ error: 'Valid email required' });
+      return;
+    }
+    if (!ALLOWED_SIZES.has(size)) {
+      res.status(400).json({ error: 'Invalid team size' });
+      return;
+    }
+
+    const apiKey = process.env.AIRTABLE_API_KEY;
+    const baseId = process.env.AIRTABLE_BASE_ID || DEFAULT_BASE_ID;
+    const table = process.env.AIRTABLE_TABLE || DEFAULT_TABLE;
+
+    if (!apiKey) {
+      console.error('waitlist: missing AIRTABLE_API_KEY');
+      res.status(500).json({ error: 'Server misconfigured: missing AIRTABLE_API_KEY' });
+      return;
+    }
+
+    const url =
+      'https://api.airtable.com/v0/' +
+      encodeURIComponent(baseId) +
+      '/' +
+      encodeURIComponent(table);
+
+    const fields: Record<string, string> = {
+      Email: email,
+      Source: 'truecourse.dev/teams',
+      'Submitted Date': new Date().toISOString(),
+    };
+    if (company) fields['Company Name'] = company;
+    if (size) fields['Company Size Range'] = SIZE_TO_AIRTABLE[size];
+
+    console.log('waitlist: posting to airtable', { baseId, table, fields: Object.keys(fields) });
+
+    let ar: Response;
+    try {
+      ar = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer ' + apiKey,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ fields, typecast: true }),
+      });
+    } catch (fetchErr) {
+      console.error('waitlist: fetch threw', fetchErr);
+      res.status(502).json({ error: 'Could not reach Airtable' });
+      return;
+    }
 
     if (!ar.ok) {
       const text = await ar.text().catch(() => '');
       console.error('waitlist: airtable error', ar.status, text.slice(0, 500));
-      res.status(502).json({ error: 'Could not save submission' });
+      res.status(502).json({ error: 'Could not save submission', upstream: ar.status });
       return;
     }
 
+    console.log('waitlist: ok');
     res.status(200).json({ ok: true });
   } catch (err) {
-    console.error('waitlist: airtable fetch threw', err);
-    res.status(502).json({ error: 'Could not reach Airtable' });
+    // Catch-all so Vercel never sees an unhandled rejection.
+    console.error('waitlist: unhandled error', err instanceof Error ? err.stack : err);
+    try {
+      res.status(500).json({ error: 'Internal error', detail: err instanceof Error ? err.message : String(err) });
+    } catch {
+      // Response already sent — nothing to do.
+    }
   }
 }
 
-function parseBody(raw: unknown): Body {
+function parseBody(raw: unknown): {
+  email?: unknown;
+  company?: unknown;
+  size?: unknown;
+  website?: unknown;
+} {
   if (!raw) return {};
   if (typeof raw === 'string') {
     try {
-      return JSON.parse(raw) as Body;
+      return JSON.parse(raw);
     } catch {
       return {};
     }
   }
-  if (typeof raw === 'object') return raw as Body;
+  if (typeof raw === 'object') return raw as Record<string, unknown>;
   return {};
 }

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -2,6 +2,7 @@
   "name": "@truecourse/landing",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite --port 3100",
     "build": "vite build",


### PR DESCRIPTION
## Summary

Production waitlist submissions were failing with \`FUNCTION_INVOCATION_FAILED\` because Vercel transpiled \`apps/landing/api/waitlist.ts\` to \`.js\` while the package had no \`"type": "module"\`, so Node loaded it as CommonJS and rejected \`export default\`. Logs showed:

> \`SyntaxError: Unexpected token 'export'\`
> \`Failed to load the ES module: ... Make sure to set "type": "module" in the nearest package.json file\`

## Fix

- Add \`"type": "module"\` to \`apps/landing/package.json\`. Vite v6 already expects this (build still succeeds).
- Wrap the handler in a top-level try/catch and add entry/posting/ok/error \`console.log\` lines so any future failure returns a structured 500 JSON instead of an opaque \`FUNCTION_INVOCATION_FAILED\`.

## Test plan

- [ ] Vercel preview deploys cleanly off this branch.
- [ ] \`POST /api/waitlist\` from the deployed form lands a row in the Airtable Waitlist table (TrueCourse Founder CRM).
- [ ] Function logs show \`waitlist: invoked → posting to airtable → ok\`.
- [ ] Local: \`pnpm --filter @truecourse/landing build\` succeeds and \`pnpm --filter @truecourse/landing dev\` still serves the SPA at :3100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)