### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/javascript/missing-rate-limiting.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/javascript/missing-rate-limiting.ts
@@ -50,6 +50,16 @@ function hasRateLimitMiddlewareCall(root: SyntaxNode): boolean {
       if (fn?.type === 'identifier') name = fn.text
       else if (fn?.type === 'member_expression') name = fn.childForFieldName('property')?.text ?? ''
       if (name && isRateLimitMiddlewareName(name)) return true
+
+      // Also catch the path-mounted pattern:
+      //   app.use('/api/v1/*', apiV1RateLimitMiddleware)
+      //   router.use(myThrottle)
+      // Rate-limit-suggestive identifiers as ARGUMENTS to `.use()` indicate
+      // rate limiting is wired in at the router level.
+      if (fn?.type === 'member_expression' && fn.childForFieldName('property')?.text === 'use') {
+        const args = n.childForFieldName('arguments')
+        if (args && hasRateLimitNamedArg(args)) return true
+      }
     }
     for (const child of n.namedChildren) {
       if (walk(child)) return true
@@ -57,6 +67,75 @@ function hasRateLimitMiddlewareCall(root: SyntaxNode): boolean {
     return false
   }
   return walk(root)
+}
+
+/**
+ * A middleware variable like `apiV1RateLimitMiddleware`, `myThrottle`,
+ * `slowDownAuth` contains a rate-limit-ish substring; treat that name passed
+ * into `.use(...)` as proof rate limiting is wired up.
+ */
+const RATE_LIMIT_NAME_SUBSTRING = /(rate[\s_-]?limit|throttle|slow[\s_-]?down|RateLimiter)/i
+
+function hasRateLimitNamedArg(args: SyntaxNode): boolean {
+  for (let i = 0; i < args.namedChildCount; i++) {
+    const arg = args.namedChild(i)
+    if (arg?.type === 'identifier' && RATE_LIMIT_NAME_SUBSTRING.test(arg.text)) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Heuristic: a file that constructs a router (`new Hono()`, `express.Router()`,
+ * `Router()`) and default-exports it is a sub-router intended to be mounted
+ * elsewhere. The mounting site is responsible for rate limiting; flagging the
+ * sub-router file is a false positive.
+ */
+function isMountedSubRouter(root: SyntaxNode): boolean {
+  const routerVarNames = new Set<string>()
+
+  function isRouterConstructor(value: SyntaxNode | null): boolean {
+    if (!value) return false
+    if (value.type === 'new_expression') {
+      const constructor = value.childForFieldName('constructor')
+      if (constructor?.type === 'identifier' && /^(Hono|Router|App)$/.test(constructor.text)) return true
+      if (constructor?.type === 'member_expression' && /^(Hono|Router|App)$/.test(constructor.childForFieldName('property')?.text ?? '')) return true
+    }
+    if (value.type === 'call_expression') {
+      const fn = value.childForFieldName('function')
+      if (fn?.type === 'identifier' && /^(Router|express|fastify|Hono)$/i.test(fn.text)) return true
+      if (fn?.type === 'member_expression' && /^(Router|router)$/.test(fn.childForFieldName('property')?.text ?? '')) return true
+    }
+    return false
+  }
+
+  function walkDecls(n: SyntaxNode): void {
+    if (n.type === 'variable_declarator') {
+      const nameNode = n.childForFieldName('name')
+      const valueNode = n.childForFieldName('value')
+      if (nameNode?.type === 'identifier' && isRouterConstructor(valueNode)) {
+        routerVarNames.add(nameNode.text)
+      }
+    }
+    for (const child of n.namedChildren) walkDecls(child)
+  }
+  walkDecls(root)
+
+  if (routerVarNames.size === 0) return false
+
+  // Look for `export default <routerVar>` at the top level
+  for (const child of root.namedChildren) {
+    if (child.type !== 'export_statement') continue
+    // tree-sitter: export_statement may be `export default X;` — children
+    // include `export`, `default`, identifier.
+    if (!child.text.startsWith('export default')) continue
+    for (let i = 0; i < child.childCount; i++) {
+      const part = child.child(i)
+      if (part?.type === 'identifier' && routerVarNames.has(part.text)) return true
+    }
+  }
+  return false
 }
 
 export const missingRateLimitingVisitor: CodeRuleVisitor = {
@@ -79,6 +158,11 @@ export const missingRateLimitingVisitor: CodeRuleVisitor = {
     // Skip if a rate-limit middleware is called by name anywhere in the file
     // (e.g. project-local `rateLimiter()` helper, custom `throttle()` middleware).
     if (hasRateLimitMiddlewareCall(node)) return null
+
+    // Skip if the file just creates a router and default-exports it — it's a
+    // sub-router meant to be mounted by another file, which is the layer that
+    // owns rate limiting.
+    if (isMountedSubRouter(node)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'medium',

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/unassigned-variable.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/unassigned-variable.ts
@@ -22,8 +22,10 @@ export const unassignedVariableVisitor: CodeRuleVisitor = {
     const assigned = new Set<string>()
     const readBeforeAssign = new Set<string>()
 
-    function processNode(n: SyntaxNode) {
-      if (n.type === 'variable_declaration' || n.type === 'lexical_declaration') {
+    function processNode(n: SyntaxNode, inNestedScope: boolean) {
+      // Declarations from nested scopes are separate bindings and must not
+      // shadow the outer-scope declaredNoInit map.
+      if (!inNestedScope && (n.type === 'variable_declaration' || n.type === 'lexical_declaration')) {
         for (const declarator of n.namedChildren) {
           if (declarator.type === 'variable_declarator') {
             const name = declarator.childForFieldName('name')
@@ -35,21 +37,38 @@ export const unassignedVariableVisitor: CodeRuleVisitor = {
         }
       }
 
-      if (n.type === 'assignment_expression') {
+      if (n.type === 'assignment_expression' || n.type === 'augmented_assignment_expression') {
         const left = n.childForFieldName('left')
         if (left?.type === 'identifier') assigned.add(left.text)
       }
 
-      // Don't recurse into nested functions
-      if (n.id !== body?.id && (n.type === 'function_declaration' || n.type === 'arrow_function' || n.type === 'function' || n.type === 'method_definition')) return
+      if (n.type === 'update_expression') {
+        const argument = n.childForFieldName('argument')
+        if (argument?.type === 'identifier') assigned.add(argument.text)
+      }
+
+      // Always recurse — assignments inside nested closures (Promise executors,
+      // event handlers, object-literal setters, etc.) DO mutate the outer
+      // variable when they don't redeclare it. Track scope so nested
+      // declarations don't pollute declaredNoInit.
+      const isNestedFunction = n.id !== body?.id && (
+        n.type === 'function_declaration' ||
+        n.type === 'arrow_function' ||
+        n.type === 'function' ||
+        n.type === 'function_expression' ||
+        n.type === 'generator_function' ||
+        n.type === 'generator_function_declaration' ||
+        n.type === 'method_definition'
+      )
+      const childInNestedScope = inNestedScope || isNestedFunction
 
       for (let i = 0; i < n.childCount; i++) {
         const child = n.child(i)
-        if (child) processNode(child)
+        if (child) processNode(child, childInNestedScope)
       }
     }
 
-    processNode(body)
+    processNode(body, false)
 
     // Find a variable that was declared without assignment and never assigned
     for (const [name, declNode] of declaredNoInit) {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/deprecated-api-usage.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/deprecated-api-usage.ts
@@ -18,13 +18,16 @@ export const deprecatedApiUsageVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     // Step 1: collect names of @deprecated declarations
     const deprecatedNames = new Set<string>()
-    const declarationNodes = new Set<SyntaxNode>()
-    collectDeprecatedDeclarations(node, deprecatedNames, declarationNodes)
+    // Track declaration nodes by `id` rather than reference — web-tree-sitter
+    // returns fresh wrapper objects for repeated traversal, so reference-based
+    // Set membership would always miss.
+    const declarationNodeIds = new Set<number>()
+    collectDeprecatedDeclarations(node, deprecatedNames, declarationNodeIds)
 
     if (deprecatedNames.size === 0) return null
 
     // Step 2: find first reference to any deprecated name (not in declaration position)
-    return findFirstDeprecatedReference(node, deprecatedNames, declarationNodes, filePath, sourceCode, this.ruleKey)
+    return findFirstDeprecatedReference(node, deprecatedNames, declarationNodeIds, filePath, sourceCode, this.ruleKey)
   },
 }
 
@@ -34,7 +37,7 @@ export const deprecatedApiUsageVisitor: CodeRuleVisitor = {
 function collectDeprecatedDeclarations(
   root: SyntaxNode,
   names: Set<string>,
-  declarationNodes: Set<SyntaxNode>,
+  declarationNodeIds: Set<number>,
 ): void {
   function walk(node: SyntaxNode): void {
     // Check statements that can have JSDoc comments
@@ -50,7 +53,7 @@ function collectDeprecatedDeclarations(
         // Extract declared names
         extractDeclaredNames(node).forEach((name) => {
           names.add(name)
-          declarationNodes.add(node)
+          declarationNodeIds.add(node.id)
         })
       }
     }
@@ -118,24 +121,30 @@ function hasPrecedingDeprecatedJsDoc(stmt: SyntaxNode): boolean {
 function findFirstDeprecatedReference(
   root: SyntaxNode,
   names: Set<string>,
-  declarationNodes: Set<SyntaxNode>,
+  declarationNodeIds: Set<number>,
   filePath: string,
   sourceCode: string,
   ruleKey: string,
 ): CodeViolation | null {
   function walk(node: SyntaxNode): CodeViolation | null {
     if (node.type === 'identifier' && names.has(node.text)) {
-      // Skip if this identifier IS the declaration (inside a declarationNode)
+      // Skip if this identifier is at a declaration site (any ancestor is one of
+      // the captured @deprecated declaration nodes), or if it lives inside an
+      // import statement (refers to an external symbol that happens to share
+      // its name with a locally-deprecated one).
       let ancestor: SyntaxNode | null = node.parent
-      let inDecl = false
+      let skip = false
       while (ancestor) {
-        if (declarationNodes.has(ancestor)) {
-          inDecl = true
+        if (
+          ancestor.type === 'import_statement' ||
+          declarationNodeIds.has(ancestor.id)
+        ) {
+          skip = true
           break
         }
         ancestor = ancestor.parent
       }
-      if (!inDecl) {
+      if (!skip) {
         // Also skip if this is a property access (a.deprecated — 'deprecated' is a property, not a reference)
         const parent = node.parent
         if (parent?.type === 'member_expression' && parent.childForFieldName('property')?.id === node.id) {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/static-method-candidate.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/static-method-candidate.ts
@@ -18,6 +18,12 @@ export const staticMethodCandidateVisitor: CodeRuleVisitor = {
     // Skip methods in classes that extend or implement — they may be overriding base class methods
     const classNode = node.parent?.parent
     if (classNode) {
+      // Skip methods inside an abstract class: even concrete methods are
+      // typically stubs intended for subclass override (e.g. `throw new
+      // Error('Not implemented')`). Making them static would break polymorphic
+      // dispatch from the subclass.
+      if (classNode.type === 'abstract_class_declaration') return null
+
       for (let i = 0; i < classNode.childCount; i++) {
         const child = classNode.child(i)
         if (child && (child.type === 'class_heritage' || child.type === 'extends_clause' || child.type === 'implements_clause')) return null

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/unchecked-array-access.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/unchecked-array-access.ts
@@ -1,7 +1,7 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
-import { findContainingStatement } from './_helpers.js'
+import { findContainingStatement, findEnclosingFunction } from './_helpers.js'
 
 export const uncheckedArrayAccessVisitor: CodeRuleVisitor = {
   ruleKey: 'reliability/deterministic/unchecked-array-access',
@@ -39,8 +39,21 @@ export const uncheckedArrayAccessVisitor: CodeRuleVisitor = {
     // Skip array writes (assignment targets) — writing to an index can't crash
     if (node.parent?.type === 'assignment_expression' && node.parent.childForFieldName('left')?.id === node.id) return null
 
-    // Skip when the result is used with a fallback (|| default, ?? default)
-    if (node.parent?.type === 'binary_expression' && /\|\||&&|\?\?/.test(node.parent.text.slice(node.text.length))) return null
+    // Skip augmented assignment targets (`obj[k] += 1`, `obj[k] ||= …`) — the
+    // read+write is an explicit update of that slot; treating it as an
+    // unguarded read confuses real reads with intentional in-place mutation.
+    if (node.parent?.type === 'augmented_assignment_expression' && node.parent.childForFieldName('left')?.id === node.id) return null
+
+    // Skip when the result (or a transparent wrapper around it) is used with a
+    // fallback. Common shape: `t(MAP[key]) ?? key` — the array access is buried
+    // in a call but the outer expression supplies a default.
+    if (hasFallbackAncestor(node)) return null
+
+    // Skip access to a local variable whose type annotation is a Record/Map —
+    // even without `noUncheckedIndexedAccess`, this is the explicit
+    // "exhaustive dictionary" pattern and the user has told the type system
+    // the keys are total.
+    if (object.type === 'identifier' && isRecordTypedLocal(object.text, node)) return null
 
     // Check if there is a bounds check nearby (same block)
     const statement = findContainingStatement(node)
@@ -104,4 +117,88 @@ export const uncheckedArrayAccessVisitor: CodeRuleVisitor = {
       'Add a bounds check (e.g., if (i < arr.length)) before accessing the array by index.',
     )
   },
+}
+
+/**
+ * Walk up through "transparent" wrappers (function call args, parens, type
+ * assertions) looking for a binary_expression with a short-circuit fallback
+ * (`||`, `??`, `&&`) where the walked-up subtree is the LEFT operand.
+ */
+function hasFallbackAncestor(start: SyntaxNode): boolean {
+  let cur: SyntaxNode = start
+  let parent: SyntaxNode | null = start.parent
+  while (parent) {
+    if (parent.type === 'binary_expression') {
+      const operator = parent.childForFieldName('operator')?.text
+      const left = parent.childForFieldName('left')
+      if (
+        left?.id === cur.id &&
+        (operator === '||' || operator === '??' || operator === '&&')
+      ) {
+        return true
+      }
+      return false
+    }
+    // Step through wrappers that don't change the value's identity for
+    // fallback-detection purposes.
+    if (
+      parent.type === 'arguments' ||
+      parent.type === 'call_expression' ||
+      parent.type === 'parenthesized_expression' ||
+      parent.type === 'as_expression' ||
+      parent.type === 'satisfies_expression' ||
+      parent.type === 'non_null_expression' ||
+      parent.type === 'type_assertion'
+    ) {
+      cur = parent
+      parent = parent.parent
+      continue
+    }
+    return false
+  }
+  return false
+}
+
+/**
+ * Look up the enclosing function for a `const/let <name>: Record<…> = {…}`
+ * declaration (or any Map/ReadonlyMap-typed declaration). If found, the
+ * subscript access is into a dictionary the author explicitly typed.
+ */
+function isRecordTypedLocal(name: string, accessNode: SyntaxNode): boolean {
+  const fn = findEnclosingFunction(accessNode)
+  if (!fn) return false
+  const body = fn.childForFieldName('body')
+  if (!body) return false
+
+  function walk(n: SyntaxNode): boolean {
+    if (n.type === 'lexical_declaration' || n.type === 'variable_declaration') {
+      for (let i = 0; i < n.namedChildCount; i++) {
+        const decl = n.namedChild(i)
+        if (decl?.type !== 'variable_declarator') continue
+        const nameNode = decl.childForFieldName('name')
+        if (nameNode?.type !== 'identifier' || nameNode.text !== name) continue
+        const typeNode = decl.childForFieldName('type')
+        if (typeNode && /\b(Record|ReadonlyMap|Map)\s*</.test(typeNode.text)) {
+          return true
+        }
+      }
+    }
+    // Don't recurse into nested functions — those are different scopes.
+    if (
+      n.id !== body!.id &&
+      (n.type === 'function_declaration' ||
+        n.type === 'arrow_function' ||
+        n.type === 'function' ||
+        n.type === 'function_expression' ||
+        n.type === 'method_definition')
+    ) {
+      return false
+    }
+    for (let i = 0; i < n.childCount; i++) {
+      const c = n.child(i)
+      if (c && walk(c)) return true
+    }
+    return false
+  }
+  return walk(body)
 }

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -595,6 +595,12 @@
       "layer": "service"
     },
     {
+      "name": "computeDefaultTimeout",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "Constants",
       "service": "utils",
       "kind": "class",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -529,6 +529,12 @@
       "layer": "service"
     },
     {
+      "name": "CaseHelpers",
+      "service": "utils",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "ClassA",
       "service": "utils",
       "kind": "class",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -661,6 +661,12 @@
       "layer": "service"
     },
     {
+      "name": "firstStringOver",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "formatters",
       "service": "utils",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -739,6 +739,12 @@
       "layer": "service"
     },
     {
+      "name": "resolveDocument",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "Secretive",
       "service": "utils",
       "kind": "class",

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/deprecated-symbol-call.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/deprecated-symbol-call.ts
@@ -1,0 +1,22 @@
+/**
+ * Negative fixture for code-quality/deterministic/deprecated-api-usage.
+ *
+ * Rule should still fire when a deprecated symbol is consumed outside its
+ * declaration site — i.e. a real caller invoking the deprecated function.
+ *
+ * File is named to avoid the substring `api`, which would otherwise flip the
+ * containing service from `library` to `api-server` in the negative fixture's
+ * graph snapshot.
+ */
+
+/**
+ * @deprecated Use `parseDocumentId` instead — handles versioned ids correctly.
+ */
+function parseLegacyId(raw: string): string {
+  return raw.trim();
+}
+
+export function resolveDocument(raw: string): string {
+  // VIOLATION: code-quality/deterministic/deprecated-api-usage
+  return parseLegacyId(raw);
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/missing-rate-limiting-main-app.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/missing-rate-limiting-main-app.ts
@@ -1,0 +1,19 @@
+/**
+ * Negative fixture for architecture/deterministic/missing-rate-limiting.
+ *
+ * A Hono app that defines a public route, exports under a different name
+ * (not the router variable), and applies no rate-limit middleware. The rule
+ * should still fire — neither the path-mounted-middleware skip nor the
+ * sub-router default-export skip apply.
+ */
+
+import { Hono } from 'hono';
+
+const app = new Hono();
+
+// VIOLATION: architecture/deterministic/missing-rate-limiting
+app.get('/public/feed', (c) => c.json({ items: [] }));
+
+app.post('/public/subscribe', (c) => c.json({ ok: true }));
+
+export const publicSurface = app;

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/static-method-non-abstract.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/static-method-non-abstract.ts
@@ -1,0 +1,14 @@
+/**
+ * Negative fixture for code-quality/deterministic/static-method-candidate.
+ *
+ * Methods on a *non-abstract* class that never reference `this`/`super` are
+ * still legitimate static-method candidates — the abstract-class skip added to
+ * suppress base-provider FPs must not also silence concrete classes.
+ */
+
+export class CaseHelpers {
+  // VIOLATION: code-quality/deterministic/static-method-candidate
+  public titleCase(input: string): string {
+    return input.replace(/\w\S*/g, (word) => word[0].toUpperCase() + word.slice(1).toLowerCase());
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unassigned-variable-truebug.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unassigned-variable-truebug.ts
@@ -1,0 +1,13 @@
+/**
+ * Negative fixture for bugs/deterministic/unassigned-variable.
+ *
+ * The rule should still fire when a `let` is declared without an initializer
+ * and never assigned anywhere within the function (including in nested
+ * closures it could plausibly delegate to).
+ */
+
+export function computeDefaultTimeout(): number {
+  // VIOLATION: bugs/deterministic/unassigned-variable
+  let timeoutMs: number;
+  return timeoutMs + 1000;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unchecked-array-access-loop.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unchecked-array-access-loop.ts
@@ -1,0 +1,12 @@
+/**
+ * Negative fixture for reliability/deterministic/unchecked-array-access.
+ *
+ * The rule should still fire when an array is indexed by a variable that is
+ * not bounded against `.length` and has no fallback / Record typing in scope.
+ */
+
+export function firstStringOver(items: string[], lookup: number[]): string {
+  // VIOLATION: reliability/deterministic/unchecked-array-access
+  const candidate = items[lookup[0]];
+  return candidate.toUpperCase();
+}

--- a/tests/fixtures/sample-js-project-positive/externals.d.ts
+++ b/tests/fixtures/sample-js-project-positive/externals.d.ts
@@ -115,6 +115,10 @@ declare module 'react-colorful' {
   export function setNonce(nonce: string): void;
 }
 
+declare module 'sample-crypto-shim' {
+  export function hashLegacy(input: string, rounds: number): string;
+}
+
 declare module '@sample/shared-utils' {
   export const logger: {
     info(message: string): void;

--- a/tests/fixtures/sample-js-project-positive/src/deprecated-api-usage-import-alias.ts
+++ b/tests/fixtures/sample-js-project-positive/src/deprecated-api-usage-import-alias.ts
@@ -1,0 +1,19 @@
+/**
+ * Positive fixture for code-quality/deterministic/deprecated-api-usage.
+ *
+ * Import alias that shadows a locally-deprecated name: importing `hashLegacy`
+ * from an external module under a different alias has nothing to do with a
+ * same-named deprecated symbol in this file. Identifiers inside an
+ * `import_statement` always refer to external symbols and must be skipped.
+ */
+
+import { hashLegacy as externalHashLegacy } from 'sample-crypto-shim';
+
+const DEFAULT_ROUNDS = 10;
+
+/**
+ * @deprecated Prefer the native crypto helpers exposed by `hashWithSalt`.
+ */
+export const hashLegacy = (password: string): string => {
+  return externalHashLegacy(password, DEFAULT_ROUNDS);
+};

--- a/tests/fixtures/sample-js-project-positive/src/deprecated-api-usage-self-decl.ts
+++ b/tests/fixtures/sample-js-project-positive/src/deprecated-api-usage-self-decl.ts
@@ -1,0 +1,19 @@
+/**
+ * Positive fixture for code-quality/deterministic/deprecated-api-usage.
+ *
+ * Declaration-site self-flag: an `export const` whose own JSDoc carries the
+ * `@deprecated` tag should be recognized as the DEFINITION of the deprecated
+ * symbol — not a *usage* of it. The visitor previously stored declaration
+ * nodes in a `Set<SyntaxNode>`, but web-tree-sitter returns fresh wrapper
+ * objects for repeated traversal, so reference-based `Set.has` always missed
+ * and the identifier at the declaration site got flagged.
+ */
+
+declare function readSetting(name: string): string | undefined;
+
+/**
+ * Temporary flag to toggle between legacy and modern rendering during rollout.
+ *
+ * @deprecated Will be removed once the modern pipeline ships.
+ */
+export const USE_LEGACY_RENDER = (): boolean => readSetting('USE_LEGACY_RENDER') === 'true';

--- a/tests/fixtures/sample-js-project-positive/src/missing-rate-limiting-router-level.ts
+++ b/tests/fixtures/sample-js-project-positive/src/missing-rate-limiting-router-level.ts
@@ -1,0 +1,35 @@
+/**
+ * Positive fixture for architecture/deterministic/missing-rate-limiting.
+ *
+ * Main router with rate limiting wired via path-mounted middleware variables:
+ *     app.use('/api/v1/*', apiV1RateLimitMiddleware);
+ * The middleware identifiers carry a rate-limit substring but the visitor
+ * only recognised CALLS to functions whose name *starts* with
+ * `rateLimit…`/`throttle…` — passing such an identifier as an argument to
+ * `.use(...)` was not recognised.
+ */
+
+import express from 'express';
+import helmet from 'helmet';
+import type { RequestHandler } from 'express';
+
+declare const apiV1RateLimitMiddleware: RequestHandler;
+declare const apiV2RateLimitMiddleware: RequestHandler;
+declare const fileUploadRateLimitMiddleware: RequestHandler;
+
+const healthHandler: RequestHandler = (_req, res): void => {
+  res.json({ ok: true });
+};
+
+const app = express();
+
+app.use(helmet());
+
+app.use('/api/v1/*', apiV1RateLimitMiddleware);
+app.use('/api/v2/*', apiV2RateLimitMiddleware);
+app.use('/api/files/upload', fileUploadRateLimitMiddleware);
+
+app.get('/health', healthHandler);
+app.get('/healthz', healthHandler);
+
+export { app };

--- a/tests/fixtures/sample-js-project-positive/src/missing-rate-limiting-sub-router.ts
+++ b/tests/fixtures/sample-js-project-positive/src/missing-rate-limiting-sub-router.ts
@@ -1,0 +1,22 @@
+/**
+ * Positive fixture for architecture/deterministic/missing-rate-limiting.
+ *
+ * A per-route sub-router file that constructs a router and default-exports
+ * it. The mounting site (a different file) is responsible for rate limiting;
+ * the sub-router file should not be flagged just because it doesn't
+ * re-declare rate limiting itself.
+ */
+
+import { Router } from 'express';
+import type { RequestHandler } from 'express';
+
+const healthHandler: RequestHandler = (_req, res): void => {
+  res.json({ ok: true });
+};
+
+const route = Router();
+
+route.get('/health', healthHandler);
+route.get('/healthz', healthHandler);
+
+export default route;

--- a/tests/fixtures/sample-js-project-positive/src/static-method-abstract-base.ts
+++ b/tests/fixtures/sample-js-project-positive/src/static-method-abstract-base.ts
@@ -1,0 +1,30 @@
+/**
+ * Positive fixture for code-quality/deterministic/static-method-candidate.
+ *
+ * Methods in an abstract base class are typically stubs that subclasses
+ * override; making them `static` would break polymorphic dispatch. The visitor
+ * only skipped classes with an explicit `extends`/`implements`, so an abstract
+ * base with no heritage clause leaked through.
+ */
+
+interface JobOptions {
+  name: string;
+}
+
+interface JobHandle {
+  cancel(): void;
+}
+
+export abstract class BaseJobProvider {
+  public triggerJob(options: JobOptions): JobHandle {
+    throw new Error(`triggerJob not implemented for job '${options.name}'`);
+  }
+
+  public defineJob(name: string, intervalMs: number): void {
+    throw new Error(`defineJob not implemented (name=${name}, interval=${intervalMs})`);
+  }
+
+  public getApiHandler(): () => Promise<void> {
+    throw new Error('getApiHandler not implemented');
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/src/unassigned-variable-closure.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unassigned-variable-closure.ts
@@ -1,0 +1,49 @@
+/**
+ * Positive fixture for bugs/deterministic/unassigned-variable.
+ *
+ * Two FP shapes that share the same root cause: the visitor only collected
+ * assignments at the same scope level as the declaration, skipping all nested
+ * functions. But it is idiomatic to declare a variable in the outer scope and
+ * assign it from a nested closure — Promise executors and registered event
+ * handlers both do this.
+ */
+
+interface Resolvers<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+export function makeResolvers<T>(): Resolvers<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+interface SelectionStage {
+  on(event: string, handler: (pointer: { x: number; y: number } | null) => void): void;
+}
+
+export function bindSelectionHandlers(stage: SelectionStage, scale: number): void {
+  let x1: number;
+  let y1: number;
+
+  stage.on('pointerdown', (pointer) => {
+    if (!pointer) return;
+    x1 = pointer.x / scale;
+    y1 = pointer.y / scale;
+  });
+
+  stage.on('pointermove', (pointer) => {
+    if (!pointer) return;
+    const dx = pointer.x / scale - x1;
+    const dy = pointer.y / scale - y1;
+    if (dx === 0 && dy === 0) return;
+  });
+}

--- a/tests/fixtures/sample-js-project-positive/src/unchecked-array-access-record.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unchecked-array-access-record.ts
@@ -1,0 +1,60 @@
+/**
+ * Positive fixture for reliability/deterministic/unchecked-array-access.
+ *
+ * Three FP shapes that the visitor previously flagged:
+ *
+ *  1. `Record<Union, V>` lookup by a value typed as `Union` — the type system
+ *     proves every key is present, but the visitor only suppressed the
+ *     inline-cast `({…} as Record<…>)[k]` shape, not a locally-typed binding.
+ *
+ *  2. Augmented assignment to a computed slot (`counts[k] += 1`). The read and
+ *     write happen together; the LHS is an intentional update, not an
+ *     unguarded read.
+ *
+ *  3. Subscript result fed through a function and the OUTER expression supplies
+ *     a fallback (`t(MAP[k]) ?? k`). The fallback applies after the wrapping
+ *     call, so the access is still safe.
+ */
+
+type WindowUnit = 's' | 'm' | 'h' | 'd';
+
+export const windowMs = (value: number, unit: WindowUnit): number => {
+  const multipliers: Record<WindowUnit, number> = {
+    s: 1000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+  };
+
+  return value * multipliers[unit];
+};
+
+type SignStatus = 'SIGNED' | 'NOT_SIGNED' | 'REJECTED';
+
+export const tallyStatuses = (
+  events: readonly { status: SignStatus }[],
+): Record<SignStatus, number> => {
+  const counts: Record<SignStatus, number> = {
+    SIGNED: 0,
+    NOT_SIGNED: 0,
+    REJECTED: 0,
+  };
+
+  for (const event of events) {
+    const { status } = event;
+    counts[status] += 1;
+  }
+
+  return counts;
+};
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: 'Administrator',
+  member: 'Member',
+};
+
+declare function translate(value: string | undefined): string | undefined;
+
+export const labelFor = (role: string): string => {
+  return translate(ROLE_LABELS[role]) ?? role;
+};


### PR DESCRIPTION
Closes #159
Closes #160
Closes #161
Closes #162
Closes #163

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
| --- | --- | --- | --- |
| `code-quality/deterministic/deprecated-api-usage` | #159 | `tests/fixtures/sample-js-project-positive/src/deprecated-api-usage-{self-decl,import-alias}.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/deprecated-symbol-call.ts` |
| `bugs/deterministic/unassigned-variable` | #160 | `tests/fixtures/sample-js-project-positive/src/unassigned-variable-closure.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unassigned-variable-truebug.ts` |
| `code-quality/deterministic/static-method-candidate` | #161 | `tests/fixtures/sample-js-project-positive/src/static-method-abstract-base.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/static-method-non-abstract.ts` |
| `reliability/deterministic/unchecked-array-access` | #162 | `tests/fixtures/sample-js-project-positive/src/unchecked-array-access-record.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unchecked-array-access-loop.ts` |
| `architecture/deterministic/missing-rate-limiting` | #163 | `tests/fixtures/sample-js-project-positive/src/missing-rate-limiting-{router-level,sub-router}.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/missing-rate-limiting-main-app.ts` |

## code-quality/deterministic/deprecated-api-usage

Closes #159.

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/constants/app.ts#L33
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/document-router/create-document-temporary.types.ts#L24`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/document-router/create-document-temporary.ts#L23
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/auth/hash.ts#L1

Positive fixture (new file — should not fire):

```diff
+/**
+ * @deprecated Will be removed once the modern pipeline ships.
+ */
+export const USE_LEGACY_RENDER = (): boolean => readSetting('USE_LEGACY_RENDER') === 'true';
```

```diff
+import { hashLegacy as externalHashLegacy } from 'sample-crypto-shim';
+
+/**
+ * @deprecated Prefer the native crypto helpers exposed by `hashWithSalt`.
+ */
+export const hashLegacy = (password: string): string => {
+  return externalHashLegacy(password, DEFAULT_ROUNDS);
+};
```

Negative fixture (new file — should fire):

```diff
+/**
+ * @deprecated Use `parseDocumentId` instead — handles versioned ids correctly.
+ */
+function parseLegacyId(raw: string): string { return raw.trim(); }
+
+export function resolveDocument(raw: string): string {
+  // VIOLATION: code-quality/deterministic/deprecated-api-usage
+  return parseLegacyId(raw);
+}
```

**Visitor change**: Track declaration nodes by `node.id` (Set<number>) instead of by SyntaxNode reference — web-tree-sitter returns fresh wrapper objects per traversal so reference-based `Set.has` always missed and the identifier at the declaration site got flagged. Also skip identifiers that live inside an `import_statement`: the imported name refers to an external symbol, not a same-named local deprecated declaration.

## bugs/deterministic/unassigned-variable

Closes #160.

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/utils/polyfills/promise-with-resolvers.ts#L18
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/utils/openapi-fetch-handler.ts#L167
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx#L250`

Positive fixture (new file — should not fire):

```diff
+export function makeResolvers<T>(): Resolvers<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export function bindSelectionHandlers(stage: SelectionStage, scale: number): void {
+  let x1: number;
+  let y1: number;
+  stage.on('pointerdown', (pointer) => {
+    if (!pointer) return;
+    x1 = pointer.x / scale;
+    y1 = pointer.y / scale;
+  });
+}
```

Negative fixture (new file — should fire):

```diff
+export function computeDefaultTimeout(): number {
+  // VIOLATION: bugs/deterministic/unassigned-variable
+  let timeoutMs: number;
+  return timeoutMs + 1000;
+}
```

**Visitor change**: Recurse into nested closures while tracking scope. Declarations inside nested functions are kept out of the outer scope's `declaredNoInit` map, but assignments inside nested closures DO count toward the outer scope's `assigned` set. That fixes Promise executors, registered event handlers, and object-literal setters — all idioms where the outer `let` is mutated from a nested callback. Also recognise `augmented_assignment_expression` and `update_expression` (`++x` / `x += …`) as assignments.

## code-quality/deterministic/static-method-candidate

Closes #161.

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/base.ts#L7
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/base.ts#L12
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/base.ts#L16

Positive fixture (new file — should not fire):

```diff
+export abstract class BaseJobProvider {
+  public triggerJob(options: JobOptions): JobHandle {
+    throw new Error(`triggerJob not implemented for job '${options.name}'`);
+  }
+  public defineJob(name: string, intervalMs: number): void {
+    throw new Error(`defineJob not implemented (name=${name}, interval=${intervalMs})`);
+  }
+  public getApiHandler(): () => Promise<void> {
+    throw new Error('getApiHandler not implemented');
+  }
+}
```

Negative fixture (new file — should fire):

```diff
+export class CaseHelpers {
+  // VIOLATION: code-quality/deterministic/static-method-candidate
+  public titleCase(input: string): string {
+    return input.replace(/\w\S*/g, (word) => word[0].toUpperCase() + word.slice(1).toLowerCase());
+  }
+}
```

**Visitor change**: Skip methods inside an `abstract_class_declaration`. Concrete methods on an abstract base are conventionally `throw new Error('Not implemented')` stubs intended for subclass override; making them `static` breaks polymorphic dispatch from the subclass. The visitor only skipped classes with an explicit `extends`/`implements` clause, so an abstract base with no heritage leaked through.

## reliability/deterministic/unchecked-array-access

Closes #162.

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/rate-limit/rate-limit.ts#L42
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/admin/get-recipients-stats.ts#L26
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/organisation-group-create-dialog.tsx#L164`

Positive fixture (new file — should not fire):

```diff
+export const windowMs = (value: number, unit: WindowUnit): number => {
+  const multipliers: Record<WindowUnit, number> = {
+    s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000,
+  };
+  return value * multipliers[unit];
+};
+
+export const tallyStatuses = (events: readonly { status: SignStatus }[]): Record<SignStatus, number> => {
+  const counts: Record<SignStatus, number> = { SIGNED: 0, NOT_SIGNED: 0, REJECTED: 0 };
+  for (const event of events) {
+    const { status } = event;
+    counts[status] += 1;
+  }
+  return counts;
+};
+
+export const labelFor = (role: string): string => {
+  return translate(ROLE_LABELS[role]) ?? role;
+};
```

Negative fixture (new file — should fire):

```diff
+export function firstStringOver(items: string[], lookup: number[]): string {
+  // VIOLATION: reliability/deterministic/unchecked-array-access
+  const candidate = items[lookup[0]];
+  return candidate.toUpperCase();
+}
```

**Visitor change**: Three additions. (1) Skip access to a local variable whose type annotation is `Record<…>`/`Map<…>`/`ReadonlyMap<…>` — the author has typed the container as a total dictionary. (2) Skip when the subscript is the LHS of an `augmented_assignment_expression` (`counts[k] += 1`) — that's an explicit slot update, not an unguarded read. (3) Walk up through transparent wrappers (`call_expression`, `parenthesized_expression`, `as_expression`, `satisfies_expression`, `non_null_expression`, `type_assertion`) when looking for a short-circuit fallback, so patterns like `translate(MAP[k]) ?? k` correctly see the `??` that lives one level out from the access.

## architecture/deterministic/missing-rate-limiting

Closes #163.

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/files/routes/get-envelope-item-pdf.ts#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/router.ts#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/files/routes/get-envelope-item-pdf-by-token.ts#L1

Positive fixtures (new files — should not fire):

```diff
+const app = express();
+app.use('/api/v1/*', apiV1RateLimitMiddleware);
+app.use('/api/v2/*', apiV2RateLimitMiddleware);
+app.use('/api/files/upload', fileUploadRateLimitMiddleware);
+app.get('/health', healthHandler);
+app.get('/healthz', healthHandler);
+export { app };
```

```diff
+const route = Router();
+route.get('/health', healthHandler);
+route.get('/healthz', healthHandler);
+export default route;
```

Negative fixture (new file — should fire):

```diff
+const app = new Hono();
+// VIOLATION: architecture/deterministic/missing-rate-limiting
+app.get('/public/feed', (c) => c.json({ items: [] }));
+app.post('/public/subscribe', (c) => c.json({ ok: true }));
+export const publicSurface = app;
```

**Visitor change**: Two additions. (1) When scanning for rate-limit middleware calls, also treat `app.use(path, middleware)`/`router.use(middleware)` as proof of rate-limit setup when any argument is an identifier whose name contains a rate-limit substring (`rate-limit` / `throttle` / `slow-down` / `RateLimiter`). The existing matcher required names to *start* with `rateLimit…`, so path-mounted middleware variables like `apiV1RateLimitMiddleware` were missed. (2) Skip files that construct a router (`new Hono()`, `Router()`, `express.Router()`, `Hono()`) and `export default` that variable — they are sub-router files mounted by another file, and the mounting site owns rate limiting.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjfAQF4SbLXWT6YeuYaLeC)_