### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/javascript/route-without-auth-middleware.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/javascript/route-without-auth-middleware.ts
@@ -34,6 +34,17 @@ function isPublicPath(path: string): boolean {
 }
 
 /**
+ * Routes that embed a credential in the URL path (`:token`, `:apiKey`,
+ * `:secret`, `:hash`) are themselves token-authenticated — the handler reads
+ * the token from `params` and validates it. Treat them as authed.
+ */
+const URL_CREDENTIAL_PARAMS = /:(?:token|apiKey|api_key|secret|hash|signature)(?:\/|$)/i
+
+function isUrlCredentialAuthedPath(path: string): boolean {
+  return URL_CREDENTIAL_PARAMS.test(path)
+}
+
+/**
  * Extract identifier names from the middleware arguments to a route definition.
  * Express/Koa/Hono pattern: `app.get('/path', mw1, mw2, handler)`
  * — middleware are args[1..n-2], handler is args[n-1].
@@ -140,18 +151,28 @@ export const routeWithoutAuthMiddlewareVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     if (!isRouteHandler(node)) return null
 
+    // `app.use(...)` / `router.use(...)` is middleware registration, not a
+    // route handler — applying it as a global hook or mounting a sub-router.
+    // Auth on those is governed by what's *inside* the mounted router or by
+    // the order of middleware, not by the .use() call's own argument list.
+    const fn = node.childForFieldName('function')
+    const prop = fn?.childForFieldName('property')
+    if (prop?.text === 'use') return null
+
     // Skip if we don't recognize the framework — can't reason about middleware
     // chains we don't understand.
     const framework = detectWebFramework(node)
     if (framework === 'unknown') return null
 
-    // Skip public endpoints by path
+    // Skip public endpoints by path, and routes that authenticate via a
+    // credential embedded in the URL path itself.
     const args = node.childForFieldName('arguments')
     if (!args) return null
     const firstArg = args.namedChildren[0]
-    if (firstArg?.type === 'string') {
+    if (firstArg?.type === 'string' || firstArg?.type === 'template_string') {
       const path = firstArg.text.replace(/^['"`]|['"`]$/g, '')
       if (isPublicPath(path)) return null
+      if (isUrlCredentialAuthedPath(path)) return null
     }
 
     // Check this specific route's middleware chain

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/array-callback-missing-return.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/array-callback-missing-return.ts
@@ -33,6 +33,12 @@ export const arrayCallbackMissingReturnVisitor: CodeRuleVisitor = {
     if (!firstArg) return null
     if (firstArg.type !== 'arrow_function' && firstArg.type !== 'function' && firstArg.type !== 'function_expression') return null
 
+    // Async callbacks always return a Promise (the body's value is wrapped in
+    // Promise.resolve regardless of explicit return). The common idiom
+    // `Promise.all(arr.map(async (x) => { await … }))` collects those promises,
+    // so a missing return is not a bug.
+    if (firstArg.children.some((c) => c.type === 'async' || c.text === 'async')) return null
+
     const body = firstArg.childForFieldName('body')
     if (!body || body.type !== 'statement_block') return null
 

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/array-callback-return.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/array-callback-return.ts
@@ -25,6 +25,12 @@ export const arrayCallbackReturnVisitor: CodeRuleVisitor = {
     // The callback must be arrow_function, function, or function_expression
     if (firstArg.type !== 'arrow_function' && firstArg.type !== 'function' && firstArg.type !== 'function_expression') return null
 
+    // Async callbacks always return a Promise (the body's value is wrapped in
+    // Promise.resolve regardless of explicit return). The idiomatic
+    // `Promise.all(arr.map(async (x) => { await … }))` collects those promises,
+    // so a missing return is not a bug.
+    if (firstArg.children.some((c) => c.type === 'async' || c.text === 'async')) return null
+
     const body = firstArg.childForFieldName('body')
     if (!body) return null
 

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/computed-enum-value.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/computed-enum-value.ts
@@ -6,7 +6,11 @@ export const computedEnumValueVisitor: CodeRuleVisitor = {
   languages: ['typescript', 'tsx'],
   nodeTypes: ['enum_assignment'],
   visit(node, filePath, sourceCode) {
-    const value = node.namedChildren[0]
+    // tree-sitter exposes the RHS via the `value` field — `namedChildren[0]`
+    // was returning the LHS `property_identifier` (the enum member name), so
+    // string-literal initializers like `FREE = 'free'` were being misclassified
+    // as non-literal "computed" values.
+    const value = node.childForFieldName('value')
     if (!value) return null
 
     if (value.type === 'string' || value.type === 'number') return null

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/process-exit-in-library.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/process-exit-in-library.ts
@@ -24,7 +24,17 @@ export const processExitInLibraryVisitor: CodeRuleVisitor = {
       lowerPath.includes('server.') ||
       lowerPath.includes('app.') ||
       lowerPath.endsWith('/worker.ts') || lowerPath.endsWith('/worker.js') ||
-      lowerPath.includes('entrypoint.')
+      lowerPath.includes('entrypoint.') ||
+      // Seed scripts (`packages/prisma/seed-database.ts`, `prisma/seed.ts`,
+      // `seeds/initial.ts`) are CLI entrypoints invoked by the framework
+      // (Prisma's `prisma db seed`, custom seed runners) — process.exit is
+      // the conventional way they terminate after running.
+      /(?:^|\/)seeds?(?:[-.\/]|$)/.test(lowerPath) ||
+      // Example scripts (`packages/api/v1/examples/*.ts`) are runnable demos,
+      // not library code. They're executed as standalone scripts.
+      lowerPath.includes('/examples/') ||
+      // Migration scripts are one-shot entrypoints just like seeds.
+      /(?:^|\/)migrations?(?:[-.\/]|$)/.test(lowerPath)
     ) {
       return null
     }

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/arch-violations.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/arch-violations.ts
@@ -54,6 +54,11 @@ export function assertEverything(data: unknown) {
   return { str, num, arr, obj };
 }
 
+// VIOLATION: architecture/deterministic/route-without-auth-middleware
+router.post('/api/admin/audit-logs/wipe', (req, res) => {
+  res.json({ cleared: true });
+});
+
 // VIOLATION: architecture/deterministic/unused-import
 import { HealthService } from '../services/health.service';
 

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/reliability.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/reliability.ts
@@ -78,6 +78,11 @@ export function exitProcess(code: number) {
   process.exit(code);
 }
 
+// VIOLATION: reliability/deterministic/process-exit-in-library
+export function failHard() {
+  process.exit(2);
+}
+
 // VIOLATION: reliability/deterministic/unchecked-array-access
 export function getElement(arr: number[], index: number) {
   const value = arr[index].toFixed(2);

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-typescript.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-typescript.ts
@@ -164,5 +164,11 @@ export class UselessDefault {
   constructor(public value: string = undefined) {}
 }
 
+// VIOLATION: code-quality/deterministic/computed-enum-value
+export enum DerivedEnum {
+  BASE = 10,
+  DOUBLED = 10 * 2,
+}
+
 declare const UserId: any;
 declare const ignoredValueRef: any;

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/misc-bugs.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/misc-bugs.ts
@@ -257,4 +257,18 @@ export async function forgot() {
   return p;
 }
 
+// VIOLATION: bugs/deterministic/array-callback-missing-return
+export function doubleAll(nums: readonly number[]): number[] {
+  return nums.map((n) => {
+    n * 2;
+  });
+}
+
+// VIOLATION: bugs/deterministic/array-callback-return
+export function squaredOnly(nums: readonly number[]): number[] {
+  return nums.filter((n) => {
+    n > 0;
+  });
+}
+
 export { readFile };

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/seed-database-from-documenso-documenso.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/seed-database-from-documenso-documenso.ts
@@ -1,0 +1,23 @@
+/**
+ * Paraphrased FP from documenso/documenso for
+ * reliability/deterministic/process-exit-in-library.
+ *
+ * Seed scripts and runnable example scripts are CLI entrypoints — they're
+ * invoked by `prisma db seed`, by direct `node` invocation, or by README
+ * snippets. `process.exit` is the conventional way they signal success or
+ * failure to the parent shell. They are NOT library code.
+ */
+
+declare const console: { error(msg: string, err?: unknown): void };
+declare const process: { exit(code?: number): never };
+
+export const runSeed = async (): Promise<void> => {
+  await Promise.resolve();
+};
+
+runSeed()
+  .then(() => process.exit(0))
+  .catch((err: unknown) => {
+    console.error('Seed failed:', err);
+    process.exit(1);
+  });

