### PR TITLE
FP automation: post-release verify; fp-discover manual-only

### DIFF
--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -41,18 +41,26 @@ For each target OSS repo:
       issue.
 5. When the PR merges (closing the issue), the routine fires again and the
    next `fp-fix`-labelled issue is picked up automatically.
-6. When no `fp-fix` issues remain open for the current target, re-run
-   `truecourse analyze --no-llm`. If TP rate ≥ 90 %, open a **campaign-close
-   PR** (see below). When that PR merges, a different routine pushes
-   `vX.Y.Z` and dispatches the next campaign's discovery run.
+6. When no `fp-fix` issues remain open for the current target, open a
+   **campaign-close PR** (see below) that bumps the version and flips
+   the campaign to `status: verifying`. **No local analyze is run** at
+   this point — the "did we hit 90 %" check happens post-release.
+7. When the campaign-close PR merges, `fp-campaign-close` runs in two
+   phases: tag + npm publish (Phase 1), then analyze with the
+   just-published `npx -y truecourse@<version>` (Phase 2). Phase 2
+   decides whether the campaign is `done` (TP ≥ 90 %) or continues
+   (TP < 90 %, file new `fp-fix` issues, another release follows).
+8. Once a campaign is `done`, the user clicks **Run now** on
+   `fp-discover` to start the next pending campaign. No auto-chain.
 
 ### Campaign-close PR
 
-When a campaign hits ≥ 90 % TP, the session opens a single PR that:
+When fp-next-fix runs out of `fp-fix` issues for a campaign, it opens
+a campaign-close PR that:
 
-- Sets `status: done` for the campaign in `docs/fp-automation/campaigns.yaml`.
-- Fills the `final.*` block (analyzed_at, target_ref, total_violations,
-  tp, fp, tp_rate).
+- Sets `status: verifying` for the campaign in
+  `docs/fp-automation/campaigns.yaml`. Does **not** fill `final.*` —
+  fp-campaign-close fills that after the post-release verify.
 - Bumps the patch version (FP fixes are bug fixes) in all four required
   places, per CLAUDE.md:
   1. `tools/cli/package.json`
@@ -62,14 +70,16 @@ When a campaign hits ≥ 90 % TP, the session opens a single PR that:
 - Carries the **`fp-campaign-complete`** label.
 - Branch name `claude/fp-campaign-close/<owner>-<repo>`.
 
-On merge, two routines fire in parallel on the same event:
-- **fp-campaign-close** reads the new version from
-  `tools/cli/package.json`, creates and pushes `vX.Y.Z`. The existing
-  `.github/workflows/publish.yml` picks the tag up and publishes
-  `truecourse` to npm + creates the GitHub Release.
-- **fp-discover** reads `campaigns.yaml` (which the merged PR already
-  flipped to `status: done` for the just-closed campaign), picks the
-  next `pending` campaign, and starts discovery.
+On merge, `fp-campaign-close` runs Phase 1 (tag + wait for npm publish)
+then Phase 2 (analyze with `npx -y truecourse@<version>` against the
+target). Phase 2 either:
+- Opens a `fp-verify` PR flipping `status: done` + filling `final.*`
+  (TP ≥ 90 %), or
+- Files new `fp-fix` issues and leaves `status: verifying` so the next
+  queue-empty path produces another release (TP < 90 %).
+
+A campaign can therefore produce multiple version bumps before it's
+marked done.
 
 ### Borderline FPs
 
