### PR TITLE
Fix landing SPA routing: serve index.html for non-API paths

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/((?!api/).*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Direct visits to client-side routes (\`/teams\`, \`/teams#waitlist\`, anything not \`/\`) return \`NOT_FOUND\` on production because the build only emits \`index.html\` at the root and Vercel's filesystem router can't find a matching file. Classic SPA fallback issue.

## Fix

\`apps/landing/vercel.json\`:

\`\`\`json
{
  "rewrites": [
    { "source": "/((?!api/).*)", "destination": "/index.html" }
  ]
}
\`\`\`

The negative lookahead \`(?!api/)\` keeps \`/api/waitlist\` (and any future API route) routing to the serverless function. Filesystem matches still take precedence over rewrites in Vercel's routing model, so static assets (\`/logo.svg\`, hashed bundles) keep serving from disk.

## Test plan

After deploy:
- [ ] \`https://www.truecourse.dev/\` loads (regression check)
- [ ] \`https://www.truecourse.dev/teams\` loads directly (no NOT_FOUND)
- [ ] \`https://www.truecourse.dev/teams#waitlist\` loads and scrolls to the waitlist form
- [ ] \`https://www.truecourse.dev/anything-bogus\` loads home (catch-all behavior — fine for an SPA)
- [ ] \`POST https://www.truecourse.dev/api/waitlist\` still hits the function (the form submission still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)