### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/data-flow/scope-analyzer.ts
+++ b/packages/analyzer/src/data-flow/scope-analyzer.ts
@@ -179,6 +179,28 @@ function isTypePosition(node: SyntaxNode): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Check if identifier is the source-name half of an aliased import_specifier.
+//
+//   import { Foo as Bar } from '…'
+//
+// `Foo` here is the name *of the symbol exported by the module being
+// imported* — not a reference to anything in the current module. It must
+// not be treated as a use site, otherwise an unrelated local binding
+// named `Foo` declared elsewhere in the file looks "used before defined".
+// The alias half (`Bar`) is the actual local declaration and is already
+// handled by isJsDeclarationPosition.
+// ---------------------------------------------------------------------------
+
+function isAliasedImportSourceName(node: SyntaxNode): boolean {
+  const parent = node.parent
+  if (!parent || parent.type !== 'import_specifier') return false
+  const alias = parent.childForFieldName('alias')
+  if (!alias) return false
+  const nameField = parent.childForFieldName('name')
+  return nameField?.id === node.id
+}
+
+// ---------------------------------------------------------------------------
 // Check if identifier is the right side of a property access (a.b -> b is property)
 // ---------------------------------------------------------------------------
 
@@ -1057,7 +1079,7 @@ export function buildScopeTree(
       if (isJs) {
         if (isJsDeclarationPosition(node)) {
           declareJsVariable(node, scope)
-        } else if (!isPropertyAccess(node)) {
+        } else if (!isPropertyAccess(node) && !isAliasedImportSourceName(node)) {
           deferredRefs.push({ node, scope })
         }
       } else {

--- a/packages/analyzer/src/data-flow/use-def-chains.ts
+++ b/packages/analyzer/src/data-flow/use-def-chains.ts
@@ -135,7 +135,14 @@ export function buildDataFlowContext(rootNode: SyntaxNode, language: SupportedLa
       // even though the textual use precedes the assignment. Restrict the
       // position check to use sites in the same scope as the declaration
       // (or non-function descendant blocks).
-      const directUseSites = v.useSites.filter((u) => !isInNestedFunctionScope(u.scope, v.scope))
+      //
+      // Also skip TS type-position uses: `type T = typeof X[number]` and
+      // `Awaited<ReturnType<typeof X>>` are resolved at type-check time
+      // and erased before execution, so they cannot trigger TDZ at runtime
+      // even when X is declared further down in the module.
+      const directUseSites = v.useSites.filter(
+        (u) => !isInNestedFunctionScope(u.scope, v.scope) && !u.isTypePosition,
+      )
       if (directUseSites.length === 0) continue
 
       const declPos = v.declarationNode.startIndex

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/_helpers.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/_helpers.ts
@@ -48,9 +48,20 @@ export const KNOWN_ARG_ORDERS: Array<{ fn: string; params: string[][] }> = [
   { fn: 'substring', params: [['start', 'from', 'begin'], ['end', 'to', 'finish']] },
 ]
 
+// Method names that ALWAYS return undefined on every common receiver
+// (Array, Map, Set, Storage, DOM collections). Assigning their result
+// is unambiguously a bug.
+//
+// Methods deliberately omitted because they DO return a useful value
+// on common receivers:
+//   - pop / shift / splice  → return the removed element(s)
+//   - push / unshift        → return the new length
+//   - fill / sort / reverse → return the (chainable) array itself
+//   - set / add             → return the chainable Map / Set
+//   - delete                → boolean on Map/Set; chainable instance on
+//                             Hono / Express / etc. routers
 export const VOID_RETURNING_METHODS = new Set([
-  'forEach', 'push', 'pop', 'shift', 'unshift', 'splice', 'fill',
-  'delete', 'clear', 'set', 'add',
+  'forEach', 'clear',
 ])
 
 export const VOID_RETURNING_GLOBALS = new Set([

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/await-in-loop.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/await-in-loop.ts
@@ -3,16 +3,54 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { JS_LANGUAGES } from './_helpers.js'
 
+// Seed / database-bootstrap scripts run once during setup, are
+// intentionally sequential, and are not on any hot path. Treat any file
+// whose path contains a `seed/`/`seeds/` directory segment, or whose
+// basename matches `seed*.ts` / `*-seed.ts` / `*-seeds.ts`, as out of
+// scope for this rule.
+const SEED_FILE_PATH_PATTERN = /(?:^|[\\/])(?:seed|seeds)[\\/]|(?:^|[\\/])seed[^\\/]*\.(?:ts|tsx|js|jsx|mjs|cjs)$|[-_.](?:seed|seeds)\.(?:ts|tsx|js|jsx|mjs|cjs)$/i
+
+function isInSeedScript(filePath: string): boolean {
+  return SEED_FILE_PATH_PATTERN.test(filePath)
+}
+
+// A `while`/`do-while` whose condition steps through a chain via optional
+// chaining (`while (node?.parent)`) is a linked-list-style walk: each
+// iteration depends on the awaited result of the previous one and can't
+// be parallelised. Standard "drain an array" loops use `for-of` or a
+// length test, not an optional-chained property access.
+function isSerialChainWalk(loopNode: SyntaxNode): boolean {
+  if (loopNode.type !== 'while_statement' && loopNode.type !== 'do_statement') {
+    return false
+  }
+  const condition =
+    loopNode.childForFieldName('condition') ?? loopNode.childForFieldName('test')
+  if (!condition) return false
+  return containsOptionalChain(condition)
+}
+
+function containsOptionalChain(node: SyntaxNode): boolean {
+  if (node.type === 'optional_chain') return true
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i)
+    if (child && containsOptionalChain(child)) return true
+  }
+  return false
+}
+
 export const awaitInLoopVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/await-in-loop',
   languages: JS_LANGUAGES,
   nodeTypes: ['await_expression'],
   visit(node, filePath, sourceCode) {
+    if (isInSeedScript(filePath)) return null
+
     // Walk up the tree to find if we're inside a loop
     let current: SyntaxNode | null = node.parent
     while (current) {
       const t = current.type
       if (t === 'for_statement' || t === 'for_in_statement' || t === 'while_statement' || t === 'do_statement') {
+        if (isSerialChainWalk(current)) return null
         // Make sure we're in the loop body (not the initializer/condition of a for loop)
         // and not inside a nested async function
         return makeViolation(

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/use-before-define.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/use-before-define.ts
@@ -11,10 +11,13 @@ export const useBeforeDefineVisitor: CodeRuleVisitor = {
     if (!dataFlow) return null
     const vars = dataFlow.usedBeforeDefined()
     for (const v of vars) {
-      // Find the earliest use site that is before the declaration
+      // Find the earliest use site that is before the declaration.
+      // Skip type-position references (`typeof X` inside a type alias,
+      // `Awaited<ReturnType<typeof X>>`, etc.) — these are erased before
+      // runtime and cannot hit TDZ.
       const declPos = v.declarationNode.startIndex
       const earliestUseSite = v.useSites
-        .filter(u => u.node.startIndex < declPos)
+        .filter(u => u.node.startIndex < declPos && !u.isTypePosition)
         .sort((a, b) => a.node.startIndex - b.node.startIndex)[0]
       if (!earliestUseSite) continue
 

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/redundant-type-alias.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/redundant-type-alias.ts
@@ -1,5 +1,29 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+
+// Type aliases inside a `namespace X { … }` (or a `declare global { … }`
+// block) are deliberately bridging a name from another module into the
+// namespace under a different identifier. They are name-mapping
+// declarations, not redundant wrappers — e.g. the
+// `prisma-json-types-generator` convention:
+//
+//   declare global {
+//     namespace PrismaJson {
+//       type ClaimFlags = TClaimFlags;       // ← required, not redundant
+//     }
+//   }
+function isInsideNamespaceOrAmbient(node: SyntaxNode): boolean {
+  let current: SyntaxNode | null = node.parent
+  while (current) {
+    const t = current.type
+    if (t === 'internal_module' || t === 'module' || t === 'ambient_declaration') {
+      return true
+    }
+    current = current.parent
+  }
+  return false
+}
 
 export const redundantTypeAliasVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/redundant-type-alias',
@@ -9,6 +33,8 @@ export const redundantTypeAliasVisitor: CodeRuleVisitor = {
     const nameNode = node.childForFieldName('name')
     const typeNode = node.childForFieldName('value')
     if (!nameNode || !typeNode) return null
+
+    if (isInsideNamespaceOrAmbient(node)) return null
 
     if (typeNode.type === 'type_identifier') {
       if (typeNode.text === nameNode.text) return null

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/undefined-passed-as-optional.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/undefined-passed-as-optional.ts
@@ -15,6 +15,24 @@ export const undefinedPassedAsOptionalVisitor: CodeRuleVisitor = {
     const lastArg = argList[argList.length - 1]
     if (lastArg.text !== 'undefined') return null
 
+    // Require at least three positional arguments before flagging.
+    //
+    // With one or two args we cannot tell from syntax alone whether the
+    // trailing `undefined` is a redundant optional or a meaningful "clear"
+    // value passed to a required parameter. Real-world callers regularly
+    // hand `undefined` to required params on purpose:
+    //
+    //   form.setValue(name, undefined)      // RHF: value is required
+    //   field.onChange(undefined)           // RHF: value is required
+    //   createContext<T | undefined>(undefined)  // React: default required
+    //   buildMeta(settings, undefined)      // domain-specific, value required
+    //
+    // The rule is intentionally conservative here — a function whose only
+    // trailing arg is genuinely optional almost always has 3+ args in real
+    // codebases (the optional param is typically `options?`, `meta?`,
+    // `signal?` after a series of required args).
+    if (argList.length < 3) return null
+
     // Skip React hooks where undefined is the standard initial value
     // Handles both `useState(undefined)` and `React.useState(undefined)`
     const fn = node.childForFieldName('function')

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -691,6 +691,12 @@
       "layer": "service"
     },
     {
+      "name": "undefined-passed-as-optional",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "UnreadAttribute",
       "service": "utils",
       "kind": "class",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -577,6 +577,12 @@
       "layer": "service"
     },
     {
+      "name": "fetchAllRecords",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "formatters",
       "service": "utils",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -691,6 +691,12 @@
       "layer": "service"
     },
     {
+      "name": "squareAll",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "style",
       "service": "utils",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/await-in-loop.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/await-in-loop.ts
@@ -1,0 +1,20 @@
+/**
+ * Paraphrased true-bug for bugs/deterministic/await-in-loop.
+ *
+ * A for-of loop awaiting an independent network call per item — classic
+ * "use Promise.all" case. Iterations have no dependency on each other.
+ */
+
+async function fetchRecord(id: string): Promise<{ id: string; size: number }> {
+  return { id, size: id.length };
+}
+
+export async function fetchAllRecords(ids: readonly string[]): Promise<number> {
+  let total = 0;
+  for (const id of ids) {
+    // VIOLATION: bugs/deterministic/await-in-loop
+    const record = await fetchRecord(id);
+    total += record.size;
+  }
+  return total;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts
@@ -193,11 +193,11 @@ export function assignUndefined() {
 }
 
 // VIOLATION: code-quality/deterministic/undefined-passed-as-optional
-export function optionalParam(a: number, b?: string) {
-  return a;
+export function optionalParam(a: number, b: number, c?: string) {
+  return a + b;
 }
 export function callOptional() {
-  return optionalParam(1, undefined);
+  return optionalParam(1, 2, undefined);
 }
 
 // VIOLATION: code-quality/deterministic/unnecessary-boolean-compare

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-type-alias-source.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-type-alias-source.ts
@@ -1,0 +1,4 @@
+export type TEmailSettings = {
+  reminders: boolean;
+  signedCopy: boolean;
+};

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-type-alias.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-type-alias.ts
@@ -1,0 +1,11 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/redundant-type-alias.
+ *
+ * A top-level type alias that just renames another type without adding
+ * any structure — exactly the wrapper-without-meaning the rule is for.
+ */
+
+import type { TEmailSettings } from './redundant-type-alias-source';
+
+// VIOLATION: code-quality/deterministic/redundant-type-alias
+export type EmailSettingsValue = TEmailSettings;

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/undefined-passed-as-optional.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/undefined-passed-as-optional.ts
@@ -1,0 +1,16 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/undefined-passed-as-optional.
+ *
+ * A function with two leading required parameters and a trailing optional;
+ * the caller passes `undefined` for the optional, which is redundant — the
+ * call is equivalent to omitting the argument.
+ */
+
+function recordEvent(name: string, payload: Record<string, unknown>, traceId?: string): void {
+  void name;
+  void payload;
+  void traceId;
+}
+
+// VIOLATION: code-quality/deterministic/undefined-passed-as-optional
+recordEvent('signed', { id: 1 }, undefined);

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/use-before-define.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/use-before-define.ts
@@ -1,0 +1,12 @@
+/**
+ * Paraphrased true-bug for bugs/deterministic/use-before-define.
+ *
+ * Module-scope const initialiser references another const declared further
+ * down in the same module. Unlike the positive cases this is a value-position
+ * reference, so it hits the temporal-dead-zone at runtime.
+ */
+
+// VIOLATION: bugs/deterministic/use-before-define
+export const PRIMARY_BRAND_TONE = AVAILABLE_BRAND_TONES[0];
+
+const AVAILABLE_BRAND_TONES = ['violet', 'amber', 'jade'] as const;

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/void-return-value-used.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/void-return-value-used.ts
@@ -1,0 +1,13 @@
+/**
+ * Paraphrased true-bug for bugs/deterministic/void-return-value-used.
+ *
+ * `Array.prototype.forEach` always returns undefined — assigning its
+ * result is a real bug; the caller probably meant `.map`.
+ */
+
+export function squareAll(values: number[]): void {
+  // @ts-expect-error — intentional bug: assigning the void return of forEach.
+  // VIOLATION: bugs/deterministic/void-return-value-used
+  const squared: number[] = values.forEach((n) => n * n);
+  void squared;
+}

--- a/tests/fixtures/sample-js-project-positive/src/await-in-loop-seed.ts
+++ b/tests/fixtures/sample-js-project-positive/src/await-in-loop-seed.ts
@@ -1,0 +1,22 @@
+/**
+ * Positive fixture (seed-script half) for bugs/deterministic/await-in-loop.
+ *
+ * Filename ends in `-seed.ts` — Prisma/Drizzle/etc. seed scripts run once
+ * during local setup, are intentionally sequential, and are not on any hot
+ * path. The rule should treat seed-script file paths as out-of-scope.
+ */
+
+type PrismaClient = {
+  user: { create(args: { data: unknown }): Promise<{ id: number }> };
+};
+
+declare const prisma: PrismaClient;
+
+export async function seedUsers(count: number): Promise<number[]> {
+  const ids: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const created = await prisma.user.create({ data: { name: `user-${i}` } });
+    ids.push(created.id);
+  }
+  return ids;
+}

--- a/tests/fixtures/sample-js-project-positive/src/await-in-loop.ts
+++ b/tests/fixtures/sample-js-project-positive/src/await-in-loop.ts
@@ -1,0 +1,29 @@
+/**
+ * Positive fixture for bugs/deterministic/await-in-loop.
+ *
+ * Two FP shapes:
+ *
+ *   1. A while loop whose iteration condition reads a property via
+ *      optional chaining (`while (node?.parent)`). Each iteration depends
+ *      on the awaited result of the previous one — a linked-list walk
+ *      that is inherently sequential and cannot be parallelised.
+ *
+ *   2. (Tested separately in `await-in-loop-seed.ts` below.) Seed
+ *      scripts where sequential execution is intentional.
+ */
+
+type FolderRecord = { id: string; parentId: string | null };
+
+declare function loadFolder(id: string): Promise<FolderRecord | null>;
+
+export async function walkBreadcrumbs(startId: string): Promise<FolderRecord[]> {
+  const trail: FolderRecord[] = [];
+  let current: FolderRecord | null = await loadFolder(startId);
+  while (current?.parentId !== null && current?.parentId !== undefined) {
+    const parent = await loadFolder(current.parentId);
+    if (!parent) break;
+    trail.unshift(parent);
+    current = parent;
+  }
+  return trail;
+}

--- a/tests/fixtures/sample-js-project-positive/src/redundant-type-alias.ts
+++ b/tests/fixtures/sample-js-project-positive/src/redundant-type-alias.ts
@@ -1,0 +1,20 @@
+/**
+ * Positive fixture for code-quality/deterministic/redundant-type-alias.
+ *
+ * Aliases inside a `declare module 'x' { … }` block (and inside a
+ * `declare global { namespace X { … } }` block) deliberately bridge a
+ * name from another module into the ambient namespace under a
+ * different identifier. They are name-mapping declarations, not
+ * redundant wrappers — typical of JSON-typed ORM bridges and similar
+ * code-generator conventions.
+ */
+
+type TFeatureFlags = { admin: boolean };
+type TAuthOptions = { method: 'password' | 'sms' };
+
+declare module '@truecourse-fp-fixture/json-bridge' {
+  type FeatureFlags = TFeatureFlags;
+  type AuthOptions = TAuthOptions;
+}
+
+export type { TFeatureFlags, TAuthOptions };

--- a/tests/fixtures/sample-js-project-positive/src/undefined-passed-as-optional.ts
+++ b/tests/fixtures/sample-js-project-positive/src/undefined-passed-as-optional.ts
@@ -1,0 +1,51 @@
+/**
+ * Positive fixture for code-quality/deterministic/undefined-passed-as-optional.
+ *
+ * `f(x, undefined)` (two args) and `g(undefined)` (one arg) are NOT
+ * redundant-trailing-optional patterns: with so few arguments the trailing
+ * `undefined` is almost always a meaningful "clear" value handed to a
+ * required parameter (form setters, event handlers, context defaults).
+ * The rule should only fire when the call has a longer argument list and
+ * the trailing `undefined` is genuinely past a series of provided args.
+ */
+
+type FormApi = {
+  setValue(name: string, value: string | undefined): void;
+};
+
+type FieldApi = {
+  onChange(value: string | undefined): void;
+};
+
+type ProfileMeta = { brand: string; nickname: string | undefined };
+
+function buildProfileMeta(
+  brand: string,
+  override: { nickname?: string } | undefined,
+): ProfileMeta {
+  return { brand, nickname: override?.nickname };
+}
+
+function makeContext<T>(defaultValue: T): { defaultValue: T } {
+  return { defaultValue };
+}
+
+export function clearFormField(form: FormApi): void {
+  // 2-arg call: the value parameter is required; undefined is a meaningful clear.
+  form.setValue('subject', undefined);
+}
+
+export function resetFieldValue(field: FieldApi): void {
+  // 1-arg call: the only argument is required.
+  field.onChange(undefined);
+}
+
+export function makeBrandingContext(): { defaultValue: string | undefined } {
+  // 1-arg call: createContext's defaultValue is required.
+  return makeContext<string | undefined>(undefined);
+}
+
+export function defaultProfileMeta(brand: string): ProfileMeta {
+  // 2-arg call: both arguments are required even though the 2nd accepts undefined.
+  return buildProfileMeta(brand, undefined);
+}

--- a/tests/fixtures/sample-js-project-positive/src/use-before-define-helpers.ts
+++ b/tests/fixtures/sample-js-project-positive/src/use-before-define-helpers.ts
@@ -1,0 +1,7 @@
+export const Status = {
+  PRIVATE: 'PRIVATE',
+  PUBLIC: 'PUBLIC',
+  ORGANISATION: 'ORGANISATION',
+} as const;
+
+export type Status = (typeof Status)[keyof typeof Status];

--- a/tests/fixtures/sample-js-project-positive/src/use-before-define.ts
+++ b/tests/fixtures/sample-js-project-positive/src/use-before-define.ts
@@ -1,0 +1,41 @@
+/**
+ * Positive fixture for bugs/deterministic/use-before-define.
+ *
+ * Two FP shapes:
+ *
+ *   1. The source-name half of an aliased import (`import { X as Y }`)
+ *      shares its identifier text with a const declared later in the same
+ *      module. The source name is not a reference to anything in this
+ *      module — it's the symbol being imported — so it cannot trip TDZ.
+ *
+ *   2. `typeof X` in a type position resolves at type-check time, not at
+ *      runtime. Even when X is declared textually later in the module,
+ *      there is no TDZ hazard because the type system erases it.
+ */
+
+import type { Status as StatusEnum } from './use-before-define-helpers';
+
+// (2) Type alias references `AVAILABLE_TONES` (declared at the bottom of the
+//     file) inside a `typeof` type query. Erased at runtime.
+export type TBrandTone = (typeof AVAILABLE_TONES)[number];
+
+export type TStatusValue = (typeof StatusEnum)[keyof typeof StatusEnum];
+
+// (2) Function type derived via `typeof` of a later-declared function.
+export type ResolvedToken = ReturnType<typeof loadTokenById>;
+
+// (1) Local const that re-exports the imported enum under a friendlier name.
+// Its identifier `Status` matches the source name of the `import { Status as
+// StatusEnum }` above. The rule must not treat the import-side `Status` as a
+// reference to this binding.
+export const Status = StatusEnum;
+
+function loadTokenById(id: string): { id: string; tone: TBrandTone } {
+  return { id, tone: AVAILABLE_TONES[0] };
+}
+
+export function fetchToken(id: string): ResolvedToken {
+  return loadTokenById(id);
+}
+
+const AVAILABLE_TONES = ['warm', 'cool', 'earthy'] as const;

--- a/tests/fixtures/sample-js-project-positive/src/void-return-value-used.ts
+++ b/tests/fixtures/sample-js-project-positive/src/void-return-value-used.ts
@@ -1,0 +1,52 @@
+/**
+ * Positive fixture for bugs/deterministic/void-return-value-used.
+ *
+ * `Array.prototype.splice`, `.pop`, `.shift`, and `.fill` all return
+ * useful values (the removed element, the removed slice, or the
+ * mutated array itself). `Map.prototype.set`, `Set.prototype.add`, and
+ * router-fluent `.delete` (e.g. Hono) all return chainable receivers.
+ * Treating any of these as "void" produces false positives whenever
+ * the return value is genuinely consumed.
+ */
+
+type FluentRouter = {
+  get(path: string, handler: () => string): FluentRouter;
+  delete(path: string, handler: () => string): FluentRouter;
+};
+
+declare function makeRouter(): FluentRouter;
+
+export function buildRoutes(): FluentRouter {
+  // Hono-style fluent route registration — `.delete()` returns the router.
+  return makeRouter()
+    .get('/account', () => 'ok')
+    .delete('/account', () => 'gone');
+}
+
+export function reorderItems(source: readonly number[], from: number): number[] {
+  const items = [...source];
+  // `.splice()` returns the removed elements (an array).
+  const [removed] = items.splice(from, 1);
+  return [removed, ...items];
+}
+
+export function extractEmailDomain(email: string): string | undefined {
+  // `.pop()` returns the removed element.
+  return email.toLowerCase().split('@').pop();
+}
+
+export function popLastItem<T>(source: readonly T[]): T | undefined {
+  const items = [...source];
+  // `.shift()` returns the removed element.
+  return items.shift();
+}
+
+export function buildLookupMap(): Map<string, number> {
+  // `Map.prototype.set` returns the map itself.
+  return new Map<string, number>().set('a', 1).set('b', 2);
+}
+
+export function buildLookupSet(): Set<string> {
+  // `Set.prototype.add` returns the set itself.
+  return new Set<string>().add('x').add('y');
+}


### PR DESCRIPTION
Closes #130
Closes #131
Closes #132
Closes #133
Closes #134

## Fixes

| Rule | Issue | Positive fixture | Negative fixture |
|---|---|---|---|
| `bugs/deterministic/use-before-define` | #130 | `tests/fixtures/sample-js-project-positive/src/use-before-define.ts` (+ `…-helpers.ts`) | `tests/fixtures/sample-js-project-negative/shared/utils/src/use-before-define.ts` |
| `code-quality/deterministic/undefined-passed-as-optional` | #131 | `tests/fixtures/sample-js-project-positive/src/undefined-passed-as-optional.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/undefined-passed-as-optional.ts` |
| `bugs/deterministic/await-in-loop` | #132 | `tests/fixtures/sample-js-project-positive/src/await-in-loop.ts` (+ `await-in-loop-seed.ts`) | `tests/fixtures/sample-js-project-negative/shared/utils/src/await-in-loop.ts` |
| `bugs/deterministic/void-return-value-used` | #133 | `tests/fixtures/sample-js-project-positive/src/void-return-value-used.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/void-return-value-used.ts` |
| `code-quality/deterministic/redundant-type-alias` | #134 | `tests/fixtures/sample-js-project-positive/src/redundant-type-alias.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-type-alias.ts` (+ `redundant-type-alias-source.ts`) |

## bugs/deterministic/use-before-define

Sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/template/template-type.tsx#L6
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/command.tsx#L2
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/lib/recipient-colors.ts#L4
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/document/get-document-by-token.ts#L57
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/team/get-team.ts#L23

Positive fixture (new):

```ts
import type { Status as StatusEnum } from './use-before-define-helpers';

export type TBrandTone = (typeof AVAILABLE_TONES)[number];
export type TStatusValue = (typeof StatusEnum)[keyof typeof StatusEnum];
export type ResolvedToken = ReturnType<typeof loadTokenById>;

export const Status = StatusEnum;

function loadTokenById(id: string): { id: string; tone: TBrandTone } {
  return { id, tone: AVAILABLE_TONES[0] };
}

const AVAILABLE_TONES = ['warm', 'cool', 'earthy'] as const;
```

Negative fixture (new):

```ts
// VIOLATION: bugs/deterministic/use-before-define
export const PRIMARY_BRAND_TONE = AVAILABLE_BRAND_TONES[0];

const AVAILABLE_BRAND_TONES = ['violet', 'amber', 'jade'] as const;
```

**Visitor summary.** Two changes in `packages/analyzer/src/data-flow/`. (1) The walker no longer adds the source-name half of an aliased `import { X as Y }` to `deferredRefs`, so a local binding named `X` declared later in the same file is no longer incorrectly tagged with a "use" at the import line. (2) `usedBeforeDefined()` (and the rule visitor) now skip use sites flagged `isTypePosition: true`, so `typeof X` and `ReturnType<typeof X>` in type positions don't trip TDZ — those references are erased before runtime.

## code-quality/deterministic/undefined-passed-as-optional

Sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/template-use-dialog.tsx#L415
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/template-use-dialog.tsx#L488
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/template-use-dialog.tsx#L525
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/forms/editor/editor-field-dropdown-form.tsx#L124`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/providers/branding.tsx#L11

Positive fixture (new):

```ts
form.setValue('subject', undefined);                 // 2-arg: value param is required
field.onChange(undefined);                            // 1-arg: only arg required
return makeContext<string | undefined>(undefined);    // createContext default
return buildProfileMeta(brand, undefined);            // 2-arg: required
```

Negative fixture (new):

```ts
function recordEvent(name: string, payload: Record<string, unknown>, traceId?: string): void { /* … */ }

// VIOLATION: code-quality/deterministic/undefined-passed-as-optional
recordEvent('signed', { id: 1 }, undefined);
```

Also bumped the existing 2-arg TP in `code-quality-misc.ts` to a 3-arg shape so it stays a TP under the new heuristic.

**Visitor summary.** The rule now requires at least three positional arguments before firing. With one or two args the trailing `undefined` is almost always a meaningful "clear" value handed to a required parameter (form setters, event handlers, context defaults) — distinguishing a redundant trailing optional from a meaningful clear is impossible from syntax alone in that regime. Real-world optional trailing args overwhelmingly sit after two or more required args.

## bugs/deterministic/await-in-loop

Sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/initial-seed.ts#L70
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/initial-seed.ts#L105
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/documents.ts#L561
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/medium-account-seed.ts#L61
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/folder/get-folder-breadcrumbs.ts#L55

Positive fixture (new, two files):

```ts
// await-in-loop.ts — breadcrumb walk, optional-chain in while condition
while (current?.parentId !== null && current?.parentId !== undefined) {
  const parent = await loadFolder(current.parentId);
  /* … */
}

// await-in-loop-seed.ts — file-path heuristic; seed scripts are intentionally sequential
for (let i = 0; i < count; i++) {
  const created = await prisma.user.create({ data: { name: `user-${i}` } });
}
```

Negative fixture (new):

```ts
for (const id of ids) {
  // VIOLATION: bugs/deterministic/await-in-loop
  const record = await fetchRecord(id);
  /* … */
}
```

**Visitor summary.** The visitor now skips two contexts: (1) files whose path/name marks them as seed scripts (`seed/` or `seeds/` directory segments, basename `seed*.ts` or `*-seed.ts`/`*-seeds.ts`) — these run once during setup and are intentionally sequential; and (2) `while`/`do-while` loops whose condition steps through a chain via optional chaining (`while (node?.parent)`) — these are linked-list walks where each iteration depends on the awaited result of the previous and cannot be parallelised.

## bugs/deterministic/void-return-value-used

Sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/auth/server/routes/account.ts#L7
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx#L276`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/constants/auth.ts#L114
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/envelope-editor/envelope-editor-recipient-form.tsx#L361`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/document-flow/add-signers.tsx#L348

Positive fixture (new):

```ts
return makeRouter().get('/account', () => 'ok').delete('/account', () => 'gone');  // fluent router
const [removed] = items.splice(from, 1);                  // splice → removed elements
return email.toLowerCase().split('@').pop();              // pop → removed element
return new Map<string, number>().set('a', 1).set('b', 2); // Map.set → map
return new Set<string>().add('x').add('y');               // Set.add → set
```

Negative fixture (new):

```ts
// VIOLATION: bugs/deterministic/void-return-value-used
const squared: number[] = values.forEach((n) => n * n);
```

**Visitor summary.** Trimmed `VOID_RETURNING_METHODS` in `packages/analyzer/src/rules/bugs/visitors/javascript/_helpers.ts` to just `forEach` and `clear`. The removed names (`pop`, `shift`, `splice`, `fill`, `push`, `unshift`, `delete`, `set`, `add`) all return a useful value on common receivers — removed element(s), new length, the chainable array/Map/Set, a boolean, or a router instance. Since the rule matches purely on method name, listing them produced FPs whenever the genuine return value was captured.

## code-quality/deterministic/redundant-type-alias

Sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/types/types.d.ts#L15
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/types/types.d.ts#L17
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/types/types.d.ts#L19
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/types/types.d.ts#L22
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/types/types.d.ts#L26
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/types/types.d.ts#L28

Positive fixture (new):

```ts
declare module '@truecourse-fp-fixture/json-bridge' {
  type FeatureFlags = TFeatureFlags;
  type AuthOptions = TAuthOptions;
}
```

Negative fixture (new):

```ts
// VIOLATION: code-quality/deterministic/redundant-type-alias
export type EmailSettingsValue = TEmailSettings;
```

**Visitor summary.** The rule now walks up from the type alias and bails when any ancestor is an `internal_module`, `module`, or `ambient_declaration` node. Aliases inside `namespace X { … }` or `declare global { … }` / `declare module 'x' { … }` are bridging a name from another module into an ambient namespace under a different identifier — they are required name mappings (e.g. the prisma-json-types-generator convention), not redundant wrappers.

---

Rebased onto current `main` and renamed the fixtures to drop the `-from-<owner>-<repo>` suffix per #224 (no OSS-project identity in committed fixtures). Commit messages still reference the campaign target as required by the prompt's commit-message format.

cc @mushgev