### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/javascript/raw-error-in-response.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/javascript/raw-error-in-response.ts
@@ -16,13 +16,45 @@ export const rawErrorInResponseVisitor: CodeRuleVisitor = {
     if (!param) return null
     const errName = param.text.replace(/:.+/, '').trim()
 
-    // Check if error details are sent in response
-    if (
-      bodyText.includes(`${errName}.stack`) ||
-      bodyText.includes(`${errName}.message`) ||
-      // res.json(err) or res.send(err)
-      bodyText.match(new RegExp(`res\\.(?:json|send)\\(${errName}\\)`))
-    ) {
+    // res.json(err) / res.send(err) — passing the whole error is always unsafe.
+    if (bodyText.match(new RegExp(`res\\.(?:json|send)\\(${errName}\\)`))) {
+      return makeViolation(
+        this.ruleKey, node, filePath, 'medium',
+        'Error details exposed in API response',
+        `Error details (stack, message) from '${errName}' sent to client. This leaks implementation details.`,
+        sourceCode,
+        'Send a generic error message to the client and log the full error server-side.',
+      )
+    }
+
+    // Find each `errName.message` / `errName.stack` reference and classify
+    // the surrounding context. Skip cases where the access is:
+    //   - gated by an `errName instanceof X` check (curated error class —
+    //     the message has been blessed by the developer)
+    //   - used as a computed property key: `OBJ[err.message]`
+    //   - fed into a pattern matcher: `match(err.message)` / `.with(err.message)`
+    //   - passed to a React state setter: `setSomething(err.message ...)`
+    const usagePattern = new RegExp(`\\b${errName}\\.(?:message|stack)\\b`, 'g')
+    let hasUnsafeUsage = false
+    for (const usage of bodyText.matchAll(usagePattern)) {
+      const idx = usage.index ?? 0
+      const before = bodyText.slice(Math.max(0, idx - 200), idx)
+
+      // Computed-member access: prev non-space char is `[`
+      if (/\[\s*$/.test(before)) continue
+      // Pattern-matcher input
+      if (/(?:\bmatch|\.with)\s*\(\s*$/.test(before)) continue
+      // React state setter call
+      if (/\bset[A-Z]\w*\s*\(\s*$/.test(before)) continue
+      // Inside an instanceof-gated branch — search the recent window for
+      // an `errName instanceof X` check.
+      if (new RegExp(`\\b${errName}\\s+instanceof\\b`).test(before)) continue
+
+      hasUnsafeUsage = true
+      break
+    }
+
+    if (hasUnsafeUsage) {
       return makeViolation(
         this.ruleKey, node, filePath, 'medium',
         'Error details exposed in API response',

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/unhandled-promise.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/unhandled-promise.ts
@@ -19,6 +19,10 @@ export const unhandledPromiseVisitor: CodeRuleVisitor = {
     // Skip if already handled: void expr, expr.catch(), await expr
     if (expr.type === 'await_expression') return null
     if (expr.type === 'void_expression') return null
+    // Skip assignments — the promise is being stored (e.g. into a ref,
+    // module-level cache, or instance property), and can be awaited or
+    // chained later. This isn't a floating promise.
+    if (expr.type === 'assignment_expression') return null
     // Skip resolve/reject calls inside Promise constructors
     if (expr.type === 'call_expression') {
       const fn = expr.childForFieldName('function')

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/triple-slash-reference.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/triple-slash-reference.ts
@@ -7,11 +7,14 @@ export const tripleSlashReferenceVisitor: CodeRuleVisitor = {
   nodeTypes: ['comment'],
   visit(node, filePath, sourceCode) {
     const text = node.text.trim()
-    if (/^\/\/\/\s*<reference\s+(path|types|lib)=/.test(text)) {
+    // Only the `path=` form is legacy and replaceable by a regular `import`.
+    // `types=` (ambient declarations) and `lib=` (TS lib selection) are the
+    // canonical TypeScript directives for things `import` cannot express.
+    if (/^\/\/\/\s*<reference\s+path=/.test(text)) {
       return makeViolation(
         this.ruleKey, node, filePath, 'low',
         'Triple-slash reference directive',
-        'Triple-slash `/// <reference ...>` directives are legacy. Use `import` statements instead.',
+        'Triple-slash `/// <reference path=...>` directives are legacy. Use `import` statements instead.',
         sourceCode,
         'Replace the triple-slash reference with an `import` statement.',
       )

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unnecessary-type-parameter.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unnecessary-type-parameter.ts
@@ -1,6 +1,20 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { TS_LANGUAGES } from './_helpers.js'
+
+function appearsInsideTypeArguments(root: SyntaxNode, paramName: string): boolean {
+  const re = new RegExp(`\\b${paramName}\\b`)
+  function walk(node: SyntaxNode): boolean {
+    if (node.type === 'type_arguments' && re.test(node.text)) return true
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i)
+      if (child && walk(child)) return true
+    }
+    return false
+  }
+  return walk(root)
+}
 
 /**
  * Detect: Generic type parameter that appears only once — unnecessary complexity.
@@ -67,6 +81,27 @@ export const unnecessaryTypeParameterVisitor: CodeRuleVisitor = {
               continue
             }
           }
+        }
+
+        // Skip when the type parameter is used inside another generic's type
+        // arguments (e.g. `param: Foo<T>` or `Component<TData>(...): JSX`).
+        // Removing T would change `Foo<T>` to `Foo<unknown>`, losing the
+        // caller's ability to instantiate the generic — that's not safely
+        // replaceable.
+        if (appearsInsideTypeArguments(params, paramName)
+          || (returnType && appearsInsideTypeArguments(returnType, paramName))) {
+          continue
+        }
+
+        // Skip when the type parameter is referenced by another type
+        // parameter's constraint or default (e.g. `<TFieldValues, TName extends
+        // FieldPath<TFieldValues>>`). The two parameters are linked.
+        const otherTparamsText = typeParams.namedChildren
+          .filter((other) => other.id !== tp.id)
+          .map((other) => other.text)
+          .join(' ')
+        if (new RegExp(`\\b${paramName}\\b`).test(otherTparamsText)) {
+          continue
         }
 
         return makeViolation(

--- a/packages/analyzer/src/rules/security/visitors/universal.ts
+++ b/packages/analyzer/src/rules/security/visitors/universal.ts
@@ -63,11 +63,13 @@ export const hardcodedSecretVisitor: CodeRuleVisitor = {
         const name = nameNode.text.toLowerCase()
         const secretNames = ['password', 'passwd', 'secret', 'apikey', 'api_key', 'token', 'auth_token', 'access_token', 'private_key']
         // Exclude variable names that are clearly not secrets (URIs, URLs, endpoints, types)
-        const isNonSecretName = /(?:uri|url|endpoint|type|scope|name|header|grant|method)/.test(name)
+        const isNonSecretName = /(?:uri|url|endpoint|type|scope|name|header|grant|method|identifier)/.test(name)
         const isNonSecretValue =
           /https?:\/\//.test(stripped)                          // URLs
           || /^(true|false|null|undefined|localhost|None|True|False|Bearer)$/i.test(stripped) // literals & common tokens
           || /[[\]<>{}()#.=\s]/.test(stripped)                  // selectors, HTML, format strings, paths
+          || /^[A-Z][A-Z0-9_]*$/.test(stripped)                 // UPPER_SNAKE_CASE enum/error codes
+          || /^[a-z][a-z0-9]*(?:-[a-z0-9]+)+$/.test(stripped)   // kebab-case identifier labels
 
         // Vocabulary-tag pattern: the literal *is* the field name (or a
         // plain-text extension of it). Catches things like

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/hardcoded-secret-credential.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/hardcoded-secret-credential.ts
@@ -1,0 +1,10 @@
+/**
+ * Negative fixture for security/deterministic/hardcoded-secret.
+ *
+ * Variable name says "token" and the value is a high-entropy mixed-case
+ * string with digits — exactly the credential-shaped pattern the
+ * variable-name fallback is meant to catch.
+ */
+
+// VIOLATION: security/deterministic/hardcoded-secret
+export const apiToken = 'x9fK3jdf83HsJd92AcBnK0';

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/triple-slash-reference-path.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/triple-slash-reference-path.ts
@@ -1,0 +1,11 @@
+/**
+ * Negative fixture for code-quality/deterministic/triple-slash-reference.
+ *
+ * `/// <reference path="..." />` is the legacy way of pulling in another
+ * source file. Modern TypeScript code should use `import` instead.
+ */
+
+// VIOLATION: code-quality/deterministic/triple-slash-reference
+/// <reference path="./legacy-types.ts" />
+
+export const LEGACY = true;

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/remaining-typescript.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/remaining-typescript.ts
@@ -12,6 +12,11 @@ export function typeMismatch() {
 // VIOLATION: code-quality/deterministic/filename-class-mismatch
 export default class WrongNameClass {
   value = 42;
+
+  // VIOLATION: code-quality/deterministic/unnecessary-type-parameter
+  logVerbose<T>(x: T): string {
+    return String(x);
+  }
 }
 
 // VIOLATION: code-quality/deterministic/internal-api-usage

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/routes/raw-error-in-response-sanitized.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/routes/raw-error-in-response-sanitized.ts
@@ -1,0 +1,54 @@
+// Catch handlers that *look* like raw-error-in-response targets (file
+// path contains `routes`, catch body mentions `err.message`) but the
+// message is gated by an instanceof check, used as a key into an enum,
+// or fed into a pattern matcher — never sent raw to the client.
+
+type AppError = Error & { code: string };
+declare const AppError: { new (code: string): AppError };
+
+const STATUS_UNAUTHORIZED = 401;
+const STATUS_INTERNAL = 500;
+
+const ERROR_CODES: Record<string, string> = {
+  UNAUTHORIZED: 'unauthorized',
+  UNKNOWN: 'unknown',
+};
+
+declare function callExternal(): Promise<void>;
+
+declare const res: {
+  status: (code: number) => { json: (body: unknown) => void };
+};
+
+export async function instanceOfGatedHandler(): Promise<void> {
+  try {
+    await callExternal();
+  } catch (err: unknown) {
+    let message = 'Unauthorized';
+    if (err instanceof AppError) {
+      message = err.message;
+    }
+    res.status(STATUS_UNAUTHORIZED).json({ message });
+  }
+}
+
+export async function ternaryGatedHandler(): Promise<void> {
+  try {
+    await callExternal();
+  } catch (error: unknown) {
+    const message =
+      error instanceof AppError ? error.message : 'Operation failed';
+    res.status(STATUS_INTERNAL).json({ message });
+  }
+}
+
+export async function enumKeyHandler(): Promise<void> {
+  try {
+    await callExternal();
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      const code = ERROR_CODES[err.message] ?? ERROR_CODES.UNKNOWN;
+      res.status(STATUS_INTERNAL).json({ error: code });
+    }
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/hardcoded-secret-enum-tag.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/hardcoded-secret-enum-tag.ts
@@ -1,0 +1,20 @@
+// Error-code enum: property values are UPPER_SNAKE_CASE tags that mirror
+// the property key. These are dispatch identifiers, not credentials, but
+// the property names contain "token" which would otherwise trip the
+// hardcoded-secret variable-name fallback.
+export const AuthErrorCode = {
+  InvalidToken: 'INVALID_TOKEN',
+  MissingToken: 'MISSING_TOKEN',
+  ExpiredToken: 'EXPIRED_TOKEN',
+  RevokedToken: 'REVOKED_TOKEN',
+} as const;
+
+export type AuthErrorCode =
+  (typeof AuthErrorCode)[keyof typeof AuthErrorCode];
+
+// Kebab-case identifier used as a token-purpose discriminator. The
+// constant name ends in TOKEN_IDENTIFIER but the value is a public
+// human-readable label, not a credential.
+export const ACCOUNT_LINK_VERIFICATION_TOKEN_IDENTIFIER =
+  'account-link-verification';
+export const SIGNUP_CONFIRMATION_TOKEN_IDENTIFIER = 'confirmation-link';

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/triple-slash-reference-ambient-types.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/triple-slash-reference-ambient-types.ts
@@ -1,0 +1,11 @@
+/// <reference types="./ambient-env.d.ts" />
+/// <reference types="@truecourse-test/ambient-augmentation" />
+
+// `/// <reference types="..." />` is the canonical TypeScript directive
+// for pulling in ambient .d.ts declarations that cannot be expressed via
+// `import` (e.g. global augmentations, library client types). It is
+// not a legacy form and should not be flagged.
+
+export function getAmbient(): string {
+  return 'ambient';
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/unhandled-promise-stored.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/unhandled-promise-stored.ts
@@ -1,0 +1,40 @@
+// Promise-returning calls that are *assigned* somewhere (an object
+// property or a ref) — they're retained, not floating, and can be
+// awaited or chained later by the holder.
+
+declare function fetchRemote(): Promise<string>;
+
+const cache = new Map<string, Promise<string>>();
+
+export function ensureFetch(key: string): Promise<string> {
+  let pending = cache.get(key);
+  if (!pending) {
+    pending = fetchRemote();
+    cache.set(key, pending);
+  }
+  return pending;
+}
+
+const pendingRef: { current: Promise<string> | null } = { current: null };
+
+export async function autosave(): Promise<void> {
+  pendingRef.current = fetchRemote();
+  try {
+    await pendingRef.current;
+  } finally {
+    pendingRef.current = null;
+  }
+}
+
+export function makeResolverPair<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  const handle: { resolve: (value: T) => void } = {
+    resolve: () => undefined,
+  };
+  const promise = new Promise<T>((res) => {
+    handle.resolve = res;
+  });
+  return { promise, resolve: handle.resolve };
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/unnecessary-type-parameter-threaded.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/unnecessary-type-parameter-threaded.ts
@@ -1,0 +1,34 @@
+// Type parameters that thread type information through generic
+// applications. Each tparam appears textually once, but inside another
+// generic — removing it would change the instantiation and break the
+// caller's inference.
+
+type JobDefinition<N extends string, T> = {
+  id: string;
+  trigger: { name: N; payload: T };
+};
+
+type ListProps<TRow> = {
+  rows: TRow[];
+  renderRow: (row: TRow) => string;
+};
+
+type FieldPath<TForm> = keyof TForm & string;
+type FieldRenderProps<TForm, TName extends FieldPath<TForm>> = {
+  name: TName;
+  value: TForm[TName];
+};
+
+export function defineJob<N extends string, T>(definition: JobDefinition<N, T>): string {
+  return definition.id;
+}
+
+export function renderList<TRow>(props: ListProps<TRow>): number {
+  return props.rows.length;
+}
+
+export function renderField<TForm, TName extends FieldPath<TForm>>(
+  props: FieldRenderProps<TForm, TName>,
+): string {
+  return String(props.name);
+}


### PR DESCRIPTION
Closes #154
Closes #155
Closes #156
Closes #157
Closes #158

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
| --- | --- | --- | --- |
| `security/deterministic/hardcoded-secret` | #154 | `tests/fixtures/sample-js-project-positive/shared/utils/src/hardcoded-secret-enum-tag.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/hardcoded-secret-credential.ts` |
| `code-quality/deterministic/triple-slash-reference` | #155 | `tests/fixtures/sample-js-project-positive/shared/utils/src/triple-slash-reference-ambient-types.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/triple-slash-reference-path.ts` |
| `code-quality/deterministic/unnecessary-type-parameter` | #156 | `tests/fixtures/sample-js-project-positive/shared/utils/src/unnecessary-type-parameter-threaded.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/remaining-typescript.ts` (added method to existing `WrongNameClass`) |
| `architecture/deterministic/raw-error-in-response` | #157 | `tests/fixtures/sample-js-project-positive/services/api-gateway/src/routes/raw-error-in-response-sanitized.ts` | _(covered by existing `tests/fixtures/sample-js-project-negative/services/user-service/src/handlers/user.handler.ts`)_ |
| `bugs/deterministic/unhandled-promise` | #158 | `tests/fixtures/sample-js-project-positive/shared/utils/src/unhandled-promise-stored.ts` | _(covered by existing `tests/fixtures/sample-js-project-negative/shared/utils/src/misc-bugs.ts`)_ |

## security/deterministic/hardcoded-secret

Closes #154.

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/auth/server/lib/errors/error-codes.ts#L7
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/auth/server/lib/errors/error-codes.ts#L8
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/constants/organisations.ts#L130
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/constants/email.ts#L18

Positive fixture (new file — should not fire):

```diff
+// Error-code enum: property values are UPPER_SNAKE_CASE tags that mirror
+// the property key. These are dispatch identifiers, not credentials, but
+// the property names contain "token" which would otherwise trip the
+// hardcoded-secret variable-name fallback.
+export const AuthErrorCode = {
+  InvalidToken: 'INVALID_TOKEN',
+  MissingToken: 'MISSING_TOKEN',
+  ExpiredToken: 'EXPIRED_TOKEN',
+  RevokedToken: 'REVOKED_TOKEN',
+} as const;
+
+export type AuthErrorCode =
+  (typeof AuthErrorCode)[keyof typeof AuthErrorCode];
+
+// Kebab-case identifier used as a token-purpose discriminator. The
+// constant name ends in TOKEN_IDENTIFIER but the value is a public
+// human-readable label, not a credential.
+export const ACCOUNT_LINK_VERIFICATION_TOKEN_IDENTIFIER =
+  'account-link-verification';
+export const SIGNUP_CONFIRMATION_TOKEN_IDENTIFIER = 'confirmation-link';
```

Negative fixture (new file — should fire):

```diff
+// VIOLATION: security/deterministic/hardcoded-secret
+export const apiToken = 'x9fK3jdf83HsJd92AcBnK0';
```

**Visitor change**: Extended the hardcoded-secret variable-name fallback's non-secret-value list to skip UPPER_SNAKE_CASE enum codes (e.g. `INVALID_TOKEN`) and kebab-case identifiers (e.g. `confirmation-email`). Also added `identifier` to the non-secret-name list so token-purpose constants like `*_TOKEN_IDENTIFIER` are no longer flagged.

## code-quality/deterministic/triple-slash-reference

Closes #155.

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/stripe/index.ts#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/utils/env.ts#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/index.ts#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/vite-env.d.ts#L1

Positive fixture (new file — should not fire):

```diff
+/// <reference types="./ambient-env.d.ts" />
+/// <reference types="@truecourse-test/ambient-augmentation" />
+
+// `/// <reference types="..." />` is the canonical TypeScript directive
+// for pulling in ambient .d.ts declarations that cannot be expressed via
+// `import` (e.g. global augmentations, library client types). It is
+// not a legacy form and should not be flagged.
+
+export function getAmbient(): string {
+  return 'ambient';
+}
```

Negative fixture (new file — should fire):

```diff
+// VIOLATION: code-quality/deterministic/triple-slash-reference
+/// <reference path="./legacy-types.ts" />
+
+export const LEGACY = true;
```

**Visitor change**: Narrowed the triple-slash-reference rule to only flag `/// <reference path=...>`, the truly legacy form. `<reference types=...>` and `<reference lib=...>` are the canonical ways to pull in ambient `.d.ts` and TS lib declarations that `import` cannot replace.

## code-quality/deterministic/unnecessary-type-parameter

Closes #156.

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/bullmq.ts#L99
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/data-table-pagination.tsx#L20
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/form/form.tsx#L24
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/inngest.ts#L36

Positive fixture (new file — should not fire):

```diff
+type JobDefinition<N extends string, T> = {
+  id: string;
+  trigger: { name: N; payload: T };
+};
+type ListProps<TRow> = {
+  rows: TRow[];
+  renderRow: (row: TRow) => string;
+};
+type FieldPath<TForm> = keyof TForm & string;
+type FieldRenderProps<TForm, TName extends FieldPath<TForm>> = {
+  name: TName;
+  value: TForm[TName];
+};
+
+export function defineJob<N extends string, T>(definition: JobDefinition<N, T>): string {
+  return definition.id;
+}
+
+export function renderList<TRow>(props: ListProps<TRow>): number {
+  return props.rows.length;
+}
+
+export function renderField<TForm, TName extends FieldPath<TForm>>(
+  props: FieldRenderProps<TForm, TName>,
+): string {
+  return String(props.name);
+}
```

Negative fixture (added method to existing `WrongNameClass`):

```diff
 export default class WrongNameClass {
   value = 42;
+
+  // VIOLATION: code-quality/deterministic/unnecessary-type-parameter
+  logVerbose<T>(x: T): string {
+    return String(x);
+  }
 }
```

**Visitor change**: Made the unnecessary-type-parameter heuristic skip type parameters that appear inside another generic's type arguments (e.g. `Foo<T>`) — those thread type info to the caller and cannot be replaced with the constraint. Also skip when one type parameter is referenced by another's constraint or default (e.g. `<TFieldValues, TName extends FieldPath<TFieldValues>>`).

## architecture/deterministic/raw-error-in-response

Closes #157.

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/api/v1/middleware/authenticated.ts#L97
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/ai/detect-recipients.ts#L110
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/embed+/playground.tsx#L260
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ee/server-only/limits/handler.ts#L28

Positive fixture (new file — should not fire):

```diff
+export async function instanceOfGatedHandler(): Promise<void> {
+  try {
+    await callExternal();
+  } catch (err: unknown) {
+    let message = 'Unauthorized';
+    if (err instanceof AppError) {
+      message = err.message;
+    }
+    res.status(STATUS_UNAUTHORIZED).json({ message });
+  }
+}
+
+export async function ternaryGatedHandler(): Promise<void> {
+  try {
+    await callExternal();
+  } catch (error: unknown) {
+    const message =
+      error instanceof AppError ? error.message : 'Operation failed';
+    res.status(STATUS_INTERNAL).json({ message });
+  }
+}
+
+export async function enumKeyHandler(): Promise<void> {
+  try {
+    await callExternal();
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      const code = ERROR_CODES[err.message] ?? ERROR_CODES.UNKNOWN;
+      res.status(STATUS_INTERNAL).json({ error: code });
+    }
+  }
+}
```

Negative fixture: existing `tests/fixtures/sample-js-project-negative/services/user-service/src/handlers/user.handler.ts:55` already covers the raw `res.status(500).json({ error: err.message, stack: err.stack })` pattern.

**Visitor change**: Refined the raw-error-in-response rule to classify each `err.message`/`err.stack` reference in the catch body. References that are gated by an `err instanceof X` check, used as a computed-property key (`OBJ[err.message]`), fed into a pattern matcher (`match(err.message)` / `.with(err.message)`), or passed to a React state setter (`setX(...)`) are treated as safe — they don't put the raw error into the outgoing response.

## bugs/deterministic/unhandled-promise

Closes #158.

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/hooks/use-envelope-autosave.ts#L67
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/hooks/use-envelope-autosave.ts#L33
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/hooks/use-analytics.ts#L7
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/utils/polyfills/promise-with-resolvers.ts#L22

Positive fixture (new file — should not fire):

```diff
+declare function fetchRemote(): Promise<string>;
+
+const cache = new Map<string, Promise<string>>();
+
+export function ensureFetch(key: string): Promise<string> {
+  let pending = cache.get(key);
+  if (!pending) {
+    pending = fetchRemote();
+    cache.set(key, pending);
+  }
+  return pending;
+}
+
+const pendingRef: { current: Promise<string> | null } = { current: null };
+
+export async function autosave(): Promise<void> {
+  pendingRef.current = fetchRemote();
+  try {
+    await pendingRef.current;
+  } finally {
+    pendingRef.current = null;
+  }
+}
+
+export function makeResolverPair<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  const handle: { resolve: (value: T) => void } = { resolve: () => undefined };
+  const promise = new Promise<T>((res) => {
+    handle.resolve = res;
+  });
+  return { promise, resolve: handle.resolve };
+}
```

Negative fixture: existing `tests/fixtures/sample-js-project-negative/shared/utils/src/misc-bugs.ts:208` already covers the bare floating `Promise.resolve(42)` expression-statement pattern.

**Visitor change**: Skip floating-promise detection when the expression is an `assignment_expression` (`x = somePromise()`). Assignments store the promise into the target — a ref, a module-level cache, an instance property — so it can be awaited or chained by the holder and isn't actually floating.

## Skipped this batch

- #153 (`code-quality/deterministic/useless-empty-export`) — refactor required. The correct fix is to skip bare `export {}` in files with no other top-level import/export (the module-marker pattern), but the existing unit test `tests/analyzer/code-quality-rules.test.ts:3376` pins the buggy behaviour by asserting bare `export {};` always fires. Updating that test is outside this routine's allowed scope.

The TP rate of the analyzer against `node dist/cli.mjs` (the exact artifact `publish.yml` ships to npm) for the documenso campaign was measured before this batch; merging this PR will refire `fp-next-fix` against the next oldest open `fp-fix` issue in the queue.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_015zCQ5UhYPX9sWRHzzPUJSo)_