@@ -112,10 +122,9 @@ So an FP fix means:
 ```
 ┌──────────────────────────┐        ┌─────────────────────────┐
 │ campaigns.yaml           │───────▶│ Routine: fp-discover    │
-│ ordered repo list +      │ next   │ trigger: same as        │
-│ baseline / final results │        │  fp-campaign-close,     │
-└──────────────────────────┘        │  + Run now for bootstrap│
-                                    │ (analyze --no-llm,      │
+│ ordered repo list +      │ pick   │ trigger: MANUAL ONLY    │
+│ baseline / final results │  next  │ (Run now from web UI)   │
+└──────────────────────────┘        │ (analyze --no-llm,      │
                                     │  writes baseline back,  │
                                     │  files fp-fix issues)   │
 ┌─────────────────────────┐         └────────────┬────────────┘
@@ -145,20 +154,24 @@ So an FP fix means:
            │ on fp-fix PR merge           │
            │                              ▼
 ┌──────────────────────────────────────────────────────────┐
-│ Routine: fp-campaign-close (parallel with fp-discover)   │
+│ Routine: fp-campaign-close                               │
 │ trigger: pull_request.closed                             │
 │   Is merged=true, Head Branch starts-with                │
 │   claude/fp-campaign-close/,                             │
 │   Labels is-one-of fp-campaign-complete                  │
 │                                                          │
-│ 1. Read new version from tools/cli/package.json          │
-│ 2. git tag vX.Y.Z, git push --tags                       │
-│    (existing publish.yml ships to npm + GitHub Release)  │
+│ Phase 1: tag → publish.yml ships to npm                  │
+│   1. Read new version, sanity-check 4 locations          │
+│   2. git tag vX.Y.Z, git push origin vX.Y.Z              │
+│   3. Poll `npm view truecourse@X.Y.Z` until live         │
 │                                                          │
-│ fp-discover listens to the SAME merge event and runs in  │
-│ parallel — it reads campaigns.yaml on main (which the    │
-│ merged PR already flipped to status: done) and starts    │
-│ discovery for the next pending campaign.                 │
+│ Phase 2: verify against the published version            │
+│   4. Clone target at baseline.target_ref                 │
+│   5. `npx -y truecourse@X.Y.Z analyze … --no-llm`        │
+│   6. If TP ≥ 90%: open fp-verify PR (status: done)       │
+│      If TP < 90%: file new fp-fix issues, status stays   │
+│                  verifying (next queue-empty cuts        │
+│                  another release)                        │
 └──────────────────────────────────────────────────────────┘
 ```
 
@@ -237,18 +250,17 @@ web-UI edit needed.
 
 | Field | Value |
 |---|---|