--- a/tests/fixtures/sample-js-project-positive/src/array-callback-missing-return-from-documenso-documenso.ts
+++ b/tests/fixtures/sample-js-project-positive/src/array-callback-missing-return-from-documenso-documenso.ts
@@ -1,0 +1,47 @@
+/**
+ * Paraphrased FP from documenso/documenso for
+ * bugs/deterministic/array-callback-missing-return.
+ *
+ * The idiomatic Promise.allSettled(arr.map(async ...)) pattern: the
+ * async callback's return value is a Promise regardless of whether the
+ * body contains an explicit `return`, so a missing return is not a bug
+ * — Promise.all/allSettled receives the Promise[] that the array of
+ * async callbacks already produces.
+ */
+
+interface Recipient {
+  id: string;
+  sendStatus: 'PENDING' | 'SENT';
+}
+
+interface JobsClient {
+  triggerJob(args: { name: string; payload: { recipientId: string } }): Promise<void>;
+}
+
+export async function expireRecipientsSweep(
+  recipients: readonly Recipient[],
+  jobs: JobsClient,
+): Promise<void> {
+  await Promise.allSettled(
+    recipients.map(async (recipient) => {
+      await jobs.triggerJob({
+        name: 'internal.process-recipient-expired',
+        payload: { recipientId: recipient.id },
+      });
+    }),
+  );
+}
+
+export async function notifyRecipients(
+  recipients: readonly Recipient[],
+  send: (id: string) => Promise<void>,
+): Promise<void> {
+  await Promise.allSettled(
+    recipients.map(async (recipient) => {
+      if (recipient.sendStatus !== 'SENT') {
+        return;
+      }
+      await send(recipient.id);
+    }),
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/src/array-callback-return-from-documenso-documenso.ts
+++ b/tests/fixtures/sample-js-project-positive/src/array-callback-return-from-documenso-documenso.ts
@@ -1,0 +1,41 @@
+/**
+ * Paraphrased FP from documenso/documenso for
+ * bugs/deterministic/array-callback-return.
+ *
+ * Same shape as the sibling FP (#116) but exercising the
+ * `Promise.all(arr.map(async ...))` idiom in a different setting — a webhook
+ * trigger loop. The async callback's return value is always a Promise; a
+ * missing explicit `return` is not a missing-result bug.
+ */
+
+interface WebhookSubscriber {
+  id: string;
+  endpoint: string;
+}
+
+interface WebhookClient {
+  fire(subscriber: WebhookSubscriber, payload: Record<string, unknown>): Promise<void>;
+}
+
+export async function triggerWebhooks(
+  subscribers: readonly WebhookSubscriber[],
+  client: WebhookClient,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  await Promise.allSettled(
+    subscribers.map(async (subscriber) => {
+      await client.fire(subscriber, payload);
+    }),
+  );
+}
+
+export async function sealDocuments(
+  envelopeIds: readonly string[],
+  sealOne: (id: string) => Promise<void>,
+): Promise<void> {
+  await Promise.allSettled(
+    envelopeIds.map(async (envelopeId) => {
+      await sealOne(envelopeId);
+    }),
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/src/computed-enum-value-from-documenso-documenso.ts
+++ b/tests/fixtures/sample-js-project-positive/src/computed-enum-value-from-documenso-documenso.ts
@@ -1,0 +1,40 @@
+/**
+ * Paraphrased FP from documenso/documenso for
+ * code-quality/deterministic/computed-enum-value.
+ *
+ * String- and number-literal enum initializers (`FREE = 'free'`,
+ * `FORBIDDEN = 'FORBIDDEN'`, `STATUS_OK = 200`) must not be flagged as
+ * "computed" — only genuinely computed expressions should be.
+ */
+
+export enum ClaimTier {
+  FREE = 'free',
+  INDIVIDUAL = 'individual',
+  TEAM = 'team',
+  EARLY_ADOPTER = 'earlyAdopter',
+  PLATFORM = 'platform',
+  ENTERPRISE = 'enterprise',
+}
+
+export enum AppErrorCode {
+  ALREADY_EXISTS = 'ALREADY_EXISTS',
+  FORBIDDEN = 'FORBIDDEN',
+  NOT_FOUND = 'NOT_FOUND',
+}
+
+export enum FieldHint {
+  SELECT_AT_MOST = 'Select at most',
+  SELECT_EXACTLY = 'Select exactly',
+}
+
+export enum HttpStatus {
+  OK = 200,
+  CREATED = 201,
+  NO_CONTENT = 204,
+}
+
+export enum SignedOffset {
+  NEG_ONE = -1,
+  ZERO = 0,
+  ONE = 1,
+}

--- a/tests/fixtures/sample-js-project-positive/src/route-without-auth-middleware-from-documenso-documenso.ts
+++ b/tests/fixtures/sample-js-project-positive/src/route-without-auth-middleware-from-documenso-documenso.ts
@@ -1,0 +1,47 @@
+/**
+ * Paraphrased FP from documenso/documenso for
+ * architecture/deterministic/route-without-auth-middleware.
+ *
+ * Two distinct shapes:
+ *   1. `app.use(...)` / `router.use(...)` — middleware registration or
+ *      sub-router mount; not a route handler that itself needs an auth
+ *      middleware in its argument list.
+ *   2. Route handlers that authenticate via a credential embedded in the URL
+ *      path (`/:token`, `/:apiKey`, …). The handler validates the token
+ *      against the database; an auth middleware is not the auth mechanism.
+ */
+
+interface Ctx {
+  req: { valid: (kind: 'param') => Record<string, string> };
+  json: (body: unknown, status?: number) => Response;
+}
+
+interface Hono {
+  use(path: string, mw: (c: Ctx) => Response): void;
+  route(path: string, sub: unknown): void;
+  get(path: string, handler: (c: Ctx) => Response): void;
+}
+
+declare const app: Hono;
+declare const apiV1RateLimitMiddleware: (c: Ctx) => Response;
+declare const trpcRateLimitMiddleware: (c: Ctx) => Response;
+declare const filesRoute: unknown;
+
+export function mountRouter(): void {
+  // `.use(path, mw)` is middleware registration, not a route handler.
+  app.use('/api/v1/*', apiV1RateLimitMiddleware);
+  app.use('/api/trpc/*', trpcRateLimitMiddleware);
+  app.use('/api/trpc/*', () => new Response(null));
+  // `.route(path, sub)` mounts a sub-router; auth is enforced inside.
+  app.route('/api/files', filesRoute);
+}
+
+export function registerTokenAuthedRoute(): void {
+  // The route authenticates via the URL-embedded `:token` parameter — the
+  // handler reads it from params and validates it server-side. No auth
+  // middleware in the chain by design.
+  app.get('/token/:token/envelope/:envelopeId/item.pdf', (c) => {
+    const { token } = c.req.valid('param');
+    return c.json({ ok: token.length > 0 });
+  });
+}


### PR DESCRIPTION
Closes #116
Closes #118
Closes #120
Closes #121
Closes #123

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| bugs/deterministic/array-callback-missing-return | #116 | src/array-callback-missing-return-from-documenso-documenso.ts | shared/utils/src/misc-bugs.ts (append `doubleAll`) |
| code-quality/deterministic/computed-enum-value | #118 | src/computed-enum-value-from-documenso-documenso.ts | shared/utils/src/code-quality-typescript.ts (append `DerivedEnum`) |
| architecture/deterministic/route-without-auth-middleware | #120 | src/route-without-auth-middleware-from-documenso-documenso.ts | api-gateway/src/services/arch-violations.ts (append `/api/admin/audit-logs/wipe`) |
| bugs/deterministic/array-callback-return | #121 | src/array-callback-return-from-documenso-documenso.ts | shared/utils/src/misc-bugs.ts (append `squaredOnly`) |
| reliability/deterministic/process-exit-in-library | #123 | shared/utils/src/seed-database-from-documenso-documenso.ts | api-gateway/src/services/reliability.ts (append `failHard`) |

## bugs/deterministic/array-callback-missing-return

OSS samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/admin/admin-super-delete-document.ts#L66
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/expire-recipients-sweep.handler.ts#L38`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/send-signing-reminders-sweep.handler.ts#L39`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/initial-seed.ts#L523
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/recipient/update-recipient-next-reminder.ts#L89

Positive fixture diff (`tests/fixtures/sample-js-project-positive/src/array-callback-missing-return-from-documenso-documenso.ts`):

```diff
+ // idiomatic Promise.all(arr.map(async (x) => { await … })) pattern — async
+ // callback returns Promise regardless of explicit return.
+ await Promise.allSettled(
+   recipients.map(async (recipient) => {
+     await jobs.triggerJob({ name: 'internal.process-recipient-expired', payload: { recipientId: recipient.id } });
+   }),
+ );
```

Negative fixture diff (`tests/fixtures/sample-js-project-negative/shared/utils/src/misc-bugs.ts`):

```diff
+ // VIOLATION: bugs/deterministic/array-callback-missing-return
+ export function doubleAll(nums: readonly number[]): number[] {
+   return nums.map((n) => {
+     n * 2;
+   });
+ }
```

The visitor flagged every `.map`/`.filter`/etc. callback with a statement-block body and no explicit `return` — including the idiomatic `Promise.all(arr.map(async (x) => { await … }))` pattern. Async callbacks always return a Promise regardless of whether the body contains a `return` statement, so a missing return is not a missing-result bug. The fix early-returns when the callback function carries an `async` modifier.

## code-quality/deterministic/computed-enum-value

OSS samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/types/subscription.ts#L112
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/errors/app-error.ts#L19
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/document-flow/field-items-advanced-settings/constants.ts#L22`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/types/subscription.ts#L116
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/errors/app-error.ts#L8

Positive fixture diff (`tests/fixtures/sample-js-project-positive/src/computed-enum-value-from-documenso-documenso.ts`):

```diff
+ export enum ClaimTier {
+   FREE = 'free',
+   INDIVIDUAL = 'individual',
+   PLATFORM = 'platform',
+   ENTERPRISE = 'enterprise',
+ }
+ export enum AppErrorCode {
+   FORBIDDEN = 'FORBIDDEN',
+   NOT_FOUND = 'NOT_FOUND',
+ }
+ export enum HttpStatus { OK = 200, CREATED = 201 }
+ export enum SignedOffset { NEG_ONE = -1, ZERO = 0, ONE = 1 }
```

Negative fixture diff (`tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-typescript.ts`):

```diff
+ // VIOLATION: code-quality/deterministic/computed-enum-value
+ export enum DerivedEnum {
+   BASE = 10,
+   DOUBLED = 10 * 2,
+ }
```

The visitor read the enum member's RHS via `node.namedChildren[0]`, but tree-sitter's `enum_assignment` exposes the `property_identifier` (the LHS name) as `namedChildren[0]` and the value behind the `value` field. So every member's "value" was the member name (always identifier-typed, never `string`/`number`), causing all string-literal initializers like `FREE = 'free'` to be flagged as computed. Switched to `node.childForFieldName('value')`.

## architecture/deterministic/route-without-auth-middleware

OSS samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/router.ts#L106
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/router.ts#L118
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/router.ts#L125
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/router.ts#L135
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/files/routes/get-envelope-item-pdf-by-token.ts#L23

Positive fixture diff (`tests/fixtures/sample-js-project-positive/src/route-without-auth-middleware-from-documenso-documenso.ts`):

```diff
+ export function mountRouter(): void {
+   app.use('/api/v1/*', apiV1RateLimitMiddleware);
+   app.use('/api/trpc/*', trpcRateLimitMiddleware);
+   app.use('/api/trpc/*', () => new Response(null));
+   app.route('/api/files', filesRoute);
+ }
+ export function registerTokenAuthedRoute(): void {
+   app.get('/token/:token/envelope/:envelopeId/item.pdf', (c) => {
+     const { token } = c.req.valid('param');
+     return c.json({ ok: token.length > 0 });
+   });
+ }
```

Negative fixture diff (`tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/arch-violations.ts`):

```diff
+ // VIOLATION: architecture/deterministic/route-without-auth-middleware
+ router.post('/api/admin/audit-logs/wipe', (req, res) => {
+   res.json({ cleared: true });
+ });
```

Two FP shapes addressed:

1. `app.use(path, mw)` / `router.use(path, sub)` was being treated as a route handler because `isRouteHandler`'s shared `EXPRESS_ROUTE_METHODS` set includes `use`. But `.use` is middleware registration / sub-router mount, not a leaf route handler. Added an early-return on `prop === 'use'` inside this specific visitor (leaving `isRouteHandler` shared with rate-limiting detection unchanged).
2. Routes that authenticate via a URL-embedded credential parameter (`/token/:token/...`) verify the credential inside the handler — there is no auth middleware in the chain by design. Added an `isUrlCredentialAuthedPath` skip for `:token`, `:apiKey`/`:api_key`, `:secret`, `:hash`, `:signature` parameters.

## bugs/deterministic/array-callback-return

OSS samples:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/seal-document-sweep.handler.ts#L88`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/embedding-router/apply-multi-sign-signature.ts#L60
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/document/delete-document.ts#L196
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/expire-recipients-sweep.handler.ts#L38`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/webhooks/trigger/handler.ts#L46

Positive fixture diff (`tests/fixtures/sample-js-project-positive/src/array-callback-return-from-documenso-documenso.ts`):

```diff
+ export async function triggerWebhooks(
+   subscribers: readonly WebhookSubscriber[],
+   client: WebhookClient,
+   payload: Record<string, unknown>,
+ ): Promise<void> {
+   await Promise.allSettled(
+     subscribers.map(async (subscriber) => {
+       await client.fire(subscriber, payload);
+     }),
+   );
+ }
```

Negative fixture diff (`tests/fixtures/sample-js-project-negative/shared/utils/src/misc-bugs.ts`):

```diff
+ // VIOLATION: bugs/deterministic/array-callback-return
+ export function squaredOnly(nums: readonly number[]): number[] {
+   return nums.filter((n) => {
+     n > 0;
+   });
+ }
```

Sibling rule of `array-callback-missing-return` with the identical FP shape — both rules detect missing-return in array callbacks, with slightly different method sets (`array-callback-return` includes `sort`; `array-callback-missing-return` includes `findLast`/`findLastIndex`). Both fire on the same `Promise.all(arr.map(async))` pattern. Applied the same async-skip here so the two visitors stay in step. Shares the visitor-change shape with #116.

## reliability/deterministic/process-exit-in-library

OSS samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed-database.ts#L31
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed-database.ts#L35
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/api/v1/examples/05-add-a-recipient.ts#L37
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/api/v1/examples/04-remove-a-field.ts#L30
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/api/v1/examples/07-remove-a-recipient.ts#L30

Positive fixture diff (`tests/fixtures/sample-js-project-positive/shared/utils/src/seed-database-from-documenso-documenso.ts`):

```diff
+ export const runSeed = async (): Promise<void> => { await Promise.resolve(); };
+ runSeed()
+   .then(() => process.exit(0))
+   .catch((err: unknown) => {
+     console.error('Seed failed:', err);
+     process.exit(1);
+   });
```

Negative fixture diff (`tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/reliability.ts`):

```diff
+ // VIOLATION: reliability/deterministic/process-exit-in-library
+ export function failHard() {
+   process.exit(2);
+ }
```

The entry-point allowlist already covered `scripts/`, `bin/`, `cli.`, `worker.`, etc. but missed two common CLI-script shapes: seed scripts (`packages/prisma/seed-database.ts`, `prisma/seed.ts`, `seeds/initial.ts`) and example scripts (`packages/api/v1/examples/*.ts`). Both are runnable entrypoints — invoked by `prisma db seed` or by direct `node` invocation — where `process.exit` is the conventional way to signal status back to the parent shell. Added `seeds?` and `/examples/` (plus `migrations?` for symmetry) to the allowlist.

## Skipped this batch

- [#117](https://github.com/truecourse-ai/truecourse/issues/117) (bugs/deterministic/void-zero-argument) — cross-rule interaction. Fixing this rule to only fire on `void 0` is correct and trivial, but `code-quality/deterministic/no-void` also fires on the same `void <call>` fire-and-forget idiom (205 sites, 1:1 overlap with this rule's FPs). Resolving the FP holistically needs a paired fix to `no-void` or a separate fp-fix issue for it.
- [#119](https://github.com/truecourse-ai/truecourse/issues/119) (architecture/deterministic/data-layer-depends-on-api) — refactor required. The checker fires correctly; root cause is upstream layer misclassification in `packages/analyzer/src/layer-detector.ts` (type-only imports promote files into `data`/`api` layers; `**/*view*.{ts,js}` matches non-API filenames like `pdf-viewer.ts`). `layer-detector.ts` is outside the routine's allowed paths.
- [#122](https://github.com/truecourse-ai/truecourse/issues/122) (code-quality/deterministic/unsafe-any-usage) — refactor required. The visitor faithfully reports `isAnyType(...)` results; the FPs originate in `packages/analyzer/src/ts-compiler.ts` failing to resolve external library types (Zod, tRPC, Prisma, React). Outside the routine's allowed paths.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjCsaYGKrnxVUNiL37kX9P)_