### PR TITLE
fix(architecture): resolve architecture/deterministic/dead-module FP from documenso/documenso

### DIFF
--- a/docs/fp-automation/campaigns.yaml
+++ b/docs/fp-automation/campaigns.yaml
@@ -24,7 +24,7 @@ campaigns:
     tech_stack: [typescript, nextjs, prisma]
     priority: 1
     status: discovering
-    baseline: { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
+    baseline: { analyzed_at: "2026-05-17", target_ref: "8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f", total_violations: 57492, tp: 763, fp: 458, tp_rate: 0.62 }
     final:    { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     notes: []
 

--- a/docs/fp-automation/campaigns.yaml
+++ b/docs/fp-automation/campaigns.yaml
@@ -23,7 +23,7 @@ campaigns:
   - target_repo: documenso/documenso
     tech_stack: [typescript, nextjs, prisma]
     priority: 1
-    status: pending
+    status: discovering
     baseline: { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     final:    { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     notes: []

--- a/packages/analyzer/src/rules/architecture/checker.ts
+++ b/packages/analyzer/src/rules/architecture/checker.ts
@@ -490,6 +490,34 @@ export function checkModuleRules(
       moduleMethodNames.set(mKey, arr)
     }
 
+    // Safety net for the case where module-extractor drops a module-level edge because
+    // the importer consumes an exported constant (not a tracked class/function) or the
+    // importer file has no extracted module (e.g. a framework router).  If a file is
+    // imported directly AND the importer is not merely re-exporting it through a barrel,
+    // the file is reachable and should not be flagged as dead.
+    //
+    // "Truly imported" means: ∃ a raw file dep (source→target) where target = mod.filePath
+    // AND not every imported name from that dep is re-exported by source unchanged.
+    // This excludes barrel files (export { X } from '...') which just pass names through.
+    const fileReExportNames = new Map<string, Set<string>>()
+    if (fileAnalyses) {
+      for (const fa of fileAnalyses) {
+        const reExports = new Set<string>()
+        for (const exp of fa.exports) {
+          if (exp.source) reExports.add(exp.name)
+        }
+        if (reExports.size > 0) fileReExportNames.set(fa.filePath, reExports)
+      }
+    }
+    const trulyImportedFiles = new Set<string>()
+    for (const dep of fileDependencies) {
+      const reExports = fileReExportNames.get(dep.source)
+      const allAreReExports =
+        dep.importedNames.length > 0 &&
+        dep.importedNames.every((name) => reExports?.has(name))
+      if (!allAreReExports) trulyImportedFiles.add(dep.target)
+    }
+
     for (const mod of modules) {
       const key = `${mod.serviceName}::${mod.name}`
       if (!connectedModules.has(key) && !dbConnectedModuleKeys?.has(key)) {
@@ -510,6 +538,9 @@ export function checkModuleRules(
           const modMethods = moduleMethodNames.get(key) || []
           if (sameFileRefs.has(mod.name) || modMethods.some((m) => sameFileRefs.has(m))) continue
         }
+
+        // Skip modules whose file is genuinely imported (not just re-exported by a barrel).
+        if (trulyImportedFiles.has(mod.filePath)) continue
 
         violations.push({
           ruleKey: 'architecture/deterministic/dead-module',

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -613,6 +613,12 @@
       "layer": "service"
     },
     {
+      "name": "processAbandonedQueue",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "PropertyStore",
       "service": "utils",
       "kind": "class",

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/dead-job-from-documenso-documenso.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/dead-job-from-documenso-documenso.ts
@@ -1,0 +1,6 @@
+// VIOLATION: architecture/deterministic/dead-module
+// Regression case: a job-definition-style export that is never imported.
+// The dead-module rule SHOULD fire here.
+export function processAbandonedQueue(items: string[]): number {
+  return items.length;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/index.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/index.ts
@@ -1,3 +1,4 @@
 export { formatUser } from './formatters';
 export { validateEmail, validateName } from './validators';
 export { logger } from './logger';
+export { processAbandonedQueue } from './dead-job-from-documenso-documenso';

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/jobs/job-registry-from-documenso-documenso.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/jobs/job-registry-from-documenso-documenso.ts
@@ -1,0 +1,3 @@
+import { NOTIFY_USER_JOB } from './notification-job-from-documenso-documenso';
+
+export const jobRegistry = [NOTIFY_USER_JOB] as const;

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/jobs/notification-job-from-documenso-documenso.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/jobs/notification-job-from-documenso-documenso.ts
@@ -1,0 +1,12 @@
+// Paraphrase of the documenso job-definition pattern.
+// This file exports only a constant whose name differs from the module identifier.
+// It IS imported by job-registry-from-documenso-documenso.ts, so the dead-module
+// rule must NOT fire here.
+
+export const NOTIFY_USER_JOB = {
+  id: 'notify-user',
+  name: 'Notify User',
+  version: '1.0.0',
+  trigger: { name: 'notify-user' },
+  run: (userId: string): string => `notifying ${userId}`,
+} as const;


### PR DESCRIPTION
Closes #110

## OSS source

- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/2fa/is-2fa-availble.ts#L1
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/emails/send-organisation-member-left-email.ts#L1`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/seal-document-sweep.ts#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/bulk-send-template.ts#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/execute-webhook.ts#L1

## Paraphrased fixture

Two files added to `sample-js-project-positive/services/api-gateway/src/jobs/`:

```diff
diff --git a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/jobs/notification-job-from-documenso-documenso.ts b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/jobs/notification-job-from-documenso-documenso.ts
new file mode 100644
--- /dev/null
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/jobs/notification-job-from-documenso-documenso.ts
@@ -0,0 +1,12 @@
+// Paraphrase of the documenso job-definition pattern.
+// This file exports only a constant whose name differs from the module identifier.
+// It IS imported by job-registry-from-documenso-documenso.ts, so the dead-module
+// rule must NOT fire here.
+
+export const NOTIFY_USER_JOB = {
+  id: 'notify-user',
+  name: 'Notify User',
+  version: '1.0.0',
+  trigger: { name: 'notify-user' },
+  run: (userId: string): string => `notifying ${userId}`,
+} as const;
diff --git a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/jobs/job-registry-from-documenso-documenso.ts b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/jobs/job-registry-from-documenso-documenso.ts
new file mode 100644
--- /dev/null
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/jobs/job-registry-from-documenso-documenso.ts
@@ -0,0 +1,3 @@
+import { NOTIFY_USER_JOB } from './notification-job-from-documenso-documenso';
+
+export const jobRegistry = [NOTIFY_USER_JOB] as const;
```

## Regression case

New file in `sample-js-project-negative/shared/utils/src/` plus barrel update:

```diff
diff --git a/tests/fixtures/sample-js-project-negative/shared/utils/src/dead-job-from-documenso-documenso.ts b/tests/fixtures/sample-js-project-negative/shared/utils/src/dead-job-from-documenso-documenso.ts
new file mode 100644
--- /dev/null
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/dead-job-from-documenso-documenso.ts
@@ -0,0 +1,6 @@
+// VIOLATION: architecture/deterministic/dead-module
+// Regression case: a job-definition-style export that is never imported.
+// The dead-module rule SHOULD fire here.
+export function processAbandonedQueue(items: string[]): number {
+  return items.length;
+}
diff --git a/tests/fixtures/sample-js-project-negative/shared/utils/src/index.ts b/tests/fixtures/sample-js-project-negative/shared/utils/src/index.ts
index 8a11474..78b34a8 100644
--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/index.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/index.ts
@@ -1,3 +1,4 @@
 export { formatUser } from './formatters';
 export { validateEmail, validateName } from './validators';
 export { logger } from './logger';
+export { processAbandonedQueue } from './dead-job-from-documenso-documenso';
```

The regression file is re-exported by the barrel so it is not treated as an entry point, yet nobody in the codebase ever imports `processAbandonedQueue` directly — dead-module must fire.

## Visitor change

`module-extractor.ts` drops a module-level dependency edge when the imported name is an exported constant (not a tracked class or function), or when the importer has no extracted module (e.g. a framework router). The dead-module rule then falsely flags the target as unused.

The fix adds a `trulyImportedFiles` safety net in `checkModuleRules`: for each raw file-level dep, if the importer is **not** a pure barrel (i.e. it does not re-export every imported name verbatim via `export { X } from '...'`), the target file is considered genuinely reachable and the dead-module check is skipped. Barrel-only importers (the re-export chain pattern) are deliberately excluded so that modules that are re-exported but never actually consumed continue to fire.

https://claude.ai/code/session_01VX33Zg7p7H8pohmGuCs6Ks

---
_Generated by [Claude Code](https://claude.ai/code/session_01VX33Zg7p7H8pohmGuCs6Ks)_