### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/_shared/javascript-helpers.ts
+++ b/packages/analyzer/src/rules/_shared/javascript-helpers.ts
@@ -130,6 +130,40 @@ function checkDirectMemberAccess(node: SyntaxNode): UserInputSource | null {
 }
 
 /**
+ * Returns true if `variable` is a positional function parameter — i.e., its
+ * declaration is a direct identifier in a `formal_parameters` list, not nested
+ * inside an `object_pattern` or `array_pattern`.
+ *
+ * Pattern 2 in `findUserInputAccess` only applies to positional params:
+ * `(req, res) => ...` makes `req` mean "the HTTP request object", but
+ * `({ ctx, input }) => ...` (the standard tRPC handler shape) destructures
+ * `ctx` out of a procedure context object — it is NOT a request, even though
+ * the name overlaps with Koa's positional `ctx` handler param.
+ */
+function isPositionalParameter(variable: Variable): boolean {
+  let current: SyntaxNode | null = variable.declarationNode
+  while (current) {
+    if (current.type === 'object_pattern' || current.type === 'array_pattern') {
+      return false
+    }
+    if (current.type === 'formal_parameters') {
+      return true
+    }
+    if (
+      current.type === 'function_declaration' ||
+      current.type === 'arrow_function' ||
+      current.type === 'function_expression' ||
+      current.type === 'method_definition' ||
+      current.type === 'program'
+    ) {
+      return false
+    }
+    current = current.parent
+  }
+  return false
+}
+
+/**
  * Walk up from a Variable's declarationNode to find the assigned value
  * (the right-hand side of `const x = ...`).
  *
@@ -199,8 +233,15 @@ export function findUserInputAccess(
     if (n.type === 'identifier' && dataFlow) {
       const variable = dataFlow.resolveReference(n)
       if (variable) {
-        // Pattern 2: parameter named like a request object
-        if (variable.kind === 'parameter' && REQUEST_OBJECT_NAMES.has(variable.name)) {
+        // Pattern 2: positional parameter named like a request object.
+        // Destructured params (e.g. tRPC's `({ ctx, input }) => ...`) are
+        // skipped because the name overlap is incidental — the destructured
+        // `ctx` is a procedure context, not an HTTP request.
+        if (
+          variable.kind === 'parameter' &&
+          REQUEST_OBJECT_NAMES.has(variable.name) &&
+          isPositionalParameter(variable)
+        ) {
           return { kind: 'parameter', accessor: variable.name }
         }
         // Pattern 3: variable initialized from a user input source

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/invalid-void-type.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/invalid-void-type.ts
@@ -14,7 +14,16 @@ export const invalidVoidTypeVisitor: CodeRuleVisitor = {
     const typeAnnotation = node.namedChildren.find((c) => c.type === 'type_annotation')
     if (!typeAnnotation) return null
 
-    const voidType = findVoidType(typeAnnotation)
+    // Only flag `void` when it is the parameter's direct type. `void` nested
+    // inside a function return type (`(cb: () => void) => void`), a generic
+    // argument (`Promise<void>`), or similar wrapper is a valid usage.
+    const directType = typeAnnotation.namedChildren[0]
+    if (!directType) return null
+    const voidType =
+      directType.type === 'void_type' ||
+      (directType.type === 'predefined_type' && directType.text === 'void')
+        ? directType
+        : null
     if (!voidType) return null
 
     const paramName = node.namedChildren[0]?.text ?? 'parameter'
@@ -29,12 +38,3 @@ export const invalidVoidTypeVisitor: CodeRuleVisitor = {
   },
 }
 
-function findVoidType(node: import('web-tree-sitter').Node): import('web-tree-sitter').Node | null {
-  for (const child of node.children) {
-    if (child.type === 'void_type') return child
-    if (child.type === 'predefined_type' && child.text === 'void') return child
-    const found = findVoidType(child)
-    if (found) return found
-  }
-  return null
-}

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/unbound-method.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/unbound-method.ts
@@ -72,16 +72,28 @@ export const unboundMethodVisitor: CodeRuleVisitor = {
 
     const methodName = property.text
 
-    // Skip if the method is an arrow function property (lexically bound this)
+    // Walk the enclosing class body to figure out whether `methodName` refers
+    // to an actual method (callable, has `this` binding) or just a data field.
+    // Fields whose value/type isn't a function never had `this` bound to
+    // begin with, so referencing them as values is not an unbound-method risk.
     let classBody: SyntaxNode | null = node.parent
     while (classBody && classBody.type !== 'class_body') classBody = classBody.parent
     if (classBody) {
       for (const member of classBody.namedChildren) {
         if (member.type === 'public_field_definition' || member.type === 'field_definition') {
           const nameNode = member.children.find((c) => c.type === 'property_identifier')
-          if (nameNode?.text === methodName) {
-            const value = member.childForFieldName('value')
-            if (value?.type === 'arrow_function') return null
+          if (nameNode?.text !== methodName) continue
+          const value = member.childForFieldName('value')
+          // Arrow / function field — bound by construction.
+          if (value?.type === 'arrow_function' || value?.type === 'function_expression') return null
+          // Field with any other initializer — data, not a method.
+          if (value) return null
+          // No initializer: look at the type annotation. Anything that isn't
+          // a function type means it's a data field assigned later.
+          const typeAnnot = member.namedChildren.find((c) => c.type === 'type_annotation')
+          const typeChild = typeAnnot?.namedChildren[0]
+          if (typeChild && typeChild.type !== 'function_type' && typeChild.type !== 'constructor_type') {
+            return null
           }
         }
       }

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/uncaught-exception-no-handler.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/uncaught-exception-no-handler.ts
@@ -12,14 +12,24 @@ export const uncaughtExceptionNoHandlerVisitor: CodeRuleVisitor = {
     if (lowerPath.includes('/packages/') || lowerPath.includes('/lib/')) {
       return null
     }
-    if (
-      !lowerPath.includes('index.') &&
-      !lowerPath.includes('main.') &&
-      !lowerPath.includes('server.') &&
-      !lowerPath.includes('app.') &&
-      !lowerPath.endsWith('/worker.ts') && !lowerPath.endsWith('/worker.js') &&
-      !lowerPath.includes('bin/')
-    ) {
+    // Skip framework route modules — these are imported by the framework
+    // runtime, not started as their own process. Remix v2 puts route files
+    // under `app/routes/`; Next.js Pages router uses `pages/`.
+    if (lowerPath.includes('/routes/') || lowerPath.includes('/pages/')) {
+      return null
+    }
+    // Match on the basename so we only catch real entry-point filenames
+    // (`index.ts`, `server.ts`, `main.ts`, `app.ts`). A `.includes('index.')`
+    // / `.includes('server.')` check on the full path leaks across Remix's
+    // `_index.tsx` route files and `*.server.ts` server-only modules.
+    const basename = (lowerPath.split('/').pop() ?? lowerPath)
+    const isEntryBasename =
+      basename.startsWith('index.') ||
+      basename.startsWith('main.') ||
+      basename.startsWith('server.') ||
+      basename.startsWith('app.') ||
+      basename === 'worker.ts' || basename === 'worker.js'
+    if (!isEntryBasename && !lowerPath.includes('/bin/')) {
       return null
     }
 

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/unhandled-rejection-no-handler.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/unhandled-rejection-no-handler.ts
@@ -12,14 +12,24 @@ export const unhandledRejectionNoHandlerVisitor: CodeRuleVisitor = {
     if (lowerPath.includes('/packages/') || lowerPath.includes('/lib/')) {
       return null
     }
-    if (
-      !lowerPath.includes('index.') &&
-      !lowerPath.includes('main.') &&
-      !lowerPath.includes('server.') &&
-      !lowerPath.includes('app.') &&
-      !lowerPath.endsWith('/worker.ts') && !lowerPath.endsWith('/worker.js') &&
-      !lowerPath.includes('bin/')
-    ) {
+    // Skip framework route modules — these are imported by the framework
+    // runtime, not started as their own process. Remix v2 puts route files
+    // under `app/routes/`; Next.js Pages router uses `pages/`.
+    if (lowerPath.includes('/routes/') || lowerPath.includes('/pages/')) {
+      return null
+    }
+    // Match on the basename so we only catch real entry-point filenames
+    // (`index.ts`, `server.ts`, `main.ts`, `app.ts`). A `.includes('index.')`
+    // / `.includes('server.')` check on the full path leaks across Remix's
+    // `_index.tsx` route files and `*.server.ts` server-only modules.
+    const basename = (lowerPath.split('/').pop() ?? lowerPath)
+    const isEntryBasename =
+      basename.startsWith('index.') ||
+      basename.startsWith('main.') ||
+      basename.startsWith('server.') ||
+      basename.startsWith('app.') ||
+      basename === 'worker.ts' || basename === 'worker.js'
+    if (!isEntryBasename && !lowerPath.includes('/bin/')) {
       return null
     }
 

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/server.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/server.ts
@@ -1,8 +1,13 @@
 /**
- * Server bootstrap — missing body size limit.
+ * Server bootstrap — missing body size limit and missing process-level
+ * unhandledRejection handler. A real process entry-point at this filename
+ * (`server.ts`) is exactly what `unhandled-rejection-no-handler` is meant
+ * to flag.
  */
 import express from 'express';
 
