### PR TITLE
chore(fp): start discovery for documenso/documenso

### DIFF
--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -21,12 +21,15 @@ finishes, sessions update that file in the campaign-close PR.
 
 For each target OSS repo:
 
-1. Run `truecourse analyze --no-llm` (deterministic rules only — keeps cost
-   bounded; LLM-rule FPs are a separate phase).
+1. `pnpm install && pnpm build:dist` in the truecourse working copy, then
+   `node dist/cli.mjs analyze /tmp/target --no-llm` (deterministic rules
+   only — keeps cost bounded). We always invoke the analyzer via the
+   freshly-built `dist/` artifact — same bytes publish.yml will ship to
+   npm. We never `npx truecourse` or `npm install truecourse`.
 2. Triage violations into TPs / FPs.
 3. For every rule with at least one FP, file one GitHub issue labelled
-   `fp-fix` describing the rule, the target repo, links to OSS snippets, and
-   the FP count.
+   `fp-fix` describing the rule, the target repo, links to OSS snippets,
+   and the FP count.
 4. The fix loop consumes the open `fp-fix` issues one at a time:
    a. Paraphrase one FP-triggering snippet from the issue into the
       `sample-js-project-positive` (or `…-python-positive`) fixture — the
@@ -41,26 +44,25 @@ For each target OSS repo:
       issue.
 5. When the PR merges (closing the issue), the routine fires again and the
    next `fp-fix`-labelled issue is picked up automatically.
-6. When no `fp-fix` issues remain open for the current target, open a
-   **campaign-close PR** (see below) that bumps the version and flips
-   the campaign to `status: verifying`. **No local analyze is run** at
-   this point — the "did we hit 90 %" check happens post-release.
-7. When the campaign-close PR merges, `fp-campaign-close` runs in two
-   phases: tag + npm publish (Phase 1), then analyze with the
-   just-published `npx -y truecourse@<version>` (Phase 2). Phase 2
-   decides whether the campaign is `done` (TP ≥ 90 %) or continues
-   (TP < 90 %, file new `fp-fix` issues, another release follows).
-8. Once a campaign is `done`, the user clicks **Run now** on
-   `fp-discover` to start the next pending campaign. No auto-chain.
+6. When no `fp-fix` issues remain for the current target, fp-next-fix
+   **re-runs analyze against the freshly-built local dist** (containing
+   every merged fix). If TP ≥ 90 %, it opens a **campaign-close PR**
+   (see below) that bumps the version and flips campaign `status: done`.
+   If TP < 90 %, it files new `fp-fix` issues; the campaign continues
+   without a release.
+7. When the campaign-close PR merges, two routines fire in parallel:
+   `fp-campaign-close` pushes `vX.Y.Z` (publish.yml ships from dist —
+   byte-equal to what fp-next-fix just verified), and `fp-discover`
+   starts the next pending campaign.
 
 ### Campaign-close PR
 
-When fp-next-fix runs out of `fp-fix` issues for a campaign, it opens
-a campaign-close PR that:
+When fp-next-fix's queue-empty path measures `tp_rate >= 0.90` against
+the freshly-built dist, it opens a campaign-close PR that:
 
-- Sets `status: verifying` for the campaign in
-  `docs/fp-automation/campaigns.yaml`. Does **not** fill `final.*` —
-  fp-campaign-close fills that after the post-release verify.
+- Sets `status: done` for the campaign in
+  `docs/fp-automation/campaigns.yaml` and fills `final.*` (analyzed_at,
+  target_ref, total_violations, tp, fp, tp_rate).
 - Bumps the patch version (FP fixes are bug fixes) in all four required
   places, per CLAUDE.md:
   1. `tools/cli/package.json`
@@ -70,16 +72,9 @@ a campaign-close PR that:
 - Carries the **`fp-campaign-complete`** label.
 - Branch name `claude/fp-campaign-close/<owner>-<repo>`.
 
-On merge, `fp-campaign-close` runs Phase 1 (tag + wait for npm publish)
-then Phase 2 (analyze with `npx -y truecourse@<version>` against the
-target). Phase 2 either:
-- Opens a `fp-verify` PR flipping `status: done` + filling `final.*`
-  (TP ≥ 90 %), or
-- Files new `fp-fix` issues and leaves `status: verifying` so the next
-  queue-empty path produces another release (TP < 90 %).
-
-A campaign can therefore produce multiple version bumps before it's
-marked done.
+On merge, `fp-campaign-close` pushes the tag (publish.yml ships to npm)
+and `fp-discover` fires on the same event to start the next pending
+campaign — both routines run in parallel, each doing one job.
 
 ### Borderline FPs
 
