### PR TITLE
Fix analyze invocation in fp-automation prompts

### DIFF
--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -21,11 +21,14 @@ finishes, sessions update that file in the campaign-close PR.
 
 For each target OSS repo:
 
-1. `pnpm install && pnpm build:dist` in the truecourse working copy, then
-   `node dist/cli.mjs analyze /tmp/target --no-llm` (deterministic rules
-   only — keeps cost bounded). We always invoke the analyzer via the
-   freshly-built `dist/` artifact — same bytes publish.yml will ship to
-   npm. We never `npx truecourse` or `npm install truecourse`.
+1. `pnpm install && pnpm build:dist` in the truecourse working copy,
+   then `cd /tmp/target && node $TRUECOURSE_DIR/dist/cli.mjs analyze
+   --no-llm --no-stash --no-skills` (the CLI operates on the cwd and
+   writes results to `<cwd>/.truecourse/LATEST.json` — there's no path
+   argument and no `--output` flag). Deterministic rules only — keeps
+   cost bounded. We always invoke via the freshly-built `dist/`
+   artifact — same bytes publish.yml will ship to npm. We never
+   `npx truecourse` or `npm install truecourse`.
 2. Triage violations into TPs / FPs.
 3. For every rule with at least one FP, file one GitHub issue labelled
    `fp-fix` describing the rule, the target repo, links to OSS snippets,
@@ -265,7 +268,10 @@ Steps the session takes:
    (produces `dist/cli.mjs`, byte-equal to what publish.yml would
    ship). We never analyze via `npx truecourse` or `npm install`.
 4. Clone the target repo at HEAD; record commit SHA as `target_ref`.
-5. `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/analysis.json`.
+5. `cd /tmp/target && node $TRUECOURSE_DIR/dist/cli.mjs analyze --no-llm
+   --no-stash --no-skills`. Read results from
+   `/tmp/target/.truecourse/LATEST.json` (the `LatestSnapshot.violations[]`
+   array).
 6. Per rule with ≥ 1 violation: sample up to 10 violations, classify
    TP/FP. If FP rate ≥ 10 %, file an `fp-fix` +
    `fp-target:<owner>-<repo>` issue using the YAML schema above.
@@ -292,8 +298,10 @@ Steps the session takes:
 3. Parse the YAML block from the issue body. Clone target repo at
    `target_ref` to `/tmp/target`.
 4. `pnpm install && pnpm build:dist`, then
-   `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/analysis.json`.
-   Filter to this rule. (Always dist, never `npx truecourse`.)
+   `cd /tmp/target && node $TRUECOURSE_DIR/dist/cli.mjs analyze --no-llm
+   --no-stash --no-skills`. Read `/tmp/target/.truecourse/LATEST.json`
+   and filter `.violations[]` to this rule. (Always dist, never
+   `npx truecourse`.)
 5. Re-confirm the FP still reproduces. If not (upstream fixed, or a
    previous fix already resolved it), close the issue with comment
    "no longer reproduces" and end.
@@ -318,9 +326,11 @@ Steps the session takes:
 
 1. `pnpm install && pnpm build:dist` to rebuild dist with all merged
    fixes on `main`.
