### PR TITLE
chore(fp): start discovery for documenso/documenso

### DIFF
--- a/docs/fp-automation/campaigns.yaml
+++ b/docs/fp-automation/campaigns.yaml
@@ -23,7 +23,7 @@ campaigns:
   - target_repo: documenso/documenso
     tech_stack: [typescript, nextjs, prisma]
     priority: 1
-    status: pending
+    status: discovering
     baseline: { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     final:    { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     notes: []


### PR DESCRIPTION
## fp-discover: documenso/documenso

Starting a discovery run for the `documenso/documenso` campaign (priority 1).

This PR:
- Marks the campaign `status: discovering` in `docs/fp-automation/campaigns.yaml`
- Will be updated with baseline metrics once analysis completes

**Do not merge until the fp-discover session posts its final summary comment below.**

This PR is informational — it can be merged at any time after the discovery run completes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGDLifAjyT4ujAudz22nM6)_