### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/filename-class-mismatch.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/filename-class-mismatch.ts
@@ -1,6 +1,16 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
+/**
+ * Default-export names that conventionally describe the module's *role*
+ * rather than mirroring its filename. Treating these as mismatches is a
+ * false positive: `export default app` from `router.ts` or `export
+ * default route` from a route module is idiomatic.
+ */
+const CONVENTIONAL_DEFAULT_NAMES = new Set([
+  'app', 'router', 'route', 'handler', 'server', 'config', 'default', 'middleware', 'plugin',
+])
+
 export const filenameClassMismatchVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/filename-class-mismatch',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -31,9 +41,26 @@ export const filenameClassMismatchVisitor: CodeRuleVisitor = {
     // Skip config files — export default config is a standard convention
     if (/\.(config|rc)\.(ts|js|mjs|cjs)$/.test(filePath)) return null
 
+    // Skip framework route modules — their filename encodes a URL path
+    // (Remix flat-routes `users.$id._index.tsx`, Next.js `[id]/page.tsx`,
+    // etc.) and never mirrors the component name.
+    if (/[\\/]routes?[\\/]/.test(filePath)) return null
+
     // Extract filename without extension
     const fileBase = filePath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? ''
     if (!fileBase) return null
+
+    // Skip index files — `index.ts` re-exports / barrel files conventionally
+    // export a value with a different name.
+    if (fileBase === 'index' || fileBase === 'index.d') return null
+
+    // Skip filenames containing routing-convention characters (`.`, `$`,
+    // `+`, `[`, `]`) — Remix/SvelteKit/Nuxt encode route paths in
+    // filenames where a strict class-name match is impossible.
+    if (/[.$+[\]]/.test(fileBase)) return null
+
+    // Skip when the default export uses a conventional generic name.
+    if (CONVENTIONAL_DEFAULT_NAMES.has(exportedName.toLowerCase())) return null
 
     // Normalize: compare case-insensitively and strip common suffixes
     const normalizeFileName = (s: string) => s.toLowerCase().replace(/[-_.]/g, '')

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/identical-functions.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/identical-functions.ts
@@ -15,7 +15,12 @@ export const identicalFunctionsVisitor: CodeRuleVisitor = {
         // Skip functions that are arguments to calls (e.g., Drizzle column defs)
         if (n.parent?.type === 'arguments') { return }
         const body = getFunctionBody(n)
-        if (body && body.namedChildCount > 0) {
+        // Skip concise-body arrows (`(x) => expr`): these are by definition
+        // single-expression lambdas — typically trivial event handlers or
+        // prop adapters where identical text is JSX boilerplate, not
+        // duplicated logic worth extracting.
+        const isConciseArrow = n.type === 'arrow_function' && body !== null && body.type !== 'statement_block'
+        if (body && body.namedChildCount > 0 && !isConciseArrow) {
           const normalized = body.text.replace(/\s+/g, ' ').trim()
           bodies.push({ body: normalized, fnNode: n })
         }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/restricted-api-usage.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/restricted-api-usage.ts
@@ -39,19 +39,20 @@ export const restrictedApiUsageVisitor: CodeRuleVisitor = {
       if (parent.type === 'property_identifier') return null
       if (parent.type === 'import_specifier' || parent.type === 'export_specifier') return null
 
-      // Skip if identifier is declared as a local variable or parameter in scope
+      // Skip if identifier is declared as a local variable or parameter
+      // in any enclosing scope. Closures can reference outer-scope bindings,
+      // so the walk must continue past function boundaries.
       const declPattern = new RegExp(`\\b(?:const|let|var)\\s+${node.text}\\b`)
+      const paramPattern = new RegExp(`\\b${node.text}\\b`)
       let scope: typeof node.parent = node.parent
       while (scope) {
         if (scope.type === 'statement_block' || scope.type === 'program') {
           if (declPattern.test(scope.text)) return null
         }
-        // Also check function parameters
         if (scope.type === 'arrow_function' || scope.type === 'function_declaration' ||
             scope.type === 'function_expression' || scope.type === 'method_definition') {
           const params = scope.childForFieldName('parameters')
-          if (params && params.text.includes(node.text)) return null
-          break
+          if (params && paramPattern.test(params.text)) return null
         }
         scope = scope.parent
       }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unused-private-member.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unused-private-member.ts
@@ -20,6 +20,10 @@ export const unusedPrivateMemberVisitor: CodeRuleVisitor = {
         const nameNode = member.children.find((c) => c.type === 'property_identifier' || c.type === 'private_property_identifier')
         if (nameNode) {
           const name = nameNode.text.replace(/^#/, '')
+          // Constructors are invoked implicitly by `new` (often kept
+          // private deliberately to enforce the Singleton pattern), which
+          // the `this.X` usage detector below cannot see.
+          if (name === 'constructor') continue
           privateMembers.set(name, nameNode)
         }
       }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unused-private-method.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unused-private-method.ts
@@ -29,15 +29,14 @@ export const unusedPrivateMethodVisitor: CodeRuleVisitor = {
       )
       if (!nameNode) continue
       const name = nameNode.text.replace(/^#/, '')
-      // Don't flag constructor, getters/setters
-      const isStatic = member.children.some((c) => c.text === 'static')
-      const kind = member.children.find((c) => c.type === 'property_identifier' || c.type === 'private_property_identifier')
+      // Skip constructors — they're invoked implicitly by `new` (or kept
+      // deliberately private to enforce the Singleton pattern), neither of
+      // which the AST-level call detector below can see.
+      if (name === 'constructor') continue
       // Skip getters/setters — they are "called" implicitly
       const hasGetSet = member.children.some((c) => c.text === 'get' || c.text === 'set')
       if (hasGetSet) continue
-      if (!isStatic || name !== 'constructor') {
-        privateMethods.set(name, nameNode)
-      }
+      privateMethods.set(name, nameNode)
     }
 
     if (privateMethods.size === 0) return null

--- a/packages/analyzer/src/rules/security/visitors/javascript/insecure-random.ts
+++ b/packages/analyzer/src/rules/security/visitors/javascript/insecure-random.ts
@@ -4,11 +4,28 @@ import { makeViolation } from '../../../types.js'
 /** Security-related variable name keywords that indicate cryptographic use */
 const SECURITY_KEYWORDS = ['token', 'secret', 'key', 'nonce', 'salt', 'csrf', 'password', 'session', 'hash', 'iv']
 
+/**
+ * Seed scripts and test files generate fixture/dev data — the "tokens"
+ * produced here never reach production, so Math.random() is appropriate
+ * and flagging it is a false positive.
+ */
+function isFixtureOrTestFile(filePath: string): boolean {
+  const lower = filePath.toLowerCase()
+  return (
+    /[\\/]seeds?[\\/]/.test(lower) ||
+    /[\\/](?:seed|seeds)\.(?:ts|tsx|js|jsx|mts|cts|mjs|cjs)$/.test(lower) ||
+    /\.seed\.(?:ts|tsx|js|jsx|mts|cts|mjs|cjs)$/.test(lower) ||
+    /[\\/]__tests__[\\/]/.test(lower) ||
+    /\.(?:test|spec)\.(?:ts|tsx|js|jsx|mts|cts|mjs|cjs)$/.test(lower)
+  )
+}
+
 export const insecureRandomVisitor: CodeRuleVisitor = {
   ruleKey: 'security/deterministic/insecure-random',
   languages: ['typescript', 'tsx', 'javascript'],
   nodeTypes: ['call_expression'],
   visit(node, filePath, sourceCode) {
+    if (isFixtureOrTestFile(filePath)) return null
     const fn = node.childForFieldName('function')
     if (!fn) return null
 

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -79,6 +79,12 @@
       "layer": "service"
     },
     {
+      "name": "insecure-random-prod-token",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "logger",
       "service": "api-gateway",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -787,6 +787,12 @@
       "layer": "service"
     },
     {
+      "name": "IdenticalFunctionsBlockBody",
+      "service": "web",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "Links",
       "service": "web",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -91,6 +91,12 @@
       "layer": "api"
     },
     {
+      "name": "logImplicitGlobalEvent",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "performance",
       "service": "api-gateway",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -787,6 +787,12 @@
       "layer": "service"
     },
     {
+      "name": "CompletelyUnrelatedWidget",
+      "service": "web",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "Dashboard",
       "service": "web",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -115,6 +115,12 @@
       "layer": "api"
     },
     {
+      "name": "StringFormatter",
+      "service": "api-gateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "UserController",
       "service": "api-gateway",
       "kind": "class",

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/insecure-random-prod-token.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/insecure-random-prod-token.ts
@@ -1,0 +1,11 @@
+export function buildResetToken(): string {
+  // VIOLATION: security/deterministic/insecure-random
+  const token = Math.random().toString(36).slice(2, 18);
+  return token;
+}
+
+export function buildApiSecret(): string {
+  const prefix = 'sk_';
+  // VIOLATION: security/deterministic/insecure-random
+  return prefix + Math.random().toString(36).slice(2, 20);
+}

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/restricted-api-usage-global-event.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/restricted-api-usage-global-event.ts
@@ -1,0 +1,4 @@
+export function logImplicitGlobalEvent(): string {
+  // VIOLATION: code-quality/deterministic/restricted-api-usage
+  return String(event);
+}

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/unused-private-method-helper.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/unused-private-method-helper.ts
@@ -1,0 +1,10 @@
+export class StringFormatter {
+  // VIOLATION: code-quality/deterministic/unused-private-method
+  private appendSuffix(input: string): string {
+    return `${input}-x`;
+  }
+
+  public format(input: string): string {
+    return input.trim().toLowerCase();
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/IdenticalFunctionsBlockBody.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/IdenticalFunctionsBlockBody.tsx
@@ -1,0 +1,12 @@
+// VIOLATION: code-quality/deterministic/identical-functions
+export function normalizeSlugA(input: string): string {
+  const trimmed = input.trim().toLowerCase();
+  const segments = trimmed.split('-');
+  return segments.filter(Boolean).join(' ');
+}
+
+export function normalizeSlugB(input: string): string {
+  const trimmed = input.trim().toLowerCase();
+  const segments = trimmed.split('-');
+  return segments.filter(Boolean).join(' ');
+}

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/filename-class-mismatch-bad-export.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/filename-class-mismatch-bad-export.tsx
@@ -1,0 +1,4 @@
+// VIOLATION: code-quality/deterministic/filename-class-mismatch
+export default class CompletelyUnrelatedWidget {
+  readonly id = 'widget-1';
+}

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/seed/insecure-random-seed-script.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/seed/insecure-random-seed-script.ts
@@ -1,0 +1,15 @@
+const TOKEN_END = 10;
+const SECRET_END = 16;
+const SESSION_END = 12;
+const RADIX = 36;
+
+export function seedDemoAccount(): { token: string; secret: string } {
+  const token = Math.random().toString(RADIX).slice(2, TOKEN_END);
+  const secret = Math.random().toString(RADIX).slice(2, SECRET_END);
+  return { token, secret };
+}
+
+export function seedDemoSession(): { sessionKey: string } {
+  const sessionKey = `sess_${Math.random().toString(RADIX).slice(2, SESSION_END)}`;
+  return { sessionKey };
+}

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/services/restricted-api-usage-closure-event.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/services/restricted-api-usage-closure-event.ts
@@ -1,0 +1,33 @@
+interface WebhookPayload {
+  readonly type: string;
+  readonly data: Record<string, string>;
+}
+
+function constructEvent(): WebhookPayload {
+  return { type: 'demo.created', data: { id: 'demo-1' } };
+}
+
+export function handleWebhook(): { kind: string; payload: Record<string, string> } | null {
+  const event = constructEvent();
+
+  const branchOnType = (matcher: (kind: string) => boolean): { kind: string; payload: Record<string, string> } | null => {
+    if (matcher(event.type)) {
+      return { kind: event.type, payload: event.data };
+    }
+    return null;
+  };
+
+  return branchOnType((kind) => kind === 'demo.created');
+}
+
+export function trackInteraction(): string[] {
+  const out: string[] = [];
+  const capture = (event: string, properties: Record<string, unknown>): void => {
+    const formatPayload = (data: Record<string, unknown>): string => {
+      return `${event}:${JSON.stringify(data)}`;
+    };
+    out.push(formatPayload(properties));
+  };
+  capture('demo-event', { ok: true });
+  return out;
+}

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/services/unused-private-method-singleton.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/services/unused-private-method-singleton.ts
@@ -1,0 +1,15 @@
+export class UtilityRegistry {
+  private readonly id: string;
+
+  private constructor(id: string) {
+    this.id = id;
+  }
+
+  public static create(label: string): UtilityRegistry {
+    return new UtilityRegistry(label);
+  }
+
+  public describe(): string {
+    return `registry(${this.id})`;
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/services/web/src/components/IdenticalFunctionsConciseArrows.tsx
+++ b/tests/fixtures/sample-js-project-positive/services/web/src/components/IdenticalFunctionsConciseArrows.tsx
@@ -1,0 +1,36 @@
+interface ClickEvent {
+  readonly preventDefault: () => void;
+}
+
+interface MenuItemProps {
+  readonly label: string;
+  readonly onClick: (e: ClickEvent) => void;
+}
+
+function MenuItem({ label, onClick }: MenuItemProps): JSX.Element {
+  return <li><button type="button" onClick={onClick}>{label}</button></li>;
+}
+
+interface PanelProps {
+  readonly onClose: () => void;
+  readonly onConfirm: () => void;
+}
+
+export function Panel({ onClose, onConfirm }: PanelProps): JSX.Element {
+  const preventA = (e: ClickEvent): void => e.preventDefault();
+  const preventB = (e: ClickEvent): void => e.preventDefault();
+  const closeA = (): void => onClose();
+  const closeB = (): void => onClose();
+  const confirmA = (): void => onConfirm();
+  const confirmB = (): void => onConfirm();
+  return (
+    <ul>
+      <MenuItem label="Cancel" onClick={preventA} />
+      <MenuItem label="Confirm" onClick={preventB} />
+      <MenuItem label="Close" onClick={closeA} />
+      <MenuItem label="Back" onClick={closeB} />
+      <MenuItem label="OK" onClick={confirmA} />
+      <MenuItem label="Yes" onClick={confirmB} />
+    </ul>
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/services/web/src/routes/filename-class-mismatch-flat-routes.tsx
+++ b/tests/fixtures/sample-js-project-positive/services/web/src/routes/filename-class-mismatch-flat-routes.tsx
@@ -1,0 +1,5 @@
+function ThingsPage(): JSX.Element {
+  return <div>things</div>;
+}
+
+export default ThingsPage;


### PR DESCRIPTION
Closes #140
Closes #141
Closes #142
Closes #143
Closes #144

Five FPs from `documenso/documenso` resolved in this batch.

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
| --- | --- | --- | --- |
| code-quality/deterministic/identical-functions | #140 | `tests/fixtures/sample-js-project-positive/services/web/src/components/IdenticalFunctionsConciseArrows.tsx` | `tests/fixtures/sample-js-project-negative/services/web/src/components/IdenticalFunctionsBlockBody.tsx` |
| security/deterministic/insecure-random | #141 | `tests/fixtures/sample-js-project-positive/services/user-service/src/seed/insecure-random-seed-script.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/insecure-random-prod-token.ts` |
| code-quality/deterministic/filename-class-mismatch | #142 | `tests/fixtures/sample-js-project-positive/services/web/src/routes/filename-class-mismatch-flat-routes.tsx` | `tests/fixtures/sample-js-project-negative/services/web/src/components/filename-class-mismatch-bad-export.tsx` |
| code-quality/deterministic/unused-private-method | #143 | `tests/fixtures/sample-js-project-positive/services/user-service/src/services/unused-private-method-singleton.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/unused-private-method-helper.ts` |
| code-quality/deterministic/restricted-api-usage | #144 | `tests/fixtures/sample-js-project-positive/services/user-service/src/services/restricted-api-usage-closure-event.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/restricted-api-usage-global-event.ts` |

## code-quality/deterministic/identical-functions

OSS sources:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/tables/documents-table-action-dropdown.tsx#L153`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/tables/settings-security-passkey-table-actions.tsx#L96`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document-signing/document-signing-form.tsx#L134`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document/document-page-view-dropdown.tsx#L106`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/document-flow/field-item.tsx#L254

Positive fixture (`IdenticalFunctionsConciseArrows.tsx`):
```tsx
const preventA = (e: ClickEvent): void => e.preventDefault();
const preventB = (e: ClickEvent): void => e.preventDefault();
const closeA = (): void => onClose();
const closeB = (): void => onClose();
const confirmA = (): void => onConfirm();
const confirmB = (): void => onConfirm();
```

Negative fixture (`IdenticalFunctionsBlockBody.tsx`):
```ts
// VIOLATION: code-quality/deterministic/identical-functions
export function normalizeSlugA(input: string): string {
  const trimmed = input.trim().toLowerCase();
  const segments = trimmed.split('-');
  return segments.filter(Boolean).join(' ');
}
export function normalizeSlugB(input: string): string { /* same body */ }
```

Visitor change: skip concise-body arrow functions (`(x) => expr` rather than `(x) => { ... }`) when collecting candidate function bodies. Concise arrows are by definition single expressions — typically JSX event-handler boilerplate where identical text is not duplicated logic worth extracting. Block-body functions and methods continue to be checked.

## security/deterministic/insecure-random

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/initial-seed.ts#L97
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/initial-seed.ts#L136
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/initial-seed.ts#L370
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/templates.ts#L126
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/templates.ts#L186

Positive fixture (`src/seed/insecure-random-seed-script.ts`):
```ts
export function seedDemoAccount(): { token: string; secret: string } {
  const token = Math.random().toString(RADIX).slice(2, TOKEN_END);
  const secret = Math.random().toString(RADIX).slice(2, SECRET_END);
  return { token, secret };
}
```

Negative fixture (`insecure-random-prod-token.ts`):
```ts
export function buildResetToken(): string {
  // VIOLATION: security/deterministic/insecure-random
  const token = Math.random().toString(36).slice(2, 18);
  return token;
}
```

Visitor change: skip files whose path matches seed-script or test-file conventions (`/seed/`, `/seeds/`, `*.seed.*`, `seed.*`, `__tests__/`, `*.test.*`, `*.spec.*`). Tokens generated in these files never reach production, so `Math.random()` is appropriate. Production token generation in regular source files continues to be flagged.

## code-quality/deterministic/filename-class-mismatch

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/tailwind-config/index.d.ts#L4
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/router.ts#L157
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/settings+/_dynamic_personal_routes+/webhooks._index.tsx#L5`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/files/routes/get-envelope-item-pdf.ts#L156
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/files/routes/get-envelope-item-pdf-by-token.ts#L80

Positive fixture (`services/web/src/routes/filename-class-mismatch-flat-routes.tsx`):
```tsx
function ThingsPage(): JSX.Element {
  return <div>things</div>;
}

export default ThingsPage;
```

Negative fixture (`filename-class-mismatch-bad-export.tsx`):
```ts
// VIOLATION: code-quality/deterministic/filename-class-mismatch
export default class CompletelyUnrelatedWidget {
  readonly id = 'widget-1';
}
```

Visitor change: in addition to the existing `*.config.*` / `*.rc.*` exemption, skip (a) files under any `/routes/` directory (framework route modules whose filename encodes a URL path), (b) `index` and `index.d` files (barrel re-exports conventionally export a value with a different name), (c) filenames containing routing-convention characters `.`, `$`, `+`, `[`, `]` (Remix flat-routes, Next.js dynamic segments), and (d) default exports named `app`, `router`, `route`, `handler`, `server`, `config`, `default`, `middleware`, or `plugin` (idiomatic composition-root names).

## code-quality/deterministic/unused-private-method

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/bullmq.ts#L38
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/license/license-client.ts#L33
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/telemetry/telemetry-client.ts#L35
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/local.ts#L47

Positive fixture (`unused-private-method-singleton.ts`):
```ts
export class UtilityRegistry {
  private readonly id: string;

  private constructor(id: string) {
    this.id = id;
  }

  public static create(label: string): UtilityRegistry {
    return new UtilityRegistry(label);
  }

  public describe(): string {
    return `registry(${this.id})`;
  }
}
```

Negative fixture (`unused-private-method-helper.ts`):
```ts
export class StringFormatter {
  // VIOLATION: code-quality/deterministic/unused-private-method
  private appendSuffix(input: string): string {
    return `${input}-x`;
  }

  public format(input: string): string {
    return input.trim().toLowerCase();
  }
}
```

Visitor change: in both `unused-private-method` and the sibling `unused-private-member` visitor, skip private constructors. Constructors are invoked implicitly by `new` (often deliberately kept private to enforce the Singleton pattern), which the AST-level `this.X` call detector cannot see. The same constructor-skip is needed in `unused-private-member` because the positive fixture's `private constructor` would otherwise trip that sibling rule.

## code-quality/deterministic/restricted-api-usage

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ee/server-only/stripe/webhook/handler.ts#L72
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ee/server-only/stripe/webhook/handler.ts#L85
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ee/server-only/stripe/webhook/handler.ts#L95
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/embed+/playground.tsx#L177
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/hooks/use-analytics.ts#L29

Positive fixture (`restricted-api-usage-closure-event.ts`):
```ts
export function handleWebhook(): ... {
  const event = constructEvent();
  const branchOnType = (matcher): ... => {
    if (matcher(event.type)) {
      return { kind: event.type, payload: event.data };
    }
    return null;
  };
  ...
}
```

Negative fixture (`restricted-api-usage-global-event.ts`):
```ts
export function logImplicitGlobalEvent(): string {
  // VIOLATION: code-quality/deterministic/restricted-api-usage
  return String(event);
}
```

Visitor change: the scope walk used to bail at the first enclosing function, so `event` declared in an outer function and referenced from a nested closure (inside `.then`, `.with`, a `match` chain, a `useEffect` callback, etc.) was wrongly treated as the deprecated implicit global. The fix continues walking up through every enclosing scope, checking each function's parameters and each block-or-program scope for local declarations. Parameter matching is also tightened to a word-boundary regex so an `eventType` parameter no longer masks an unrelated `event` use.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_015CiHBLN5Jdp87WLTLQURz3)_