-2. Re-clone target at `baseline.target_ref` and run
-   `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/final.json`.
-   Compute TP rate.
+2. Re-clone target at `baseline.target_ref` to `/tmp/target`, then
+   `cd /tmp/target && node $TRUECOURSE_DIR/dist/cli.mjs analyze
+   --no-llm --no-stash --no-skills`. Read
+   `/tmp/target/.truecourse/LATEST.json`; compute TP rate from
+   `.violations[]`.
 3. **If ≥ 90 %**: open a **campaign-close PR** on
    `claude/fp-campaign-close/<owner>-<repo>` containing:
    - `docs/fp-automation/campaigns.yaml` updated (`status: done`,

--- a/docs/fp-automation/prompts/fp-discover.md
+++ b/docs/fp-automation/prompts/fp-discover.md
@@ -49,11 +49,23 @@ Run exactly one campaign per invocation. Do **not** loop across campaigns.
 ### 4. Clone and analyze the target repo
 
 - `git clone --depth=1 https://github.com/<target_repo>.git /tmp/target`.
-- Record the commit SHA as `target_ref` (full hash).
-- `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/analysis.json`.
-- If analyze fails: post the failure in a comment on the discovery PR
-  from step 2 with the error tail, set the campaign `status: blocked`
-  in the same PR, end.
+- Record the commit SHA as `target_ref` (full hash). Get it with
+  `git -C /tmp/target rev-parse HEAD`.
+- Run analyze **from inside the target repo** — the CLI operates on the
+  current working directory and writes results to `<cwd>/.truecourse/`:
+  ```
+  cd /tmp/target && \
+    node $TRUECOURSE_DIR/dist/cli.mjs analyze --no-llm --no-stash --no-skills
+  ```
+  (`$TRUECOURSE_DIR` is the path the truecourse-ai/truecourse repo was
+  cloned to in this session — typically `/home/user/truecourse`.)
+- After analyze completes, read results from
+  `/tmp/target/.truecourse/LATEST.json`. The schema is `LatestSnapshot`
+  from `packages/core/src/types/snapshot.ts` — the field you care about
+  is `.violations[]` (each entry has `ruleKey`, file location, etc.).
+- If analyze fails (non-zero exit, or LATEST.json missing): post the
+  failure in a comment on the discovery PR from step 2 with the error
+  tail, set the campaign `status: blocked` in the same PR, end.
 
 ### 5. Triage violations
 

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -46,10 +46,22 @@ Run exactly one issue per invocation. Do **not** start a second.
 
 - `git clone https://github.com/<target_repo>.git /tmp/target`.
 - `git -C /tmp/target checkout <target_ref>`.
-- In truecourse: `pnpm install && pnpm build:dist`. The dist build is
-  the artifact publish.yml ships to npm; we always analyze against this,
-  never `npx truecourse@…`. See "Hard constraints".
-- `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/analysis.json`.
+- In the truecourse working copy: `pnpm install && pnpm build:dist`.
+  The dist build is the artifact publish.yml ships to npm; we always
+  analyze against this, never `npx truecourse@…`. See "Hard
+  constraints".
+- Run analyze **from inside the target repo** — the CLI operates on the
+  current working directory and writes results to `<cwd>/.truecourse/`:
+  ```
+  cd /tmp/target && \
+    node $TRUECOURSE_DIR/dist/cli.mjs analyze --no-llm --no-stash --no-skills
+  ```
+  (`$TRUECOURSE_DIR` is the path the truecourse-ai/truecourse repo was
+  cloned to in this session — typically `/home/user/truecourse`.)
+- Read results from `/tmp/target/.truecourse/LATEST.json`. Filter
+  `.violations[]` to entries with `ruleKey == <rule_key>`. Cross-
+  reference at least one of the URLs in `samples[].url` from the
+  issue.
 - Filter `/tmp/analysis.json` to violations with `rule_key == <rule_key>`.
   Cross-reference at least one of the URLs in `samples[].url`.
 - If no violations remain for this rule at this ref (upstream changed
@@ -151,8 +163,13 @@ If step 1 found no open `fp-fix` issues for the current campaign:
 2. Re-build truecourse from local source (with all merged fixes):
    - `pnpm install && pnpm build:dist`.
 3. Re-clone the campaign's target at the recorded `baseline.target_ref`
-   to `/tmp/target` and run analyze against the freshly-built dist:
-   - `node dist/cli.mjs analyze /tmp/target --no-llm --output /tmp/final.json`.
+   to `/tmp/target` and analyze against the freshly-built dist:
+   ```
+   cd /tmp/target && \
+     node $TRUECOURSE_DIR/dist/cli.mjs analyze --no-llm --no-stash --no-skills
+   ```
+   Read `/tmp/target/.truecourse/LATEST.json` and process
+   `.violations[]`.
 4. Classify violations and compute final `tp`, `fp`, `tp_rate` using
    the same rubric as fp-discover step 5.
 5. **If `tp_rate >= 0.90`** — campaign is done. Open a campaign-close PR:


### PR DESCRIPTION
## Summary

First `fp-discover` session surfaced two bugs in the prompts:

1. `truecourse analyze` doesn't take a repository path argument — it
   operates on the current working directory.
2. There's no `--output` flag — results are always written to
   `<cwd>/.truecourse/LATEST.json`.

Fixes all three prompts and the README to use the correct invocation:

```
cd /tmp/target && \
  node $TRUECOURSE_DIR/dist/cli.mjs analyze --no-llm --no-stash --no-skills
```

Then read `/tmp/target/.truecourse/LATEST.json` and process its
`.violations[]` array (`LatestSnapshot` in
`packages/core/src/types/snapshot.ts`).

Also adds `--no-stash` and `--no-skills` so a routine never blocks on
an interactive prompt for stashing changes or installing skills.

`$TRUECOURSE_DIR` is documented as "typically `/home/user/truecourse`" —
the path the truecourse-ai/truecourse repo gets cloned to in routine
sessions.

## Test plan

- [ ] Merge and re-fire `fp-discover` Run now on the documenso
      campaign. Session should reach the analyze step and write
      `LATEST.json` cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_