### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/function-in-loop.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/function-in-loop.ts
@@ -1,6 +1,23 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { JS_FUNCTION_TYPES } from './_helpers.js'
+
+function loopHasFreshPerIterationBinding(loop: SyntaxNode): boolean {
+  // `for (const|let x of/in arr)` creates a fresh per-iteration binding, so a
+  // function defined in the body cannot suffer the classical
+  // capture-by-reference hazard. Classical `for (...; ...; ...)`, `while`,
+  // and `do…while` are intentionally left alone — long-lived closures
+  // captured from them are still a real concern and several existing
+  // detection tests pin that behaviour.
+  if (loop.type === 'for_in_statement' || loop.type === 'for_of_statement') {
+    for (const child of loop.children) {
+      if (child.type === 'const' || child.type === 'let') return true
+      if (child.type === 'var') return false
+    }
+  }
+  return false
+}
 
 export const functionInLoopVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/function-in-loop',
@@ -20,6 +37,14 @@ export const functionInLoopVisitor: CodeRuleVisitor = {
     let parent = node.parent
     while (parent) {
       if (LOOP_TYPES.has(parent.type)) {
+        // Modern `let`/`const` loops create a fresh per-iteration binding, so
+        // capturing the loop variable in a closure is not a shared-reference
+        // hazard. Only `var` in for-statements (or `var x of/in` head) keeps
+        // the classical capture-by-reference pitfall.
+        if (loopHasFreshPerIterationBinding(parent)) {
+          parent = parent.parent
+          continue
+        }
         return makeViolation(
           this.ruleKey, node, filePath, 'medium',
           'Function defined in loop',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/redundant-template-expression.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/redundant-template-expression.ts
@@ -6,6 +6,11 @@ export const redundantTemplateExpressionVisitor: CodeRuleVisitor = {
   languages: ['typescript', 'tsx', 'javascript'],
   nodeTypes: ['template_string'],
   visit(node, filePath, sourceCode) {
+    // Tagged templates (`tag\`${x}\``) parse as call_expression > template_string
+    // in tree-sitter-typescript; the tag function controls the return value,
+    // so the template is not a redundant string wrapper.
+    if (node.parent?.type === 'call_expression') return null
+
     const children = node.children
     const namedChildren = node.namedChildren
     if (namedChildren.length !== 1) return null

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-empty-group.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-empty-group.ts
@@ -2,6 +2,36 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { getRegexSource } from './_helpers.js'
 
+function hasEmptyGroupOutsideCharClass(src: string): boolean {
+  let inCharClass = false
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i]
+    if (ch === '\\') {
+      i++ // skip the next char (it's an escape)
+      continue
+    }
+    if (inCharClass) {
+      if (ch === ']') inCharClass = false
+      continue
+    }
+    if (ch === '[') {
+      inCharClass = true
+      continue
+    }
+    if (ch === '(') {
+      // Skip lookaround/non-capturing prefixes: (?= (?! (?<= (?<! (?: (?<name>
+      let j = i + 1
+      if (src[j] === '?') {
+        // Treat any `(?` group as non-empty for the purpose of this rule;
+        // empty `()` literally requires the immediate `()` pair.
+        continue
+      }
+      if (src[j] === ')') return true
+    }
+  }
+  return false
+}
+
 export const regexEmptyGroupVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/regex-empty-group',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -10,7 +40,7 @@ export const regexEmptyGroupVisitor: CodeRuleVisitor = {
     const src = getRegexSource(node)
     if (!src) return null
 
-    if (/(?<!\?[=!<])\(\)/.test(src)) {
+    if (hasEmptyGroupOutsideCharClass(src)) {
       return makeViolation(
         this.ruleKey, node, filePath, 'low',
         'Empty regex group',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/required-type-annotations.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/required-type-annotations.ts
@@ -42,6 +42,10 @@ function checkFunctionDeclaration(
     // const fn = (...) => {} or const fn = function() {}
     const declarator = decl.namedChildren.find((c) => c.type === 'variable_declarator')
     if (!declarator) return null
+    // If the variable itself is typed (`const fn: SomeFunctionType = ...`),
+    // TypeScript infers each parameter's type from the contextual function
+    // type, so per-parameter annotations are redundant.
+    if (declarator.childForFieldName('type')) return null
     const value = declarator.childForFieldName('value')
     if (value && (value.type === 'arrow_function' || value.type === 'function_expression' || value.type === 'function')) {
       fnNode = value

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/unsafe-json-parse.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/unsafe-json-parse.ts
@@ -15,6 +15,20 @@ export const unsafeJsonParseVisitor: CodeRuleVisitor = {
     const prop = fn.childForFieldName('property')
     if (obj?.text !== 'JSON' || prop?.text !== 'parse') return null
 
+    // `JSON.parse(JSON.stringify(x))` is the structured-clone idiom — the
+    // input is guaranteed valid JSON because it was just produced by
+    // JSON.stringify, so no try/catch is needed.
+    const args = node.childForFieldName('arguments')
+    const firstArg = args?.namedChildren[0]
+    if (firstArg?.type === 'call_expression') {
+      const innerFn = firstArg.childForFieldName('function')
+      if (innerFn?.type === 'member_expression') {
+        const innerObj = innerFn.childForFieldName('object')
+        const innerProp = innerFn.childForFieldName('property')
+        if (innerObj?.text === 'JSON' && innerProp?.text === 'stringify') return null
+      }
+    }
+
     if (isInsideTryCatch(node)) return null
 
     return makeViolation(

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -685,6 +685,12 @@
       "layer": "service"
     },
     {
+      "name": "function-in-loop-var-binding",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "http-call-no-timeout-external",
       "service": "utils",
       "kind": "standalone",
@@ -793,6 +799,12 @@
       "layer": "service"
     },
     {
+      "name": "redundant-template-expression-bare",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "regex-bugs",
       "service": "utils",
       "kind": "standalone",
@@ -805,7 +817,19 @@
       "layer": "service"
     },
     {
+      "name": "regex-empty-group-bare",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "remaining-bugs",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "required-type-annotations-bare-arrow",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"
@@ -898,6 +922,12 @@
       "name": "UnreadAttribute",
       "service": "utils",
       "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "unsafe-json-parse-untrusted",
+      "service": "utils",
+      "kind": "standalone",
       "layer": "service"
     },
     {

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/function-in-loop-var-binding.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/function-in-loop-var-binding.ts
@@ -1,0 +1,25 @@
+// Negative cases: classical `var` loop bindings and a `while` loop both
+// carry the capture-by-reference hazard — a function defined inside must
+// still be flagged.
+
+export function makeVarOfHandlers(items: readonly string[]): Array<() => string> {
+  const out: Array<() => string> = [];
+  for (var item of items) {
+    // VIOLATION: code-quality/deterministic/function-in-loop
+    const handler = function (): string { return item; };
+    out.push(handler);
+  }
+  return out;
+}
+
+export function makeWhileHandlers(limit: number): Array<() => number> {
+  const out: Array<() => number> = [];
+  let counter = 0;
+  while (counter < limit) {
+    // VIOLATION: code-quality/deterministic/function-in-loop
+    const handler = function (): number { return counter; };
+    out.push(handler);
+    counter = counter + 1;
+  }
+  return out;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-template-expression-bare.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-template-expression-bare.ts
@@ -1,0 +1,12 @@
+// Negative cases that the rule must still catch — bare template literals
+// that wrap a single substitution with no surrounding text.
+
+// VIOLATION: code-quality/deterministic/redundant-template-expression
+export function formatLabel(label: string): string {
+  return `${label}`;
+}
+
+// VIOLATION: code-quality/deterministic/redundant-template-expression
+export function formatTag(tag: string): string {
+  return `${tag}`;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/regex-empty-group-bare.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/regex-empty-group-bare.ts
@@ -1,0 +1,16 @@
+// Negative cases: a true empty capture group `()` outside of any character
+// class — matches the empty string and is almost always a mistake.
+
+// VIOLATION: code-quality/deterministic/regex-empty-group
+const emptyGroupAlpha = /foo()bar/;
+
+// VIOLATION: code-quality/deterministic/regex-empty-group
+const emptyGroupAtEnd = /^abc()/;
+
+export function probeEmptyAlpha(value: string): boolean {
+  return emptyGroupAlpha.test(value);
+}
+
+export function probeEmptyAtEnd(value: string): boolean {
+  return emptyGroupAtEnd.test(value);
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/required-type-annotations-bare-arrow.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/required-type-annotations-bare-arrow.ts
@@ -1,0 +1,12 @@
+// Negative case: a plain exported arrow function with no variable-level type
+// annotation should still require explicit parameter types.
+
+// VIOLATION: code-quality/deterministic/required-type-annotations
+export const combineValues = (left, right: number): number => {
+  return Number(left) + right;
+};
+
+// VIOLATION: code-quality/deterministic/required-type-annotations
+export const sumPair = (first, second: number): number => {
+  return Number(first) + second;
+};

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unsafe-json-parse-untrusted.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unsafe-json-parse-untrusted.ts
@@ -1,0 +1,13 @@
+// Negative cases: JSON.parse called on untrusted/unvalidated input outside
+// of any try/catch — input may not be valid JSON and the call can throw.
+
+export function readSessionPayload(raw: string): unknown {
+  // VIOLATION: reliability/deterministic/unsafe-json-parse
+  return JSON.parse(raw);
+}
+
+export function decodeStorageEntry(stored: string | null): unknown {
+  if (stored === null) return null;
+  // VIOLATION: reliability/deterministic/unsafe-json-parse
+  return JSON.parse(stored);
+}

--- a/tests/fixtures/sample-js-project-positive/src/function-in-loop-fresh-binding.ts
+++ b/tests/fixtures/sample-js-project-positive/src/function-in-loop-fresh-binding.ts
@@ -1,0 +1,31 @@
+/**
+ * Positive fixture for code-quality/deterministic/function-in-loop.
+ *
+ * `for (const x of arr)` and `for (let x of arr)` create a fresh
+ * per-iteration binding, so a closure defined inside the loop body does NOT
+ * carry the capture-by-reference hazard. The visitor should not flag
+ * function-in-loop for these `for…of` / `for…in` forms with `const`/`let`.
+ */
+
+interface ItemRecord {
+  readonly id: string;
+  readonly title: string;
+}
+
+export function buildIdFormatters(items: readonly ItemRecord[]): string[] {
+  const results: string[] = [];
+  for (const item of items) {
+    const formatId = (): string => `id:${item.id}`;
+    results.push(formatId());
+  }
+  return results;
+}
+
+export function buildTitleFormatters(items: readonly ItemRecord[]): string[] {
+  const results: string[] = [];
+  for (let item of items) {
+    const formatTitle = (): string => `t:${item.title}`;
+    results.push(formatTitle());
+  }
+  return results;
+}

--- a/tests/fixtures/sample-js-project-positive/src/redundant-template-expression-tagged.ts
+++ b/tests/fixtures/sample-js-project-positive/src/redundant-template-expression-tagged.ts
@@ -1,0 +1,26 @@
+/**
+ * Positive fixture for code-quality/deterministic/redundant-template-expression.
+ *
+ * A tagged template like `tag\`${value}\`` is NOT a redundant string template.
+ * The tag function receives the template parts and substitutions and returns
+ * whatever it wants (e.g. a structured descriptor object), so the wrapper
+ * cannot be replaced with the bare expression. The visitor must not fire
+ * when the template_string sits directly under a tagged call_expression.
+ */
+
+interface LocalizedDescriptor {
+  parts: readonly string[];
+  values: readonly unknown[];
+}
+
+function describe(strings: TemplateStringsArray, ...values: readonly unknown[]): LocalizedDescriptor {
+  return { parts: Array.from(strings), values };
+}
+
+export function describeAgent(agent: string): LocalizedDescriptor {
+  return describe`${agent}`;
+}
+
+export function describeSelection(label: string): LocalizedDescriptor {
+  return describe`${label}`;
+}

--- a/tests/fixtures/sample-js-project-positive/src/regex-empty-group-char-class.ts
+++ b/tests/fixtures/sample-js-project-positive/src/regex-empty-group-char-class.ts
@@ -1,0 +1,25 @@
+/**
+ * Positive fixture for code-quality/deterministic/regex-empty-group.
+ *
+ * `()` appearing inside a character class `[...]` is literal `(` and `)` — it
+ * does NOT create an empty capture group. The visitor must scan the regex
+ * source while tracking whether the cursor is inside a character class.
+ *
+ * Built dynamically via `new RegExp` so unrelated regex-literal rules
+ * (unnamed-regex-capture, require-unicode-regexp) are not engaged.
+ */
+
+function makeCharClassMatcher(extra: string): RegExp {
+  return new RegExp(`[!@#$%^&*()${extra}]`, 'u');
+}
+
+const specialChars = makeCharClassMatcher('_+=-');
+const punctuationOrParen = makeCharClassMatcher('.,;:?');
+
+export function hasSpecial(value: string): boolean {
+  return specialChars.test(value);
+}
+
+export function hasPunctuation(value: string): boolean {
+  return punctuationOrParen.test(value);
+}

--- a/tests/fixtures/sample-js-project-positive/src/required-type-annotations-typed-declarator.ts
+++ b/tests/fixtures/sample-js-project-positive/src/required-type-annotations-typed-declarator.ts
@@ -1,0 +1,27 @@
+/**
+ * Positive fixture for code-quality/deterministic/required-type-annotations.
+ *
+ * `export const fn: SomeFunctionType = (a, b) => …` types the variable as a
+ * function type. TypeScript infers each parameter's type from the contextual
+ * function type, so per-parameter annotations are redundant. The visitor must
+ * not flag parameters when the variable declarator itself carries a type
+ * annotation.
+ */
+
+type LoaderFn<T> = (input: { id: string }, init?: { status?: number }) => T;
+
+interface ItemProps {
+  readonly title: string;
+  readonly subtitle: string;
+}
+
+type ItemComponent = (props: ItemProps) => string;
+
+export const loadItem: LoaderFn<{ status: string }> = (input, init = {}) => {
+  const status = init.status ? String(init.status) : input.id;
+  return { status };
+};
+
+export const renderItem: ItemComponent = ({ title, subtitle }) => {
+  return title + subtitle;
+};

--- a/tests/fixtures/sample-js-project-positive/src/unsafe-json-parse-structured-clone.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unsafe-json-parse-structured-clone.ts
@@ -1,0 +1,16 @@
+/**
+ * Positive fixture for reliability/deterministic/unsafe-json-parse.
+ *
+ * `JSON.parse(JSON.stringify(value))` is the canonical structured-clone
+ * idiom — the input is guaranteed to be valid JSON because it was just
+ * produced by JSON.stringify of an in-memory value, so the parse cannot
+ * throw and no try/catch is necessary.
+ */
+
+export function cloneAny(value: unknown): unknown {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function cloneAndDescribe(value: unknown, label: string): unknown {
+  return [label, JSON.parse(JSON.stringify(value))];
+}


### PR DESCRIPTION
Closes #179
Closes #180
Closes #181
Closes #182
Closes #183

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
| --- | --- | --- | --- |
| `code-quality/deterministic/redundant-template-expression` | #179 | `tests/fixtures/sample-js-project-positive/src/redundant-template-expression-tagged.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-template-expression-bare.ts` |
| `code-quality/deterministic/required-type-annotations` | #180 | `tests/fixtures/sample-js-project-positive/src/required-type-annotations-typed-declarator.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/required-type-annotations-bare-arrow.ts` |
| `reliability/deterministic/unsafe-json-parse` | #181 | `tests/fixtures/sample-js-project-positive/src/unsafe-json-parse-structured-clone.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unsafe-json-parse-untrusted.ts` |
| `code-quality/deterministic/regex-empty-group` | #182 | `tests/fixtures/sample-js-project-positive/src/regex-empty-group-char-class.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/regex-empty-group-bare.ts` |
| `code-quality/deterministic/function-in-loop` | #183 | `tests/fixtures/sample-js-project-positive/src/function-in-loop-fresh-binding.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/function-in-loop-var-binding.ts` |

## code-quality/deterministic/redundant-template-expression

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/tables/internal-audit-log-table.tsx#L57
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/pdf/render-audit-logs.ts#L725

Positive fixture (`tests/fixtures/sample-js-project-positive/src/redundant-template-expression-tagged.ts`):

```ts
interface LocalizedDescriptor {
  parts: readonly string[];
  values: readonly unknown[];
}

function describe(strings: TemplateStringsArray, ...values: readonly unknown[]): LocalizedDescriptor {
  return { parts: Array.from(strings), values };
}

export function describeAgent(agent: string): LocalizedDescriptor {
  return describe`${agent}`;
}

export function describeSelection(label: string): LocalizedDescriptor {
  return describe`${label}`;
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-template-expression-bare.ts`):

```ts
// VIOLATION: code-quality/deterministic/redundant-template-expression
export function formatLabel(label: string): string {
  return `${label}`;
}

// VIOLATION: code-quality/deterministic/redundant-template-expression
export function formatTag(tag: string): string {
  return `${tag}`;
}
```

Visitor change: in tree-sitter-typescript a tagged template `` tag`${x}` `` parses as `call_expression > template_string` (no `arguments` wrapper, distinguishing it from `f(\`${x}\`)`). The visitor now bails out when `node.parent?.type === 'call_expression'` so the tag function's return type — which is not necessarily a string — is respected.

## code-quality/deterministic/required-type-annotations

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/stepper.tsx#L25
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/utils/super-json-loader.ts#L29

Positive fixture (`tests/fixtures/sample-js-project-positive/src/required-type-annotations-typed-declarator.ts`):

```ts
type LoaderFn<T> = (input: { id: string }, init?: { status?: number }) => T;

interface ItemProps {
  readonly title: string;
  readonly subtitle: string;
}

type ItemComponent = (props: ItemProps) => string;

export const loadItem: LoaderFn<{ status: string }> = (input, init = {}) => {
  const status = init.status ? String(init.status) : input.id;
  return { status };
};

export const renderItem: ItemComponent = ({ title, subtitle }) => {
  return title + subtitle;
};
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/required-type-annotations-bare-arrow.ts`):

```ts
// VIOLATION: code-quality/deterministic/required-type-annotations
export const combineValues = (left, right: number): number => {
  return Number(left) + right;
};

// VIOLATION: code-quality/deterministic/required-type-annotations
export const sumPair = (first, second: number): number => {
  return Number(first) + second;
};
```

Visitor change: when checking an exported `lexical_declaration`, look up the `variable_declarator`'s `type` field and bail out if it is set. With `const fn: SomeFunctionType = (a, b) => …` TypeScript supplies parameter types from the contextual function type, so flagging the parameters is noise.

## reliability/deterministic/unsafe-json-parse

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/multiselect.tsx#L111

Positive fixture (`tests/fixtures/sample-js-project-positive/src/unsafe-json-parse-structured-clone.ts`):

```ts
export function cloneAny(value: unknown): unknown {
  return JSON.parse(JSON.stringify(value));
}

export function cloneAndDescribe(value: unknown, label: string): unknown {
  return [label, JSON.parse(JSON.stringify(value))];
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/unsafe-json-parse-untrusted.ts`):

```ts
export function readSessionPayload(raw: string): unknown {
  // VIOLATION: reliability/deterministic/unsafe-json-parse
  return JSON.parse(raw);
}

export function decodeStorageEntry(stored: string | null): unknown {
  if (stored === null) return null;
  // VIOLATION: reliability/deterministic/unsafe-json-parse
  return JSON.parse(stored);
}
```

Visitor change: before flagging a `JSON.parse(…)` call outside a try/catch, inspect the first argument. If it is itself a `JSON.stringify(…)` call (the standard structured-clone idiom), the input is guaranteed to be valid JSON because it was just produced by `JSON.stringify`, so no try/catch is necessary.

## code-quality/deterministic/regex-empty-group

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/auth-router/schema.ts#L18
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/auth/server/types/email-password.ts#L31

Positive fixture (`tests/fixtures/sample-js-project-positive/src/regex-empty-group-char-class.ts`):

```ts
function makeCharClassMatcher(extra: string): RegExp {
  return new RegExp(`[!@#$%^&*()${extra}]`, 'u');
}

const specialChars = makeCharClassMatcher('_+=-');
const punctuationOrParen = makeCharClassMatcher('.,;:?');

export function hasSpecial(value: string): boolean {
  return specialChars.test(value);
}

export function hasPunctuation(value: string): boolean {
  return punctuationOrParen.test(value);
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/regex-empty-group-bare.ts`):

```ts
// VIOLATION: code-quality/deterministic/regex-empty-group
const emptyGroupAlpha = /foo()bar/;

// VIOLATION: code-quality/deterministic/regex-empty-group
const emptyGroupAtEnd = /^abc()/;
```

Visitor change: replaced the unconditional `/(?<!\?[=!<])\(\)/` substring check with a character-by-character scan that honours character-class boundaries (`[` / `]`) and escapes (`\\`). Empty groups are only reported when the `()` pair lives outside any `[...]` and is not part of a `(?…)` lookaround/non-capturing prefix.

## code-quality/deterministic/function-in-loop

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/seal-document.handler.ts#L226
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/seal-document.handler.ts#L234

Positive fixture (`tests/fixtures/sample-js-project-positive/src/function-in-loop-fresh-binding.ts`):

```ts
interface ItemRecord {
  readonly id: string;
  readonly title: string;
}

export function buildIdFormatters(items: readonly ItemRecord[]): string[] {
  const results: string[] = [];
  for (const item of items) {
    const formatId = (): string => `id:${item.id}`;
    results.push(formatId());
  }
  return results;
}

export function buildTitleFormatters(items: readonly ItemRecord[]): string[] {
  const results: string[] = [];
  for (let item of items) {
    const formatTitle = (): string => `t:${item.title}`;
    results.push(formatTitle());
  }
  return results;
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/function-in-loop-var-binding.ts`):

```ts
export function makeVarOfHandlers(items: readonly string[]): Array<() => string> {
  const out: Array<() => string> = [];
  for (var item of items) {
    // VIOLATION: code-quality/deterministic/function-in-loop
    const handler = function (): string { return item; };
    out.push(handler);
  }
  return out;
}

export function makeWhileHandlers(limit: number): Array<() => number> {
  const out: Array<() => number> = [];
  let counter = 0;
  while (counter < limit) {
    // VIOLATION: code-quality/deterministic/function-in-loop
    const handler = function (): number { return counter; };
    out.push(handler);
    counter = counter + 1;
  }
  return out;
}
```

Visitor change: added a `loopHasFreshPerIterationBinding` helper that recognises `for (const|let x of/in arr)` (tree-sitter exposes both as `for_in_statement`/`for_of_statement` with a leading `const`/`let` keyword child). Those loops give each iteration its own binding, so closures captured in the body do not share state. Classical `for (…; …; …)`, `while`, `do…while`, and any `var` head still trip the rule.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDkwiSsxBnvQKQF5TanF1M)_