### PR TITLE
chore(fp): start discovery for documenso/documenso

### DIFF
--- a/docs/fp-automation/campaigns.yaml
+++ b/docs/fp-automation/campaigns.yaml
@@ -24,7 +24,7 @@ campaigns:
     tech_stack: [typescript, nextjs, prisma]
     priority: 1
     status: discovering
-    baseline: { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
+    baseline: { analyzed_at: "2026-05-17", target_ref: "8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f", total_violations: 57492, tp: 763, fp: 458, tp_rate: 0.62 }
     final:    { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     notes: []
 

--- a/docs/fp-automation/campaigns.yaml
+++ b/docs/fp-automation/campaigns.yaml
@@ -23,7 +23,7 @@ campaigns:
   - target_repo: documenso/documenso
     tech_stack: [typescript, nextjs, prisma]
     priority: 1
-    status: pending
+    status: discovering
     baseline: { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     final:    { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     notes: []


### PR DESCRIPTION
Starting an **fp-discover** run for [`documenso/documenso`](https://github.com/documenso/documenso).

Marked the campaign as `status: discovering` in `docs/fp-automation/campaigns.yaml`. Will:

1. Build truecourse from local source via `pnpm build:dist` (same artifact `publish.yml` ships to npm).
2. Clone documenso at its current default-branch HEAD and run `truecourse analyze --no-llm --no-stash --no-skills`.
3. Triage up to 10 violations per rule (TP/FP/borderline).
4. File one `[fp-fix]` issue per rule with FP rate >= 10% (labels: `fp-fix`, `fp-target:documenso-documenso`).
5. Push baseline numbers into the campaign block on this branch.
6. Post a summary comment here.

This PR is informational — it can be merged at any time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBxua95UsFNiSEMLYivxW9)_