### PR TITLE
fix(fp): resolve 3 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/database/visitors/javascript/_helpers.ts
+++ b/packages/analyzer/src/rules/database/visitors/javascript/_helpers.ts
@@ -124,3 +124,43 @@ export function bodyHasTransactionCall(body: SyntaxNode): boolean {
     /\b(transaction|begintransaction|begin_transaction|withTransaction|begin\(\))\b/.test(text)
   )
 }
+
+const TRANSACTION_CALLEE_NAMES = new Set([
+  'transaction', '$transaction', 'withTransaction', 'runInTransaction',
+])
+
+/**
+ * True when `node` lives inside a function that is being passed as an argument
+ * to a `*.transaction()` / `*.$transaction()` style call (e.g. Prisma's
+ * `prisma.$transaction(async (tx) => { ... })`). The substring check in
+ * `bodyHasTransactionCall` misses these because the call wraps the function
+ * rather than appearing inside it.
+ */
+export function isInsideTransactionCallback(node: SyntaxNode): boolean {
+  let current: SyntaxNode | null = node.parent
+  while (current) {
+    if (
+      current.type === 'arrow_function' ||
+      current.type === 'function' ||
+      current.type === 'function_declaration' ||
+      current.type === 'method_definition'
+    ) {
+      let argParent: SyntaxNode | null = current.parent
+      if (argParent?.type === 'arguments') {
+        const call = argParent.parent
+        if (call?.type === 'call_expression') {
+          const fn = call.childForFieldName('function')
+          let mName = ''
+          if (fn?.type === 'member_expression') {
+            mName = fn.childForFieldName('property')?.text ?? ''
+          } else if (fn?.type === 'identifier') {
+            mName = fn.text
+          }
+          if (TRANSACTION_CALLEE_NAMES.has(mName)) return true
+        }
+      }
+    }
+    current = current.parent
+  }
+  return false
+}

