### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/duplicate-string.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/duplicate-string.ts
@@ -13,6 +13,11 @@ export const duplicateStringVisitor: CodeRuleVisitor = {
       if (n.type === 'string') {
         const content = n.text
         if (content.length <= 5) return
+        // Single-identifier tokens (e.g. 'json', 'number', 'error') are typically
+        // framework API tokens, typeof return values, or status/kind discriminants —
+        // not domain strings worth extracting to a constant.
+        const inner = content.slice(1, -1)
+        if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(inner)) return
         const parent = n.parent
         // Skip TypeScript type keywords (e.g., `string` inside `predefined_type`)
         if (parent?.type === 'predefined_type') return

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/magic-string.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/magic-string.ts
@@ -29,6 +29,10 @@ export const magicStringVisitor: CodeRuleVisitor = {
           if (n.parent?.type === 'jsx_expression' && n.parent.parent?.type === 'jsx_attribute') return
           const text = n.text
           const inner = text.slice(1, -1) // strip quotes
+          // Single-identifier tokens (e.g. 'json', 'number', 'error') are typically
+          // framework API tokens, typeof return values, or status/kind discriminants —
+          // not magic strings worth extracting to a constant.
+          if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(inner)) return
           // Only flag non-trivial strings
           if (inner.length >= MIN_LENGTH && /^[a-zA-Z]/.test(inner) && !inner.includes('${')) {
             const existing = counts.get(text) ?? []

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/namespace-usage.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/namespace-usage.ts
@@ -9,6 +9,18 @@ export const namespaceUsageVisitor: CodeRuleVisitor = {
     const keywordChild = node.children.find((c) => c.type === 'namespace' || c.text === 'namespace')
     if (!keywordChild) return null
 
+    // Declaration files (`.d.ts`) carry typing-only declarations; namespaces
+    // here are module / global augmentation (NodeJS.ProcessEnv, third-party
+    // type packages), which is the canonical TS pattern, not deprecated usage.
+    if (filePath.endsWith('.d.ts')) return null
+
+    // `declare namespace X { ... }` and `declare global { namespace X { ... } }`
+    // both surface as an `internal_module` nested under an `ambient_declaration`.
+    // These are augmentation, not first-party namespace usage.
+    for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
+      if (ancestor.type === 'ambient_declaration') return null
+    }
+
     const nameNode = node.childForFieldName('name')
     const name = nameNode?.text ?? 'namespace'
 

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/type-guard-preference.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/type-guard-preference.ts
@@ -67,7 +67,14 @@ function hasBooleanReturn(bodyNode: SyntaxNode): boolean {
   function walk(n: SyntaxNode) {
     if (found) return
     if (n.type === 'return_statement') {
-      const val = n.namedChildren[0]
+      let val: SyntaxNode | undefined = n.namedChildren[0]
+      // Unwrap parenthesized expressions so `return (typeof x === 'string')`
+      // is treated the same as `return typeof x === 'string'`. Without
+      // unwrapping, React components that `return (<jsx />)` look like
+      // boolean returns and trip the rule.
+      while (val && val.type === 'parenthesized_expression') {
+        val = val.namedChildren[0]
+      }
       if (!val) return
       if (val.type === 'true' || val.type === 'false') { found = true; return }
       // return x instanceof Foo or return typeof x === 'string'
@@ -76,7 +83,6 @@ function hasBooleanReturn(bodyNode: SyntaxNode): boolean {
         const hasBoolOp = val.children.some((c) => c.text === '===' || c.text === '!==')
         if (hasInstanceof || hasBoolOp) { found = true; return }
       }
-      if (val.type === 'parenthesized_expression') { found = true; return }
     }
     for (let i = 0; i < n.childCount; i++) {
       const child = n.child(i)

--- a/packages/analyzer/src/rules/security/visitors/javascript/jwt-no-expiry.ts
+++ b/packages/analyzer/src/rules/security/visitors/javascript/jwt-no-expiry.ts
@@ -10,14 +10,23 @@ export const jwtNoExpiryVisitor: CodeRuleVisitor = {
     if (!fn) return null
 
     let methodName = ''
+    let receiverIsJwt = false
     if (fn.type === 'member_expression') {
       const prop = fn.childForFieldName('property')
       if (prop) methodName = prop.text
-    } else if (fn.type === 'identifier') {
-      methodName = fn.text
+      const obj = fn.childForFieldName('object')
+      // Only treat `jwt.sign`, `jsonwebtoken.sign`, `JWT.sign` as JWT calls.
+      // Other `.sign(...)` calls — pdf.sign, libsodium.sign, SignJWT fluent
+      // chains (jose) — are not jsonwebtoken-style and have their own expiry
+      // controls (or none, by design).
+      if (obj?.type === 'identifier' && /^(jwt|jsonwebtoken|JWT)$/.test(obj.text)) {
+        receiverIsJwt = true
+      }
     }
+    // Bare `sign(...)` (no receiver) is too ambiguous — usually an internal
+    // HMAC/crypto helper, not jwt.sign. Don't flag.
 
-    if (methodName !== 'sign') return null
+    if (methodName !== 'sign' || !receiverIsJwt) return null
 
     const args = node.childForFieldName('arguments')
     if (!args) return null

--- a/packages/analyzer/src/rules/security/visitors/universal.ts
+++ b/packages/analyzer/src/rules/security/visitors/universal.ts
@@ -184,6 +184,16 @@ export const clearTextProtocolVisitor: CodeRuleVisitor = {
         if (/w3\.org|schema\.org|xmlns|openxmlformats|xmlsoap|purl\.org/.test(lower)) {
           return null
         }
+        // Exclude template strings whose host is interpolated right after the
+        // protocol (e.g. `http://${addr}`, `http://[${addr}]`). These are URL
+        // templates built for parsing — `new URL(...)`, isPrivateUrl(...) /
+        // SSRF validators — not hardcoded plaintext connection targets.
+        if (node.type === 'template_string') {
+          const afterProtocol = stripped.slice(protocol.length)
+          if (afterProtocol.startsWith('${') || afterProtocol.startsWith('[${')) {
+            return null
+          }
+        }
         // Exclude string comparisons/checks — the protocol URL is being inspected, not used
         // as a connection target. E.g., input.startsWith('http://'), url.includes('http://').
         const parent = node.parent

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -559,6 +559,12 @@
       "layer": "service"
     },
     {
+      "name": "clear-text-protocol-hardcoded-host",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "code-quality-advanced",
       "service": "utils",
       "kind": "standalone",
@@ -643,6 +649,12 @@
       "layer": "service"
     },
     {
+      "name": "duplicate-string-error-message",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "EarlyThis",
       "service": "utils",
       "kind": "class",
@@ -685,6 +697,12 @@
       "layer": "service"
     },
     {
+      "name": "jwt-no-expiry-options-without-expiresin",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "legacy",
       "service": "utils",
       "kind": "standalone",
@@ -712,6 +730,12 @@
       "name": "MissingSuperCall",
       "service": "utils",
       "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "namespace-usage-internal-module",
+      "service": "utils",
+      "kind": "standalone",
       "layer": "service"
     },
     {
@@ -800,6 +824,12 @@
     },
     {
       "name": "style",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "type-guard-preference-typeof",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/clear-text-protocol-hardcoded-host.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/clear-text-protocol-hardcoded-host.ts
@@ -1,0 +1,16 @@
+/**
+ * A hardcoded plaintext URL passed straight to fetch — credentials and
+ * payload would travel over an unencrypted channel.
+ */
+
+declare function fetch(url: string): Promise<Response>;
+
+export async function postAuditEvent(payload: Record<string, unknown>): Promise<Response> {
+  // VIOLATION: security/deterministic/clear-text-protocol
+  return fetch('http://audit.example.com/events');
+}
+
+export async function fetchExternalConfig(): Promise<Response> {
+  // VIOLATION: security/deterministic/clear-text-protocol
+  return fetch(`http://config.example.com/v1/settings?ts=${Date.now()}`);
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/duplicate-string-error-message.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/duplicate-string-error-message.ts
@@ -1,0 +1,24 @@
+/**
+ * A genuine duplicate-string bug pattern: the same multi-word error
+ * message is repeated across several validators in the same file.
+ * Extracting it to a named constant would deduplicate the message and
+ * keep wording consistent across call sites.
+ */
+
+// VIOLATION: code-quality/deterministic/duplicate-string
+export function ensureTokenPresent(token: string | undefined): string {
+  if (!token) throw new Error('Authentication token is required for this operation');
+  return token;
+}
+
+export function ensureTokenLength(token: string): string {
+  if (token.length < 8) throw new Error('Authentication token is required for this operation');
+  return token;
+}
+
+export function ensureTokenShape(token: string): string {
+  if (!/^[a-z0-9]+$/i.test(token)) {
+    throw new Error('Authentication token is required for this operation');
+  }
+  return token;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/jwt-no-expiry-options-without-expiresin.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/jwt-no-expiry-options-without-expiresin.ts
@@ -1,0 +1,18 @@
+/**
+ * jwt.sign called with an options object that omits expiresIn — token
+ * never expires. The rule should still flag this when options are passed.
+ */
+
+const jwt = {
+  sign: (payload: unknown, secret: string, opts?: Record<string, unknown>): string => 'token',
+};
+
+export function issueSessionToken(userId: string): string {
+  // VIOLATION: security/deterministic/jwt-no-expiry
+  return jwt.sign({ userId }, 'session-secret', { algorithm: 'HS256' });
+}
+
+export function issueServiceToken(serviceId: string): string {
+  // VIOLATION: security/deterministic/jwt-no-expiry
+  return jwt.sign({ serviceId }, 'service-secret', { algorithm: 'HS512' });
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/namespace-usage-internal-module.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/namespace-usage-internal-module.ts
@@ -1,0 +1,14 @@
+/**
+ * First-party TS namespace used as an internal module — the deprecated
+ * pre-ES2015 form. Should be flagged so the team migrates to ES module
+ * exports.
+ */
+
+// VIOLATION: code-quality/deterministic/namespace-usage
+namespace MathHelpers {
+  export const square = (n: number): number => n * n;
+  export const cube = (n: number): number => n * n * n;
+}
+
+export const four = MathHelpers.square(2);
+export const eight = MathHelpers.cube(2);

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/type-guard-preference-typeof.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/type-guard-preference-typeof.ts
@@ -1,0 +1,14 @@
+/**
+ * Two functions that narrow with `typeof` and return the resulting
+ * boolean. Both should declare their return type as a type predicate.
+ */
+
+// VIOLATION: code-quality/deterministic/type-guard-preference
+export function isStringValue(input: unknown): boolean {
+  return typeof input === 'string';
+}
+
+// VIOLATION: code-quality/deterministic/type-guard-preference
+export function isNumberValue(input: unknown): boolean {
+  return typeof input === 'number';
+}

--- a/tests/fixtures/sample-js-project-positive/src/clear-text-protocol-url-template.ts
+++ b/tests/fixtures/sample-js-project-positive/src/clear-text-protocol-url-template.ts
@@ -1,0 +1,17 @@
+/**
+ * Template strings that build a URL whose host is interpolated immediately
+ * after the protocol are URL constructions for parsing/validation (e.g.
+ * `new URL(...)`, SSRF allowlist checks), not hardcoded plaintext
+ * connection targets, and should not trigger clear-text-protocol.
+ */
+
+declare function isPrivateAddress(url: string): boolean;
+
+export const buildHostUrl = (address: string): string =>
+  address.includes(':') ? `http://[${address}]` : `http://${address}`;
+
+export const looksPrivate = (mappedHost: string): boolean =>
+  isPrivateAddress(`http://${mappedHost}`);
+
+export const buildHostPortUrl = (host: string, port: number): string =>
+  `http://${host}:${port}/health`;

--- a/tests/fixtures/sample-js-project-positive/src/duplicate-string-typeof-and-api-tokens.ts
+++ b/tests/fixtures/sample-js-project-positive/src/duplicate-string-typeof-and-api-tokens.ts
@@ -1,0 +1,35 @@
+/**
+ * Single-identifier string literals appearing multiple times in technical
+ * contexts — typeof comparisons, framework API tokens passed as call
+ * arguments, or status field values — are not duplicated *domain* strings
+ * and should not be flagged by duplicate-string or magic-string.
+ */
+
+type Bounds = { min?: unknown; max?: unknown };
+
+export function describeBounds(bounds: Bounds): string {
+  const parts: string[] = [];
+  if (typeof bounds.min === 'number') {
+    parts.push(`min=${bounds.min}`);
+  }
+  if (typeof bounds.max === 'number') {
+    parts.push(`max=${bounds.max}`);
+  }
+  if (typeof bounds.min === 'number' && typeof bounds.max === 'number') {
+    parts.push(`span=${bounds.max - bounds.min}`);
+  }
+  return parts.join(', ');
+}
+
+type ValidatorTarget = 'json' | 'query' | 'form';
+
+declare function apiValidator<T>(target: ValidatorTarget, schema: T): T;
+declare const userSchema: { fields: unknown };
+declare const orderSchema: { fields: unknown };
+declare const ticketSchema: { fields: unknown };
+
+export const validators: ReadonlyArray<{ fields: unknown }> = [
+  apiValidator('json', userSchema),
+  apiValidator('json', orderSchema),
+  apiValidator('json', ticketSchema),
+];

--- a/tests/fixtures/sample-js-project-positive/src/jwt-no-expiry-non-jwt-sign.ts
+++ b/tests/fixtures/sample-js-project-positive/src/jwt-no-expiry-non-jwt-sign.ts
@@ -1,0 +1,48 @@
+/**
+ * `.sign(...)` and bare `sign(...)` calls on non-JWT receivers — internal
+ * HMAC signing helpers, PDF document signing, jose's SignJWT fluent chain
+ * with setExpirationTime — should not be flagged as jwt-no-expiry.
+ */
+
+declare function sign(data: Uint8Array): Uint8Array;
+
+export function signPayload(data: Uint8Array): Uint8Array {
+  return sign(data);
+}
+
+type PdfSigner = {
+  sign(args: { signer: unknown; reason: string }): Promise<{ bytes: Uint8Array }>;
+};
+
+declare const pdf: PdfSigner;
+declare const signerInstance: unknown;
+
+export async function signPdf(): Promise<Uint8Array> {
+  const { bytes } = await pdf.sign({
+    signer: signerInstance,
+    reason: 'Signed by service',
+  });
+  return bytes;
+}
+
+type SignJwtChain = {
+  setProtectedHeader(header: { alg: string }): SignJwtChain;
+  setIssuedAt(): SignJwtChain;
+  setExpirationTime(at: Date): SignJwtChain;
+  sign(secret: Uint8Array): Promise<string>;
+};
+
+declare const SignJWT: new (claims: Record<string, unknown>) => SignJwtChain;
+declare const tokenSecret: Uint8Array;
+
+export function issuePresignToken(
+  audience: string,
+  subject: string,
+  expiresAt: Date,
+): Promise<string> {
+  return new SignJWT({ aud: audience, sub: subject })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime(expiresAt)
+    .sign(tokenSecret);
+}

--- a/tests/fixtures/sample-js-project-positive/src/namespace-usage-augmentation.ts
+++ b/tests/fixtures/sample-js-project-positive/src/namespace-usage-augmentation.ts
@@ -1,0 +1,25 @@
+/**
+ * `declare namespace …` is the canonical TS pattern for augmenting global
+ * or third-party types — the ES module equivalent does not exist. These
+ * ambient namespace declarations should not be flagged as deprecated
+ * namespace usage.
+ */
+
+declare namespace AppRuntime {
+  interface RuntimeEnv {
+    SERVICE_NAME?: string;
+    LOG_LEVEL?: 'debug' | 'info' | 'warn' | 'error';
+  }
+  interface ServiceClient {
+    name: string;
+    invoke(): Promise<void>;
+  }
+}
+
+declare namespace ThirdPartyBridge {
+  type FeatureFlags = { admin: boolean };
+  type AuthOptions = { method: 'password' | 'sms' };
+}
+
+export type RuntimeEnv = AppRuntime.RuntimeEnv;
+export type FeatureFlags = ThirdPartyBridge.FeatureFlags;

--- a/tests/fixtures/sample-js-project-positive/src/type-guard-preference-react-component.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/type-guard-preference-react-component.tsx
@@ -1,0 +1,39 @@
+/**
+ * React components that render JSX and happen to narrow a prop via
+ * `typeof` should not be flagged as type-guard candidates. They return
+ * JSX wrapped in parens, not a boolean expression.
+ */
+
+import * as React from 'react';
+
+type MetricProps = {
+  title: string;
+  value?: string | number;
+};
+
+export const MetricCard = ({ title, value }: MetricProps) => {
+  const display = typeof value === 'number' ? value : (value ?? '');
+  return (
+    <div className="metric-card">
+      <h3>{title}</h3>
+      <p>{display}</p>
+    </div>
+  );
+};
+
+type SelectorProps = {
+  count: number;
+  primary: string;
+  secondary?: string | number;
+};
+
+export const ItemSelector = ({ count, primary, secondary }: SelectorProps) => {
+  const trailing = typeof secondary === 'number' ? secondary : (secondary ?? '');
+  return (
+    <div className="item-selector">
+      <span>{count}</span>
+      <span>{primary}</span>
+      <span>{trailing}</span>
+    </div>
+  );
+};


### PR DESCRIPTION
Closes #164
Closes #165
Closes #166
Closes #167
Closes #168

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
| --- | --- | --- | --- |
| `code-quality/deterministic/duplicate-string` | #164 | `tests/fixtures/sample-js-project-positive/src/duplicate-string-typeof-and-api-tokens.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/duplicate-string-error-message.ts` |
| `security/deterministic/jwt-no-expiry` | #165 | `tests/fixtures/sample-js-project-positive/src/jwt-no-expiry-non-jwt-sign.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/jwt-no-expiry-options-without-expiresin.ts` |
| `code-quality/deterministic/namespace-usage` | #166 | `tests/fixtures/sample-js-project-positive/src/namespace-usage-augmentation.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/namespace-usage-internal-module.ts` |
| `code-quality/deterministic/type-guard-preference` | #167 | `tests/fixtures/sample-js-project-positive/src/type-guard-preference-react-component.tsx` | `tests/fixtures/sample-js-project-negative/shared/utils/src/type-guard-preference-typeof.ts` |
| `security/deterministic/clear-text-protocol` | #168 | `tests/fixtures/sample-js-project-positive/src/clear-text-protocol-url-template.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/clear-text-protocol-hardcoded-host.ts` |

## code-quality/deterministic/duplicate-string

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/advanced-fields-validation/validate-number.ts#L36
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/auth/server/routes/two-factor.ts#L40
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/api+/branding.logo.team.%24teamId.ts#L16

Positive fixture (added):
```ts
/**
 * Single-identifier string literals appearing multiple times in technical
 * contexts — typeof comparisons, framework API tokens passed as call
 * arguments, or status field values — are not duplicated *domain* strings
 * and should not be flagged by duplicate-string or magic-string.
 */

type Bounds = { min?: unknown; max?: unknown };

export function describeBounds(bounds: Bounds): string {
  const parts: string[] = [];
  if (typeof bounds.min === 'number') {
    parts.push(`min=${bounds.min}`);
  }
  if (typeof bounds.max === 'number') {
    parts.push(`max=${bounds.max}`);
  }
  if (typeof bounds.min === 'number' && typeof bounds.max === 'number') {
    parts.push(`span=${bounds.max - bounds.min}`);
  }
  return parts.join(', ');
}

type ValidatorTarget = 'json' | 'query' | 'form';
declare function apiValidator<T>(target: ValidatorTarget, schema: T): T;
declare const userSchema: { fields: unknown };
declare const orderSchema: { fields: unknown };
declare const ticketSchema: { fields: unknown };

export const validators: ReadonlyArray<{ fields: unknown }> = [
  apiValidator('json', userSchema),
  apiValidator('json', orderSchema),
  apiValidator('json', ticketSchema),
];
```

Negative fixture (added):
```ts
// VIOLATION: code-quality/deterministic/duplicate-string
export function ensureTokenPresent(token: string | undefined): string {
  if (!token) throw new Error('Authentication token is required for this operation');
  return token;
}

export function ensureTokenLength(token: string): string {
  if (token.length < 8) throw new Error('Authentication token is required for this operation');
  return token;
}

export function ensureTokenShape(token: string): string {
  if (!/^[a-z0-9]+$/i.test(token)) {
    throw new Error('Authentication token is required for this operation');
  }
  return token;
}
```

**Visitor fix:** Skip identifier-shape string literals (matching `/^[A-Za-z_$][A-Za-z0-9_$]*$/`) in both `duplicate-string` and `magic-string` visitors. Tokens like `'json'`, `'number'`, `'error'`, `'true'` are typically framework API arguments (Hono `sValidator('json', …)`), `typeof` return values, or status/kind discriminants — not domain strings worth extracting to a constant. The two rules share the same FP pattern and per-file scan, so the same skip is added to both.

## security/deterministic/jwt-no-expiry

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/local.ts#L362
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/embedding-presign/create-embedding-presign-token.ts#L41`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/signing/index.ts#L43

Positive fixture (added):
```ts
declare function sign(data: Uint8Array): Uint8Array;
export function signPayload(data: Uint8Array): Uint8Array { return sign(data); }

type PdfSigner = {
  sign(args: { signer: unknown; reason: string }): Promise<{ bytes: Uint8Array }>;
};
declare const pdf: PdfSigner;
declare const signerInstance: unknown;

export async function signPdf(): Promise<Uint8Array> {
  const { bytes } = await pdf.sign({ signer: signerInstance, reason: 'Signed by service' });
  return bytes;
}

type SignJwtChain = {
  setProtectedHeader(header: { alg: string }): SignJwtChain;
  setIssuedAt(): SignJwtChain;
  setExpirationTime(at: Date): SignJwtChain;
  sign(secret: Uint8Array): Promise<string>;
};
declare const SignJWT: new (claims: Record<string, unknown>) => SignJwtChain;
declare const tokenSecret: Uint8Array;

export function issuePresignToken(audience: string, subject: string, expiresAt: Date): Promise<string> {
  return new SignJWT({ aud: audience, sub: subject })
    .setProtectedHeader({ alg: 'HS256' })
    .setIssuedAt()
    .setExpirationTime(expiresAt)
    .sign(tokenSecret);
}
```

Negative fixture (added):
```ts
const jwt = { sign: (payload: unknown, secret: string, opts?: Record<string, unknown>): string => 'token' };

export function issueSessionToken(userId: string): string {
  // VIOLATION: security/deterministic/jwt-no-expiry
  return jwt.sign({ userId }, 'session-secret', { algorithm: 'HS256' });
}

export function issueServiceToken(serviceId: string): string {
  // VIOLATION: security/deterministic/jwt-no-expiry
  return jwt.sign({ serviceId }, 'service-secret', { algorithm: 'HS512' });
}
```

**Visitor fix:** Restrict `jwt-no-expiry` to method calls whose receiver is `jwt`, `jsonwebtoken`, or `JWT` (the conventional `jsonwebtoken` import names). Bare `sign(...)` calls and `.sign(...)` calls on non-JWT receivers — PDF signers, jose's `SignJWT` fluent chains, internal HMAC helpers — are no longer flagged. Existing `jwt.sign(payload, secret)` detection is preserved.

## code-quality/deterministic/namespace-usage

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/types/types.d.ts#L14
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/stripe/stripe.d.ts#L2
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/tsconfig/process-env.d.ts#L1

Positive fixture (added):
```ts
declare namespace AppRuntime {
  interface RuntimeEnv {
    SERVICE_NAME?: string;
    LOG_LEVEL?: 'debug' | 'info' | 'warn' | 'error';
  }
  interface ServiceClient {
    name: string;
    invoke(): Promise<void>;
  }
}

declare namespace ThirdPartyBridge {
  type FeatureFlags = { admin: boolean };
  type AuthOptions = { method: 'password' | 'sms' };
}

export type RuntimeEnv = AppRuntime.RuntimeEnv;
export type FeatureFlags = ThirdPartyBridge.FeatureFlags;
```

Negative fixture (added):
```ts
// VIOLATION: code-quality/deterministic/namespace-usage
namespace MathHelpers {
  export const square = (n: number): number => n * n;
  export const cube = (n: number): number => n * n * n;
}

export const four = MathHelpers.square(2);
export const eight = MathHelpers.cube(2);
```

**Visitor fix:** Skip `namespace-usage` in `.d.ts` files and skip any `internal_module` whose ancestor chain contains an `ambient_declaration` (i.e. `declare namespace X { … }` or `declare global { namespace X { … } }`). These are module / global augmentation — the canonical TS pattern for typing `process.env`, `PrismaJson`, Stripe extensions — with no ES-module equivalent. First-party `namespace X { … }` usage in regular `.ts` files is still flagged.

## code-quality/deterministic/type-guard-preference

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/docs/src/components/ai/page-actions.tsx#L63
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/envelope-editor/envelope-file-selector.tsx#L14`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/metric-card.tsx#L12

Positive fixture (added):
```tsx
import * as React from 'react';

type MetricProps = { title: string; value?: string | number };

export const MetricCard = ({ title, value }: MetricProps) => {
  const display = typeof value === 'number' ? value : (value ?? '');
  return (
    <div className="metric-card">
      <h3>{title}</h3>
      <p>{display}</p>
    </div>
  );
};

type SelectorProps = { count: number; primary: string; secondary?: string | number };

export const ItemSelector = ({ count, primary, secondary }: SelectorProps) => {
  const trailing = typeof secondary === 'number' ? secondary : (secondary ?? '');
  return (
    <div className="item-selector">
      <span>{count}</span>
      <span>{primary}</span>
      <span>{trailing}</span>
    </div>
  );
};
```

Negative fixture (added):
```ts
// VIOLATION: code-quality/deterministic/type-guard-preference
export function isStringValue(input: unknown): boolean {
  return typeof input === 'string';
}

// VIOLATION: code-quality/deterministic/type-guard-preference
export function isNumberValue(input: unknown): boolean {
  return typeof input === 'number';
}
```

**Visitor fix:** Unwrap `parenthesized_expression` in the `hasBooleanReturn` heuristic so `return (<jsx />)` is no longer treated as a boolean return. Previously any parenthesized return matched (the old branch literally said `if (val.type === 'parenthesized_expression') { found = true }`), which caused React components with inline `typeof` narrowing to be misclassified as type-guard candidates. After the fix, `return (typeof x === 'string')` still fires (the unwrapped value is a `binary_expression`), but `return (<div>…</div>)` does not.

## security/deterministic/clear-text-protocol

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/webhooks/assert-webhook-url.ts#L27
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/webhooks/is-private-url.ts#L75

Positive fixture (added):
```ts
declare function isPrivateAddress(url: string): boolean;

export const buildHostUrl = (address: string): string =>
  address.includes(':') ? `http://[${address}]` : `http://${address}`;

export const looksPrivate = (mappedHost: string): boolean =>
  isPrivateAddress(`http://${mappedHost}`);

export const buildHostPortUrl = (host: string, port: number): string =>
  `http://${host}:${port}/health`;
```

Negative fixture (added):
```ts
declare function fetch(url: string): Promise<Response>;

export async function postAuditEvent(payload: Record<string, unknown>): Promise<Response> {
  // VIOLATION: security/deterministic/clear-text-protocol
  return fetch('http://audit.example.com/events');
}

export async function fetchExternalConfig(): Promise<Response> {
  // VIOLATION: security/deterministic/clear-text-protocol
  return fetch(`http://config.example.com/v1/settings?ts=${Date.now()}`);
}
```

**Visitor fix:** Skip cleartext-protocol template strings whose host is interpolated immediately after the protocol — `` `http://${addr}` ``, `` `http://[${addr}]` ``, `` `http://${host}:${port}/…` ``. These are URL templates built for parsing or SSRF validation (`new URL(...)`, `isPrivateUrl(...)` allowlist checks), not hardcoded plaintext connection targets. Hardcoded literal targets like `fetch('http://audit.example.com/…')` and `` `http://api.example.com/v1/…?ts=${ts}` `` (where the host is a literal and only the path/query has interpolation) are still flagged.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dj9kmXPDdwwQpS1xabwTbv)_