### PR TITLE
fp-next-fix: advance to next issue when current can't produce a PR

### DIFF
--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -38,8 +38,10 @@ For each target OSS repo:
    the inner loop.
 4. **Merging the discovery PR** lands the baseline on main and fires
    `fp-next-fix` (via its discovery-PR trigger). The fix loop then
-   consumes the open `fp-fix` issues one at a time:
-   a. Paraphrase one FP-triggering snippet from the issue into the
+   consumes the open `fp-fix` issues in **batches of up to 5 per
+   session** (to fit within the 15-runs/day routine cap — see "Batched
+   mode" below). For each issue in the batch:
+   a. Paraphrase the FP-triggering snippet into the
       `sample-js-project-positive` (or `…-python-positive`) fixture — the
       positive project asserts **zero violations**, so adding FP code there
       makes the test fail until the visitor is fixed.
@@ -48,10 +50,12 @@ For each target OSS repo:
       and break genuine detection.
    c. Fix the visitor / rule until both tests pass and full `pnpm test` is
       green.
-   d. Commit, push to `claude/fp-fix/<rule-key>`, open a PR that closes the
-      issue.
-5. When the PR merges (closing the issue), the routine fires again and the
-   next `fp-fix`-labelled issue is picked up automatically.
+
+   At the end of the batch, commit all fixture + visitor changes, push
+   to `claude/fp-fix/batch-<YYYYMMDDHHMM>`, and open one PR that closes
+   all N issues in the batch.
+5. When the batched PR merges (auto-closing all linked issues), the
+   routine fires again and processes the next batch.
 6. When no `fp-fix` issues remain for the current target, fp-next-fix
    **re-runs analyze against the freshly-built local dist** (containing
    every merged fix). If TP ≥ 90 %, it opens a **campaign-close PR**
@@ -159,12 +163,13 @@ So an FP fix means:
 │   Is merged=true, Head Branch starts-with                │
 │   claude/fp-fix/, Labels is-one-of fp-fix                │
 │                                                          │
-│ 1. Pick oldest open fp-fix issue                         │
-│ 2. Clone target OSS repo, re-confirm FP                  │
-│ 3. Paraphrase into …-positive fixture (no annotation)    │
-│ 4. Paraphrase true-bug into …-negative (+ marker)        │
-│ 5. Fix visitor, full tests green                         │
-│ 6. Push claude/fp-fix/<rule-key>, open PR (closes #N)    │
+│ Batched: per session, up to 5 fixes (cap 10 attempts)    │
+│ Per issue: pick oldest, lock, paraphrase FP into         │
+│   …-positive fixture, paraphrase true-bug into           │
+│   …-negative (+ // VIOLATION marker), fix visitor,       │
+│   full tests green, accumulate.                          │
+│ At end: push claude/fp-fix/batch-<YYYYMMDDHHMM>,         │
+│   open ONE PR with Closes #N per fixed issue             │
 │ — OR, if queue empty and TP ≥ 90%:                       │
 │   open campaign-close PR on claude/fp-campaign-close/*   │
 │ — OR, if queue empty and TP < 90%: re-discover           │
@@ -334,36 +339,49 @@ are on main before any fp-fix work begins.
 No concurrency worry: discovery PR merges and fp-fix PR merges never
 coincide, so the two routines never fire simultaneously.
 
-Steps the session takes:
-1. List open issues with label `fp-fix` (excluding `fp-in-progress`).
-   Pick the oldest. If none → go to "queue empty" path below.
-2. Add label `fp-in-progress` to the issue (concurrency lock).
-3. Parse the YAML block from the issue body. Clone target repo at
-   `target_ref` to `/tmp/target`.
-4. `pnpm install && pnpm build:dist`, then
-   `cd /tmp/target && node $TRUECOURSE_DIR/dist/cli.mjs analyze --no-llm
-   --no-stash --no-skills`. Read `/tmp/target/.truecourse/LATEST.json`
-   and filter `.violations[]` to this rule. (Always dist, never
-   `npx truecourse`.)
-5. Re-confirm the FP still reproduces. If not (upstream fixed, or a
-   previous fix already resolved it), close the issue with comment
-   "no longer reproduces" and end.
-6. Pick the most representative FP sample. Paraphrase (rename
-   identifiers, change trivial structure, drop unrelated context) into
-   `tests/fixtures/sample-{js,python}-project-positive/`. **No** `// VIOLATION`
-   comment — the positive project asserts zero violations.
-7. Paraphrase a true-bug variant into `…-project-negative/` with a
-   `// VIOLATION: <rule-key>` comment.
-8. Run `pnpm test 2>&1 | tee /tmp/test.log`. Confirm the new positive
-   case fails and the new negative case passes.
-9. Edit the rule under `packages/analyzer/src/rules/<domain>/…` until
-   both pass and full `pnpm test` is green. No unrelated changes.
-10. Push branch `claude/fp-fix/<rule-key>`. Open a PR with:
-    - Label `fp-fix` (required for the next trigger to fire).
-    - Body that includes `Closes #<issue>` and links the OSS sample URLs.
-11. Comment on the issue with the PR link; leave the issue open (it auto-
-    closes when the PR merges).
-12. End. The next merge of that PR will refire the routine.
+**Batched mode**: each session processes up to **5 successful fixes**
+(cap **10 attempts** total to allow for skipped issues). All fixture +
+visitor changes accumulate in one branch, and one PR is opened at the
+end with `Closes #N` lines for every fixed issue. This trades a bigger
+review surface per PR for ~5× throughput within the 15-runs/day routine
+cap. See the per-issue loop in
+`docs/fp-automation/prompts/fp-next-fix.md` for the full mechanics
+(success vs attempt counters, skipped-issue handling, partial-batch
+revert rules).
+
+**Session setup (once)**: `pnpm install && pnpm build:dist`; lazily
+clone target repo and run analyze on first issue. Counters:
+`successes`, `attempts`, `fixed_issues`.
+
+**Per-issue loop** (continues while `successes < 5 AND attempts < 10`):
+1. List open `fp-fix` issues (excluding `fp-in-progress`, `fp-blocked`,
+   `fp-skipped`, and any already in `fixed_issues`). Pick oldest. If
+   none → exit loop, go to "Open the batched PR".
+2. Add `fp-in-progress` label (concurrency lock; retry next-oldest on
+   collision, max 3 retries).
+3. Parse YAML; on malformed → mark blocked, increment `attempts`,
+   continue loop.
+4. Filter `LATEST.json` to this rule; on no-reproduce → close issue,
+   increment `attempts`, continue.
+5. Add paraphrased FP to positive fixture (no annotation).
+6. Add true-bug to negative fixture (with `// VIOLATION: <rule-key>`).
+7. Run tests; if negative case fails too → revert this issue's
+   fixtures, mark blocked, increment `attempts`, continue.
+8. Edit the rule's visitor / pattern. If can't without a cross-module
+   refactor → revert this issue's fixtures, post `## Refactor needed`,
+   mark blocked, increment `attempts`, continue.
+9. Re-run full tests; on unrelated breakage → revert this issue's
+   visitor AND fixtures, mark blocked, increment `attempts`, continue.
+10. Record success: append to `fixed_issues`. Increment both
+    `successes` AND `attempts`. Keep `fp-in-progress` label until the
+    batch PR opens. If caps hit → exit loop.
+
+**Open the batched PR**:
+- If `successes == 0` → end session, no PR.
+- Else → push `claude/fp-fix/batch-<YYYYMMDDHHMM>`, open one PR with
+  one `Closes #N` per fixed issue, per-rule sections in body, optional
+  "## Skipped this batch" section, label `fp-fix`. Comment + unlock
+  each fixed issue. End.
 
 **Queue empty path** (no open `fp-fix` issues for the current campaign):
 
@@ -469,16 +487,16 @@ One-time, before the first run:
 
 An **fp-fix PR** is mergeable when:
 
-- New positive-fixture case for the FP exists and the test passes (no
-  violation fires).
-- New negative-fixture case for the true-bug pattern exists with
-  `// VIOLATION:` comment and the test passes.
-- Full `pnpm test` is green (no regressions).
-- PR body links the original OSS snippet (URL only — no paste, to keep
-  clear of upstream licences) and shows the paraphrased fixture diff
-  inline.
-- PR closes its parent issue.
-- Branch matches `claude/fp-fix/<rule-key>` and carries label `fp-fix`.
+- Contains 1–5 rule fixes (typically 5).
+- For each fix: a new positive-fixture case (test asserts no
+  violation), a new negative-fixture case with `// VIOLATION:`
+  comment, and a scoped visitor edit under `packages/analyzer/src/`.
+- Full `pnpm test` is green (no regressions across the whole batch).
+- PR body has one `Closes #N` line per fixed issue (auto-closes all
+  on merge), per-rule sections with OSS source URLs (URL only — no
+  paste, to keep clear of upstream licences) and fixture diffs.
+- Branch matches `claude/fp-fix/batch-<YYYYMMDDHHMM>` and carries
+  label `fp-fix`.
 
 A **campaign-close PR** is mergeable when:
 
@@ -527,7 +545,8 @@ trail.
    cap + regular subscription usage (not API spend on an
    `ANTHROPIC_API_KEY`).
 7. **Branch hygiene**: branches use the `claude/` prefix
-   (`claude/fp-fix/<rule-key>`, `claude/fp-campaign-close/<owner>-<repo>`,
+   (`claude/fp-fix/batch-<YYYYMMDDHHMM>`,
+   `claude/fp-campaign-close/<owner>-<repo>`,
    `claude/fp-discover/<owner>-<repo>`) to fit the routine default
    push policy. Auto-delete head branches on merge.
 8. **Concurrency**: session adds `fp-in-progress` to the picked issue

--- a/docs/fp-automation/prompts/fp-campaign-close.md
+++ b/docs/fp-automation/prompts/fp-campaign-close.md
@@ -32,7 +32,8 @@ the next pending campaign — you don't chain to it.
 - If any of the four disagree: do **not** push the tag. Open an issue
   on `truecourse-ai/truecourse` titled `[fp-campaign-close] version
   mismatch after merge` with the four observed values and the merge
-  commit SHA, and end.
+  commit SHA. End the issue body with `cc @mushgev` so the reviewer
+  is notified. End the session.
 
 ### 2. Push the tag
 
@@ -59,7 +60,7 @@ the next pending campaign — you don't chain to it.
 
 - **Tag push fails** (e.g. permissions): do not retry. Open an issue
   titled `[fp-campaign-close] tag push failed for v<version>` with
-  the error, end.
+  the error. End the issue body with `cc @mushgev`. End the session.
 - **Version mismatch across the four locations**: see step 1. Do not
   push; open the mismatch issue and end.
 

--- a/docs/fp-automation/prompts/fp-discover.md
+++ b/docs/fp-automation/prompts/fp-discover.md
@@ -35,6 +35,9 @@ Run exactly one campaign per invocation. Do **not** loop across campaigns.
   in `docs/fp-automation/campaigns.yaml`.
 - Open a PR titled `chore(fp): start discovery for <owner>/<repo>`
   with body explaining you're starting a discovery run.
+- End the PR body with a line `cc @mushgev` — GitHub fires a
+  notification email on @mention regardless of authorship, so the
+  reviewer is alerted as soon as the PR appears.
 - **Apply label `fp-discover` to this PR.** This is what fires
   fp-next-fix when the PR merges, kicking off the inner loop. Without
   this label, the chain doesn't start automatically.

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -5,7 +5,11 @@ cloud session, autonomously, with no human in the loop. Your job is to
 take **one** open `fp-fix` issue, paraphrase its FP into the analyzer's
 test fixtures, fix the visitor, and open a PR that closes the issue.
 
-Run exactly one issue per invocation. Do **not** start a second.
+Per invocation, do at most one **PR-opening**, but you may **advance**
+through up to 5 issues that fail to produce a PR (blocked, FP no longer
+reproduces, malformed YAML, refactor required). See "Advancing to the
+next issue" below — this prevents the loop from stalling when the
+oldest issue is unfixable.
 
 ## Inputs
 
@@ -40,7 +44,8 @@ Run exactly one issue per invocation. Do **not** start a second.
   `target_ref`, `rule_key`, `samples[]`.
 - If the YAML is malformed: comment on the issue
   ("malformed YAML in body — needs human review"), add label
-  `fp-blocked`, remove `fp-in-progress`, end.
+  `fp-blocked`, remove `fp-in-progress`, **advance** (see "Advancing
+  to the next issue").
 
 ### 4. Clone the target and confirm the FP still reproduces
 
@@ -62,12 +67,12 @@ Run exactly one issue per invocation. Do **not** start a second.
   `.violations[]` to entries with `ruleKey == <rule_key>`. Cross-
   reference at least one of the URLs in `samples[].url` from the
   issue.
-- Filter `/tmp/analysis.json` to violations with `rule_key == <rule_key>`.
-  Cross-reference at least one of the URLs in `samples[].url`.
 - If no violations remain for this rule at this ref (upstream changed
   or a previous fix already resolved it): close the issue with comment
   "FP no longer reproduces at `<target_ref>`", remove `fp-in-progress`,
-  end.
+  **advance** (see "Advancing to the next issue"). This is a clean
+  outcome — closing one issue is real progress; advance to keep the
+  loop moving.
 
 ### 5. Add a paraphrased FP to the positive fixture
 
@@ -108,7 +113,9 @@ To make sure the visitor fix doesn't over-correct and miss real bugs:
   - The new negative case **passes** (rule fires where it should).
 - If the negative case fails too: the rule is broken in more ways than
   the FP — comment on the issue with the test output, add label
-  `fp-blocked`, remove `fp-in-progress`, end.
+  `fp-blocked`, remove `fp-in-progress`, **advance** (see "Advancing
+  to the next issue"). Revert the fixture files you just added before
+  advancing — they belong to the blocked issue, not the next one.
 
 ### 8. Fix the visitor
 
@@ -206,20 +213,46 @@ If step 1 found no open `fp-fix` issues for the current campaign:
 
 If step 8 reveals the fix needs a refactor across modules:
 
-1. Revert any partial visitor changes.
+1. Revert any partial visitor changes **and** the positive/negative
+   fixture files you added in steps 5–6.
 2. On the issue: post a `## Refactor needed` comment explaining what
    would be required (which types/services/extractors would need to
    change), and why a localized visitor fix isn't possible.
 3. Add label `fp-blocked` to the issue.
 4. Remove `fp-in-progress`.
-5. End.
+5. **Advance** (see "Advancing to the next issue").
 
 The user will read the comment and decide whether to greenlight the
 refactor.
 
+## Advancing to the next issue
+
+Whenever you hit a path that ends with "advance" (malformed YAML, FP
+no longer reproduces, broken-beyond-FP, refactor required), do the
+following instead of ending the session:
+
+1. Increment an internal counter (start at 0; this counts
+   non-PR-producing attempts in this session).
+2. If the counter has reached **5**, end the session. The user will
+   click **Run now** if they want to keep clearing blocked issues.
+3. Otherwise, return to step 1 ("Pick the next issue") and try
+   again with the next oldest open `fp-fix` issue.
+
+The cap exists so a stretch of all-blocked issues can't burn through
+your routine cap on a single session. PR-opening (step 10) always
+ends the session — the merge of that PR will fire fp-next-fix again
+via Trigger B, which is the normal continuation path.
+
+If the queue becomes empty during advancement, take the queue-empty
+path immediately — don't count it against the advance budget.
+
 ## Hard constraints
 
-- One issue per session. Never start a second.
+- At most one **PR-opening** per session — opening the PR ends the
+  session, and its merge fires the next one via Trigger B.
+- Up to **5 advances** per session for issues that can't produce a PR
+  (blocked / no-reproduces / refactor-required). See "Advancing to
+  the next issue".
 - Never push outside `claude/`-prefixed branches.
 - Never run `truecourse analyze` without `--no-llm`.
 - **Never use `npx truecourse`, `npx -y truecourse@<…>`, or

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -152,6 +152,8 @@ To make sure the visitor fix doesn't over-correct and miss real bugs:
     negative-fixture file.
   - A "## Visitor change" section with a 2-3 sentence summary of what
     you changed and why.
+  - End the body with a line `cc @mushgev` so the reviewer gets a
+    notification email on PR creation.
 - Labels: `fp-fix` (this label must be on the PR — it's what fires the
   next routine invocation on merge).
 - Comment on the issue with the PR URL. Leave the issue open; it
@@ -199,7 +201,9 @@ If step 1 found no open `fp-fix` issues for the current campaign:
      `fp-target:<owner>-<repo>` + state merged), the before/after
      TP-rate, and the new version. Note in the body that the TP rate
      was measured against `node dist/cli.mjs` from the freshly-built
-     dist — the exact artifact publish.yml will ship.
+     dist — the exact artifact publish.yml will ship. End the body
+     with a line `cc @mushgev` so the reviewer gets an email on PR
+     creation.
    - End. When this PR merges, fp-campaign-close pushes the tag and
      fp-discover (firing on the same event) starts the next campaign.
 6. **If `tp_rate < 0.90`** — campaign continues. File one new fp-fix

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -2,77 +2,96 @@
 
 You are the **fp-next-fix** routine. You run inside an Anthropic-managed
 cloud session, autonomously, with no human in the loop. Your job is to
-take **one** open `fp-fix` issue, paraphrase its FP into the analyzer's
-test fixtures, fix the visitor, and open a PR that closes the issue.
+take a **batch of up to 5 open `fp-fix` issues**, paraphrase each FP
+into the analyzer's test fixtures, fix each visitor, and open a single
+PR containing all the fixes.
 
-Per invocation, do at most one **PR-opening**, but you may **advance**
-through up to 5 issues that fail to produce a PR (blocked, FP no longer
-reproduces, malformed YAML, refactor required). See "Advancing to the
-next issue" below — this prevents the loop from stalling when the
-oldest issue is unfixable.
+The 15-sessions-per-day routine cap is the binding constraint, so each
+session does meaningful batch work instead of one fix at a time. With
+N = 5, 15 sessions/day = ~75 fixes/day instead of 15.
+
+Per invocation:
+- Process issues until you've accumulated **5 successful fixes**, OR
+  you've attempted **10 issues**, OR the queue is empty.
+- Issues that can't produce a fix (malformed YAML / FP no longer
+  reproduces / broken-beyond-FP / refactor required) are skipped per
+  their respective paths; they count toward the 10-attempt cap but
+  not the 5-success cap.
+- Open ONE PR at the end with all successful fixes (or end with no PR
+  if zero successes).
 
 ## Inputs
 
 - The repository `truecourse-ai/truecourse` is cloned.
-- The triggering event is `pull_request.closed` (merged) on a previous
-  `fp-fix` PR. You don't need details from that PR — its merge is just
+- The triggering event is `pull_request.closed` (merged) on either a
+  previous fp-fix PR (Trigger B) or the campaign's discovery PR
+  (Trigger A, fp-next-fix-bootstrap). Either way, the merge is just
   the cue that a new session should run.
 
-## Step-by-step
+## Session setup (once)
+
+Before the per-issue loop:
+
+- Track three counters in your head: `successes = 0`, `attempts = 0`,
+  and a list `fixed_issues = []` of `(issue_number, rule_key,
+  positive_fixture_path, negative_fixture_path, visitor_summary)`.
+- Build truecourse once: `pnpm install && pnpm build:dist`. The dist
+  artifact is what publish.yml ships to npm; always analyze against
+  this, never `npx truecourse@…`. See "Hard constraints".
+- Lazily clone the target repo: when the first issue needs it, clone
+  to `/tmp/target` and `git -C /tmp/target checkout <target_ref>`.
+  All `fp-fix` issues in a single campaign share `target_repo` +
+  `target_ref`, so you only clone once per session.
+- Lazily analyze: run `cd /tmp/target && node $TRUECOURSE_DIR/dist/cli.mjs
+  analyze --no-llm --no-stash --no-skills` once after the clone.
+  Re-read `/tmp/target/.truecourse/LATEST.json` per issue to filter
+  to that rule.
+
+## Per-issue loop
+
+Repeat the steps below while `successes < 5 AND attempts < 10`. Each
+iteration is one "attempt" (success or skip).
 
 ### 1. Pick the next issue
 
 - List open issues on `truecourse-ai/truecourse` with label `fp-fix`,
   **excluding** any with label `fp-in-progress`, `fp-blocked`, or
   `fp-skipped`.
-- If none → **queue-empty path** (see "Queue-empty path" below).
+- Also exclude any issue already in `fixed_issues` for this session.
+- If none → break out of the loop and go to "Open the batched PR".
 - Otherwise: pick the **oldest** by `created_at`.
 
 ### 2. Take the concurrency lock
 
 - Add label `fp-in-progress` to the picked issue **before** doing
-  anything else. This prevents a near-simultaneous session from
-  grabbing the same issue.
+  anything else.
 - Re-fetch the issue. If `fp-in-progress` was already present when you
-  added it (another session was faster), pick the next oldest and
-  retry. Stop after 3 retries; if all attempts collide, end the
-  session.
+  added it (another session was faster), skip this issue and pick the
+  next oldest. Stop after 3 collision retries within one iteration; if
+  all attempts collide, break out of the loop.
 
 ### 3. Parse the issue
 
 - Parse the YAML block from the issue body. Extract `target_repo`,
   `target_ref`, `rule_key`, `samples[]`.
-- If the YAML is malformed: comment on the issue
-  ("malformed YAML in body — needs human review"), add label
-  `fp-blocked`, remove `fp-in-progress`, **advance** (see "Advancing
-  to the next issue").
+- If the YAML is malformed: comment on the issue ("malformed YAML in
+  body — needs human review"), add label `fp-blocked`, remove
+  `fp-in-progress`, increment `attempts`, **continue to next iteration**.
 
-### 4. Clone the target and confirm the FP still reproduces
+### 4. Confirm the FP still reproduces
 
-- `git clone https://github.com/<target_repo>.git /tmp/target`.
-- `git -C /tmp/target checkout <target_ref>`.
-- In the truecourse working copy: `pnpm install && pnpm build:dist`.
-  The dist build is the artifact publish.yml ships to npm; we always
-  analyze against this, never `npx truecourse@…`. See "Hard
-  constraints".
-- Run analyze **from inside the target repo** — the CLI operates on the
-  current working directory and writes results to `<cwd>/.truecourse/`:
-  ```
-  cd /tmp/target && \
-    node $TRUECOURSE_DIR/dist/cli.mjs analyze --no-llm --no-stash --no-skills
-  ```
-  (`$TRUECOURSE_DIR` is the path the truecourse-ai/truecourse repo was
-  cloned to in this session — typically `/home/user/truecourse`.)
-- Read results from `/tmp/target/.truecourse/LATEST.json`. Filter
-  `.violations[]` to entries with `ruleKey == <rule_key>`. Cross-
-  reference at least one of the URLs in `samples[].url` from the
-  issue.
+- If `target_repo`/`target_ref` differs from any earlier issue in this
+  session, that's surprising — all fp-fix issues in a campaign should
+  share the same target. Comment on the issue noting the mismatch,
+  add `fp-blocked`, remove `fp-in-progress`, increment `attempts`,
+  continue.
+- Filter `/tmp/target/.truecourse/LATEST.json` `.violations[]` to
+  entries with `ruleKey == <rule_key>`. Cross-reference at least one
+  of the URLs in `samples[].url`.
 - If no violations remain for this rule at this ref (upstream changed
-  or a previous fix already resolved it): close the issue with comment
-  "FP no longer reproduces at `<target_ref>`", remove `fp-in-progress`,
-  **advance** (see "Advancing to the next issue"). This is a clean
-  outcome — closing one issue is real progress; advance to keep the
-  loop moving.
+  or an earlier fix in this batch already resolved it): close the
+  issue with comment "FP no longer reproduces at `<target_ref>`",
+  remove `fp-in-progress`, increment `attempts`, continue.
 
 ### 5. Add a paraphrased FP to the positive fixture
 
@@ -84,95 +103,125 @@ or `tests/analyzer/python-positive.test.ts` is a false positive.
   the surrounding ~30 lines of source from the target repo.
 - **Paraphrase** it (do not copy-paste): rename identifiers, drop
   unrelated context, simplify trivial structure. Keep the *shape* that
-  triggers the rule. The result should be syntactically valid,
-  buildable code that *looks like* the OSS pattern without being a
-  copy.
+  triggers the rule.
 - Add the paraphrase as a new file under
   `tests/fixtures/sample-js-project-positive/` (or
   `…-python-project-positive/` if the rule is Python) with a filename
   that makes the source recognisable, e.g.
   `<rule-key-slug>-from-<owner>-<repo>.ts`.
-- **No `// VIOLATION:` comment.** The positive fixture's presence in
-  that project is the assertion ("rule should NOT fire here").
+- **No `// VIOLATION:` comment.** Remember the path as
+  `positive_fixture_path` for the batch PR body.
 
 ### 6. Add a true-bug case to the negative fixture
-
-To make sure the visitor fix doesn't over-correct and miss real bugs:
 
 - Construct a small, paraphrased example of the actual bug pattern
   this rule is meant to catch.
 - Add it under `tests/fixtures/sample-js-project-negative/` (or the
   Python equivalent) with `// VIOLATION: <rule-key>` on the offending
   line (or the language-appropriate comment for Python).
+- Remember the path as `negative_fixture_path`.
 
-### 7. Run tests, confirm expected failure
+### 7. Confirm expected pre-fix state
 
-- `pnpm test 2>&1 | tee /tmp/test-before.log`.
-- Expected state:
+- `pnpm test 2>&1 | tee /tmp/test-rule-<rule-key>.log`.
+- Expected state for this rule:
   - The new positive case **fails** (rule fires where it shouldn't).
   - The new negative case **passes** (rule fires where it should).
-- If the negative case fails too: the rule is broken in more ways than
-  the FP — comment on the issue with the test output, add label
-  `fp-blocked`, remove `fp-in-progress`, **advance** (see "Advancing
-  to the next issue"). Revert the fixture files you just added before
-  advancing — they belong to the blocked issue, not the next one.
+- All *previously-added* positive cases in this batch should still
+  fire because their visitors haven't been fixed yet — that's fine,
+  tolerated until step 9 below.
+- If the new negative case fails: the rule is broken in more ways
+  than the FP — comment on the issue with the test output, add
+  `fp-blocked`, remove `fp-in-progress`, **revert** this issue's
+  positive and negative fixture files (keep earlier-batch files
+  intact), increment `attempts`, continue.
 
 ### 8. Fix the visitor
 
 - Edit only the rule's visitor / pattern under
   `packages/analyzer/src/rules/<domain>/…` (and/or
-  `packages/analyzer/src/patterns/<domain>-patterns.ts` if the fix is
-  a pattern adjustment).
+  `packages/analyzer/src/patterns/<domain>-patterns.ts` if the fix
+  is a pattern adjustment).
 - No unrelated refactors. Do not touch types, file discovery,
   resolvers, etc. unless the rule lives there.
 - If you can't fix it without a refactor that crosses module
-  boundaries → **refactor-required path** below.
+  boundaries: revert this issue's fixture additions, post a
+  `## Refactor needed` comment on the issue, add `fp-blocked` label,
+  remove `fp-in-progress`, increment `attempts`, continue.
 
 ### 9. Re-run tests, confirm green
 
-- `pnpm test 2>&1 | tee /tmp/test-after.log`.
-- Required state: full test suite green, including all existing
-  positive and negative cases.
-- If anything other than the two new cases fails: revert your visitor
-  changes, take the refactor-required path.
+- `pnpm test 2>&1 | tee /tmp/test-after-<rule-key>.log`.
+- Required state: full test suite green, including all earlier-batch
+  fixes (their visitors are fixed too, so their positive cases now
+  pass).
+- If anything other than expected cases fails: revert this issue's
+  visitor change AND fixture files, comment on the issue with the
+  failure, add `fp-blocked`, remove `fp-in-progress`, increment
+  `attempts`, continue.
 
-### 10. Open the PR
+### 10. Mark success
 
-- Branch: `claude/fp-fix/<rule-key>` (replace `/` in rule_key with `-`
-  for the filesystem-safe form, e.g. `claude/fp-fix/bugs-missing-await`).
-- Commit message: `fix(<domain>): resolve <rule-key> FP from <owner>/<repo>`.
-- PR title: same as commit message.
-- PR body:
-  - `Closes #<issue-number>`.
-  - A "## OSS source" section linking each `samples[].url` from the
-    issue (URLs only, no pasted code).
-  - A "## Paraphrased fixture" section with the inline diff of the new
-    positive-fixture file.
-  - A "## Regression case" section with the inline diff of the new
-    negative-fixture file.
-  - A "## Visitor change" section with a 2-3 sentence summary of what
-    you changed and why.
-  - End the body with a line `cc @mushgev` so the reviewer gets a
-    notification email on PR creation.
-- Labels: `fp-fix` (this label must be on the PR — it's what fires the
-  next routine invocation on merge).
-- Comment on the issue with the PR URL. Leave the issue open; it
-  closes automatically when the PR merges.
-- Remove the `fp-in-progress` label from the issue (the merge event
-  will fire the next session, which picks a new issue).
-- End.
+- Append `(issue_number, rule_key, positive_fixture_path,
+  negative_fixture_path, visitor_summary)` to `fixed_issues`.
+  `visitor_summary` is a 2–3 sentence summary of what you changed
+  and why.
+- Increment `successes` AND `attempts`.
+- **Do not** remove `fp-in-progress` yet — the issue stays locked
+  until the batch PR opens (in case the loop breaks early due to
+  attempts cap or queue empty).
+- If `successes == 5` or `attempts == 10`: break out of the loop.
+- Otherwise: continue to next iteration.
+
+## Open the batched PR
+
+After the loop:
+
+- If `successes == 0`: end the session with no PR. (Comment on the
+  most recent `fp-fix` issue noting that the session ended with no
+  successful fixes after `attempts` attempts.)
+- If `successes >= 1`:
+  - Branch: `claude/fp-fix/batch-<YYYYMMDDHHMM>` (use the session start
+    time in UTC).
+  - Commit message: `fix(fp): resolve <N> FPs from <owner>/<repo>`
+    where N = `successes`.
+  - PR title: same as commit message.
+  - PR body:
+    - One `Closes #<issue-number>` line per fixed issue (each on its
+      own line so GitHub auto-closes all on merge).
+    - A "## Fixes" overview table: `rule_key | issue | positive-fixture | negative-fixture`.
+    - One "## <rule_key>" section per fixed issue, each containing:
+      - OSS source URLs from the issue's `samples[].url`.
+      - Inline diff of the positive-fixture file.
+      - Inline diff of the negative-fixture file.
+      - The `visitor_summary` for that issue.
+    - A "## Skipped this batch" section (only if any `attempts >
+      successes`): brief list of issues that were attempted but
+      skipped, with reason (malformed YAML / no-reproduces /
+      broken-beyond-FP / refactor-required). One line each, link
+      to the issue.
+    - End the body with a line `cc @mushgev` so the reviewer gets a
+      notification email on PR creation.
+  - Labels: `fp-fix` (this label must be on the PR — it's what fires
+    the next routine invocation on merge).
+  - For each fixed issue: comment on the issue with the PR URL, then
+    remove the `fp-in-progress` label (the merge will auto-close the
+    issue via `Closes #N`).
+- End the session.
 
 ## Queue-empty path
 
-If step 1 found no open `fp-fix` issues for the current campaign:
+If the per-issue loop's step 1 found zero open `fp-fix` issues (true
+queue empty, not just exhausted-the-batch), AND `successes == 0` so
+far in this session:
 
 1. Find the campaign in `docs/fp-automation/campaigns.yaml` with
    `status: in_progress` or `status: discovering`. There should be
    exactly one.
-2. Re-build truecourse from local source (with all merged fixes):
-   - `pnpm install && pnpm build:dist`.
-3. Re-clone the campaign's target at the recorded `baseline.target_ref`
-   to `/tmp/target` and analyze against the freshly-built dist:
+2. Re-build truecourse: `pnpm install && pnpm build:dist` (only if
+   not already built this session).
+3. Re-clone the campaign's target at `baseline.target_ref` (only if
+   not already cloned this session) and analyze:
    ```
    cd /tmp/target && \
      node $TRUECOURSE_DIR/dist/cli.mjs analyze --no-llm --no-stash --no-skills
@@ -181,19 +230,19 @@ If step 1 found no open `fp-fix` issues for the current campaign:
    `.violations[]`.
 4. Classify violations and compute final `tp`, `fp`, `tp_rate` using
    the same rubric as fp-discover step 5.
-5. **If `tp_rate >= 0.90`** — campaign is done. Open a campaign-close PR:
+5. **If `tp_rate >= 0.90`** — campaign is done. Open a campaign-close
+   PR:
    - Branch: `claude/fp-campaign-close/<owner>-<repo>`.
    - File changes:
-     - `docs/fp-automation/campaigns.yaml`: set the campaign's
-       `status: done`. Fill `final.*` (analyzed_at, target_ref,
-       total_violations, tp, fp, tp_rate).
+     - `docs/fp-automation/campaigns.yaml`: set `status: done`. Fill
+       `final.*` (analyzed_at, target_ref, total_violations, tp, fp,
+       tp_rate).
      - Patch-bump the version in all four required locations from
        CLAUDE.md:
        1. `tools/cli/package.json` — `version`
        2. `packages/core/package.json` — `version`
        3. `apps/dashboard/server/package.json` — `version`
-       4. `tools/cli/src/index.ts` — the `.version("X.Y.Z")` call on
-          the commander program
+       4. `tools/cli/src/index.ts` — the `.version("X.Y.Z")` call.
      - **No** fixture or visitor changes.
    - Title: `chore(fp): close <owner>/<repo> campaign, bump to vX.Y.Z`.
    - Labels: `fp-campaign-complete`.
@@ -202,10 +251,9 @@ If step 1 found no open `fp-fix` issues for the current campaign:
      TP-rate, and the new version. Note in the body that the TP rate
      was measured against `node dist/cli.mjs` from the freshly-built
      dist — the exact artifact publish.yml will ship. End the body
-     with a line `cc @mushgev` so the reviewer gets an email on PR
-     creation.
-   - End. When this PR merges, fp-campaign-close pushes the tag and
-     fp-discover (firing on the same event) starts the next campaign.
+     with `cc @mushgev`.
+   - End. The merge fires fp-campaign-close (tags + ships) and
+     fp-discover (next campaign).
 6. **If `tp_rate < 0.90`** — campaign continues. File one new fp-fix
    issue per rule with FPs (same shape as discovery). Leave the
    campaign's `status` as `in_progress`. **Do not** open a
@@ -213,61 +261,31 @@ If step 1 found no open `fp-fix` issues for the current campaign:
    will refire fp-next-fix to keep working through the new issues.
    End.
 
-## Refactor-required path
-
-If step 8 reveals the fix needs a refactor across modules:
-
-1. Revert any partial visitor changes **and** the positive/negative
-   fixture files you added in steps 5–6.
-2. On the issue: post a `## Refactor needed` comment explaining what
-   would be required (which types/services/extractors would need to
-   change), and why a localized visitor fix isn't possible.
-3. Add label `fp-blocked` to the issue.
-4. Remove `fp-in-progress`.
-5. **Advance** (see "Advancing to the next issue").
-
-The user will read the comment and decide whether to greenlight the
-refactor.
-
-## Advancing to the next issue
-
-Whenever you hit a path that ends with "advance" (malformed YAML, FP
-no longer reproduces, broken-beyond-FP, refactor required), do the
-following instead of ending the session:
-
-1. Increment an internal counter (start at 0; this counts
-   non-PR-producing attempts in this session).
-2. If the counter has reached **5**, end the session. The user will
-   click **Run now** if they want to keep clearing blocked issues.
-3. Otherwise, return to step 1 ("Pick the next issue") and try
-   again with the next oldest open `fp-fix` issue.
-
-The cap exists so a stretch of all-blocked issues can't burn through
-your routine cap on a single session. PR-opening (step 10) always
-ends the session — the merge of that PR will fire fp-next-fix again
-via Trigger B, which is the normal continuation path.
-
-If the queue becomes empty during advancement, take the queue-empty
-path immediately — don't count it against the advance budget.
+If the queue empties during the per-issue loop **after** at least one
+success, go to "Open the batched PR" with what you have — don't run
+the queue-empty path in the same session. The next session's loop will
+hit a true empty queue and run the close logic.
 
 ## Hard constraints
 
-- At most one **PR-opening** per session — opening the PR ends the
-  session, and its merge fires the next one via Trigger B.
-- Up to **5 advances** per session for issues that can't produce a PR
-  (blocked / no-reproduces / refactor-required). See "Advancing to
-  the next issue".
+- At most one **PR-opening** per session.
+- At most **5 successful fixes** and **10 total attempts** per session.
 - Never push outside `claude/`-prefixed branches.
 - Never run `truecourse analyze` without `--no-llm`.
 - **Never use `npx truecourse`, `npx -y truecourse@<…>`, or
   `npm install truecourse`.** Always analyze with `node dist/cli.mjs`
   from a fresh `pnpm build:dist`. The dist artifact is exactly what
-  publish.yml ships to npm, so it's the authoritative local invocation.
+  publish.yml ships to npm.
 - Never copy-paste OSS code — paraphrase only. Link the source by URL
   in the PR body.
 - Never change anything outside `packages/analyzer/src/rules/`,
   `packages/analyzer/src/patterns/`, `tests/fixtures/sample-*/`, and
   (in the queue-empty path) `docs/fp-automation/campaigns.yaml` +
   the four version-bump locations.
-- If anything is ambiguous, document it on the issue and end. Do not
-  invent state, do not skip steps, do not "try one more thing."
+- A skipped (blocked / no-reproduces / refactor) issue only reverts
+  **its own** fixture and visitor changes, never earlier-batch
+  changes. The session's working tree is the accumulating draft of
+  the batch PR.
+- If anything is ambiguous, document it on the issue and continue the
+  loop (or end the loop if it's session-wide). Do not invent state,
+  do not skip steps, do not "try one more thing."


### PR DESCRIPTION
## Summary

When the oldest queued fp-fix issue can't produce a PR (blocked, FP no longer reproduces, malformed YAML, refactor required), fp-next-fix used to just end the session. No PR means no merge event means fp-next-fix doesn't refire via Trigger B — the loop stalled until you clicked **Run now**.

Patch: those paths now **advance** instead of ending. Session goes back to step 1 and tries the next oldest open issue. Capped at 5 advances per session so a stretch of all-blocked issues can't burn through your routine cap.

PR-opening still ends the session — that's the normal path; the merge fires the next session via Trigger B.

## Changes

- New "Advancing to the next issue" section in the prompt.
- Each previously-terminal early-exit path (malformed YAML / no-reproduces / negative-case-fails / refactor-required) now says "advance" instead of "end".
- Hard constraints updated: "one issue per session" → "one PR-opening per session + up to 5 advances".
- Cleaned up a stale reference to `/tmp/analysis.json` left over from the `--output` flag we dropped in PR #102.

## Behaviour

- Best case: oldest issue is fixable → PR opened → session ends → Trigger B fires on merge. No change from today.
- Stalled case: oldest issue blocked → previously stalled; now advances and tries the next, up to 5 times.
- Bad case: 5 consecutive issues unfixable → session ends after 5 advances. User clicks Run now.
- Queue empties during advance attempts → takes the queue-empty path immediately (doesn't count against the budget).

## Test plan

- [ ] Picks up on the next fp-next-fix invocation (prompt is bootstrap-pointed to the repo file, so no routine config change needed).
- [ ] Watch the first session that hits a blocked or no-reproduces case to confirm it advances and tries the next.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_