### PR TITLE
fp-next-fix prompt: forbid OSS-project identity in committed fixtures

### DIFF
--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -118,9 +118,21 @@ or `tests/analyzer/python-positive.test.ts` is a false positive.
   triggers the rule.
 - Add the paraphrase as a new file under
   `tests/fixtures/sample-js-project-positive/` (or
-  `…-python-project-positive/` if the rule is Python) with a filename
-  that makes the source recognisable, e.g.
-  `<rule-key-slug>-from-<owner>-<repo>.ts`.
+  `…-python-project-positive/` if the rule is Python).
+- **Filename and content must not identify the upstream OSS project.**
+  The fixtures are committed to a public repo — don't expose which
+  projects we use as our FP corpus.
+  - Filename: `<rule-key-slug>.ts` (or `.tsx`/`.py` as appropriate).
+    If a fixture for that rule already exists, append a short
+    descriptive suffix that describes the *pattern shape*, not the
+    source — e.g. `<rule-key-slug>-typeof.ts`,
+    `<rule-key-slug>-shadowed-bindings.tsx`. Never use `-from-<owner>-<repo>`,
+    upstream filenames (`template-type`, `pdf-viewer`), or
+    upstream-specific identifiers.
+  - Content: rename all OSS-project-themed identifiers to neutral
+    domain-agnostic names. Comments must not name the upstream project
+    or its files. (Linking the OSS source URL in the **PR body** is
+    fine — that's a hyperlink, not a committed artifact.)
 - **No `// VIOLATION:` comment.** Remember the path as
   `positive_fixture_path` for the batch PR body.
 
@@ -131,6 +143,10 @@ or `tests/analyzer/python-positive.test.ts` is a false positive.
 - Add it under `tests/fixtures/sample-js-project-negative/` (or the
   Python equivalent) with `// VIOLATION: <rule-key>` on the offending
   line (or the language-appropriate comment for Python).
+- **Same anonymization rules as step 5**: filename based on rule key
+  + optional pattern-shape suffix (never `-from-<owner>-<repo>`);
+  content uses neutral identifiers and comments that don't name the
+  upstream OSS project.
 - Remember the path as `negative_fixture_path`.
 
 ### 7. Confirm expected pre-fix state
@@ -297,7 +313,13 @@ hit a true empty queue and run the close logic.
   from a fresh `pnpm build:dist`. The dist artifact is exactly what
   publish.yml ships to npm.
 - Never copy-paste OSS code — paraphrase only. Link the source by URL
-  in the PR body.
+  in the PR body (PR descriptions are review context, not committed
+  artifacts).
+- **No OSS-project identity in committed code.** Fixture filenames,
+  paths, identifiers, and comments must not reference the upstream
+  OSS owner/repo, the upstream's source filenames, or upstream-themed
+  identifiers. The committed fixture should look like generic
+  domain-agnostic code that happens to trigger the rule.
 - Never change anything outside `packages/analyzer/src/rules/`,
   `packages/analyzer/src/patterns/`, `tests/fixtures/sample-*/`, and
   (in the queue-empty path) `docs/fp-automation/campaigns.yaml` +


### PR DESCRIPTION
## Summary

The fixture filename guidance in `fp-next-fix.md` literally said:

> with a filename that makes the source recognisable, e.g. `<rule-key-slug>-from-<owner>-<repo>.ts`

— which is the *opposite* of what we want for a public repo. Sessions following that instruction shipped filenames like `use-before-define-from-documenso-documenso.ts`, exposing exactly which OSS projects we use as our FP corpus.

## Changes (prompt only)

`docs/fp-automation/prompts/fp-next-fix.md`:

1. **Step 5 (positive fixture)**: filename is `<rule-key-slug>.ts` with an optional pattern-shape suffix (e.g. `-typeof.ts`, `-shadowed-bindings.tsx`); never `-from-<owner>-<repo>` or upstream filenames. Fixture content uses neutral identifiers and comments — no upstream project names.
2. **Step 6 (negative fixture)**: same anonymization rules.
3. **Hard constraints**: a new rule explicitly forbidding OSS-project identity in committed code (filenames, paths, identifiers, comments). PR descriptions can still link OSS source URLs — those are hyperlinks in review context, not committed artifacts.

## No file renames needed in this PR

The fixtures already merged with OSS-themed names (3 from #212, 1 from #219) were already renamed by **#219**'s cleanup. The current `main` is clean of OSS identity in committed code:

- `find tests/fixtures -iname "*documenso*" -o -iname "*-from-*"` → 0 hits
- `grep -rIln documenso tests packages apps` → 0 hits

Remaining `documenso` mentions in `docs/fp-automation/{campaigns.yaml,README.md}` are appropriate (campaign config + docs naming the campaign target, not analyzer artifacts).

## Test plan

- [ ] Merge.
- [ ] Next fp-next-fix session opens a PR whose fixture filenames are `<rule-key-slug>(-<shape-suffix>)?.{ts,tsx,py}` with no `-from-*` suffix and no upstream-themed identifiers in the file content.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_