### PR TITLE
fp-next-fix: create the fp-fix branch up front so Trigger B fires

### DIFF
--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -32,6 +32,18 @@ Per invocation:
 
 Before the per-issue loop:
 
+- **Create the batch branch FIRST**, before any other work in the
+  truecourse repo. The routine starts the session on a default
+  randomly-named branch (e.g. `claude/<adjective-noun-XXXX>`); pushing
+  from that branch will **not** fire Trigger B because its filter is
+  `Head Branch starts-with claude/fp-fix/`. Run:
+  ```
+  git fetch origin main && \
+    git checkout -b claude/fp-fix/batch-$(date -u +%Y%m%d%H%M) origin/main
+  ```
+  Remember the exact branch name; you'll push to it in the final
+  step. **All commits this session go on this branch.** If you find
+  yourself on any other branch when about to commit, stop and switch.
 - Track three counters in your head: `successes = 0`, `attempts = 0`,
   and a list `fixed_issues = []` of `(issue_number, rule_key,
   positive_fixture_path, negative_fixture_path, visitor_summary)`.
@@ -181,8 +193,16 @@ After the loop:
   most recent `fp-fix` issue noting that the session ended with no
   successful fixes after `attempts` attempts.)
 - If `successes >= 1`:
+  - **Verify your branch.** Run `git rev-parse --abbrev-ref HEAD` and
+    confirm it starts with `claude/fp-fix/batch-`. If it doesn't —
+    e.g. you're still on the routine's default `claude/<random>`
+    branch — STOP. Create the correct branch now
+    (`git checkout -b claude/fp-fix/batch-$(date -u +%Y%m%d%H%M)`),
+    cherry-pick or move your in-progress commits onto it, then
+    delete the wrong branch locally. Pushing from the wrong branch
+    will not fire Trigger B and the chain will stall.
   - Branch: `claude/fp-fix/batch-<YYYYMMDDHHMM>` (use the session start
-    time in UTC).
+    time in UTC; this is the branch you created in session setup).
   - Commit message: `fix(fp): resolve <N> FPs from <owner>/<repo>`
     where N = `successes`.
   - PR title: same as commit message.


### PR DESCRIPTION
## Summary

PR #212 was opened by an fp-next-fix-bootstrap session on `claude/funny-noether-ztiwZ` — the routine's default randomly-named branch — instead of `claude/fp-fix/<rule-key>`. Its merge therefore did NOT fire Trigger B (filter: `Head Branch starts-with claude/fp-fix/`), and the inner loop stalled.

**Root cause**: the fp-next-fix prompt only mentioned the branch name in step 10 ("Open the PR"). By that point, the session had already committed to whatever branch it started on. Explicit branch creation needs to happen up front.

## Changes

Two edits to `docs/fp-automation/prompts/fp-next-fix.md`:

1. **Session setup** gets a new first bullet:
   ```
   git fetch origin main && \
     git checkout -b claude/fp-fix/batch-$(date -u +%Y%m%d%H%M) origin/main
   ```
   with an inline note explaining why (Trigger B's branch-prefix filter; default routine branch won't match).

2. **"Open the batched PR"** gets a pre-push sanity check: run `git rev-parse --abbrev-ref HEAD`, abort if it doesn't start with `claude/fp-fix/batch-`, with recovery instructions (create the right branch, cherry-pick, delete the wrong one).

## Why only fp-next-fix

- **fp-discover** already had branch creation as step 2 (right after campaign selection). PR #109 hit the correct branch.
- **fp-campaign-close** only pushes a tag, no PR. No branch issue.

## Unblocking

After merge, click **Run now** on `fp-next-fix` once to bootstrap a session under the new prompt. From its batched PR onward, the chain self-sustains because each batched PR uses `claude/fp-fix/batch-*` and merges fire Trigger B.

## Test plan

- [ ] Merge.
- [ ] Click Run now on `fp-next-fix`.
- [ ] Confirm the session opens a PR with `head.ref` starting with `claude/fp-fix/batch-`.
- [ ] Confirm merging that PR fires `fp-next-fix` again (next session reads new batched prompt).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_