### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/redos-vulnerable-regex.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/redos-vulnerable-regex.ts
@@ -2,11 +2,14 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { JS_LANGUAGES } from './_helpers.js'
 
-// Detect obvious ReDoS patterns in regex literals:
-// Nested quantifiers: (a+)+ (a*)* (a+)* (a*)+ etc.
-// Overlapping alternation with quantifiers: (a|aa)+
-
-const NESTED_QUANTIFIER_RE = /\([^)]*[+*][^)]*\)[+*?{]/
+// Detect canonical ReDoS shapes: a group containing a SINGLE quantified atom
+// (`a+`, `\d+`, `[a-z]+`, `.+`, …) that is itself repeated with an unbounded
+// outer quantifier (`+`/`*`). Patterns with `?` outer quantifier (e.g.
+// `(P)?`) repeat at most once and are not vulnerable. Patterns with an
+// anchor character/class before the inner quantifier (e.g. `([-_][a-z]+)*`)
+// have bounded backtracking because adjacent iterations are separated by a
+// distinct atom.
+const NESTED_QUANTIFIER_RE = /\((?:\?:)?(?:\\[a-zA-Z]|\\[^a-zA-Z]|\.|\[[^\]]*\]|[a-zA-Z0-9_])[+*]\??\)[+*]\??/
 
 export const redosVulnerableRegexVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/redos-vulnerable-regex',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/indexed-loop-over-for-of.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/indexed-loop-over-for-of.ts