@@ -122,10 +117,11 @@ So an FP fix means:
 ```
 ┌──────────────────────────┐        ┌─────────────────────────┐
 │ campaigns.yaml           │───────▶│ Routine: fp-discover    │
-│ ordered repo list +      │ pick   │ trigger: MANUAL ONLY    │
-│ baseline / final results │  next  │ (Run now from web UI)   │
-└──────────────────────────┘        │ (analyze --no-llm,      │
-                                    │  writes baseline back,  │
+│ ordered repo list +      │ pick   │ trigger: same as        │
+│ baseline / final results │  next  │  fp-campaign-close,     │
+└──────────────────────────┘        │  + Run now for bootstrap│
+                                    │ (analyze via node       │
+                                    │  dist/cli.mjs --no-llm, │
                                     │  files fp-fix issues)   │
 ┌─────────────────────────┐         └────────────┬────────────┘
 │ N × GitHub issues       │◄─────────────────────┘
@@ -154,24 +150,20 @@ So an FP fix means:
            │ on fp-fix PR merge           │
            │                              ▼
 ┌──────────────────────────────────────────────────────────┐
-│ Routine: fp-campaign-close                               │
+│ Routine: fp-campaign-close (parallel with fp-discover)   │
 │ trigger: pull_request.closed                             │
 │   Is merged=true, Head Branch starts-with                │
 │   claude/fp-campaign-close/,                             │
 │   Labels is-one-of fp-campaign-complete                  │
 │                                                          │
-│ Phase 1: tag → publish.yml ships to npm                  │
-│   1. Read new version, sanity-check 4 locations          │
-│   2. git tag vX.Y.Z, git push origin vX.Y.Z              │
-│   3. Poll `npm view truecourse@X.Y.Z` until live         │
+│ 1. Read new version from tools/cli/package.json,         │
+│    sanity-check the 4 locations agree                    │
+│ 2. git tag vX.Y.Z, git push origin vX.Y.Z                │
+│    (publish.yml ships dist/ to npm + creates GH Release) │
 │                                                          │
-│ Phase 2: verify against the published version            │
-│   4. Clone target at baseline.target_ref                 │
-│   5. `npx -y truecourse@X.Y.Z analyze … --no-llm`        │
-│   6. If TP ≥ 90%: open fp-verify PR (status: done)       │
-│      If TP < 90%: file new fp-fix issues, status stays   │
-│                  verifying (next queue-empty cuts        │
-│                  another release)                        │
+│ No analyze, no verification — fp-next-fix already        │
+│ measured TP ≥ 90% against the same dist artifact         │
+│ publish.yml is about to ship.                            │
 └──────────────────────────────────────────────────────────┘
 ```
 
@@ -250,33 +242,36 @@ web-UI edit needed.
 
 | Field | Value |
 |---|---|
-| **Trigger** | **Manual only** (no triggers configured). Fired from the **Run now** button on the routine page when a human decides to start a new campaign. |
+| **Trigger** | GitHub event: `pull_request.closed` on `truecourse-ai/truecourse` |
+| **Filters** | `Is merged` equals `true` AND `Head Branch` starts with `claude/fp-campaign-close/` AND `Labels` is one of `fp-campaign-complete` |
+| **Bootstrap** | First-time run is **Run now** from the routine page (no PR has merged yet). Same button works for any manual re-run. |
 | **Repositories** | `truecourse-ai/truecourse` |
 | **Branch push policy** | Default (`claude/`-prefixed only) |