--- a/packages/analyzer/src/rules/database/visitors/javascript/missing-transaction.ts
+++ b/packages/analyzer/src/rules/database/visitors/javascript/missing-transaction.ts
@@ -1,7 +1,7 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
-import { getMethodName, ORM_WRITE_METHODS, getEnclosingFunctionBody, bodyHasTransactionCall } from './_helpers.js'
+import { getMethodName, ORM_WRITE_METHODS, getEnclosingFunctionBody, bodyHasTransactionCall, isInsideTransactionCallback } from './_helpers.js'
 
 export const missingTransactionVisitor: CodeRuleVisitor = {
   ruleKey: 'database/deterministic/missing-transaction',
@@ -16,6 +16,10 @@ export const missingTransactionVisitor: CodeRuleVisitor = {
 
     // If there's already a transaction call in this body, skip
     if (bodyHasTransactionCall(body)) return null
+
+    // If this function is itself the callback to a *.transaction() /
+    // *.$transaction() call, the writes are already inside a transaction.
+    if (isInsideTransactionCallback(node)) return null
 
     // Count write calls in the body, tracking DIFFERENT table names.
     // A single insert or single update on the same table doesn't need a transaction.

--- a/packages/analyzer/src/rules/performance/visitors/javascript/sync-fs-in-request-handler.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/sync-fs-in-request-handler.ts
@@ -2,6 +2,13 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { SYNC_FS_METHODS, isInsideAsyncFunctionOrHandler } from './_helpers.js'
 
+// Seed / database-bootstrap scripts run once at local setup and aren't on
+// any request path, so sync FS calls there don't block a hot event loop.
+// Matches a `seed/`/`seeds/` directory segment, or a basename starting with
+// `seed` or ending in `-seed`/`.seed` (etc.) — same shape used by
+// bugs/await-in-loop.
+const SEED_FILE_PATH_PATTERN = /(?:^|[\\/])(?:seed|seeds)[\\/]|(?:^|[\\/])seed[^\\/]*\.(?:ts|tsx|js|jsx|mjs|cjs)$|[-_.](?:seed|seeds)\.(?:ts|tsx|js|jsx|mjs|cjs)$/i
+
 export const syncFsInRequestHandlerVisitor: CodeRuleVisitor = {
   ruleKey: 'performance/deterministic/sync-fs-in-request-handler',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -23,6 +30,7 @@ export const syncFsInRequestHandlerVisitor: CodeRuleVisitor = {
     // Skip standalone scripts (not request handlers)
     const lowerPath = filePath.toLowerCase()
     if (lowerPath.includes('/scripts/') || lowerPath.includes('/bin/') || lowerPath.includes('/cli/')) return null
+    if (SEED_FILE_PATH_PATTERN.test(filePath)) return null
 
     if (!isInsideAsyncFunctionOrHandler(node)) return null
 

--- a/packages/analyzer/src/rules/security/visitors/universal.ts
+++ b/packages/analyzer/src/rules/security/visitors/universal.ts
@@ -132,6 +132,17 @@ export const hardcodedIpVisitor: CodeRuleVisitor = {
     // Skip version-like numbers in User-Agent strings, semver, etc.
     if (/Mozilla|Chrome|Safari|Firefox|AppleWebKit|Gecko/i.test(stripped)) return null
 
+    // Skip when the match is embedded in a longer numeric sequence — SVG
+    // `<path d="...">` coordinate strings are the main source of these,
+    // e.g. `013.002.027.012` snapped out of `.013.002.027.012.013`. The
+    // regex's `\b` anchors don't distinguish a real IP from a path
+    // command, but the surrounding `.` does.
+    const matchStart = match.index
+    const matchEnd = matchStart + match[0].length
+    const before = matchStart > 0 ? stripped[matchStart - 1] : ''
+    const after = matchEnd < stripped.length ? stripped[matchEnd] : ''
+    if (before === '.' || after === '.') return null
+
     // Validate each octet is 0-255
     const octets = ip.split('.')
     if (octets.some((o) => parseInt(o, 10) > 255)) return null

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -121,6 +121,12 @@
       "layer": "api"
     },
     {
+      "name": "serveTemplate",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "api"
+    },
+    {
       "name": "StringFormatter",
       "service": "api-gateway",
       "kind": "class",
@@ -368,6 +374,12 @@
     },
     {
       "name": "connection",
+      "service": "user-service",
+      "kind": "standalone",
+      "layer": "data"
+    },
+    {
+      "name": "createWidgetWithAudit",
       "service": "user-service",
       "kind": "standalone",
       "layer": "data"

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/hardcoded-ip-config.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/hardcoded-ip-config.ts
@@ -1,0 +1,9 @@
+/**
+ * Negative fixture for security/deterministic/hardcoded-ip.
+ *
+ * A real IPv4 address embedded directly in source — exactly the bug
+ * pattern this rule is meant to catch.
+ */
+
+// VIOLATION: security/deterministic/hardcoded-ip
+export const UPSTREAM_HOST = '192.168.42.17';

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/sync-fs-in-request-handler-async.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/sync-fs-in-request-handler-async.ts
@@ -1,0 +1,15 @@
+/**
+ * Negative fixture for performance/deterministic/sync-fs-in-request-handler.
+ *
+ * Sync filesystem call inside a regular async handler — outside any
+ * seed-script path. This is the bug pattern: it blocks the event loop
+ * while serving a request.
+ */
+
+import fs from 'node:fs';
+
+// VIOLATION: performance/deterministic/sync-fs-in-request-handler
+export async function serveTemplate(templatePath: string): Promise<string> {
+  const buffer = fs.readFileSync(templatePath);
+  return buffer.toString('utf-8');
+}

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/db/missing-transaction-multi-table.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/db/missing-transaction-multi-table.ts
@@ -1,0 +1,20 @@
+/**
+ * Negative fixture for database/deterministic/missing-transaction.
+ *
+ * Multiple ORM writes to DIFFERENT tables in the same function with no
+ * surrounding transaction. If the second write fails the first won't be
+ * rolled back — exactly the bug this rule exists to catch.
+ */
+
+type WidgetRepo = { create(args: { data: unknown }): Promise<{ id: string }> };
+type WidgetAuditRepo = { create(args: { data: unknown }): Promise<{ id: string }> };
+
+declare const widgetRepo: WidgetRepo;
+declare const auditRepo: WidgetAuditRepo;
+
+// VIOLATION: database/deterministic/missing-transaction
+export async function createWidgetWithAudit(name: string, actorId: string) {
+  const widget = await widgetRepo.create({ data: { id: 'w_1', name } });
+  await auditRepo.create({ data: { id: 'a_1', widgetId: widget.id, actorId } });
+  return widget;
+}

--- a/tests/fixtures/sample-js-project-positive/src/hardcoded-ip-svg-path.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/hardcoded-ip-svg-path.tsx
@@ -1,0 +1,19 @@
+/**
+ * Positive fixture for security/deterministic/hardcoded-ip.
+ *
+ * SVG `<path d="...">` coordinate strings contain long sequences of
+ * decimal numbers separated by `.`, `-` and spaces. The IPv4 regex can
+ * snap onto a four-octet-shaped substring inside such a sequence (e.g.
+ * `013.002.027.012` within `.013.002.027.012.013`). The match is not an
+ * IP — it's part of a longer numeric path command. The rule must not
+ * fire on these.
+ */
+
+export function BrandMark(): JSX.Element {
+  return (
+    <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+      <path d="M22.946 43.82v3.357c0 .97 0 1.866.006 2.698.038 4.787.295 7.418 2.027 9.15 1.731 1.731z" />
+      <path d="m27.226 54.158-.013-.013.002.027.012.013zM29.849 56.78l4.289.199c-1.852-.015-3.208-.064z" />
+    </svg>
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/src/missing-transaction-tx-callback.ts
+++ b/tests/fixtures/sample-js-project-positive/src/missing-transaction-tx-callback.ts
@@ -1,0 +1,55 @@
+/**
+ * Positive fixture for database/deterministic/missing-transaction.
+ *
+ * Writes happen inside a `prisma.$transaction(async (tx) => { ... })`
+ * callback, using `tx.<model>.create(...)` for each write. The enclosing
+ * arrow function body does not contain the substring "transaction",
+ * because the call to `$transaction` wraps the arrow function rather
+ * than appearing inside it. The rule must recognise this case and
+ * not fire.
+ */
+
+type TxClient = {
+  widgetSettings: { create(args: { data: unknown }): Promise<{ id: string }> };
+  widgetClaim: { create(args: { data: unknown }): Promise<{ id: string }> };
+  widgetPortal: { create(args: { data: unknown }): Promise<{ id: string }> };
+  widget: { create(args: { data: unknown }): Promise<{ id: string }> };
+};
+
+type PrismaLike = {
+  $transaction<T>(fn: (tx: TxClient) => Promise<T>): Promise<T>;
+};
+
+declare const prisma: PrismaLike;
+
+export function createWidgetBundle(
+  ownerId: string,
+  name: string,
+): Promise<{ widgetId: string; settingsId: string }> {
+  return prisma.$transaction(async (tx) => {
+    const settings = await tx.widgetSettings.create({
+      data: { id: 'settings_1', ownerId },
+    });
+
+    const claim = await tx.widgetClaim.create({
+      data: { id: 'claim_1', ownerId },
+    });
+
+    const portal = await tx.widgetPortal.create({
+      data: { id: 'portal_1', enabled: false },
+    });
+
+    const widget = await tx.widget.create({
+      data: {
+        id: 'widget_1',
+        name,
+        ownerId,
+        settingsId: settings.id,
+        claimId: claim.id,
+        portalId: portal.id,
+      },
+    });
+
+    return { widgetId: widget.id, settingsId: settings.id };
+  });
+}

--- a/tests/fixtures/sample-js-project-positive/src/sync-fs-in-request-handler-seed.ts
+++ b/tests/fixtures/sample-js-project-positive/src/sync-fs-in-request-handler-seed.ts
@@ -1,0 +1,30 @@
+/**
+ * Positive fixture for performance/deterministic/sync-fs-in-request-handler.
+ *
+ * Seed / database-bootstrap scripts run once during local setup. Sync
+ * filesystem calls inside their async top-level entry points are fine —
+ * they aren't on any request path and don't block an event loop that
+ * matters. The filename ending in `-seed.ts` (and equivalent paths
+ * containing a `seed/` segment) marks the file as out-of-scope for this
+ * rule.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+declare const db: {
+  fixture: { create(args: { data: { payload: string } }): Promise<{ id: string }> };
+};
+
+export async function bootstrapFixtureData(): Promise<string> {
+  const pdf = fs.readFileSync(path.join(__dirname, '../assets/sample.pdf'));
+  const payload = pdf.toString('base64');
+  await db.fixture.create({ data: { payload } });
+  return payload;
+}
+
+export async function listSeedAssets(): Promise<string[]> {
+  const files = fs.readdirSync(path.join(__dirname, '../assets'));
+  await db.fixture.create({ data: { payload: files.join(',') } });
+  return files.filter((f) => f.endsWith('.pdf'));
+}


### PR DESCRIPTION
Closes #145
Closes #146
Closes #147

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `database/deterministic/missing-transaction` | #145 | `tests/fixtures/sample-js-project-positive/src/missing-transaction-tx-callback.ts` | `tests/fixtures/sample-js-project-negative/services/user-service/src/db/missing-transaction-multi-table.ts` |
| `performance/deterministic/sync-fs-in-request-handler` | #146 | `tests/fixtures/sample-js-project-positive/src/sync-fs-in-request-handler-seed.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/sync-fs-in-request-handler-async.ts` |
| `security/deterministic/hardcoded-ip` | #147 | `tests/fixtures/sample-js-project-positive/src/hardcoded-ip-svg-path.tsx` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/hardcoded-ip-config.ts` |

## `database/deterministic/missing-transaction`

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/organisation/create-organisation.ts#L52
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/auth/create-passkey.ts#L89
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/envelope-router/sign-envelope-field.ts#L216
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/recipient/set-document-recipients.ts#L212
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/document/delete-document.ts#L167

Positive fixture (`tests/fixtures/sample-js-project-positive/src/missing-transaction-tx-callback.ts`):

```ts
type TxClient = {
  widgetSettings: { create(args: { data: unknown }): Promise<{ id: string }> };
  widgetClaim: { create(args: { data: unknown }): Promise<{ id: string }> };
  widgetPortal: { create(args: { data: unknown }): Promise<{ id: string }> };
  widget: { create(args: { data: unknown }): Promise<{ id: string }> };
};

type PrismaLike = {
  $transaction<T>(fn: (tx: TxClient) => Promise<T>): Promise<T>;
};

declare const prisma: PrismaLike;

export function createWidgetBundle(
  ownerId: string,
  name: string,
): Promise<{ widgetId: string; settingsId: string }> {
  return prisma.$transaction(async (tx) => {
    const settings = await tx.widgetSettings.create({ data: { id: 'settings_1', ownerId } });
    const claim    = await tx.widgetClaim.create({    data: { id: 'claim_1',    ownerId } });
    const portal   = await tx.widgetPortal.create({   data: { id: 'portal_1',   enabled: false } });
    const widget   = await tx.widget.create({
      data: { id: 'widget_1', name, ownerId,
        settingsId: settings.id, claimId: claim.id, portalId: portal.id },
    });
    return { widgetId: widget.id, settingsId: settings.id };
  });
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/user-service/src/db/missing-transaction-multi-table.ts`):

```ts
declare const widgetRepo: { create(args: { data: unknown }): Promise<{ id: string }> };
declare const auditRepo:  { create(args: { data: unknown }): Promise<{ id: string }> };

// VIOLATION: database/deterministic/missing-transaction
export async function createWidgetWithAudit(name: string, actorId: string) {
  const widget = await widgetRepo.create({ data: { id: 'w_1', name } });
  await auditRepo.create({ data: { id: 'a_1', widgetId: widget.id, actorId } });
  return widget;
}
```

Recognise writes nested inside a `*.transaction()` / `*.$transaction()` callback (e.g. Prisma's `prisma.$transaction(async (tx) => { await tx.x.create(...); ... })`). The existing `bodyHasTransactionCall` substring check looked at the innermost function body, but the call to `$transaction` wraps that function rather than appearing inside it, so the rule fired on every write whose object was `tx.<model>`. Adds `isInsideTransactionCallback(node)` which walks up the AST and returns true when any enclosing function is being passed as an argument to a `transaction` / `$transaction` / `withTransaction` / `runInTransaction` call.

## `performance/deterministic/sync-fs-in-request-handler`

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed-database.ts#L8
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/initial-seed.ts#L462
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed-database.ts#L5
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/initial-seed.ts#L36
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed/initial-seed.ts#L296

Positive fixture (`tests/fixtures/sample-js-project-positive/src/sync-fs-in-request-handler-seed.ts`):

```ts
import fs from 'node:fs';
import path from 'node:path';

declare const db: {
  fixture: { create(args: { data: { payload: string } }): Promise<{ id: string }> };
};

export async function bootstrapFixtureData(): Promise<string> {
  const pdf = fs.readFileSync(path.join(__dirname, '../assets/sample.pdf'));
  const payload = pdf.toString('base64');
  await db.fixture.create({ data: { payload } });
  return payload;
}

export async function listSeedAssets(): Promise<string[]> {
  const files = fs.readdirSync(path.join(__dirname, '../assets'));
  await db.fixture.create({ data: { payload: files.join(',') } });
  return files.filter((f) => f.endsWith('.pdf'));
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/sync-fs-in-request-handler-async.ts`):

```ts
import fs from 'node:fs';

// VIOLATION: performance/deterministic/sync-fs-in-request-handler
export async function serveTemplate(templatePath: string): Promise<string> {
  const buffer = fs.readFileSync(templatePath);
  return buffer.toString('utf-8');
}
```

Skip seed / database-bootstrap scripts. The rule's intent is to flag sync FS on request paths, but the heuristic was "any async function"; Prisma seed scripts (`packages/prisma/seed-database.ts`, `packages/prisma/seed/initial-seed.ts`) are async by convention and trip it. Reuses the same `SEED_FILE_PATH_PATTERN` already employed by `bugs/deterministic/await-in-loop` so a `seed/` directory segment or a `seed*.ts` / `*-seed.ts` basename short-circuits the visitor.

## `security/deterministic/hardcoded-ip`

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/branding-logo-icon.tsx#L12
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/docs/src/lib/layout.shared.tsx#L13
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/branding-logo.tsx#L22
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/docs/src/lib/layout.shared.tsx#L14
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/branding-logo-icon.tsx#L13

Positive fixture (`tests/fixtures/sample-js-project-positive/src/hardcoded-ip-svg-path.tsx`):

```tsx
export function BrandMark(): JSX.Element {
  return (
    <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
      <path d="M22.946 43.82v3.357c0 .97 0 1.866.006 2.698.038 4.787.295 7.418 2.027 9.15 1.731 1.731z" />
      <path d="m27.226 54.158-.013-.013.002.027.012.013zM29.849 56.78l4.289.199c-1.852-.015-3.208-.064z" />
    </svg>
  );
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/hardcoded-ip-config.ts`):

```ts
// VIOLATION: security/deterministic/hardcoded-ip
export const UPSTREAM_HOST = '192.168.42.17';
```

Reject matches embedded inside a longer numeric sequence. The IPv4 regex's `\b` anchors treat `.` as a word boundary, so the four-octet shape `013.002.027.012` is "matched" inside an SVG `<path d="...">` coordinate stream like `.013.002.027.012.013`. The fix checks the character immediately before and after the match — if either is `.`, the match is part of a longer decimal run (path command, version-string-with-extra-dots, etc.) and is not an IP.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrpLJjQxpgnewsCmJtN7gb)_