@@ -35,11 +35,15 @@ export const indexedLoopOverForOfVisitor: CodeRuleVisitor = {
     if (lengthArithmeticRe.test(condText)) return null
 
     let usedOutsideIndex = false
+    let usedAsArrayIndex = false
     function checkIndexUsage(n: SyntaxNode) {
       if (usedOutsideIndex) return
       if (n.type === 'identifier' && n.text === indexName) {
         const parent = n.parent
-        if (parent?.type === 'subscript_expression' && parent.childForFieldName('index')?.id === n.id) return
+        if (parent?.type === 'subscript_expression' && parent.childForFieldName('index')?.id === n.id) {
+          usedAsArrayIndex = true
+          return
+        }
         if (parent?.id === condition?.id || parent?.id === increment?.id) return
         let p: SyntaxNode | null = n.parent
         while (p) {
@@ -56,7 +60,11 @@ export const indexedLoopOverForOfVisitor: CodeRuleVisitor = {
 
     checkIndexUsage(body)
 
-    if (!usedOutsideIndex) {
+    // Only flag when the loop body actually uses the index for array access.
+    // A counted loop that never indexes any array (e.g. iterates a fixed
+    // numeric upper bound for retry/window logic) cannot be replaced with
+    // `for...of` — there's no array to iterate over.
+    if (!usedOutsideIndex && usedAsArrayIndex) {
       return makeViolation(
         this.ruleKey, node, filePath, 'low',
         'Indexed loop when index not needed',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-duplicate-char-class.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-duplicate-char-class.ts
@@ -2,6 +2,56 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { getRegexSource } from './_helpers.js'
 
+// Tokenize the contents of a `[…]` character class into atomic "characters",
+// keeping each escape (\uXXXX, \u{XXXX}, \xXX, \cA, or any \-prefixed shorthand)
+// as one token. `-` is treated as a range separator and not pushed as a token.
+function tokenizeCharClass(content: string): string[] {
+  const tokens: string[] = []
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i]
+    if (ch === '\\' && i + 1 < content.length) {
+      const next = content[i + 1]
+      if (next === 'u') {
+        // \u{XXXX...} — variable-length Unicode escape (u-flag mode)
+        if (content[i + 2] === '{') {
+          const close = content.indexOf('}', i + 3)
+          if (close > 0) {
+            tokens.push(content.slice(i, close + 1))
+            i = close
+            continue
+          }
+        }
+        // \uXXXX — 4-digit Unicode escape
+        if (i + 5 < content.length && /^[0-9a-fA-F]{4}$/.test(content.slice(i + 2, i + 6))) {
+          tokens.push(content.slice(i, i + 6))
+          i += 5
+          continue
+        }
+      } else if (next === 'x') {
+        // \xXX — 2-digit hex escape
+        if (i + 3 < content.length && /^[0-9a-fA-F]{2}$/.test(content.slice(i + 2, i + 4))) {
+          tokens.push(content.slice(i, i + 4))
+          i += 3
+          continue
+        }
+      } else if (next === 'c') {
+        // \cA — control-character escape
+        if (i + 2 < content.length && /^[A-Za-z]$/.test(content[i + 2])) {
+          tokens.push(content.slice(i, i + 3))
+          i += 2
+          continue
+        }
+      }
+      // Generic \X escape (\d, \w, \s, \., …)
+      tokens.push(content.slice(i, i + 2))
+      i++
+    } else if (ch !== '-') {
+      tokens.push(ch)
+    }
+  }
+  return tokens
+}
+
 export const regexDuplicateCharClassVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/regex-duplicate-char-class',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -13,18 +63,9 @@ export const regexDuplicateCharClassVisitor: CodeRuleVisitor = {
     const classRegex = /\[([^\]]*)\]/g
     let match: RegExpExecArray | null
     while ((match = classRegex.exec(src)) !== null) {
-      const classContent = match[1]
-      const chars: string[] = []
-      for (let i = 0; i < classContent.length; i++) {
-        if (classContent[i] === '\\' && i + 1 < classContent.length) {
-          chars.push(classContent.slice(i, i + 2))
-          i++
-        } else if (classContent[i] !== '-') {
-          chars.push(classContent[i])
-        }
-      }
+      const tokens = tokenizeCharClass(match[1])
       const seen = new Set<string>()
-      for (const ch of chars) {
+      for (const ch of tokens) {
         if (seen.has(ch)) {
           return makeViolation(
             this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unused-function-parameter.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unused-function-parameter.ts
@@ -1,6 +1,38 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
+// JavaScript identifier characters: letters, digits, `_`, `$`. Tree-sitter's
+// `\b` word boundary doesn't include `$`, so identifiers like `$node` are
+// incorrectly reported as unused when surrounded by non-word characters.
+const IDENT_BOUNDARY = '[A-Za-z0-9_$]'
+
+function buildIdentRegex(name: string): RegExp {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`(?<!${IDENT_BOUNDARY})${escaped}(?!${IDENT_BOUNDARY})`)
+}
+
+// Array.prototype iteration methods whose callback signature is
+// `(element, index?, array?)`. When the callback uses `element` but ignores
+// the trailing positional `index`/`array`, that's idiomatic — flagging the
+// unused trailing parameter is a false positive.
+const ARRAY_ITERATION_METHODS = new Set([
+  'map', 'forEach', 'filter', 'reduce', 'reduceRight',
+  'some', 'every', 'find', 'findIndex', 'findLast', 'findLastIndex',
+  'flatMap',
+])
+
+function isInArrayIterationCallback(node: { parent: unknown } | null): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let parent: any = (node as any)?.parent
+  if (parent?.type === 'arguments') parent = parent.parent
+  if (parent?.type !== 'call_expression') return false
+  const fn = parent.childForFieldName?.('function')
+  if (fn?.type !== 'member_expression') return false
+  const prop = fn.childForFieldName?.('property')
+  if (!prop) return false
+  return ARRAY_ITERATION_METHODS.has(prop.text)
+}
+
 export const unusedFunctionParameterVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/unused-function-parameter',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -12,6 +44,8 @@ export const unusedFunctionParameterVisitor: CodeRuleVisitor = {
     const body = node.childForFieldName('body')
     if (!body) return null
     const bodyText = body.text
+
+    const inIterationCallback = isInArrayIterationCallback(node)
 
     paramLoop: for (let i = 0; i < params.namedChildCount; i++) {
       const param = params.namedChild(i)
@@ -62,7 +96,7 @@ export const unusedFunctionParameterVisitor: CodeRuleVisitor = {
 
       // For block bodies ({...}), strip the braces. For expression bodies, use as-is.
       const bodyContent = body.type === 'statement_block' ? bodyText.slice(1, -1) : bodyText
-      const re = new RegExp(`\\b${paramName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`)
+      const re = buildIdentRegex(paramName)
       if (!re.test(bodyContent)) {
         // If there are later parameters that ARE used, this param is a positional placeholder
         // (e.g., Next.js route handlers: (request, { params }) where request is required)
@@ -82,7 +116,7 @@ export const unusedFunctionParameterVisitor: CodeRuleVisitor = {
             if (nameNode?.type === 'identifier') laterName = nameNode.text
           }
           if (laterName && !laterName.startsWith('_')) {
-            const laterRe = new RegExp(`\\b${laterName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`)
+            const laterRe = buildIdentRegex(laterName)
             if (laterRe.test(bodyContent)) {
               laterParamUsed = true
               break
@@ -90,6 +124,35 @@ export const unusedFunctionParameterVisitor: CodeRuleVisitor = {
           }
         }
         if (laterParamUsed) continue
+
+        // In Array.prototype iteration callbacks, trailing positional params
+        // (`index`, `array`) are part of the method's contract — ignoring them
+        // when an earlier param is used is idiomatic, not a bug.
+        if (inIterationCallback && i > 0) {
+          let earlierParamUsed = false
+          for (let j = 0; j < i; j++) {
+            const earlierParam = params.namedChild(j)
+            if (!earlierParam) continue
+            if (earlierParam.type === 'object_pattern' || earlierParam.type === 'array_pattern' || earlierParam.type === 'rest_parameter') {
+              earlierParamUsed = true
+              break
+            }
+            let earlierName: string | null = null
+            if (earlierParam.type === 'identifier') earlierName = earlierParam.text
+            else if (earlierParam.type === 'required_parameter' || earlierParam.type === 'optional_parameter') {
+              const nameNode = earlierParam.childForFieldName('pattern') ?? earlierParam.namedChildren[0]
+              if (nameNode?.type === 'identifier') earlierName = nameNode.text
+            }
+            if (earlierName && !earlierName.startsWith('_')) {
+              const earlierRe = buildIdentRegex(earlierName)
+              if (earlierRe.test(bodyContent)) {
+                earlierParamUsed = true
+                break
+              }
+            }
+          }
+          if (earlierParamUsed) continue
+        }
 
         return makeViolation(
           this.ruleKey, param, filePath, 'low',

--- a/packages/analyzer/src/rules/performance/visitors/javascript/unnecessary-context-provider.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/unnecessary-context-provider.ts
@@ -1,6 +1,22 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
+// `{...spread}` attributes can forward `children` to the wrapped element,
+// reaching arbitrary descendants of that element. A Provider wrapping such
+// an element therefore has reachable context consumers, so we can't claim
+// the provider is unnecessary.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function hasSpreadAttribute(tag: any): boolean {
+  for (let i = 0; i < tag.namedChildCount; i++) {
+    const c = tag.namedChild(i)
+    if (c?.type !== 'jsx_expression') continue
+    for (let j = 0; j < c.namedChildCount; j++) {
+      if (c.namedChild(j)?.type === 'spread_element') return true
+    }
+  }
+  return false
+}
+
 export const unnecessaryContextProviderVisitor: CodeRuleVisitor = {
   ruleKey: 'performance/deterministic/unnecessary-context-provider',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -24,14 +40,18 @@ export const unnecessaryContextProviderVisitor: CodeRuleVisitor = {
 
     if (children.length === 1) {
       const child = children[0]
-      // Skip when rendering {children} — standard provider wrapper pattern
-      if (child.type === 'jsx_expression' && child.text.includes('children')) return null
+      // Any single `{expression}` child can resolve to arbitrary JSX whose
+      // subtree (any depth) may consume the context — the "single child"
+      // shape doesn't bound the consumer set.
+      if (child.type === 'jsx_expression') return null
       // Skip when the single child is a PascalCase component — wrapping one root component
       // in a Provider is the standard React pattern (app root, layout wrappers)
       if (child.type === 'jsx_element') {
         const childTag = child.namedChildren.find((c) => c.type === 'jsx_opening_element')
         const childName = childTag?.namedChildren.find((c) => c.type === 'identifier' || c.type === 'member_expression')
         if (childName && /^[A-Z]/.test(childName.text)) return null
+        // `{...spread}` may forward children to the wrapped element's subtree
+        if (childTag && hasSpreadAttribute(childTag)) return null
         // Skip when child element has complex content (nested elements/expressions) —
         // the subtree likely contains context consumers
         const childContent = child.namedChildren.filter((c) =>
@@ -41,6 +61,7 @@ export const unnecessaryContextProviderVisitor: CodeRuleVisitor = {
       if (child.type === 'jsx_self_closing_element') {
         const childName = child.namedChildren.find((c) => c.type === 'identifier' || c.type === 'member_expression')
         if (childName && /^[A-Z]/.test(childName.text)) return null
+        if (hasSpreadAttribute(child)) return null
       }
       return makeViolation(
         this.ruleKey, node, filePath, 'low',

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -787,7 +787,19 @@
       "layer": "service"
     },
     {
+      "name": "redos-vulnerable-regex-nested-quantifiers",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "regex-bugs",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "regex-duplicate-char-class-unicode-escapes",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"
@@ -847,6 +859,12 @@
       "layer": "service"
     },
     {
+      "name": "sumBytes",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "todoHandler",
       "service": "utils",
       "kind": "standalone",
@@ -880,6 +898,12 @@
       "name": "UnreadAttribute",
       "service": "utils",
       "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "unused-function-parameter-trailing-and-dollar",
+      "service": "utils",
+      "kind": "standalone",
       "layer": "service"
     },
     {
@@ -938,6 +962,12 @@
     },
     {
       "name": "IdenticalFunctionsBlockBody",
+      "service": "web",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "LeafProviderEmpty",
       "service": "web",
       "kind": "standalone",
       "layer": "service"

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/UnnecessaryContextProviderShapes.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/UnnecessaryContextProviderShapes.tsx
@@ -1,0 +1,18 @@
+// Negative cases that the rule must still catch after the spread-attribute
+// and JSX-expression-child fixes.
+
+import { createContext } from 'react';
+
+type LeafValue = { label: string };
+const LeafCtx = createContext<LeafValue>({ label: '' });
+
+// True bug: Provider wraps a single bare host element with NO spread and
+// NO inner content — context cannot be consumed by anyone. Props would suffice.
+// VIOLATION: performance/deterministic/unnecessary-context-provider
+export function LeafProviderEmpty(): JSX.Element {
+  return (
+    <LeafCtx.Provider value={{ label: 'x' }}>
+      <span className="leaf" />
+    </LeafCtx.Provider>
+  );
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/indexed-loop-array-access-shape.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/indexed-loop-array-access-shape.ts
@@ -1,0 +1,12 @@
+// Negative case: classic `for (let i = 0; i < arr.length; i++) { arr[i] }`
+// where the index is used solely to access the array. The rule must still
+// catch this — `for...of` is the idiomatic replacement.
+
+// VIOLATION: code-quality/deterministic/indexed-loop-over-for-of
+export function sumBytes(buf: number[]): number {
+  let total = 0;
+  for (let i = 0; i < buf.length; i++) {
+    total += buf[i];
+  }
+  return total;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/redos-vulnerable-regex-nested-quantifiers.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/redos-vulnerable-regex-nested-quantifiers.ts
@@ -1,0 +1,12 @@
+// Negative cases that the rule must still catch — canonical nested
+// quantifiers on a single atom (character class, wildcard, escape).
+
+// VIOLATION: bugs/deterministic/redos-vulnerable-regex
+export function matchesNestedCharClass(input: string): boolean {
+  return /^([a-z]+)+$/.test(input);
+}
+
+// VIOLATION: bugs/deterministic/redos-vulnerable-regex
+export function matchesNestedWildcard(input: string): boolean {
+  return /^(.*)+$/.test(input);
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/regex-duplicate-char-class-unicode-escapes.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/regex-duplicate-char-class-unicode-escapes.ts
@@ -1,0 +1,14 @@
+// Negative cases that the rule must still catch after the Unicode-escape
+// parsing fix.
+
+// True duplicate of a literal character — the rule should still flag this.
+// VIOLATION: code-quality/deterministic/regex-duplicate-char-class
+export function matchesLiteralDup(input: string): boolean {
+  return /[AA]/.test(input);
+}
+
+// True duplicate of a braced \u{XXXX} escape under the `u` flag.
+// VIOLATION: code-quality/deterministic/regex-duplicate-char-class
+export function matchesBracedEscapeDup(input: string): boolean {
+  return /[\u{0041}\u{0041}]/u.test(input);
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unused-function-parameter-trailing-and-dollar.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unused-function-parameter-trailing-and-dollar.ts
@@ -1,0 +1,16 @@
+// Negative cases that the rule must still catch after the iteration-callback
+// and identifier-boundary fixes.
+
+// Standalone function (NOT an Array.prototype iteration callback) with a
+// truly-unused trailing positional parameter. The rule must still flag this.
+// VIOLATION: code-quality/deterministic/unused-function-parameter
+export function buildSlug(prefix: string, index: number): string {
+  return `slug-${prefix}`;
+}
+
+// Function with a `$`-prefixed parameter that is genuinely unused. After the
+// identifier-boundary fix the rule must still flag this case.
+// VIOLATION: code-quality/deterministic/unused-function-parameter
+export function formatTotalLabel($amount: number, suffix: string): string {
+  return `total ${suffix}`;
+}

--- a/tests/fixtures/sample-js-project-positive/services/web/src/components/UnnecessaryContextProviderShapes.tsx
+++ b/tests/fixtures/sample-js-project-positive/services/web/src/components/UnnecessaryContextProviderShapes.tsx
@@ -1,0 +1,28 @@
+// Paraphrased FP shapes for performance/deterministic/unnecessary-context-provider.
+
+import { createContext } from 'react';
+
+type StepValue = { current: number; total: number };
+const StepCtx = createContext<StepValue>({ current: 0, total: 0 });
+
+// 1. Provider wrapping a single `{expression}` JSX expression. The expression
+//    can resolve to arbitrary JSX whose entire subtree (any depth) may consume
+//    the context. The current "single child" heuristic must not flag this.
+export function StepFrame({ value, child }: { value: StepValue; child: JSX.Element }): JSX.Element {
+  return <StepCtx.Provider value={value}>{child}</StepCtx.Provider>;
+}
+
+type FormItemValue = { id: string };
+const FormItemCtx = createContext<FormItemValue>({ id: '' });
+
+// 2. Provider wrapping a single lowercase host element that forwards `{...rest}`
+//    via spread. Children passed through `rest` reach descendants of the host
+//    element, so context consumers can live anywhere in that subtree.
+type ContainerProps = { itemValue: FormItemValue } & React.HTMLAttributes<HTMLDivElement>;
+export function FormItemWrapper({ itemValue, ...rest }: ContainerProps): JSX.Element {
+  return (
+    <FormItemCtx.Provider value={itemValue}>
+      <div className="form-item" {...rest} />
+    </FormItemCtx.Provider>
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/indexed-loop-counted-loop-shape.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/indexed-loop-counted-loop-shape.ts
@@ -1,0 +1,19 @@
+// Paraphrased FP shape for code-quality/deterministic/indexed-loop-over-for-of.
+//
+// Counted loop: iterate a fixed numeric upper bound without using the loop
+// variable as an array index. The upper bound is a plain count (no array
+// is involved at all), so `for...of` is inapplicable — there's nothing to
+// iterate over.
+export function tryWindowedCounter(
+  initialNow: number,
+  window: number,
+  period: number,
+): number | null {
+  let now = initialNow;
+  for (let i = 0; i < window; i++) {
+    const counter = Math.floor(now / period);
+    if (counter < 0) return null;
+    now -= period;
+  }
+  return now;
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/redos-vulnerable-regex-bounded-shapes.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/redos-vulnerable-regex-bounded-shapes.ts
@@ -1,0 +1,12 @@
+// Paraphrased FP shape for bugs/deterministic/redos-vulnerable-regex.
+
+// Optional capture group: `(P)?` repeats at most once. Even when the inner
+// quantifier matches characters from the outer group's class, no catastrophic
+// backtracking is possible because the outer multiplier is bounded to {0,1}.
+// (The slug-style anchored-repetition FP from the upstream issue is also
+// fixed by this visitor change, but it triggers a separate `regex-empty-repetition`
+// rule that uses the same over-broad detection — that one is out of scope
+// for this fixture.)
+export function isCssDimensionLike(input: string): boolean {
+  return /^(?:0|\d+(?:\.\d+)?(?:em|rem|px|%))$/iu.test(input);
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/regex-duplicate-char-class-unicode-escapes.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/regex-duplicate-char-class-unicode-escapes.ts
@@ -1,0 +1,17 @@
+// Paraphrased FP shapes for code-quality/deterministic/regex-duplicate-char-class.
+
+// 1. Four-digit \uXXXX Unicode-escape range. The hex digits inside the two
+//    escapes (\u0300 and \u036f) define the combining-diacritical-marks
+//    range — they are NOT duplicate literal characters in the class.
+export function stripCombiningMarks(input: string): string {
+  return input.replace(/[\u0300-\u036f]/gu, '');
+}
+
+// 2. Braced \u{XXXX} Unicode-escape range inside a character class with the
+// `u` flag. Each \u{...} escape denotes a single Unicode code point; the
+// parser must not treat the hex digits or braces as separate characters.
+export const allowedExtendedCharRange = /^[a-z\u{0080}-\u{FFFF}]+$/u;
+
+// 3. \xXX hex byte escape inside a character class. \x7F is a single byte;
+// its hex digits are part of the escape, not duplicate literal characters.
+export const printableAsciiPattern = /^[\x20-\x7F]+$/u;

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/unused-function-parameter-callback-shapes.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/unused-function-parameter-callback-shapes.ts
@@ -1,0 +1,27 @@
+// Paraphrased FP shapes for code-quality/deterministic/unused-function-parameter.
+
+// 1. Array iteration callback that ignores the trailing positional `index`.
+//    `Array.prototype.map` provides the index parameter as part of its contract;
+//    consumers commonly only need the element, and renaming `index` to `_index`
+//    would falsely imply intent. Flagging this is a false positive.
+type ListItem = { id: string; label: string };
+const sourceItems: ListItem[] = [
+  { id: 'a', label: 'A' },
+  { id: 'b', label: 'B' },
+];
+export const decoratedItems = sourceItems.map((item, index) => ({
+  ...item,
+  highlighted: true,
+}));
+
+// 2. Arrow function whose only parameter is `$`-prefixed and IS used in the body.
+//    The visitor's name-boundary check must treat `$` as part of the identifier;
+//    otherwise it incorrectly reports the parameter as unused.
+export function buildWatcherAttacher(): (node: HTMLElement) => string | undefined {
+  let observedTarget: HTMLElement | null = null;
+  return ($node: HTMLElement): string | undefined => {
+    if ($node === observedTarget) return undefined;
+    observedTarget = $node;
+    return $node.tagName;
+  };
+}


### PR DESCRIPTION
Batch of 5 false-positive fixes from the documenso/documenso campaign.

Closes #174
Closes #175
Closes #176
Closes #177
Closes #178

## Fixes

| rule_key | issue | positive fixture | negative fixture |
|---|---|---|---|
| `code-quality/deterministic/unused-function-parameter` | #174 | `tests/fixtures/sample-js-project-positive/shared/utils/src/unused-function-parameter-callback-shapes.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unused-function-parameter-trailing-and-dollar.ts` |
| `code-quality/deterministic/regex-duplicate-char-class` | #175 | `tests/fixtures/sample-js-project-positive/shared/utils/src/regex-duplicate-char-class-unicode-escapes.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/regex-duplicate-char-class-unicode-escapes.ts` |
| `performance/deterministic/unnecessary-context-provider` | #176 | `tests/fixtures/sample-js-project-positive/services/web/src/components/UnnecessaryContextProviderShapes.tsx` | `tests/fixtures/sample-js-project-negative/services/web/src/components/UnnecessaryContextProviderShapes.tsx` |
| `bugs/deterministic/redos-vulnerable-regex` | #177 | `tests/fixtures/sample-js-project-positive/shared/utils/src/redos-vulnerable-regex-bounded-shapes.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/redos-vulnerable-regex-nested-quantifiers.ts` |
| `code-quality/deterministic/indexed-loop-over-for-of` | #178 | `tests/fixtures/sample-js-project-positive/shared/utils/src/indexed-loop-counted-loop-shape.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/indexed-loop-array-access-shape.ts` |

TP rate is measured against `node dist/cli.mjs` from a freshly-built `pnpm build:dist` — the exact artifact `publish.yml` ships to npm.

## code-quality/deterministic/unused-function-parameter

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/app-tests/constants/field-meta-pdf.ts#L481
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/hooks/use-field-page-coords.ts#L63

Positive fixture (`tests/fixtures/sample-js-project-positive/shared/utils/src/unused-function-parameter-callback-shapes.ts`):

```ts
// 1. Array iteration callback that ignores the trailing positional `index`.
type ListItem = { id: string; label: string };
const sourceItems: ListItem[] = [
  { id: 'a', label: 'A' },
  { id: 'b', label: 'B' },
];
export const decoratedItems = sourceItems.map((item, index) => ({
  ...item,
  highlighted: true,
}));

// 2. Arrow function whose only parameter is `$`-prefixed and IS used in body.
export function buildWatcherAttacher(): (node: HTMLElement) => string | undefined {
  let observedTarget: HTMLElement | null = null;
  return ($node: HTMLElement): string | undefined => {
    if ($node === observedTarget) return undefined;
    observedTarget = $node;
    return $node.tagName;
  };
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/unused-function-parameter-trailing-and-dollar.ts`):

```ts
// VIOLATION: code-quality/deterministic/unused-function-parameter
export function buildSlug(prefix: string, index: number): string {
  return `slug-${prefix}`;
}

// VIOLATION: code-quality/deterministic/unused-function-parameter
export function formatTotalLabel($amount: number, suffix: string): string {
  return `total ${suffix}`;
}
```

Visitor change: replaced the `\b`-based identifier lookup regex with one using JavaScript identifier boundaries (`[A-Za-z0-9_$]` negative lookbehind/lookahead) so `$`-prefixed parameters are correctly matched in the function body. Added an `isInArrayIterationCallback` check that walks up to the parent call expression; in callbacks to `Array.prototype` iteration methods (`map`, `forEach`, `filter`, `reduce`, …) the rule now skips trailing positional params (`index`, `array`) when an earlier param is used.

## code-quality/deterministic/regex-duplicate-char-class

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/team-create-dialog.tsx#L117
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/utils/zod.ts#L12

Positive fixture (`tests/fixtures/sample-js-project-positive/shared/utils/src/regex-duplicate-char-class-unicode-escapes.ts`):

```ts
// 1. Four-digit \uXXXX Unicode-escape range.
export function stripCombiningMarks(input: string): string {
  return input.replace(/[̀-ͯ]/gu, '');
}

// 2. Braced \u{XXXX} Unicode-escape range inside a character class with `u`.
export const allowedExtendedCharRange = /^[a-z\u{0080}-\u{FFFF}]+$/u;

// 3. \xXX hex byte escape inside a character class.
export const printableAsciiPattern = /^[\x20-\x7F]+$/u;
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/regex-duplicate-char-class-unicode-escapes.ts`):

```ts
// VIOLATION: code-quality/deterministic/regex-duplicate-char-class
export function matchesLiteralDup(input: string): boolean {
  return /[AA]/.test(input);
}

// VIOLATION: code-quality/deterministic/regex-duplicate-char-class
export function matchesBracedEscapeDup(input: string): boolean {
  return /[\u{0041}\u{0041}]/u.test(input);
}
```

Visitor change: replaced the inline char-class tokenizer with a function that recognises `\uXXXX`, `\u{XXXX}`, `\xXX` and `\cA` escapes as atomic tokens. Hex digits inside these escapes are no longer counted as separate characters in the duplicate-detection set.

## performance/deterministic/unnecessary-context-provider

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/stepper.tsx#L97
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/form/form.tsx#L72

Positive fixture (`tests/fixtures/sample-js-project-positive/services/web/src/components/UnnecessaryContextProviderShapes.tsx`):

```tsx
// 1. Provider wrapping a single `{expression}` JSX expression.
export function StepFrame({ value, child }: { value: StepValue; child: JSX.Element }): JSX.Element {
  return <StepCtx.Provider value={value}>{child}</StepCtx.Provider>;
}

// 2. Provider wrapping a single lowercase host element that forwards `{...rest}`.
type ContainerProps = { itemValue: FormItemValue } & React.HTMLAttributes<HTMLDivElement>;
export function FormItemWrapper({ itemValue, ...rest }: ContainerProps): JSX.Element {
  return (
    <FormItemCtx.Provider value={itemValue}>
      <div className="form-item" {...rest} />
    </FormItemCtx.Provider>
  );
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/web/src/components/UnnecessaryContextProviderShapes.tsx`):

```tsx
// VIOLATION: performance/deterministic/unnecessary-context-provider
export function LeafProviderEmpty(): JSX.Element {
  return (
    <LeafCtx.Provider value={{ label: 'x' }}>
      <span className="leaf" />
    </LeafCtx.Provider>
  );
}
```

Visitor change: broadened the "single child can hold consumers" exclusions. Any `{expression}` child is now treated as potentially resolving to arbitrary JSX, and a single host-element child with a `{...spread}` attribute is treated as forwarding children through the spread. Both shapes are skipped.

## bugs/deterministic/redos-vulnerable-regex

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/types/css-vars.ts#L9
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/team-router/schema.ts#L30

Positive fixture (`tests/fixtures/sample-js-project-positive/shared/utils/src/redos-vulnerable-regex-bounded-shapes.ts`):

```ts
// Optional capture group: `(P)?` repeats at most once.
export function isCssDimensionLike(input: string): boolean {
  return /^(?:0|\d+(?:\.\d+)?(?:em|rem|px|%))$/iu.test(input);
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/redos-vulnerable-regex-nested-quantifiers.ts`):

```ts
// VIOLATION: bugs/deterministic/redos-vulnerable-regex
export function matchesNestedCharClass(input: string): boolean {
  return /^([a-z]+)+$/.test(input);
}

// VIOLATION: bugs/deterministic/redos-vulnerable-regex
export function matchesNestedWildcard(input: string): boolean {
  return /^(.*)+$/.test(input);
}
```

Visitor change: narrowed the nested-quantifier detection regex to require a single atomic inner element (escape, wildcard, character class, or single literal) followed by `+`/`*`, wrapped in a group whose outer multiplier is `+`/`*` (not `?` or `{n,m}`). The slug-style FP from the upstream issue is also covered by this narrowing (its inner has two atoms before the quantifier, so it no longer matches). The slug FP additionally triggers a separate `regex-empty-repetition` rule that uses the same over-broad pattern detector — that one is out of scope for this PR and remains for a follow-up.

## code-quality/deterministic/indexed-loop-over-for-of

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/2fa/email/validate-2fa-token-from-email.ts#L24
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/2fa/verify-2fa-token.ts#L39

Positive fixture (`tests/fixtures/sample-js-project-positive/shared/utils/src/indexed-loop-counted-loop-shape.ts`):

```ts
export function tryWindowedCounter(
  initialNow: number,
  window: number,
  period: number,
): number | null {
  let now = initialNow;
  for (let i = 0; i < window; i++) {
    const counter = Math.floor(now / period);
    if (counter < 0) return null;
    now -= period;
  }
  return now;
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/indexed-loop-array-access-shape.ts`):

```ts
// VIOLATION: code-quality/deterministic/indexed-loop-over-for-of
export function sumBytes(buf: number[]): number {
  let total = 0;
  for (let i = 0; i < buf.length; i++) {
    total += buf[i];
  }
  return total;
}
```

Visitor change: added a `usedAsArrayIndex` flag that tracks whether the loop body actually uses the loop variable as an array subscript (`arr[i]`). The rule now only fires when the body both (a) does not use the index outside array access and (b) actually performs at least one array access. Counted loops with no array involvement (TOTP retry windows, time-step counters) are no longer flagged.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4XRiSoQUhV2WNB9Qc9VLP)_