-| **Trigger** | GitHub event: `pull_request.closed` on `truecourse-ai/truecourse` |
-| **Filters** | `Is merged` equals `true` AND `Head Branch` starts with `claude/fp-campaign-close/` AND `Labels` is one of `fp-campaign-complete` |
-| **Bootstrap** | First-time run is **Run now** from the routine page (no PR has merged yet). Same button works for any manual re-run. |
+| **Trigger** | **Manual only** (no triggers configured). Fired from the **Run now** button on the routine page when a human decides to start a new campaign. |
 | **Repositories** | `truecourse-ai/truecourse` |
 | **Branch push policy** | Default (`claude/`-prefixed only) |
 | **Environment** | `fp-automation` (shared with the other two routines) |
 | **Prompt** | Bootstrap pointer (see [Prompt convention](#triggers-three-routines)) → `docs/fp-automation/prompts/fp-discover.md` |
 
-`fp-discover` shares its trigger event with `fp-campaign-close` — both
-routines fire in parallel on every campaign-close PR merge. `fp-discover`
-reads `campaigns.yaml` on `main` (the merged PR already flipped the
-just-closed campaign to `status: done`) and picks the next `pending` one.
+Manual control: `fp-discover` is deliberately not chained from
+`fp-campaign-close`. After a campaign finishes (a `fp-verify` PR
+merges marking it `status: done`), the user reviews the outcome and
+clicks **Run now** on `fp-discover` to start the next pending campaign.
+This gives a natural review checkpoint between campaigns.
 
 Steps the session takes:
 1. Read `docs/fp-automation/campaigns.yaml` from `main` on
@@ -335,16 +347,33 @@ needed` note, add `fp-blocked` label, end. The user triages later.
 | **Environment** | `fp-automation` |
 | **Prompt** | Bootstrap pointer (see [Prompt convention](#triggers-three-routines)) → `docs/fp-automation/prompts/fp-campaign-close.md` |
 
-Steps the session takes:
-1. Check out `main` at the merge commit. Read the version from
-   `tools/cli/package.json`.
-2. `git tag v<version> && git push origin v<version>`. The existing
-   `.github/workflows/publish.yml` triggers on the tag and publishes
-   `truecourse` to npm + creates the GitHub Release.
-3. End.
+Two-phase responsibilities:
 
-`fp-discover` fires on the same event independently — there's no chained
-call from this routine.
+**Phase 1 — Ship the release**
+1. Read new version from `tools/cli/package.json`. Sanity-check the
+   other three locations agree (CLAUDE.md "Releasing").
+2. `git tag v<version> && git push origin v<version>`. The existing
+   `.github/workflows/publish.yml` triggers, ships to npm, creates the
+   GitHub Release.
+3. Poll `npm view truecourse@<version>` every 15 s (timeout 15 min)
+   until the version is live on the registry.
+
+**Phase 2 — Verify against the published artifact**
+4. Find the campaign with `status: verifying` in
+   `docs/fp-automation/campaigns.yaml`.
+5. Clone the campaign's `target_repo` at `baseline.target_ref`.
+6. Analyze with `npx -y truecourse@<version> analyze /tmp/target --no-llm`
+   — explicitly the just-published version, not the local build.
+7. Classify, compute `tp_rate`.
+   - **TP ≥ 90 %**: open a `fp-verify` PR that flips campaign to
+     `status: done` and fills `final.*`. Body links the release.
+   - **TP < 90 %**: file new `fp-fix` issues for newly-surfaced FPs.
+     Leave campaign `status: verifying` (the next queue-empty path
+     will cut another release).
+
+A single campaign may produce multiple campaign-close PRs (and version
+bumps) if early releases don't clear the gate. Each release ships real
+fixes; the campaign is only `done` when a post-release verify passes.
 
 ## Setup checklist
 
@@ -369,10 +398,22 @@ One-time, before the first run:
 
    The other two routines pick the existing `fp-automation` from the
    same selector. Trigger configs are listed under each routine above.
-4. **Kick off the first run** by clicking **Run now** on `fp-discover`.
-   It reads `campaigns.yaml`, finds the first pending campaign
-   (today: `documenso/documenso`), and files the initial `fp-fix`
-   issues. From here, the loop drives itself.
+4. **Kick off the first campaign** by clicking **Run now** on
+   `fp-discover`. It reads `campaigns.yaml`, finds the first pending
+   campaign (today: `documenso/documenso`), and files the initial
+   `fp-fix` issues.
+5. **Start the inner loop** by clicking **Run now** on `fp-next-fix`
+   once any `fp-fix` issues exist. From this first PR onward, fp-fix
+   PR merges fire fp-next-fix automatically until the campaign queue
+   is empty.
+6. **The outer loop is event-driven**: when the queue empties,
+   fp-next-fix opens a campaign-close PR. Merging it fires
+   fp-campaign-close, which tags, publishes to npm, then verifies
+   against the published version. The cycle continues (more release +
+   verify) until TP ≥ 90 %, at which point a `fp-verify` PR marks the
+   campaign `done`.
+7. **Start the next campaign** by clicking **Run now** on
+   `fp-discover` again. Manual decision — no auto-chain.
 
 ## Acceptance criteria
 
@@ -407,31 +448,38 @@ campaign. The campaigns file is the audit trail.
 ## Resolved decisions
 
 1. **Runtime**: Claude Code **Routines** (Anthropic-managed cloud
-   sessions), triggered entirely by GitHub events
-   (`pull_request.closed` + filters). No self-hosted runners, no API
-   tokens, no env vars on the environment. First-time bootstrap is a
-   manual **Run now** click on `fp-discover`.
-2. **Paraphrasing licence**: paraphrased snippets must be far enough from
+   sessions). fp-next-fix and fp-campaign-close fire on
+   `pull_request.closed` events with filters. **fp-discover is manual
+   only** — humans decide when to start the next campaign by clicking
+   Run now. No self-hosted runners, no API tokens, no env vars on the
+   environment.
+2. **Verification is post-release**: the 90 % TP gate is checked by
+   fp-campaign-close against the **just-published npm version**
+   (`npx -y truecourse@<version>`), not against the local source.
+   That means the artifact users get is what we measure. A campaign
+   can produce multiple version bumps if early releases don't clear
+   the gate.
+3. **Paraphrasing licence**: paraphrased snippets must be far enough from
    the original to stand alone. PR description links the source rather
    than embedding it. Open question — still worth a legal sanity-check
    before running across GPL/AGPL repos.
-3. **Borderline FPs**: not auto-fixed. Session posts a `borderline:`
+4. **Borderline FPs**: not auto-fixed. Session posts a `borderline:`
    comment on the issue with both interpretations; user adds
    `fp-confirmed` / `tp-confirmed` to decide.
-4. **Visitor refactors**: not auto-attempted. Session opens the PR with
+5. **Visitor refactors**: not auto-attempted. Session opens the PR with
    the fixtures and a `## Refactor needed` note, labels it
    `needs-design`, ends.
-5. **Cost control**: analyze runs `--no-llm` (deterministic rules only).
+6. **Cost control**: analyze runs `--no-llm` (deterministic rules only).
    Routine sessions draw down the claude.ai subscription's daily routine
    cap + regular subscription usage (not API spend on an
    `ANTHROPIC_API_KEY`).
-6. **Branch hygiene**: branches use the `claude/` prefix
-   (`claude/fp-fix/<rule-key>`, `claude/fp-campaign-close/<owner>-<repo>`)
-   to fit the routine default push policy. Auto-delete head branches on
-   merge.
-7. **Concurrency**: session adds `fp-in-progress` to the picked issue
+7. **Branch hygiene**: branches use the `claude/` prefix
+   (`claude/fp-fix/<rule-key>`, `claude/fp-campaign-close/<owner>-<repo>`,
+   `claude/fp-verify/<owner>-<repo>-vX.Y.Z`) to fit the routine default
+   push policy. Auto-delete head branches on merge.
+8. **Concurrency**: session adds `fp-in-progress` to the picked issue
    before doing anything else; competing sessions skip labelled issues.
-8. **Target order**: `docs/fp-automation/campaigns.yaml` is the source of
+9. **Target order**: `docs/fp-automation/campaigns.yaml` is the source of
    truth. Sessions pick the first non-`done`, non-`skipped` campaign.
 
 ## What's next
@@ -445,10 +493,13 @@ If green-lit:
 2. Walk through the "Setup checklist" above to install the GitHub App,
    enable branch auto-delete, and create the three routines (sharing
    the `fp-automation` cloud environment).
-3. Click **Run now** on `fp-discover`. From there:
-   - Inner loop: fp-fix PR merges drive `fp-next-fix` until the campaign
-     queue is empty.
-   - Outer loop: campaign-close PR merges fire both `fp-campaign-close`
-     (tags the release; publish.yml ships to npm) and `fp-discover`
-     (starts the next campaign's discovery) in parallel on the same
-     event.
+3. Click **Run now** on `fp-discover` to start the first campaign.
+   From there:
+   - **Inner loop** (auto): fp-fix PR merges drive `fp-next-fix` until
+     the campaign queue is empty.
+   - **Outer loop** (auto): campaign-close PR merges fire
+     `fp-campaign-close`, which tags + publishes + verifies against the
+     just-published version. If TP < 90 % it files new fp-fix issues
+     and the inner loop resumes.
+   - **Next campaign** (manual): once a campaign reaches
+     `status: done`, click **Run now** on `fp-discover` again.

--- a/docs/fp-automation/campaigns.yaml
+++ b/docs/fp-automation/campaigns.yaml
@@ -6,9 +6,13 @@
 #
 # Status values:
 #   pending      — not yet started
-#   discovering  — analyze + issue filing in progress
+#   discovering  — fp-discover analyze + issue filing in progress
 #   in_progress  — at least one fp-fix issue still open
-#   done         — final.tp_rate >= 0.90 and no open fp-fix issues
+#   verifying    — campaign-close PR opened/merged; awaiting post-release
+#                  verify in fp-campaign-close (can cycle through multiple
+#                  releases until TP rate clears 90%)
+#   done         — final.tp_rate >= 0.90 confirmed against the
+#                  npm-published version
 #   skipped      — manually deprioritized; note explains why
 #
 # Each campaign also writes its open issues with label

--- a/docs/fp-automation/prompts/fp-campaign-close.md
+++ b/docs/fp-automation/prompts/fp-campaign-close.md
@@ -2,23 +2,24 @@
 
 You are the **fp-campaign-close** routine. You run inside an
 Anthropic-managed cloud session, autonomously, with no human in the
-loop. Your job is small and well-defined: when a `fp-campaign-complete`
-PR merges to `main`, push a release tag.
+loop. Your job has two phases: ship the release, then verify against
+the just-published artifact.
 
-The next campaign's discovery is fired by the `fp-discover` routine
-listening to the same merge event in parallel — you don't chain to it.
+You fire when a `fp-campaign-complete` PR merges to `main`. fp-discover
+is **not** automatically triggered after you — campaign starts are
+manual.
 
 ## Inputs
 
 - The repository `truecourse-ai/truecourse` is cloned at `main` at the
   merge commit.
 
-## Step-by-step
+## Phase 1: Ship the release
 
-### 1. Read the new version
+### 1.1 Read the new version
 
 - From the working copy, read `version` out of `tools/cli/package.json`.
-  This is the new version the merged PR bumped to.
+  This is the version the merged PR bumped to.
 - Sanity-check it against:
   - `packages/core/package.json` — must match.
   - `apps/dashboard/server/package.json` — must match.
@@ -29,43 +30,94 @@ listening to the same merge event in parallel — you don't chain to it.
   mismatch after merge` with the four observed values and the merge
   commit SHA, and end.
 
-### 2. Push the tag
+### 1.2 Push the tag
 
-- Verify a tag `v<version>` does **not** already exist:
+- Verify the tag `v<version>` does **not** already exist:
   `git tag -l "v<version>"` should be empty. If it exists, end without
-  pushing (the campaign was already closed, or someone tagged
-  manually).
+  pushing.
 - Create and push the tag:
   ```
   git tag v<version>
   git push origin v<version>
   ```
 - The existing `.github/workflows/publish.yml` triggers on tag push,
-  ships `truecourse` to npm, and creates the GitHub Release. You don't
-  need to do anything else.
+  ships `truecourse` to npm, and creates the GitHub Release.
 
-### 3. Summarize and end
+### 1.3 Wait for npm to have the new version
 
-- Post a brief end-of-run summary in the session log:
+- Poll `npm view truecourse@<version> version` every 15 seconds. Stop
+  when it returns the new version cleanly (no error). Timeout after
+  15 minutes — publish.yml has CI + tests + dist build + publish, so
+  5–10 min is normal.
+- If the timeout hits without the version appearing on npm: open an
+  issue `[fp-campaign-close] npm publish did not complete for
+  v<version>` linking the publish.yml run, and end. Do **not** proceed
+  to verification — we can't verify a version that isn't out.
+
+## Phase 2: Verify the campaign against the published version
+
+### 2.1 Identify the campaign and re-analyze
+
+- Find the campaign in `docs/fp-automation/campaigns.yaml` with
+  `status: verifying`. There should be exactly one.
+- Clone its `target_repo` at the campaign's recorded
+  `baseline.target_ref` to `/tmp/target`:
   ```
-  Released v<version>. publish.yml will handle npm + GitHub Release.
+  git clone https://github.com/<target_repo>.git /tmp/target
+  git -C /tmp/target checkout <baseline.target_ref>
   ```
-- End.
+- Run analyze **using the just-published npm version**, not the local
+  build:
+  ```
+  npx -y truecourse@<version> analyze /tmp/target --no-llm \
+    --output /tmp/analysis.json
+  ```
+- If analyze fails: open an issue `[fp-campaign-close] post-release
+  analyze failed for v<version>` with the error tail, leave the
+  campaign as `status: verifying`, end.
 
-## Failure modes
+### 2.2 Classify and decide
 
-- **Tag push fails** (e.g. permissions): do not retry. Open an issue
-  titled `[fp-campaign-close] tag push failed for v<version>` with
-  the error, end.
-- **Version mismatch across the four locations**: see step 1. Do not
-  push; open the mismatch issue and end.
+- Group violations by `rule_key`. Sample up to 10 per rule and
+  classify TP / FP / borderline (same rubric fp-discover uses).
+- Compute totals: `total_violations`, `tp`, `fp`, `tp_rate`.
+
+**If `tp_rate >= 0.90`**: the campaign is done.
+
+- On a branch `claude/fp-verify/<owner>-<repo>-v<version>` in
+  `truecourse-ai/truecourse`, update `docs/fp-automation/campaigns.yaml`:
+  - `status: done`
+  - Fill `final.*`: `analyzed_at` (ISO now), `target_ref`
+    (the baseline ref we just analyzed), `total_violations`, `tp`,
+    `fp`, `tp_rate`.
+- Open a PR titled `chore(fp): mark <owner>/<repo> campaign done at
+  v<version>`. Body: before/after TP rate, link to the merged
+  campaign-close PR, link to the npm release.
+- The PR can be merged at the user's convenience — it's purely
+  bookkeeping. End.
+
+**If `tp_rate < 0.90`**: the campaign continues.
+
+- File one fp-fix issue per rule with FPs (same YAML schema as
+  fp-discover). Add label `fp-target:<owner>-<repo>` (note: not
+  `fp-target:v<version>` — issues stay attached to the campaign, not
+  to a specific version).
+- Borderline cases → comment on the most recent campaign-close PR
+  for human triage, same as fp-discover.
+- Leave the campaign as `status: verifying` (not `in_progress`) so
+  the next queue-empty path opens another campaign-close PR for
+  another release. End.
 
 ## Hard constraints
 
-- Never modify files in this session. Push only the tag.
-- Never push to a branch.
-- Never run `truecourse analyze`, tests, or builds. The merged PR
-  already had CI green.
-- One tag push per session. Never push two tags.
+- Phase 1 must complete before Phase 2 starts. If the tag push fails
+  or npm doesn't publish, end without verifying.
+- Always analyze with `npx -y truecourse@<version>`, never with
+  `pnpm exec truecourse` — the whole point of this routine is to
+  verify the published artifact.
+- Never modify fixtures, visitors, rules, or any analyzer code. Only
+  `docs/fp-automation/campaigns.yaml` may be touched here, and only
+  in Phase 2.
+- Never push outside `claude/`-prefixed branches.
 - If anything is unexpected, open an issue and end. Do not invent
   state.

--- a/docs/fp-automation/prompts/fp-discover.md
+++ b/docs/fp-automation/prompts/fp-discover.md
@@ -12,12 +12,12 @@ Run exactly one campaign per invocation. Do **not** loop across campaigns.
 
 - The repository `truecourse-ai/truecourse` is cloned at the default
   branch.
-- The routine fires either from a **Run now** click (first-time
-  bootstrap, or manual re-run) or from a GitHub event:
-  `pull_request.closed` on a campaign-close PR. In both cases the
-  next campaign to run is determined by reading
-  `docs/fp-automation/campaigns.yaml` — there are no per-invocation
-  parameters.
+- The routine is **manual-only**: it fires from a **Run now** click in
+  the web UI. There is no GitHub trigger and no API trigger. A human
+  decides when to start a campaign (typically after reviewing the
+  previous campaign's outcome).
+- The next campaign to run is determined entirely by reading
+  `docs/fp-automation/campaigns.yaml` — no per-invocation parameters.
 
 ## Step-by-step
 

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -146,17 +146,15 @@ If step 1 found no open `fp-fix` issues for the current campaign:
 1. Find the campaign in `docs/fp-automation/campaigns.yaml` with
    `status: in_progress` or `status: discovering`. There should be
    exactly one.
-2. Clone the campaign's `target_repo` at the campaign's recorded
-   `baseline.target_ref` (or HEAD if missing) to `/tmp/target`.
-3. Re-run `pnpm exec truecourse analyze /tmp/target --no-llm`.
-4. Classify violations as in fp-discover step 4. Compute final `tp`,
-   `fp`, `tp_rate`.
-5. **If `tp_rate >= 0.90`**: open a campaign-close PR.
+2. **Do not** run analyze in this session. The "did we hit 90 %" check
+   happens after the release, in `fp-campaign-close`, against the
+   npm-published artifact — not against the local build.
+3. Open a campaign-close PR.
    - Branch: `claude/fp-campaign-close/<owner>-<repo>`.
    - File changes:
      - `docs/fp-automation/campaigns.yaml`: set the campaign's
-       `status: done`, fill `final.*` (analyzed_at, target_ref,
-       total_violations, tp, fp, tp_rate).
+       `status: verifying`. Do **not** fill `final.*` — that's
+       fp-campaign-close's job after the post-release analyze.
      - Patch-bump the version in all four required locations from
        CLAUDE.md:
        1. `tools/cli/package.json` — `version`
@@ -165,15 +163,20 @@ If step 1 found no open `fp-fix` issues for the current campaign:
        4. `tools/cli/src/index.ts` — the `.version("X.Y.Z")` call on
           the commander program
      - **No** fixture or visitor changes.
-   - Title: `chore(fp): close <owner>/<repo> campaign, bump to vX.Y.Z`.
+   - Title: `chore(fp): release vX.Y.Z (verifying <owner>/<repo>)`.
    - Labels: `fp-campaign-complete`.
    - Body: list merged fp-fix PRs from this campaign (search by label
-     `fp-target:<owner>-<repo>` + state merged), the before/after
-     TP-rate, and the new version.
+     `fp-target:<owner>-<repo>` + state merged) and the new version.
+     Note explicitly: "TP-rate verification happens after this PR
+     merges, in the fp-campaign-close routine, using the
+     npm-published version."
    - End.
-6. **If `tp_rate < 0.90`**: act like fp-discover step 5 — file new
-   `fp-fix` issues for newly-surfaced FPs at the new analyze run.
-   Leave the campaign `status` as is (`in_progress`). End.
+
+Note: a single campaign can produce **multiple** campaign-close PRs
+(and therefore multiple version bumps) if the post-release verify
+finds the TP rate is still < 90 %. Each release ships real fixes;
+the campaign is only considered `done` when a post-release verify
+clears the 90 % gate.
 
 ## Refactor-required path
 


### PR DESCRIPTION
## Summary

Three structural changes to the FP automation design, driven by the
realization that the "did we hit 90 % TP" check should run against the
**npm-published artifact**, not the local build.

### 1. Verification moves post-release

`fp-next-fix` no longer runs analyze in the queue-empty path. It just
opens a campaign-close PR with the version bump and `status: verifying`.

`fp-campaign-close` grows a Phase 2: after tag + waiting for
`npm view truecourse@<version>` to confirm the release is live, it runs
`npx -y truecourse@<version> analyze … --no-llm` against the campaign's
target. The result decides whether the campaign is `done` (≥ 90 %) or
continues (< 90 %, file new fp-fix issues, another release follows).

A campaign can produce multiple version bumps before being marked done.
Each release ships real fixes; the campaign is only `done` when
post-release verification clears the gate.

### 2. fp-discover is manual-only

No GitHub trigger, no API trigger. Humans decide when to start the next
campaign by clicking **Run now**. This is the natural review checkpoint
between campaigns — the user sees the prior campaign's outcome before
committing the next one.

### 3. New `verifying` status

Added to `campaigns.yaml` between `in_progress` and `done`. Tracks the
"version bumped, release shipping, awaiting post-release verify" state.

## Web-UI side effect

`fp-discover`'s routine config in https://claude.ai/code/routines still
has the GitHub event trigger from the previous design. After this PR
merges, **remove that trigger** from the routine so fp-discover becomes
Run-now-only.

## Test plan

- [ ] Review the restructure — confirm the post-release verify story
      matches intent.
- [ ] Confirm whether multiple version bumps per campaign is acceptable
      (vs squashing into a single bump at the end).
- [ ] After merge: remove the GitHub event trigger from `fp-discover` in
      the routine config.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_