-| **Environment** | `fp-automation` (shared with the other two routines) |
+| **Environment** | **Default** (shared by all three routines; no customization needed) |
 | **Prompt** | Bootstrap pointer (see [Prompt convention](#triggers-three-routines)) → `docs/fp-automation/prompts/fp-discover.md` |
 
-Manual control: `fp-discover` is deliberately not chained from
-`fp-campaign-close`. After a campaign finishes (a `fp-verify` PR
-merges marking it `status: done`), the user reviews the outcome and
-clicks **Run now** on `fp-discover` to start the next pending campaign.
-This gives a natural review checkpoint between campaigns.
+`fp-discover` shares its trigger event with `fp-campaign-close` — both
+routines fire in parallel on every campaign-close PR merge.
+`fp-discover` reads `campaigns.yaml` on `main` (the merged PR already
+flipped the just-closed campaign to `status: done`) and picks the next
+`pending` one.
 
 Steps the session takes:
-1. Read `docs/fp-automation/campaigns.yaml` from `main` on
-   `truecourse-ai/truecourse`. Pick first campaign with `status: pending`
-   (unless `text` overrides).
-2. Set its `status: discovering` (PR to bump the YAML is allowed; the
-   campaign-close PR will flip to `done` later).
-3. Clone the target repo at HEAD; record commit SHA as `target_ref`.
-4. `pnpm build && pnpm exec truecourse analyze /tmp/target --no-llm`.
-5. Per rule with ≥ 1 violation: sample up to 10 violations, classify
-   TP/FP. If FP rate ≥ 10 %, file an `fp-fix` + `fp-target:<owner>-<repo>`
-   issue using the YAML schema above. Borderline cases get a comment
-   on the issue, not auto-fix.
-6. Commit a `baseline.*` update PR to `docs/fp-automation/campaigns.yaml`
-   (separate from any FP fix PRs).
-7. End. The next `fp-next-fix` invocation (manual the first time, then
+1. Read `docs/fp-automation/campaigns.yaml`. Pick the first campaign
+   with `status: pending`. If none, end with "no pending campaigns".
+2. Set its `status: discovering` on a `claude/fp-discover/<owner>-<repo>`
+   branch + PR.
+3. `pnpm install && pnpm build:dist` in the truecourse working copy
+   (produces `dist/cli.mjs`, byte-equal to what publish.yml would
+   ship). We never analyze via `npx truecourse` or `npm install`.
+4. Clone the target repo at HEAD; record commit SHA as `target_ref`.
+5. `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/analysis.json`.
+6. Per rule with ≥ 1 violation: sample up to 10 violations, classify
+   TP/FP. If FP rate ≥ 10 %, file an `fp-fix` +
+   `fp-target:<owner>-<repo>` issue using the YAML schema above.
+   Borderline cases get a comment on the issue, not auto-fix.
+7. Commit a `baseline.*` update to the same discovery PR.
+8. End. The next `fp-next-fix` invocation (manual the first time, then
    automatic on each PR merge) consumes the issues.
 
 ### 2. `fp-next-fix` — consume one fp-fix issue on each merge
@@ -287,7 +282,7 @@ Steps the session takes:
 | **Filters** | `Is merged` equals `true` AND `Head Branch` starts with `claude/fp-fix/` AND `Labels` is one of `fp-fix` |
 | **Repositories** | `truecourse-ai/truecourse` (target OSS repo cloned inside the session into `/tmp/target`) |
 | **Branch push policy** | Default — branches are `claude/fp-fix/<rule-key>`, which fits the `claude/`-prefix rule |
-| **Environment** | `fp-automation` |
+| **Environment** | **Default** |
 | **Prompt** | Bootstrap pointer (see [Prompt convention](#triggers-three-routines)) → `docs/fp-automation/prompts/fp-next-fix.md` |
 
 Steps the session takes:
@@ -296,8 +291,9 @@ Steps the session takes:
 2. Add label `fp-in-progress` to the issue (concurrency lock).
 3. Parse the YAML block from the issue body. Clone target repo at
    `target_ref` to `/tmp/target`.
-4. `pnpm build && pnpm exec truecourse analyze /tmp/target --no-llm`.
-   Filter to this rule.
+4. `pnpm install && pnpm build:dist`, then
+   `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/analysis.json`.
+   Filter to this rule. (Always dist, never `npx truecourse`.)
 5. Re-confirm the FP still reproduces. If not (upstream fixed, or a
    previous fix already resolved it), close the issue with comment
    "no longer reproduces" and end.
@@ -320,18 +316,25 @@ Steps the session takes:
 
 **Queue empty path** (no open `fp-fix` issues for the current campaign):
 
-1. Re-run `truecourse analyze /tmp/target --no-llm`. Compute TP rate.
-2. If ≥ 90 %: open a **campaign-close PR** on
+1. `pnpm install && pnpm build:dist` to rebuild dist with all merged
+   fixes on `main`.
+2. Re-clone target at `baseline.target_ref` and run
+   `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/final.json`.
+   Compute TP rate.
+3. **If ≥ 90 %**: open a **campaign-close PR** on
    `claude/fp-campaign-close/<owner>-<repo>` containing:
    - `docs/fp-automation/campaigns.yaml` updated (`status: done`,
      `final.*` filled),
    - patch version bumped in all four locations from CLAUDE.md,
    - label `fp-campaign-complete`,
    - body listing the campaign's rule fixes by PR number and the
-     before/after TP-rate.
-3. If < 90 %: file new `fp-fix` issues for newly-discovered FPs (same
-   shape as discovery). Leave campaign `status: in_progress`.
-4. End. The campaign-close PR merge fires `fp-campaign-close`.
+     before/after TP-rate (noting the measurement was taken against
+     `node dist/cli.mjs` from the freshly-built dist).
+4. **If < 90 %**: file new `fp-fix` issues for newly-discovered FPs
+   (same shape as discovery). Leave campaign `status: in_progress`.
+   **No campaign-close PR is opened** — no release is cut.
+5. End. The campaign-close PR merge fires `fp-campaign-close` and
+   `fp-discover` in parallel.
 
 **Refactor-required path**: comment on the issue with a `## Refactor
 needed` note, add `fp-blocked` label, end. The user triages later.
@@ -344,36 +347,20 @@ needed` note, add `fp-blocked` label, end. The user triages later.
 | **Filters** | `Is merged` equals `true` AND `Head Branch` starts with `claude/fp-campaign-close/` AND `Labels` is one of `fp-campaign-complete` |
 | **Repositories** | `truecourse-ai/truecourse` |
 | **Branch push policy** | Default — only needs to push a tag, not a branch |
-| **Environment** | `fp-automation` |
+| **Environment** | **Default** |
 | **Prompt** | Bootstrap pointer (see [Prompt convention](#triggers-three-routines)) → `docs/fp-automation/prompts/fp-campaign-close.md` |
 
-Two-phase responsibilities:
-
-**Phase 1 — Ship the release**
+Steps the session takes:
 1. Read new version from `tools/cli/package.json`. Sanity-check the
    other three locations agree (CLAUDE.md "Releasing").
 2. `git tag v<version> && git push origin v<version>`. The existing
-   `.github/workflows/publish.yml` triggers, ships to npm, creates the
-   GitHub Release.
-3. Poll `npm view truecourse@<version>` every 15 s (timeout 15 min)
-   until the version is live on the registry.
+   `.github/workflows/publish.yml` triggers, ships `dist/` to npm,
+   creates the GitHub Release.
+3. End. No verification step — fp-next-fix already measured TP ≥ 90 %
+   against the same dist artifact publish.yml is shipping.
 
-**Phase 2 — Verify against the published artifact**
-4. Find the campaign with `status: verifying` in
-   `docs/fp-automation/campaigns.yaml`.
-5. Clone the campaign's `target_repo` at `baseline.target_ref`.
-6. Analyze with `npx -y truecourse@<version> analyze /tmp/target --no-llm`
-   — explicitly the just-published version, not the local build.
-7. Classify, compute `tp_rate`.
-   - **TP ≥ 90 %**: open a `fp-verify` PR that flips campaign to
-     `status: done` and fills `final.*`. Body links the release.
-   - **TP < 90 %**: file new `fp-fix` issues for newly-surfaced FPs.
-     Leave campaign `status: verifying` (the next queue-empty path
-     will cut another release).
-
-A single campaign may produce multiple campaign-close PRs (and version
-bumps) if early releases don't clear the gate. Each release ships real
-fixes; the campaign is only `done` when a post-release verify passes.
+`fp-discover` listens to the same merge event and runs in parallel,
+starting the next pending campaign from `campaigns.yaml`.
 
 ## Setup checklist
 
@@ -387,33 +374,35 @@ One-time, before the first run:
    branches tidy.
 3. **Create the three routines** at
    [claude.ai/code/routines](https://claude.ai/code/routines), pasting
-   the prompts from `docs/fp-automation/prompts/`. In the routine form,
-   the cloud icon next to the prompt opens the environment selector —
-   the first routine you create can use it to **Add environment** named
-   `fp-automation` with:
-   - Network access: **Trusted** (default allowlist covers npm, GitHub,
-     and the OSS repos we clone over HTTPS).
-   - Setup script: `pnpm install && pnpm build`.
-   - Environment variables: none required.
+   the bootstrap prompts (see [Prompt convention](#triggers-three-routines)).
+   Trigger configs are listed under each routine above — note that
+   `fp-discover` and `fp-campaign-close` share the exact same trigger
+   (they fire in parallel on each campaign-close PR merge).
 
-   The other two routines pick the existing `fp-automation` from the
-   same selector. Trigger configs are listed under each routine above.
-4. **Kick off the first campaign** by clicking **Run now** on
-   `fp-discover`. It reads `campaigns.yaml`, finds the first pending
-   campaign (today: `documenso/documenso`), and files the initial
-   `fp-fix` issues.
+   Use the **Default** environment for all three — no custom env is
+   needed because:
+   - Default already uses **Trusted** network access (allowlist covers
+     npm, GitHub, and the OSS repos we clone over HTTPS).
+   - pnpm is pre-installed; project deps (`pnpm install && pnpm build:dist`)
+     run inside each session as the prompt's first step, not via a
+     setup script. (Setup scripts run **before** the per-session repo
+     clone, so they can't `pnpm install` anything from the repo.)
+   - No env vars are required.
+4. **Bootstrap the first campaign** by clicking **Run now** on
+   `fp-discover` (no campaign-close PR has merged yet, so the GitHub
+   trigger has nothing to fire on). It reads `campaigns.yaml`, finds
+   the first pending campaign (today: `documenso/documenso`), and
+   files the initial `fp-fix` issues.
 5. **Start the inner loop** by clicking **Run now** on `fp-next-fix`
    once any `fp-fix` issues exist. From this first PR onward, fp-fix
-   PR merges fire fp-next-fix automatically until the campaign queue
-   is empty.
-6. **The outer loop is event-driven**: when the queue empties,
-   fp-next-fix opens a campaign-close PR. Merging it fires
-   fp-campaign-close, which tags, publishes to npm, then verifies
-   against the published version. The cycle continues (more release +
-   verify) until TP ≥ 90 %, at which point a `fp-verify` PR marks the
-   campaign `done`.
-7. **Start the next campaign** by clicking **Run now** on
-   `fp-discover` again. Manual decision — no auto-chain.
+   PR merges fire `fp-next-fix` automatically until the campaign
+   queue is empty.
+6. **Outer loop is fully automatic**: when the queue empties,
+   fp-next-fix re-analyzes against the freshly-built dist; if TP ≥ 90 %
+   it opens a campaign-close PR. Merging that PR fires
+   `fp-campaign-close` (tags + publishes) and `fp-discover` (starts
+   the next pending campaign) in parallel — no human action needed
+   between campaigns.
 
 ## Acceptance criteria
 
@@ -441,24 +430,25 @@ A **campaign-close PR** is mergeable when:
 - Branch matches `claude/fp-campaign-close/<owner>-<repo>` and carries
   label `fp-campaign-complete`.
 
-A repo is "done" when its campaign-close PR is merged, `vX.Y.Z` is tagged,
-and the `fp-campaign-close` routine has fired `fp-discover` for the next
-campaign. The campaigns file is the audit trail.
+A repo is "done" when its campaign-close PR is merged and `vX.Y.Z` is
+tagged. The 90 % gate was verified pre-merge by fp-next-fix against the
+dist artifact; `fp-discover` fires on the same merge event to start the
+next pending campaign automatically. The campaigns file is the audit
+trail.
 
 ## Resolved decisions
 
 1. **Runtime**: Claude Code **Routines** (Anthropic-managed cloud
-   sessions). fp-next-fix and fp-campaign-close fire on
-   `pull_request.closed` events with filters. **fp-discover is manual
-   only** — humans decide when to start the next campaign by clicking
-   Run now. No self-hosted runners, no API tokens, no env vars on the
-   environment.
-2. **Verification is post-release**: the 90 % TP gate is checked by
-   fp-campaign-close against the **just-published npm version**
-   (`npx -y truecourse@<version>`), not against the local source.
-   That means the artifact users get is what we measure. A campaign
-   can produce multiple version bumps if early releases don't clear
-   the gate.
+   sessions). All three routines fire on `pull_request.closed` events
+   with filters; `fp-discover` and `fp-campaign-close` share the same
+   trigger and fire in parallel. First-time bootstrap is **Run now**.
+   No self-hosted runners, no API tokens, no env vars.
+2. **Verification is pre-release**, against the local `dist/` build:
+   `pnpm build:dist` produces the exact artifact publish.yml ships to
+   npm (no transformation in between). So `node dist/cli.mjs analyze`
+   gives the same answer the eventual published version would. We
+   never `npx truecourse` or `npm install truecourse` from any
+   routine; the local dist is the authoritative invocation.
 3. **Paraphrasing licence**: paraphrased snippets must be far enough from
    the original to stand alone. PR description links the source rather
    than embedding it. Open question — still worth a legal sanity-check
@@ -475,7 +465,7 @@ campaign. The campaigns file is the audit trail.
    `ANTHROPIC_API_KEY`).
 7. **Branch hygiene**: branches use the `claude/` prefix
    (`claude/fp-fix/<rule-key>`, `claude/fp-campaign-close/<owner>-<repo>`,
-   `claude/fp-verify/<owner>-<repo>-vX.Y.Z`) to fit the routine default
+   `claude/fp-discover/<owner>-<repo>`) to fit the routine default
    push policy. Auto-delete head branches on merge.
 8. **Concurrency**: session adds `fp-in-progress` to the picked issue
    before doing anything else; competing sessions skip labelled issues.
@@ -491,8 +481,8 @@ If green-lit:
    - `fp-next-fix.md`
    - `fp-campaign-close.md`
 2. Walk through the "Setup checklist" above to install the GitHub App,
-   enable branch auto-delete, and create the three routines (sharing
-   the `fp-automation` cloud environment).
+   enable branch auto-delete, and create the three routines (all on the
+   **Default** cloud environment).
 3. Click **Run now** on `fp-discover` to start the first campaign.
    From there:
    - **Inner loop** (auto): fp-fix PR merges drive `fp-next-fix` until

--- a/docs/fp-automation/campaigns.yaml
+++ b/docs/fp-automation/campaigns.yaml
@@ -8,11 +8,10 @@
 #   pending      — not yet started
 #   discovering  — fp-discover analyze + issue filing in progress
 #   in_progress  — at least one fp-fix issue still open
-#   verifying    — campaign-close PR opened/merged; awaiting post-release
-#                  verify in fp-campaign-close (can cycle through multiple
-#                  releases until TP rate clears 90%)
-#   done         — final.tp_rate >= 0.90 confirmed against the
-#                  npm-published version
+#   done         — fp-next-fix verified tp_rate >= 0.90 against the
+#                  freshly-built dist (byte-equal to what publish.yml
+#                  ships); campaign-close PR merged; vX.Y.Z tagged
+#                  and released
 #   skipped      — manually deprioritized; note explains why
 #
 # Each campaign also writes its open issues with label

--- a/docs/fp-automation/campaigns.yaml
+++ b/docs/fp-automation/campaigns.yaml
@@ -24,7 +24,7 @@ campaigns:
     tech_stack: [typescript, nextjs, prisma]
     priority: 1
     status: discovering
-    baseline: { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
+    baseline: { analyzed_at: "2026-05-17", target_ref: "8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f", total_violations: 57492, tp: 40, fp: 51, tp_rate: 0.44 }
     final:    { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     notes: []
 

--- a/docs/fp-automation/campaigns.yaml
+++ b/docs/fp-automation/campaigns.yaml
@@ -24,7 +24,7 @@ campaigns:
   - target_repo: documenso/documenso
     tech_stack: [typescript, nextjs, prisma]
     priority: 1
-    status: pending
+    status: discovering
     baseline: { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     final:    { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     notes: []

--- a/docs/fp-automation/prompts/fp-campaign-close.md
+++ b/docs/fp-automation/prompts/fp-campaign-close.md
@@ -2,21 +2,25 @@
 
 You are the **fp-campaign-close** routine. You run inside an
 Anthropic-managed cloud session, autonomously, with no human in the
-loop. Your job has two phases: ship the release, then verify against
-the just-published artifact.
+loop. Your job is small and well-defined: when a `fp-campaign-complete`
+PR merges to `main`, push a release tag.
 
-You fire when a `fp-campaign-complete` PR merges to `main`. fp-discover
-is **not** automatically triggered after you — campaign starts are
-manual.
+The 90 % TP gate was already checked **pre-merge** by fp-next-fix
+against the local dist build — the artifact publish.yml is about to
+ship. So merging the campaign-close PR is the campaign's "done"
+signal, and your only remaining job is tagging.
+
+`fp-discover` fires on the same merge event in parallel and starts
+the next pending campaign — you don't chain to it.
 
 ## Inputs
 
 - The repository `truecourse-ai/truecourse` is cloned at `main` at the
   merge commit.
 
-## Phase 1: Ship the release
+## Step-by-step
 
-### 1.1 Read the new version
+### 1. Read the new version
 
 - From the working copy, read `version` out of `tools/cli/package.json`.
   This is the version the merged PR bumped to.
@@ -30,7 +34,7 @@ manual.
   mismatch after merge` with the four observed values and the merge
   commit SHA, and end.
 
-### 1.2 Push the tag
+### 2. Push the tag
 
 - Verify the tag `v<version>` does **not** already exist:
   `git tag -l "v<version>"` should be empty. If it exists, end without
@@ -41,83 +45,34 @@ manual.
   git push origin v<version>
   ```
 - The existing `.github/workflows/publish.yml` triggers on tag push,
-  ships `truecourse` to npm, and creates the GitHub Release.
+  ships `dist/` to npm, and creates the GitHub Release.
 
-### 1.3 Wait for npm to have the new version
+### 3. End
 
-- Poll `npm view truecourse@<version> version` every 15 seconds. Stop
-  when it returns the new version cleanly (no error). Timeout after
-  15 minutes — publish.yml has CI + tests + dist build + publish, so
-  5–10 min is normal.
-- If the timeout hits without the version appearing on npm: open an
-  issue `[fp-campaign-close] npm publish did not complete for
-  v<version>` linking the publish.yml run, and end. Do **not** proceed
-  to verification — we can't verify a version that isn't out.
-
-## Phase 2: Verify the campaign against the published version
-
-### 2.1 Identify the campaign and re-analyze
-
-- Find the campaign in `docs/fp-automation/campaigns.yaml` with
-  `status: verifying`. There should be exactly one.
-- Clone its `target_repo` at the campaign's recorded
-  `baseline.target_ref` to `/tmp/target`:
+- Post a brief end-of-run summary in the session log:
   ```
-  git clone https://github.com/<target_repo>.git /tmp/target
-  git -C /tmp/target checkout <baseline.target_ref>
+  Released v<version>. publish.yml is handling npm + GitHub Release.
   ```
-- Run analyze **using the just-published npm version**, not the local
-  build:
-  ```
-  npx -y truecourse@<version> analyze /tmp/target --no-llm \
-    --output /tmp/analysis.json
-  ```
-- If analyze fails: open an issue `[fp-campaign-close] post-release
-  analyze failed for v<version>` with the error tail, leave the
-  campaign as `status: verifying`, end.
+- End.
 
-### 2.2 Classify and decide
+## Failure modes
 
-- Group violations by `rule_key`. Sample up to 10 per rule and
-  classify TP / FP / borderline (same rubric fp-discover uses).
-- Compute totals: `total_violations`, `tp`, `fp`, `tp_rate`.
-
-**If `tp_rate >= 0.90`**: the campaign is done.
-
-- On a branch `claude/fp-verify/<owner>-<repo>-v<version>` in
-  `truecourse-ai/truecourse`, update `docs/fp-automation/campaigns.yaml`:
-  - `status: done`
-  - Fill `final.*`: `analyzed_at` (ISO now), `target_ref`
-    (the baseline ref we just analyzed), `total_violations`, `tp`,
-    `fp`, `tp_rate`.
-- Open a PR titled `chore(fp): mark <owner>/<repo> campaign done at
-  v<version>`. Body: before/after TP rate, link to the merged
-  campaign-close PR, link to the npm release.
-- The PR can be merged at the user's convenience — it's purely
-  bookkeeping. End.
-
-**If `tp_rate < 0.90`**: the campaign continues.
-
-- File one fp-fix issue per rule with FPs (same YAML schema as
-  fp-discover). Add label `fp-target:<owner>-<repo>` (note: not
-  `fp-target:v<version>` — issues stay attached to the campaign, not
-  to a specific version).
-- Borderline cases → comment on the most recent campaign-close PR
-  for human triage, same as fp-discover.
-- Leave the campaign as `status: verifying` (not `in_progress`) so
-  the next queue-empty path opens another campaign-close PR for
-  another release. End.
+- **Tag push fails** (e.g. permissions): do not retry. Open an issue
+  titled `[fp-campaign-close] tag push failed for v<version>` with
+  the error, end.
+- **Version mismatch across the four locations**: see step 1. Do not
+  push; open the mismatch issue and end.
 
 ## Hard constraints
 
-- Phase 1 must complete before Phase 2 starts. If the tag push fails
-  or npm doesn't publish, end without verifying.
-- Always analyze with `npx -y truecourse@<version>`, never with
-  `pnpm exec truecourse` — the whole point of this routine is to
-  verify the published artifact.
-- Never modify fixtures, visitors, rules, or any analyzer code. Only
-  `docs/fp-automation/campaigns.yaml` may be touched here, and only
-  in Phase 2.
-- Never push outside `claude/`-prefixed branches.
+- Never modify files in this session. Push only the tag.
+- Never push to a branch.
+- Never run `truecourse analyze`, tests, builds, or any verification.
+  The pre-merge fp-next-fix queue-empty path already verified the
+  campaign hit ≥ 90 % against the exact dist artifact publish.yml will
+  ship.
+- **Never use `npx truecourse` or `npm install truecourse`.** This
+  routine doesn't run truecourse at all — there's no analyze step.
+- One tag push per session. Never push two tags.
 - If anything is unexpected, open an issue and end. Do not invent
   state.

--- a/docs/fp-automation/prompts/fp-discover.md
+++ b/docs/fp-automation/prompts/fp-discover.md
@@ -12,12 +12,12 @@ Run exactly one campaign per invocation. Do **not** loop across campaigns.
 
 - The repository `truecourse-ai/truecourse` is cloned at the default
   branch.
-- The routine is **manual-only**: it fires from a **Run now** click in
-  the web UI. There is no GitHub trigger and no API trigger. A human
-  decides when to start a campaign (typically after reviewing the
-  previous campaign's outcome).
-- The next campaign to run is determined entirely by reading
-  `docs/fp-automation/campaigns.yaml` — no per-invocation parameters.
+- The routine fires either from a **Run now** click (first-time bootstrap
+  for a fresh repo) or from a GitHub event:
+  `pull_request.closed` on a campaign-close PR. In both cases the next
+  campaign to run is determined by reading
+  `docs/fp-automation/campaigns.yaml` — there are no per-invocation
+  parameters.
 
 ## Step-by-step
 
@@ -38,17 +38,24 @@ Run exactly one campaign per invocation. Do **not** loop across campaigns.
   for it to merge — this PR is informational and can be merged at any
   time. Continue.
 
-### 3. Clone and analyze the target repo
+### 3. Build truecourse from local source
+
+- `pnpm install`.
+- `pnpm build:dist`. This produces `dist/cli.mjs`, the **same artifact**
+  that publish.yml ships to npm. Always use this — never `npx
+  truecourse@<...>` or `npm install truecourse`. See "Hard constraints"
+  below.
+
+### 4. Clone and analyze the target repo
 
 - `git clone --depth=1 https://github.com/<target_repo>.git /tmp/target`.
 - Record the commit SHA as `target_ref` (full hash).
-- In the truecourse working copy: `pnpm install && pnpm build`.
-- `pnpm exec truecourse analyze /tmp/target --no-llm --output /tmp/analysis.json`.
+- `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/analysis.json`.
 - If analyze fails: post the failure in a comment on the discovery PR
   from step 2 with the error tail, set the campaign `status: blocked`
   in the same PR, end.
 
-### 4. Triage violations
+### 5. Triage violations
 
 - Group violations by `rule_key`.
 - For each rule with at least one violation:
@@ -58,7 +65,7 @@ Run exactly one campaign per invocation. Do **not** loop across campaigns.
      or **borderline** (could go either way).
   3. Compute the FP rate (FP count / sampled count).
 
-### 5. File one issue per rule with FPs
+### 6. File one issue per rule with FPs
 
 For each rule where FP rate ≥ 10 % (i.e. at least one clear FP out of
 the sample):
@@ -94,7 +101,7 @@ For rules where every sample is borderline (no clear FPs), do **not**
 file an issue. Instead, add a comment on the discovery PR from step 2
 listing the rule and the borderline cases for human triage.
 
-### 6. Update baseline in campaigns.yaml
+### 7. Update baseline in campaigns.yaml
 
 - Compute totals across **all** sampled violations (not just rules with
   FPs):
@@ -107,7 +114,7 @@ listing the rule and the borderline cases for human triage.
   `tp`, `fp`, `tp_rate`. Leave `status` as `discovering`.
 - Commit, push to the existing PR (do **not** open a new one).
 
-### 7. End
+### 8. End
 
 - Post a final comment on the discovery PR summarising: number of issues
   filed, baseline TP rate, target ref. Stop.
@@ -121,6 +128,12 @@ fp-next-fix; you do not need to fire it yourself.
 - One campaign per session. Never analyze a second repo.
 - Never push outside `claude/`-prefixed branches.
 - Never run `truecourse analyze` without `--no-llm`.
+- **Never use `npx truecourse`, `npx -y truecourse@<…>`, or
+  `npm install truecourse`.** Always analyze with `node dist/cli.mjs`
+  from a fresh `pnpm build:dist`. The dist artifact is exactly what
+  publish.yml ships to npm, so it's the authoritative local invocation —
+  using npm to install would either give us a stale published version
+  or introduce a layer of indirection for no benefit.
 - Never paste OSS code into issue bodies — link by URL only.
 - If anything is ambiguous (cannot pick a campaign, analyze output
   unparseable, etc.), comment on the discovery PR with the ambiguity

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -46,8 +46,10 @@ Run exactly one issue per invocation. Do **not** start a second.
 
 - `git clone https://github.com/<target_repo>.git /tmp/target`.
 - `git -C /tmp/target checkout <target_ref>`.
-- In truecourse: `pnpm install && pnpm build`.
-- `pnpm exec truecourse analyze /tmp/target --no-llm --output /tmp/analysis.json`.
+- In truecourse: `pnpm install && pnpm build:dist`. The dist build is
+  the artifact publish.yml ships to npm; we always analyze against this,
+  never `npx truecourse@…`. See "Hard constraints".
+- `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/analysis.json`.
 - Filter `/tmp/analysis.json` to violations with `rule_key == <rule_key>`.
   Cross-reference at least one of the URLs in `samples[].url`.
 - If no violations remain for this rule at this ref (upstream changed
@@ -146,15 +148,19 @@ If step 1 found no open `fp-fix` issues for the current campaign:
 1. Find the campaign in `docs/fp-automation/campaigns.yaml` with
    `status: in_progress` or `status: discovering`. There should be
    exactly one.
-2. **Do not** run analyze in this session. The "did we hit 90 %" check
-   happens after the release, in `fp-campaign-close`, against the
-   npm-published artifact — not against the local build.
-3. Open a campaign-close PR.
+2. Re-build truecourse from local source (with all merged fixes):
+   - `pnpm install && pnpm build:dist`.
+3. Re-clone the campaign's target at the recorded `baseline.target_ref`
+   to `/tmp/target` and run analyze against the freshly-built dist:
+   - `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/final.json`.
+4. Classify violations and compute final `tp`, `fp`, `tp_rate` using
+   the same rubric as fp-discover step 5.
+5. **If `tp_rate >= 0.90`** — campaign is done. Open a campaign-close PR:
    - Branch: `claude/fp-campaign-close/<owner>-<repo>`.
    - File changes:
      - `docs/fp-automation/campaigns.yaml`: set the campaign's
-       `status: verifying`. Do **not** fill `final.*` — that's
-       fp-campaign-close's job after the post-release analyze.
+       `status: done`. Fill `final.*` (analyzed_at, target_ref,
+       total_violations, tp, fp, tp_rate).
      - Patch-bump the version in all four required locations from
        CLAUDE.md:
        1. `tools/cli/package.json` — `version`
@@ -163,20 +169,21 @@ If step 1 found no open `fp-fix` issues for the current campaign:
        4. `tools/cli/src/index.ts` — the `.version("X.Y.Z")` call on
           the commander program
      - **No** fixture or visitor changes.
-   - Title: `chore(fp): release vX.Y.Z (verifying <owner>/<repo>)`.
+   - Title: `chore(fp): close <owner>/<repo> campaign, bump to vX.Y.Z`.
    - Labels: `fp-campaign-complete`.
    - Body: list merged fp-fix PRs from this campaign (search by label
-     `fp-target:<owner>-<repo>` + state merged) and the new version.
-     Note explicitly: "TP-rate verification happens after this PR
-     merges, in the fp-campaign-close routine, using the
-     npm-published version."
-   - End.
-
-Note: a single campaign can produce **multiple** campaign-close PRs
-(and therefore multiple version bumps) if the post-release verify
-finds the TP rate is still < 90 %. Each release ships real fixes;
-the campaign is only considered `done` when a post-release verify
-clears the 90 % gate.
+     `fp-target:<owner>-<repo>` + state merged), the before/after
+     TP-rate, and the new version. Note in the body that the TP rate
+     was measured against `node dist/cli.mjs` from the freshly-built
+     dist — the exact artifact publish.yml will ship.
+   - End. When this PR merges, fp-campaign-close pushes the tag and
+     fp-discover (firing on the same event) starts the next campaign.
+6. **If `tp_rate < 0.90`** — campaign continues. File one new fp-fix
+   issue per rule with FPs (same shape as discovery). Leave the
+   campaign's `status` as `in_progress`. **Do not** open a
+   campaign-close PR; no release is cut. The next fp-fix PR merge
+   will refire fp-next-fix to keep working through the new issues.
+   End.
 
 ## Refactor-required path
 
@@ -198,6 +205,10 @@ refactor.
 - One issue per session. Never start a second.
 - Never push outside `claude/`-prefixed branches.
 - Never run `truecourse analyze` without `--no-llm`.
+- **Never use `npx truecourse`, `npx -y truecourse@<…>`, or
+  `npm install truecourse`.** Always analyze with `node dist/cli.mjs`
+  from a fresh `pnpm build:dist`. The dist artifact is exactly what
+  publish.yml ships to npm, so it's the authoritative local invocation.
 - Never copy-paste OSS code — paraphrase only. Link the source by URL
   in the PR body.
 - Never change anything outside `packages/analyzer/src/rules/`,


### PR DESCRIPTION
## fp-discover: documenso/documenso

Starting a discovery run for the first FP-fix campaign: `documenso/documenso`.

**What this PR does:**
- Marks the campaign `status: discovering` in `docs/fp-automation/campaigns.yaml`

**What happens next (in this same session):**
1. Clone `documenso/documenso` at HEAD and run `truecourse analyze --no-llm`
2. Triage violations by rule — classify each sample as TP / FP / borderline
3. File one GitHub issue per rule with FP rate ≥ 10%
4. Update `baseline.*` in `campaigns.yaml` with totals and push to this branch

This PR is **informational** and can be merged at any time. The fp-next-fix routine is triggered automatically when any `fp-fix`-labelled PR merges — not by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRTSnXs8jaqeRHJJwTieCV)_