### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unnecessary-condition.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unnecessary-condition.ts
@@ -43,6 +43,16 @@ export const unnecessaryConditionVisitor: CodeRuleVisitor = {
     // Skip any/unknown
     if (typeStr === 'any' || typeStr === 'unknown') return null
 
+    // Boolean literal types on an identifier are unreliable: TypeScript only
+    // narrows `let` variables along the linear control flow inside the current
+    // function, so a `let isCancelled = false` mutated inside a sibling
+    // callback (a common React useEffect / async-watch idiom) still narrows to
+    // `false` at every read. Limit `'true'` / `'false'` reports to literal
+    // expressions and member accesses, where the literal type is intentional.
+    if ((typeStr === 'true' || typeStr === 'false') && expr.type === 'identifier') {
+      return null
+    }
+
     // Always truthy types
     const alwaysTruthy = new Set(['object', 'Function', 'symbol', 'RegExp'])
     if (typeStr === 'true' || alwaysTruthy.has(typeStr)) {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unnecessary-type-conversion.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unnecessary-type-conversion.ts
@@ -31,6 +31,20 @@ export const unnecessaryTypeConversionVisitor: CodeRuleVisitor = {
     const expectedType = conversionMap[fn.text]
     if (!expectedType) return null
 
+    // Skip logical-operator chains (`a || b`, `a && b`, `a ?? b`). The TS
+    // checker often narrows these to the target type when one operand already
+    // has that type, but the wrapper is a deliberate coercion idiom — the
+    // developer wants exactly `true | false` from a truthy chain, not the
+    // possibly-widened union of the operands. Flagging these is a false
+    // positive.
+    if (arg.type === 'binary_expression') {
+      for (const child of arg.children) {
+        if (child.type === '||' || child.type === '&&' || child.type === '??') {
+          return null
+        }
+      }
+    }
+
     const argType = typeQuery.getTypeAtPosition(
       filePath,
       arg.startPosition.row,

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unused-private-member.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unused-private-member.ts
@@ -33,11 +33,20 @@ export const unusedPrivateMemberVisitor: CodeRuleVisitor = {
 
     const usedNames = new Set<string>()
 
+    // Static singleton members are accessed via the class name (e.g.
+    // `Foo._instance = new Foo()` inside `Foo.getInstance`), not via `this`.
+    // Resolve the enclosing class's identifier so those self-references count
+    // as uses.
+    const classNameNode = node.namedChildren.find(
+      (c) => c.type === 'type_identifier' || c.type === 'identifier',
+    )
+    const className = classNameNode?.text
+
     function walk(n: SyntaxNode) {
       if (n.type === 'member_expression') {
         const obj = n.childForFieldName('object')
         const prop = n.childForFieldName('property')
-        if (obj?.text === 'this' && prop) {
+        if (prop && (obj?.text === 'this' || (className && obj?.text === className))) {
           usedNames.add(prop.text.replace(/^#/, ''))
         }
       }

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/http-call-no-timeout.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/http-call-no-timeout.ts
@@ -22,8 +22,11 @@ export const httpCallNoTimeoutVisitor: CodeRuleVisitor = {
 
     const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'request', 'head'])
 
-    // fetch() call
-    if (funcName === 'fetch') {
+    // fetch() call. Only the bare global `fetch(...)` is the timeout-less
+    // browser/node API — `obj.fetch(...)` (e.g. Playwright's `request.fetch`
+    // from `page.context()`, or wrapper-client APIs) is a library method with
+    // its own timeout semantics. Treat those as out of scope.
+    if (funcName === 'fetch' && fn.type === 'identifier') {
       // Skip client-side React components fetching own API — browser fetch has default timeouts
       if (/\.tsx$/.test(filePath) && /\/components\//.test(filePath)) return null
       const args = node.childForFieldName('arguments')
@@ -37,6 +40,10 @@ export const httpCallNoTimeoutVisitor: CodeRuleVisitor = {
           const urlText = urlArg.text
           // Relative URLs start with '/' or backtick template starting with /
           if (urlText.startsWith("'/") || urlText.startsWith('"/') || urlText.startsWith('`/')) return null
+          // Skip bundled-asset URLs resolved at build time from
+          // `import.meta.url` — these are `file://`-style references to assets
+          // packaged with the app, not external HTTP endpoints.
+          if (urlText.includes('import.meta.url')) return null
         }
       }
       return makeViolation(

--- a/packages/analyzer/src/rules/style/visitors/javascript/js-style-preference.ts
+++ b/packages/analyzer/src/rules/style/visitors/javascript/js-style-preference.ts
@@ -8,16 +8,22 @@ export const jsStylePreferenceVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     // Flag use of var
     const firstChild = node.children[0]
-    if (firstChild?.text === 'var') {
-      return makeViolation(
-        this.ruleKey, node, filePath, 'low',
-        'Use of var instead of const/let',
-        'var has function scope and hoisting issues. Use const for constants or let for variables.',
-        sourceCode,
-        'Replace var with const (if not reassigned) or let.',
-      )
+    if (firstChild?.text !== 'var') return null
+
+    // `var` is the only declaration form TypeScript accepts inside an ambient
+    // declaration (`declare var X`, `declare global { var X }`, `declare
+    // module '…' { var X }`). These are required for typing global properties
+    // and module augmentation — not a style choice.
+    for (let p = node.parent; p; p = p.parent) {
+      if (p.type === 'ambient_declaration') return null
     }
 
-    return null
+    return makeViolation(
+      this.ruleKey, node, filePath, 'low',
+      'Use of var instead of const/let',
+      'var has function scope and hoisting issues. Use const for constants or let for variables.',
+      sourceCode,
+      'Replace var with const (if not reassigned) or let.',
+    )
   },
 }

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -613,6 +613,12 @@
       "layer": "service"
     },
     {
+      "name": "CounterBox",
+      "service": "utils",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "crypto",
       "service": "utils",
       "kind": "standalone",
@@ -644,6 +650,18 @@
     },
     {
       "name": "formatters",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "http-call-no-timeout-external",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "js-style-preference-var",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"
@@ -764,6 +782,18 @@
     },
     {
       "name": "undefined-passed-as-optional",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "unnecessary-condition-literal",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "unnecessary-type-conversion-bool",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/http-call-no-timeout-external.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/http-call-no-timeout-external.ts
@@ -1,0 +1,7 @@
+async function fetchExternalSafe(): Promise<unknown> {
+  // VIOLATION: reliability/deterministic/http-call-no-timeout
+  const res = await fetch('https://api.example.com/v1/widgets');
+  return res.json();
+}
+
+export const externalSnapshot = fetchExternalSafe();

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/js-style-preference-var.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/js-style-preference-var.ts
@@ -1,0 +1,8 @@
+function legacyAccumulator(): number {
+  // VIOLATION: style/deterministic/js-style-preference
+  var total = 0;
+  total += 1;
+  return total;
+}
+
+export const accumulated = legacyAccumulator();

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-condition-literal.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-condition-literal.ts
@@ -1,0 +1,9 @@
+function isNever(): string {
+  // VIOLATION: code-quality/deterministic/unnecessary-condition
+  if (false) {
+    return 'never';
+  }
+  return 'always';
+}
+
+export const branchResult = isNever();

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-conversion-bool.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-conversion-bool.ts
@@ -1,0 +1,6 @@
+function wrapBool(flag: boolean) {
+  // VIOLATION: code-quality/deterministic/unnecessary-type-conversion
+  return Boolean(flag);
+}
+
+export const wrappedFlag = wrapBool(true);

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unused-private-member-static.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unused-private-member-static.ts
@@ -1,0 +1,11 @@
+// VIOLATION: code-quality/deterministic/unused-private-member
+class CounterBox {
+  private static _ghost: CounterBox;
+  private count = 0;
+
+  bump(): number {
+    return ++this.count;
+  }
+}
+
+export const sharedBox = new CounterBox();

--- a/tests/fixtures/sample-js-project-positive/src/http-call-no-timeout.ts
+++ b/tests/fixtures/sample-js-project-positive/src/http-call-no-timeout.ts
@@ -1,0 +1,31 @@
+/**
+ * Positive fixture for reliability/deterministic/http-call-no-timeout.
+ *
+ * Two FP shapes:
+ *
+ *   1. `fetch(new URL(..., import.meta.url))` — bundled local asset whose URL
+ *      is resolved at build time from `import.meta.url`. This is a `file://`
+ *      or in-process URL, not an external HTTP call. There is nothing to time
+ *      out against.
+ *
+ *   2. `obj.fetch(...)` (member-access form, e.g. Playwright's
+ *      `request.fetch()` from `page.context()`) — the `fetch` method belongs
+ *      to a library object, not the global `fetch`. The rule must not
+ *      conflate it with the global timeout-less browser/node `fetch`.
+ */
+
+declare const baseUrl: string;
+declare const sessionPath: string;
+declare const page: {
+  context(): {
+    request: { fetch(url: string, opts?: { method?: string }): Promise<Response> };
+  };
+};
+
+export const fetchBundledAsset = () =>
+  fetch(new URL(`${baseUrl}/assets/icon.ttf`, import.meta.url));
+
+export const playwrightFetch = () => {
+  const { request } = page.context();
+  return request.fetch(sessionPath, { method: 'get' });
+};

--- a/tests/fixtures/sample-js-project-positive/src/js-style-preference.ts
+++ b/tests/fixtures/sample-js-project-positive/src/js-style-preference.ts
@@ -1,0 +1,25 @@
+/**
+ * Positive fixture for style/deterministic/js-style-preference.
+ *
+ * `var` inside an ambient declaration (`declare global { var X }`,
+ * `declare module '…' { var X }`, `declare var X`) is the only declaration
+ * form TypeScript accepts for augmenting `globalThis` or a module's namespace
+ * — `const` and `let` produce a compile error in that position. The rule must
+ * not flag these as a style preference.
+ */
+
+declare global {
+
+  var __memoCache: Map<string, unknown> | undefined;
+}
+
+declare module 'truecourse-fp-fixture-ambient' {
+
+  var ambientCounter: number;
+}
+
+declare var globalRegistry: { count: number };
+
+export function readCounter(): number {
+  return globalRegistry.count;
+}

--- a/tests/fixtures/sample-js-project-positive/src/unnecessary-condition.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unnecessary-condition.ts
@@ -1,0 +1,39 @@
+/**
+ * Positive fixture for code-quality/deterministic/unnecessary-condition.
+ *
+ * Closure-mutated flag pattern: a `let` boolean is declared `false`, captured
+ * by a callback that mutates it, and read after intervening async work.
+ * TypeScript narrows the variable to the literal type `false` because its
+ * control-flow analysis only looks at the local scope — it does not see the
+ * reassignment in the sibling closure. Flagging the read as a dead-condition
+ * is therefore a false positive.
+ */
+
+interface Handle {
+  dispose(): void;
+}
+
+declare function scheduleAt(fn: () => void): Handle;
+
+export async function watchAsync(): Promise<string | null> {
+  let isCancelled = false;
+
+  const stop = (): void => {
+    isCancelled = true;
+  };
+
+  const handle = scheduleAt(stop);
+
+  await Promise.resolve();
+  if (isCancelled) {
+    return null;
+  }
+  await Promise.resolve();
+  if (isCancelled) {
+    handle.dispose();
+    return null;
+  }
+
+  handle.dispose();
+  return 'done';
+}

--- a/tests/fixtures/sample-js-project-positive/src/unnecessary-type-conversion.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unnecessary-type-conversion.ts
@@ -1,0 +1,19 @@
+/**
+ * Positive fixture for code-quality/deterministic/unnecessary-type-conversion.
+ *
+ * Calling `Boolean(...)` on a logical-OR, logical-AND, or nullish-coalescing
+ * chain is a common defensive idiom for coercing a possibly-truthy chain to an
+ * exact `true | false`. The TypeScript checker frequently narrows the result
+ * of such a chain to `boolean`, especially when one operand is already typed
+ * as `boolean`, but the wrapper still communicates intent and protects against
+ * future widening of any operand. The rule must not flag these forms.
+ */
+
+declare const isOwner: boolean;
+declare const isMember: boolean;
+declare const isPublic: boolean;
+declare const isAdmin: boolean;
+
+export const canManage = Boolean(isOwner || isMember);
+export const canView = Boolean(isPublic && isMember);
+export const canEdit = Boolean(isOwner ?? isAdmin);

--- a/tests/fixtures/sample-js-project-positive/src/unused-private-member.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unused-private-member.ts
@@ -1,0 +1,26 @@
+/**
+ * Positive fixture for code-quality/deterministic/unused-private-member.
+ *
+ * Singleton / registry pattern: a `private static` field is read and written
+ * via the enclosing class's name (`Registry.cache.set(...)`), not via `this`.
+ * The rule must recognise the class-name self-reference as a use, otherwise
+ * the canonical singleton/registry implementation always looks "unused".
+ */
+
+export class WidgetRegistry {
+  private static readonly cache: Map<string, WidgetRegistry> = new Map();
+
+  readonly key: string;
+
+  constructor(key: string) {
+    this.key = key;
+  }
+
+  static getOrCreate(key: string): WidgetRegistry {
+    const existing = WidgetRegistry.cache.get(key);
+    if (existing) return existing;
+    const created = new WidgetRegistry(key);
+    WidgetRegistry.cache.set(key, created);
+    return created;
+  }
+}


### PR DESCRIPTION
Closes #148
Closes #149
Closes #150
Closes #151
Closes #152

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/unnecessary-type-conversion` | #148 | [unnecessary-type-conversion.ts](../blob/claude/fp-fix/batch-202605210302/tests/fixtures/sample-js-project-positive/src/unnecessary-type-conversion.ts) | [unnecessary-type-conversion-bool.ts](../blob/claude/fp-fix/batch-202605210302/tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-conversion-bool.ts) |
| `reliability/deterministic/http-call-no-timeout` | #149 | [http-call-no-timeout.ts](../blob/claude/fp-fix/batch-202605210302/tests/fixtures/sample-js-project-positive/src/http-call-no-timeout.ts) | [http-call-no-timeout-external.ts](../blob/claude/fp-fix/batch-202605210302/tests/fixtures/sample-js-project-negative/shared/utils/src/http-call-no-timeout-external.ts) |
| `code-quality/deterministic/unused-private-member` | #150 | [unused-private-member.ts](../blob/claude/fp-fix/batch-202605210302/tests/fixtures/sample-js-project-positive/src/unused-private-member.ts) | [unused-private-member-static.ts](../blob/claude/fp-fix/batch-202605210302/tests/fixtures/sample-js-project-negative/shared/utils/src/unused-private-member-static.ts) |
| `code-quality/deterministic/unnecessary-condition` | #151 | [unnecessary-condition.ts](../blob/claude/fp-fix/batch-202605210302/tests/fixtures/sample-js-project-positive/src/unnecessary-condition.ts) | [unnecessary-condition-literal.ts](../blob/claude/fp-fix/batch-202605210302/tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-condition-literal.ts) |
| `style/deterministic/js-style-preference` | #152 | [js-style-preference.ts](../blob/claude/fp-fix/batch-202605210302/tests/fixtures/sample-js-project-positive/src/js-style-preference.ts) | [js-style-preference-var.ts](../blob/claude/fp-fix/batch-202605210302/tests/fixtures/sample-js-project-negative/shared/utils/src/js-style-preference-var.ts) |

## code-quality/deterministic/unnecessary-type-conversion

**Sources** (documenso/documenso @ 8f6be47):
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document/document-page-view-dropdown.tsx#L64`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/tables/documents-table-action-dropdown.tsx#L75
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/icons/signature.tsx#L19

**Positive fixture diff** (`tests/fixtures/sample-js-project-positive/src/unnecessary-type-conversion.ts`):

```diff
+/**
+ * Positive fixture for code-quality/deterministic/unnecessary-type-conversion.
+ *
+ * Calling `Boolean(...)` on a logical-OR, logical-AND, or nullish-coalescing
+ * chain is a common defensive idiom for coercing a possibly-truthy chain to an
+ * exact `true | false`. The TypeScript checker frequently narrows the result
+ * of such a chain to `boolean`, especially when one operand is already typed
+ * as `boolean`, but the wrapper still communicates intent and protects against
+ * future widening of any operand. The rule must not flag these forms.
+ */
+
+declare const isOwner: boolean;
+declare const isMember: boolean;
+declare const isPublic: boolean;
+declare const isAdmin: boolean;
+
+export const canManage = Boolean(isOwner || isMember);
+export const canView = Boolean(isPublic && isMember);
+export const canEdit = Boolean(isOwner ?? isAdmin);
```

**Negative fixture diff** (`tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-conversion-bool.ts`):

```diff
+function wrapBool(flag: boolean) {
+  // VIOLATION: code-quality/deterministic/unnecessary-type-conversion
+  return Boolean(flag);
+}
+
+export const wrappedFlag = wrapBool(true);
```

**Visitor summary**: The rule's type-query at the argument's start position returned the type of the first sub-node (e.g. `isOwner` in `Boolean(isOwner || isMember)`) rather than the type of the whole OR expression, so an argument that "starts with a boolean" was incorrectly classified as already-typed. Added an early-return when the argument is a `binary_expression` whose operator is `||`, `&&`, or `??` — these are intentional truthy-chain coercion idioms.

## reliability/deterministic/http-call-no-timeout

**Sources** (documenso/documenso @ 8f6be47):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_share+/share.$slug.opengraph.tsx#L33
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/pdf/legacy-insert-field-in-pdf.ts#L33
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/app-tests/e2e/fixtures/authentication.ts#L64

**Positive fixture diff** (`tests/fixtures/sample-js-project-positive/src/http-call-no-timeout.ts`):

```diff
+/**
+ * Positive fixture for reliability/deterministic/http-call-no-timeout.
+ *
+ * Two FP shapes:
+ *
+ *   1. `fetch(new URL(..., import.meta.url))` — bundled local asset whose URL
+ *      is resolved at build time from `import.meta.url`. This is a `file://`
+ *      or in-process URL, not an external HTTP call. There is nothing to time
+ *      out against.
+ *
+ *   2. `obj.fetch(...)` (member-access form, e.g. Playwright's
+ *      `request.fetch()` from `page.context()`) — the `fetch` method belongs
+ *      to a library object, not the global `fetch`. The rule must not
+ *      conflate it with the global timeout-less browser/node `fetch`.
+ */
+
+declare const baseUrl: string;
+declare const sessionPath: string;
+declare const page: {
+  context(): {
+    request: { fetch(url: string, opts?: { method?: string }): Promise<Response> };
+  };
+};
+
+export const fetchBundledAsset = () =>
+  fetch(new URL(`${baseUrl}/assets/icon.ttf`, import.meta.url));
+
+export const playwrightFetch = () => {
+  const { request } = page.context();
+  return request.fetch(sessionPath, { method: 'get' });
+};
```

**Negative fixture diff** (`tests/fixtures/sample-js-project-negative/shared/utils/src/http-call-no-timeout-external.ts`):

```diff
+async function fetchExternalSafe(): Promise<unknown> {
+  // VIOLATION: reliability/deterministic/http-call-no-timeout
+  const res = await fetch('https://api.example.com/v1/widgets');
+  return res.json();
+}
+
+export const externalSnapshot = fetchExternalSafe();
```

**Visitor summary**: Two narrow exclusions. First, restrict the bare-`fetch` branch to `fn.type === 'identifier'` so that member-access calls like `request.fetch()` (Playwright, library clients) are not conflated with the global `fetch`. Second, skip when the URL argument text contains `import.meta.url` — those are build-resolved local assets, not external HTTP endpoints.

## code-quality/deterministic/unused-private-member

**Sources** (documenso/documenso @ 8f6be47):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/inngest.ts#L11
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/telemetry/telemetry-client.ts#L26
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/local.ts#L41

**Positive fixture diff** (`tests/fixtures/sample-js-project-positive/src/unused-private-member.ts`):

```diff
+/**
+ * Positive fixture for code-quality/deterministic/unused-private-member.
+ *
+ * Singleton / registry pattern: a `private static` field is read and written
+ * via the enclosing class's name (`Registry.cache.set(...)`), not via `this`.
+ * The rule must recognise the class-name self-reference as a use, otherwise
+ * the canonical singleton/registry implementation always looks "unused".
+ */
+
+export class WidgetRegistry {
+  private static readonly cache: Map<string, WidgetRegistry> = new Map();
+
+  readonly key: string;
+
+  constructor(key: string) {
+    this.key = key;
+  }
+
+  static getOrCreate(key: string): WidgetRegistry {
+    const existing = WidgetRegistry.cache.get(key);
+    if (existing) return existing;
+    const created = new WidgetRegistry(key);
+    WidgetRegistry.cache.set(key, created);
+    return created;
+  }
+}
```

**Negative fixture diff** (`tests/fixtures/sample-js-project-negative/shared/utils/src/unused-private-member-static.ts`):

```diff
+// VIOLATION: code-quality/deterministic/unused-private-member
+class CounterBox {
+  private static _ghost: CounterBox;
+  private count = 0;
+
+  bump(): number {
+    return ++this.count;
+  }
+}
+
+export const sharedBox = new CounterBox();
```

**Visitor summary**: The use-detector only treated `this.X` member-expression reads as a use, so `private static` fields accessed through the class name (`Foo._instance = new Foo()` inside `Foo.getInstance`) registered as unused. Resolved the enclosing class's `type_identifier`/`identifier` once and treat `ClassName.X` as a use alongside `this.X`.

## code-quality/deterministic/unnecessary-condition

**Sources** (documenso/documenso @ 8f6be47):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/pdf-viewer/pdf-viewer.tsx#L114
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/pdf-viewer/pdf-viewer.tsx#L138
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/envelope-item/replace-envelope-item-pdf.ts#L210

**Positive fixture diff** (`tests/fixtures/sample-js-project-positive/src/unnecessary-condition.ts`):

```diff
+/**
+ * Positive fixture for code-quality/deterministic/unnecessary-condition.
+ *
+ * Closure-mutated flag pattern: a `let` boolean is declared `false`, captured
+ * by a callback that mutates it, and read after intervening async work.
+ * TypeScript narrows the variable to the literal type `false` because its
+ * control-flow analysis only looks at the local scope — it does not see the
+ * reassignment in the sibling closure. Flagging the read as a dead-condition
+ * is therefore a false positive.
+ */
+
+interface Handle {
+  dispose(): void;
+}
+
+declare function scheduleAt(fn: () => void): Handle;
+
+export async function watchAsync(): Promise<string | null> {
+  let isCancelled = false;
+
+  const stop = (): void => {
+    isCancelled = true;
+  };
+
+  const handle = scheduleAt(stop);
+
+  await Promise.resolve();
+  if (isCancelled) {
+    return null;
+  }
+  await Promise.resolve();
+  if (isCancelled) {
+    handle.dispose();
+    return null;
+  }
+
+  handle.dispose();
+  return 'done';
+}
```

**Negative fixture diff** (`tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-condition-literal.ts`):

```diff
+function isNever(): string {
+  // VIOLATION: code-quality/deterministic/unnecessary-condition
+  if (false) {
+    return 'never';
+  }
+  return 'always';
+}
+
+export const branchResult = isNever();
```

**Visitor summary**: TypeScript narrows a `let isCancelled = false` to the literal type `false` at every read, because its flow analysis only looks at the current function's linear control flow — mutations inside sibling callback closures (React useEffect cleanup, async-watch handles) are missed. Skip the always-falsy / always-truthy report when the condition is a plain `identifier` with literal type `'true'` or `'false'`. Literal expressions (`if (false)`) and member accesses still fire.

## style/deterministic/js-style-preference

**Sources** (documenso/documenso @ 8f6be47):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/utils/remember.ts#L3
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/utils/remember.ts#L3
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/document-conversion/circuit-breaker.ts#L18

**Positive fixture diff** (`tests/fixtures/sample-js-project-positive/src/js-style-preference.ts`):

```diff
+/**
+ * Positive fixture for style/deterministic/js-style-preference.
+ *
+ * `var` inside an ambient declaration (`declare global { var X }`,
+ * `declare module '…' { var X }`, `declare var X`) is the only declaration
+ * form TypeScript accepts for augmenting `globalThis` or a module's namespace
+ * — `const` and `let` produce a compile error in that position. The rule must
+ * not flag these as a style preference.
+ */
+
+declare global {
+
+  var __memoCache: Map<string, unknown> | undefined;
+}
+
+declare module 'truecourse-fp-fixture-ambient' {
+
+  var ambientCounter: number;
+}
+
+declare var globalRegistry: { count: number };
+
+export function readCounter(): number {
+  return globalRegistry.count;
+}
```

**Negative fixture diff** (`tests/fixtures/sample-js-project-negative/shared/utils/src/js-style-preference-var.ts`):

```diff
+function legacyAccumulator(): number {
+  // VIOLATION: style/deterministic/js-style-preference
+  var total = 0;
+  total += 1;
+  return total;
+}
+
+export const accumulated = legacyAccumulator();
```

**Visitor summary**: Walked up the parent chain from the `variable_declaration` node; if any ancestor is an `ambient_declaration` (which covers `declare var X`, `declare global { var X }`, and `declare module '…' { var X }`), do not flag. In an ambient position TypeScript requires `var` — `const`/`let` are compile errors there — so it is not a style choice.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kstv1wi1xtxdfjQaZcMven)_