+// VIOLATION: reliability/deterministic/unhandled-rejection-no-handler
+// VIOLATION: reliability/deterministic/uncaught-exception-no-handler
 // VIOLATION: architecture/deterministic/missing-request-body-size-limit
 const app = express();
 app.use(express.json());

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/db/queries.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/db/queries.ts
@@ -95,3 +95,9 @@ export async function createFromDestructuredRequest(req: any) {
   const { body } = req;
   await User.create(body);
 }
+
+// VIOLATION: database/deterministic/unvalidated-external-data
+// Positional Koa-style handler still passes req.body straight through.
+export async function createFromKoaHandler(ctx: any) {
+  await User.create(ctx.request.body);
+}

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/models/scope-bugs.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/models/scope-bugs.ts
@@ -101,10 +101,16 @@ export class SetterWithReturn {
 }
 
 // VIOLATION: bugs/deterministic/unbound-method
+// VIOLATION: bugs/deterministic/unbound-method
 export class EventEmitter {
   items: string[] = [];
   processAll() {
     this.items.forEach(this.processItem);
+  }
+  // Second true-bug case in the same class — same shape, exercises another
+  // call site so the visitor still has to walk class members per call.
+  startTasks() {
+    return this.items.map(this.processItem);
   }
   processItem(item: string) {
     console.log(item);

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/models/types.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/models/types.ts
@@ -15,6 +15,11 @@ export function unusableParam(param: void) {
   return param;
 }
 
+// VIOLATION: bugs/deterministic/invalid-void-type
+export function optionalUnusableParam(value?: void) {
+  return value;
+}
+
 // VIOLATION: bugs/deterministic/getter-setter-type-mismatch
 export class Config {
   private _timeout: string = '5000';

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/handlers/invalid-void-type-from-documenso-documenso.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/handlers/invalid-void-type-from-documenso-documenso.ts
@@ -1,0 +1,41 @@
+// Paraphrased from documenso/documenso (apps/remix/.../use-scroll-to-page.ts,
+// packages/ui/.../canvas.ts, packages/email/.../mailchannels.ts,
+// packages/lib/.../use-autosave.ts).
+//
+// `void` as the RETURN type of a callback parameter type is valid. The rule
+// should only flag `void` when it is the direct type of the parameter itself.
+
+type Canvas = { width: number; height: number };
+type SentInfo = { messageId: string };
+
+export function registerScrollObserver(
+  containerRef: { current: HTMLElement | null },
+  scrollToItem: (index: number) => void,
+): void {
+  if (!containerRef.current) return;
+  scrollToItem(0);
+}
+
+export function registerOnChangeHandler(
+  handler: (_canvas: Canvas, _cleared: boolean) => void,
+): void {
+  handler({ width: 1, height: 1 }, false);
+}
+
+export function sendMail(
+  callback: (_err: Error | null, _info: SentInfo) => void,
+): void {
+  callback(null, { messageId: 'x' });
+}
+
+export function scheduleSave(
+  data: SentInfo,
+  onResponse?: (response: SentInfo) => void,
+): void {
+  if (onResponse) onResponse(data);
+}
+
+// Generic argument position — `void` inside `Promise<void>` is also valid.
+export async function awaitNothing(p: Promise<void>): Promise<void> {
+  await p;
+}

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/handlers/lang-cookie.server.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/handlers/lang-cookie.server.ts
@@ -1,0 +1,7 @@
+// Paraphrased from documenso/documenso (apps/remix/app/storage/lang-cookie.server.ts).
+// Remix `*.server.ts` module — imported by route loaders, not a process
+// entry. Old visitor matched `.includes('server.')` on the path.
+
+export function getLangCookieName(): string {
+  return 'i18n-lang';
+}

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/handlers/unbound-method-from-documenso-documenso.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/handlers/unbound-method-from-documenso-documenso.ts
@@ -1,0 +1,49 @@
+// Paraphrased from documenso/documenso (packages/lib/jobs/client/inngest.ts,
+// packages/lib/server-only/telemetry/telemetry-client.ts,
+// packages/lib/jobs/client/bullmq.ts, packages/lib/utils/debugger.ts).
+//
+// `this.<field>` where `<field>` is a data field (not a method) is being
+// passed around as a value — that's not an unbound-method risk because the
+// field never had `this` bound to begin with.
+
+type Client = { readonly id: string };
+type JobDef = { readonly id: string };
+
+declare function start(arg: { readonly client: Client; readonly functions: readonly JobDef[] }): void;
+declare function capture(arg: { readonly distinctId: string; readonly nodeId: string | null }): void;
+declare function processAll(defs: readonly JobDef[]): void;
+declare function appLog(context: string, message: string): void;
+
+export class InngestProvider {
+  private readonly _client: Client;
+  private readonly _functions: readonly JobDef[] = [];
+
+  constructor(client: Client) {
+    this._client = client;
+  }
+
+  public run(): void {
+    start({ client: this._client, functions: this._functions });
+  }
+
+  public report(installationId: string | null, nodeId: string | null): void {
+    capture({ distinctId: installationId ?? '', nodeId });
+    this.installationId = installationId;
+    this.nodeId = nodeId;
+  }
+
+  public installationId: string | null = null;
+  public nodeId: string | null = null;
+
+  private readonly _jobDefinitions: Record<string, JobDef> = {};
+
+  public processAll(): void {
+    processAll(Object.values(this._jobDefinitions));
+  }
+
+  private readonly context: string = 'inngest';
+
+  public log(message: string): void {
+    appLog(this.context, message);
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/handlers/unvalidated-external-data-from-documenso-documenso.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/handlers/unvalidated-external-data-from-documenso-documenso.ts
@@ -1,0 +1,55 @@
+// Paraphrased from documenso/documenso tRPC routes
+// (packages/trpc/server/.../*-router/* — many examples).
+//
+// A tRPC procedure handler receives `{ input, ctx }` via destructuring. `ctx`
+// here is a tRPC procedure context (db client, logged-in user, etc.) — it is
+// NOT an HTTP request object even though the name overlaps with Koa's `ctx`.
+// References to `ctx` from the destructured object pattern must not be treated
+// as user input, otherwise every Prisma call inside the handler trips the rule.
+// `.input(...)` validates the input via Zod before the handler ever runs.
+
+type ProcedureContext = {
+  user: { id: string };
+  logger: { info: (x: unknown) => void };
+};
+
+type Input = { organisationId: string; teamId: string };
+
+declare const prisma: {
+  organisation: {
+    findFirst: (args: unknown) => Promise<{ id: string; ownerId: string } | null>;
+    create: (args: unknown) => Promise<unknown>;
+    update: (args: unknown) => Promise<unknown>;
+  };
+};
+
+declare const adminProcedure: {
+  input: (schema: unknown) => {
+    query: (cb: (args: { input: Input; ctx: ProcedureContext }) => Promise<unknown>) => unknown;
+    mutation: (cb: (args: { input: Input; ctx: ProcedureContext }) => Promise<unknown>) => unknown;
+  };
+};
+
+declare const ZGetOrgRequestSchema: unknown;
+
+export const getOrganisationRoute = adminProcedure.input(ZGetOrgRequestSchema).query(
+  async ({ input, ctx }) => {
+    const { organisationId } = input;
+    const { user } = ctx;
+
+    ctx.logger.info({ input: { organisationId } });
+
+    const org = await prisma.organisation.findFirst({
+      where: { id: organisationId, ownerId: user.id },
+    });
+
+    if (!org) return null;
+
+    await prisma.organisation.update({
+      where: { id: org.id },
+      data: { ownerId: user.id },
+    });
+
+    return org;
+  },
+);

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/routes/_index.tsx
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/routes/_index.tsx
@@ -1,0 +1,26 @@
+// Paraphrased from documenso/documenso (apps/remix/app/routes/_index.tsx and
+// many other Remix route modules — unhandled-rejection-no-handler /
+// uncaught-exception-no-handler false positives).
+//
+// Remix route modules are imported by the Remix runtime; they are NOT
+// process entry-points and must not be required to register process-level
+// `unhandledRejection` / `uncaughtException` handlers. The basename pattern
+// `_index.tsx` is what triggered the FP — the old visitor matched any path
+// containing `index.`.
+
+declare function readSomething(): Promise<string>;
+declare function writeSomething(): Promise<void>;
+
+export const loader = async (): Promise<{ value: string }> => {
+  const value = await readSomething();
+  return { value };
+};
+
+export const action = async (): Promise<{ ok: true }> => {
+  await writeSomething();
+  return { ok: true };
+};
+
+export default function RouteComponent(): null {
+  return null;
+}

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/routes/documents._index.tsx
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/routes/documents._index.tsx
@@ -1,0 +1,14 @@
+// Paraphrased from documenso/documenso (apps/remix/.../t.$teamUrl+/documents._index.tsx).
+// Another Remix route module shape — basename starts with the route segment
+// name, then ends with `._index.tsx`. Old visitor matched `.includes('index.')`.
+
+declare function listDocuments(): Promise<readonly string[]>;
+
+export const loader = async (): Promise<{ documents: readonly string[] }> => {
+  const documents = await listDocuments();
+  return { documents };
+};
+
+export default function DocumentsIndex(): null {
+  return null;
+}


### PR DESCRIPTION
Closes #111
Closes #113
Closes #114
Closes #115
Closes #129

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `bugs/deterministic/invalid-void-type` | #111 | [`handlers/invalid-void-type-from-documenso-documenso.ts`](../tree/claude/fp-fix/batch-202605190333/tests/fixtures/sample-js-project-positive/services/user-service/src/handlers/invalid-void-type-from-documenso-documenso.ts) | [`models/types.ts`](../tree/claude/fp-fix/batch-202605190333/tests/fixtures/sample-js-project-negative/services/user-service/src/models/types.ts) |
| `database/deterministic/unvalidated-external-data` | #113 | [`handlers/unvalidated-external-data-from-documenso-documenso.ts`](../tree/claude/fp-fix/batch-202605190333/tests/fixtures/sample-js-project-positive/services/user-service/src/handlers/unvalidated-external-data-from-documenso-documenso.ts) | [`db/queries.ts`](../tree/claude/fp-fix/batch-202605190333/tests/fixtures/sample-js-project-negative/services/user-service/src/db/queries.ts) |
| `bugs/deterministic/unbound-method` | #114 | [`handlers/unbound-method-from-documenso-documenso.ts`](../tree/claude/fp-fix/batch-202605190333/tests/fixtures/sample-js-project-positive/services/user-service/src/handlers/unbound-method-from-documenso-documenso.ts) | [`models/scope-bugs.ts`](../tree/claude/fp-fix/batch-202605190333/tests/fixtures/sample-js-project-negative/services/user-service/src/models/scope-bugs.ts) |
| `reliability/deterministic/unhandled-rejection-no-handler` | #115 | `routes/_index.tsx`, `routes/documents._index.tsx`, `handlers/lang-cookie.server.ts` | [`api-gateway/src/server.ts`](../tree/claude/fp-fix/batch-202605190333/tests/fixtures/sample-js-project-negative/services/api-gateway/src/server.ts) |
| `reliability/deterministic/uncaught-exception-no-handler` | #129 | (shared with #115) | (shared with #115) |

## bugs/deterministic/invalid-void-type

OSS samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/pdf-viewer/use-scroll-to-page.ts#L12
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/signature-pad/canvas.ts#L277
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/transports/mailchannels.ts#L47
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/hooks/use-autosave.ts#L42

**Positive fixture diff** — `(callback: (...) => void)` shapes that the rule must not flag:
```diff
+ export function registerScrollObserver(
+   containerRef: { current: HTMLElement | null },
+   scrollToItem: (index: number) => void,
+ ): void { ... }
+ export function registerOnChangeHandler(handler: (_canvas: Canvas, _cleared: boolean) => void): void { ... }
+ export function sendMail(callback: (_err: Error | null, _info: SentInfo) => void): void { ... }
+ export function scheduleSave(data: SentInfo, onResponse?: (response: SentInfo) => void): void { ... }
+ export async function awaitNothing(p: Promise<void>): Promise<void> { ... }
```

**Negative fixture diff** — second true-bug shape added next to the existing one:
```diff
+ // VIOLATION: bugs/deterministic/invalid-void-type
+ export function optionalUnusableParam(value?: void) {
+   return value;
+ }
```

**Visitor summary**: The previous implementation recursed into the parameter's full `type_annotation` tree looking for any `void_type` / `predefined_type "void"`, so `void` returns of nested function types (`(index: number) => void`) and generic arguments (`Promise<void>`) matched. The new check inspects only the **direct** type child of the parameter's `type_annotation`. `(param: void)` / `(value?: void)` still flag.

## database/deterministic/unvalidated-external-data

OSS samples:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/envelope-router/envelope-fields/get-envelope-field-signatures.ts#L12`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/webhook-router/router.ts#L35
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/enterprise-router/get-invoices.ts#L11
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/team-router/delete-team-member.ts#L125
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/document-router/get-document.ts#L6

**Positive fixture diff** — a paraphrased tRPC procedure where `findUserInputAccess` previously traced `user.id` → `user` destructure → `ctx` parameter → REQUEST_OBJECT_NAMES match:
```diff
+ export const getOrganisationRoute = adminProcedure.input(ZGetOrgRequestSchema).query(
+   async ({ input, ctx }) => {
+     const { organisationId } = input;
+     const { user } = ctx;
+     ctx.logger.info({ input: { organisationId } });
+     const org = await prisma.organisation.findFirst({ where: { id: organisationId, ownerId: user.id } });
+     if (!org) return null;
+     await prisma.organisation.update({ where: { id: org.id }, data: { ownerId: user.id } });
+     return org;
+   },
+ );
```

**Negative fixture diff** — positional Koa-style handler still flags:
```diff
+ // VIOLATION: database/deterministic/unvalidated-external-data
+ export async function createFromKoaHandler(ctx: any) {
+   await User.create(ctx.request.body);
+ }
```

**Visitor summary**: Pattern 2 in `findUserInputAccess` ("parameter named like a request object") matched any parameter named `ctx`, including the destructured procedure-context param in tRPC handlers `({ ctx, input }) => ...`. Through dataFlow this propagated to any identifier eventually destructured from `ctx`, so every Prisma write inside a tRPC procedure tripped. Pattern 2 now requires the parameter to be **positional** (its declaration is a direct identifier in `formal_parameters`, not nested in an `object_pattern` / `array_pattern`). Koa-style `(ctx) => ...` and Express-style `(req, res) => ...` still trigger.

## bugs/deterministic/unbound-method

OSS samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/inngest.ts#L78
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/telemetry/telemetry-client.ts#L137
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/telemetry/telemetry-client.ts#L132
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/bullmq.ts#L135
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/utils/debugger.ts#L30

**Positive fixture diff** — `this.<field>` references that pass data, not method references:
```diff
+ export class InngestProvider {
+   private readonly _client: Client;
+   private readonly _functions: readonly JobDef[] = [];
+   ...
+   public run(): void { start({ client: this._client, functions: this._functions }); }
+   public processAll(): void { processAll(Object.values(this._jobDefinitions)); }
+   public log(message: string): void { appLog(this.context, message); }
+ }
```

**Negative fixture diff** — second true-bug call site in the existing class:
```diff
  // VIOLATION: bugs/deterministic/unbound-method
+ // VIOLATION: bugs/deterministic/unbound-method
  export class EventEmitter {
    items: string[] = [];
    processAll() { this.items.forEach(this.processItem); }
+   startTasks() { return this.items.map(this.processItem); }
    processItem(item: string) { console.log(item); }
  }
```

**Visitor summary**: The visitor previously skipped only fields whose value was an `arrow_function` (lexically bound). Plain data fields (`private context: string;`, `private _client: InngestClient;`, `private _jobDefinitions: Record<...> = {}`) still flagged even though referencing them passes data, not a method that could lose `this`. The class-body walk now also skips when the field's value is a non-function expression, or when there is no value but the type annotation isn't a `function_type` / `constructor_type`. `method_definition` members and arrow/function-typed fields still flag.

## reliability/deterministic/unhandled-rejection-no-handler

OSS samples:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/t.%24teamUrl+/documents.folders._index.tsx`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/t.%24teamUrl+/_index.tsx
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/t.%24teamUrl+/documents.%24id._index.tsx`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_index.tsx
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/t.%24teamUrl+/settings.webhooks.%24id._index.tsx`

**Positive fixture diff** — Remix route shapes that the old `.includes('index.')` / `.includes('server.')` matched:
```diff
+ // tests/.../user-service/src/routes/_index.tsx
+ export const loader = async (): Promise<{ value: string }> => { ... };
+ export const action = async (): Promise<{ ok: true }> => { ... };
+ export default function RouteComponent(): null { return null; }
+
+ // tests/.../user-service/src/routes/documents._index.tsx
+ export const loader = async (): Promise<{ documents: readonly string[] }> => { ... };
+ export default function DocumentsIndex(): null { return null; }
+
+ // tests/.../user-service/src/handlers/lang-cookie.server.ts
+ export function getLangCookieName(): string { return 'i18n-lang'; }
```

**Negative fixture diff** — a real entry point at basename `server.ts` still flags:
```diff
+ // VIOLATION: reliability/deterministic/unhandled-rejection-no-handler
+ // VIOLATION: reliability/deterministic/uncaught-exception-no-handler
  // VIOLATION: architecture/deterministic/missing-request-body-size-limit
  const app = express();
```

**Visitor summary**: Replaced full-path `.includes('index.')` / `.includes('server.')` / etc. with a basename-prefix match (`index.`, `main.`, `server.`, `app.`) so `_index.tsx`, `documents._index.tsx`, and `lang-cookie.server.ts` no longer match. Added a `/routes/` and `/pages/` skip for framework route modules. Real entry points (`server.ts`, `index.ts`, `main.js`, `/bin/`, `worker.ts`) still flag.

## reliability/deterministic/uncaught-exception-no-handler

OSS samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/admin+/users._index.tsx
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/storage/lang-cookie.server.ts
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/o.%24orgUrl.settings.groups._index.tsx`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/settings+/_dynamic_personal_routes+/webhooks._index.tsx`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/t.%24teamUrl+/templates.f.%24folderId._index.tsx`

**Visitor summary**: Sibling rule of `unhandled-rejection-no-handler` with the identical path-check bug. Applied the same basename-prefix + `/routes/`-skip restructure. Shares the positive and negative fixtures with #115 because the FPs are triggered by the same Remix route module shapes.

## Skipped this batch

- #112 (`bugs/deterministic/non-number-arithmetic`) — refactor-required. The 5 cited samples all resolve the wrong TS type for `scale` destructured from a `PageRenderData` parameter; the fix needs to live in `packages/analyzer/src/ts-compiler.ts`'s position-mapping helpers, which is outside the dirs this routine is allowed to touch. Details on the issue.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaCLfcmGYuEjaeiukPJa12)_