### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/missing-super-call.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/missing-super-call.ts
@@ -8,9 +8,19 @@ export const missingSuperCallVisitor: CodeRuleVisitor = {
   languages: JS_LANGUAGES,
   nodeTypes: ['class_declaration', 'class'],
   visit(node, filePath, sourceCode) {
-    // Check if this class has an extends clause
+    // The rule only applies to *derived* classes — those with an `extends`
+    // clause. TypeScript `class_heritage` also covers `implements`, which
+    // does not require (and cannot use) a super() call.
     const heritage = node.childForFieldName('heritage') || node.children.find((c) => c.type === 'class_heritage')
     if (!heritage) return null
+    const hasExtends = heritage.type === 'extends_clause'
+      || heritage.namedChildren.some((c) => c.type === 'extends_clause')
+      // tree-sitter for JavaScript marks the `extends` keyword directly on
+      // class_heritage children (no extends_clause node), so fall back to a
+      // text check for that variant.
+      || (heritage.type !== 'class_heritage' && /^extends\b/.test(heritage.text))
+      || heritage.children.some((c) => c.text === 'extends')
+    if (!hasExtends) return null
 
     const body = node.childForFieldName('body')
     if (!body) return null

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/this-before-super.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/this-before-super.ts
@@ -8,8 +8,16 @@ export const thisBeforeSuperVisitor: CodeRuleVisitor = {
   languages: JS_LANGUAGES,
   nodeTypes: ['class_declaration', 'class'],
   visit(node, filePath, sourceCode) {
+    // Only derived classes (those with an `extends` clause) can have a
+    // this-before-super bug. TypeScript groups `implements` under
+    // class_heritage too, but `implements` doesn't bring a super constructor.
     const heritage = node.childForFieldName('heritage') || node.children.find((c) => c.type === 'class_heritage')
     if (!heritage) return null
+    const hasExtends = heritage.type === 'extends_clause'
+      || heritage.namedChildren.some((c) => c.type === 'extends_clause')
+      || (heritage.type !== 'class_heritage' && /^extends\b/.test(heritage.text))
+      || heritage.children.some((c) => c.text === 'extends')
+    if (!hasExtends) return null
 
     const body = node.childForFieldName('body')
     if (!body) return null

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-anchor-precedence.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-anchor-precedence.ts
@@ -2,6 +2,62 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { getRegexSource } from './_helpers.js'
 
+/**
+ * Split `src` into its top-level alternatives. Returns null when there is no
+ * top-level `|` (so the regex has no alternation that needs anchor analysis).
+ *
+ * Tracks character classes (`[...]`) and groups (`(...)`) so `|` characters
+ * that live inside them are not mistaken for alternation. Also honors
+ * backslash escapes.
+ */
+function splitTopLevelAlternatives(src: string): string[] | null {
+  const alts: string[] = []
+  let current = ''
+  let depth = 0
+  let inCharClass = false
+  let escape = false
+  for (const ch of src) {
+    if (escape) {
+      current += ch
+      escape = false
+      continue
+    }
+    if (ch === '\\') {
+      current += ch
+      escape = true
+      continue
+    }
+    if (inCharClass) {
+      current += ch
+      if (ch === ']') inCharClass = false
+      continue
+    }
+    if (ch === '[') {
+      inCharClass = true
+      current += ch
+      continue
+    }
+    if (ch === '(') {
+      depth++
+      current += ch
+      continue
+    }
+    if (ch === ')') {
+      depth--
+      current += ch
+      continue
+    }
+    if (ch === '|' && depth === 0) {
+      alts.push(current)
+      current = ''
+      continue
+    }
+    current += ch
+  }
+  alts.push(current)
+  return alts.length > 1 ? alts : null
+}
+
 export const regexAnchorPrecedenceVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/regex-anchor-precedence',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -10,28 +66,27 @@ export const regexAnchorPrecedenceVisitor: CodeRuleVisitor = {
     const src = getRegexSource(node)
     if (!src) return null
 
-    if (/\|/.test(src)) {
-      const hasStartAnchorWithoutGroup = /^\^[^(]/.test(src) && /\|/.test(src)
-      const hasEndAnchorWithoutGroup = /[^)]\$$/.test(src) && /\|/.test(src)
-      const topLevelHasAlternation = (() => {
-        let depth = 0
-        for (const ch of src) {
-          if (ch === '(') depth++
-          else if (ch === ')') depth--
-          else if (ch === '|' && depth === 0) return true
-        }
-        return false
-      })()
+    const alternatives = splitTopLevelAlternatives(src)
+    if (!alternatives) return null
 
-      if (topLevelHasAlternation && (hasStartAnchorWithoutGroup || hasEndAnchorWithoutGroup)) {
-        return makeViolation(
-          this.ruleKey, node, filePath, 'low',
-          'Regex anchor precedence issue',
-          '`^` or `$` anchor in regex alternation only anchors one alternative. Wrap in a group: `^(foo|bar)$`.',
-          sourceCode,
-          'Wrap the alternation in a group: `^(a|b)$` instead of `^a|b$`.',
-        )
-      }
+    // The bug only exists when *some* alternatives are anchored and others
+    // aren't: `^a|b` matches `^a` OR just `b`. If every alternative is
+    // start- or end-anchored consistently the operator-precedence concern
+    // does not apply.
+    const startAnchored = alternatives.map((a) => /^\^/.test(a))
+    const endAnchored = alternatives.map((a) => /(?<!\\)\$$/.test(a))
+
+    const inconsistentStart = startAnchored.some(Boolean) && !startAnchored.every(Boolean)
+    const inconsistentEnd = endAnchored.some(Boolean) && !endAnchored.every(Boolean)
+
+    if (inconsistentStart || inconsistentEnd) {
+      return makeViolation(
+        this.ruleKey, node, filePath, 'low',
+        'Regex anchor precedence issue',
+        '`^` or `$` anchor in regex alternation only anchors one alternative. Wrap in a group: `^(foo|bar)$`.',
+        sourceCode,
+        'Wrap the alternation in a group: `^(a|b)$` instead of `^a|b$`.',
+      )
     }
     return null
   },

--- a/packages/analyzer/src/rules/database/visitors/javascript/missing-unique-constraint.ts
+++ b/packages/analyzer/src/rules/database/visitors/javascript/missing-unique-constraint.ts
@@ -2,11 +2,19 @@ import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import type { SchemaIndex } from '../../../../services/schema-index.js'
 import { makeViolation } from '../../../types.js'
-import { getMethodName, ORM_WRITE_METHODS, getEnclosingFunctionBody } from './_helpers.js'
+import { getMethodName, getEnclosingFunctionBody } from './_helpers.js'
 
 const FIND_ONE_METHODS = new Set([
   'findOne', 'findUnique', 'findFirst', 'findByPk', 'findBy',
   'exists', 'count',
+])
+
+// Only methods that *insert new rows* can introduce duplicates a UNIQUE
+// constraint would defend against. `update`/`delete`/`updateMany`/`deleteMany`
+// do not race-create rows, so check-then-update or check-then-delete is not
+// the pattern this rule targets.
+const INSERT_WRITE_METHODS = new Set([
+  'create', 'insert', 'upsert', 'createMany', 'bulkCreate', 'save',
 ])
 
 /**
@@ -66,6 +74,54 @@ function extractTableFromCallee(callNode: SyntaxNode): string | null {
   return tableProp.text || null
 }
 
+/**
+ * Extract the target table of an insert-style write call. Handles both:
+ *  - Prisma/Sequelize: `prisma.users.create(...)` → `users` (via callee chain)
+ *  - Drizzle:          `db.insert(users).values(...)` → `users` (first arg)
+ *
+ * Returns null when the table can't be determined (caller decides how lenient
+ * to be).
+ */
+function extractWriteTable(callNode: SyntaxNode, methodName: string): string | null {
+  const fromCallee = extractTableFromCallee(callNode)
+  if (fromCallee) return fromCallee
+  if (methodName === 'insert') {
+    const args = callNode.childForFieldName('arguments')
+    if (args) {
+      for (let i = 0; i < args.namedChildCount; i++) {
+        const c = args.namedChild(i)
+        if (c?.type === 'identifier') return c.text
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Walk `body` looking for at least one insert-style call whose target table
+ * matches `findTable` (if known). When the write's table can't be resolved we
+ * accept the match — false negatives are preferable to false positives.
+ */
+function bodyHasMatchingInsert(body: SyntaxNode, findTable: string | null): boolean {
+  const stack: SyntaxNode[] = [body]
+  while (stack.length > 0) {
+    const n = stack.pop()!
+    if (n.type === 'call_expression') {
+      const m = getMethodName(n)
+      if (INSERT_WRITE_METHODS.has(m)) {
+        if (!findTable) return true
+        const writeTable = extractWriteTable(n, m)
+        if (!writeTable || writeTable === findTable) return true
+      }
+    }
+    for (let i = 0; i < n.childCount; i++) {
+      const c = n.child(i)
+      if (c) stack.push(c)
+    }
+  }
+  return false
+}
+
 export const missingUniqueConstraintVisitor: CodeRuleVisitor = {
   ruleKey: 'database/deterministic/missing-unique-constraint',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -101,12 +157,6 @@ export const missingUniqueConstraintVisitor: CodeRuleVisitor = {
     const body = getEnclosingFunctionBody(node)
     if (!body) return null
 
-    const bodyText = body.text
-    const ormWriteArr = Array.from(ORM_WRITE_METHODS)
-    const hasWriteAfterCheck = ormWriteArr.some((m) => bodyText.includes(`.${m}(`))
-
-    if (!hasWriteAfterCheck) return null
-
     // Extract what column is being queried.
     const queried = extractQueriedColumn(node)
     if (!queried) return null
@@ -114,6 +164,12 @@ export const missingUniqueConstraintVisitor: CodeRuleVisitor = {
     const column = queried.column
     // Drizzle gives us the table directly; Prisma needs walking the callee chain
     const table = queried.table ?? extractTableFromCallee(node)
+
+    // Only fire when the enclosing function actually inserts new rows into the
+    // same table as the find. A check-then-update / check-then-delete on the
+    // same column, or a find on one table paired with a create on a different
+    // table, are not race-prone uniqueness patterns.
+    if (!bodyHasMatchingInsert(body, table)) return null
 
     // Skip queries on primary-key-shaped columns. We still try the schema index
     // first below, but this is a fast path for the common `id`/`_id`/`pk` case

--- a/packages/analyzer/src/rules/security/visitors/javascript/os-command-injection.ts
+++ b/packages/analyzer/src/rules/security/visitors/javascript/os-command-injection.ts
@@ -1,8 +1,53 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
 export const EXEC_METHODS = new Set(['exec', 'execSync'])
 const SPAWN_METHODS = new Set(['spawn', 'spawnSync'])
+
+const CHILD_PROCESS_SOURCES = new Set(['child_process', 'node:child_process'])
+
+/**
+ * For bare-identifier calls like `exec(...)`, confirm the identifier resolves
+ * to a `child_process` binding before flagging — otherwise we false-positive
+ * on locally-defined helpers that happen to be named `exec`/`execSync` (a
+ * common pattern: `const exec = async () => {...}; void exec();`).
+ */
+function isImportedFromChildProcess(callNode: SyntaxNode, name: string): boolean {
+  let root: SyntaxNode = callNode
+  while (root.parent) root = root.parent
+
+  for (const child of root.namedChildren) {
+    if (child.type === 'import_statement') {
+      const source = child.namedChildren.find((c) => c.type === 'string')
+      if (!source) continue
+      const raw = source.text.replace(/^['"`]|['"`]$/g, '')
+      if (!CHILD_PROCESS_SOURCES.has(raw)) continue
+      const importClause = child.namedChildren.find((c) => c.type === 'import_clause')
+      if (!importClause) continue
+      for (const sub of importClause.namedChildren) {
+        if (sub.type === 'named_imports') {
+          for (const spec of sub.namedChildren) {
+            if (spec.type !== 'import_specifier') continue
+            const alias = spec.childForFieldName('alias')
+            const local = (alias ?? spec.childForFieldName('name'))?.text
+            if (local === name) return true
+          }
+        }
+      }
+    } else if (child.type === 'lexical_declaration' || child.type === 'variable_declaration') {
+      // CommonJS: `const { exec } = require('child_process')` /
+      // `const { execSync: foo } = require('node:child_process')`.
+      const text = child.text
+      if (!/require\s*\(\s*['"](?:node:)?child_process['"]\s*\)/.test(text)) continue
+      const destructured = new RegExp(
+        `[{,]\\s*(?:[A-Za-z_$][\\w$]*\\s*:\\s*)?${name}\\b`,
+      )
+      if (destructured.test(text)) return true
+    }
+  }
+  return false
+}
 
 export const osCommandInjectionVisitor: CodeRuleVisitor = {
   ruleKey: 'security/deterministic/os-command-injection',
@@ -30,6 +75,12 @@ export const osCommandInjectionVisitor: CodeRuleVisitor = {
       if (fn.type === 'member_expression') {
         const CP_OBJECTS = new Set(['child_process', 'cp', 'childProcess', 'proc'])
         if (!CP_OBJECTS.has(objectName)) return null
+      } else if (fn.type === 'identifier' && methodName === 'exec') {
+        // Bare-identifier `exec(...)`: the name is commonly reused for local
+        // async helpers (`const exec = async () => {...}; exec();`), so require
+        // evidence it was actually imported from `child_process`. `execSync`
+        // is rarely shadowed, so we leave that case as-is.
+        if (!isImportedFromChildProcess(node, methodName)) return null
       }
       return makeViolation(
         this.ruleKey, node, filePath, 'critical',

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -313,6 +313,12 @@
       "layer": "data"
     },
     {
+      "name": "Animal",
+      "service": "user-service",
+      "kind": "class",
+      "layer": "data"
+    },
+    {
       "name": "array-bugs",
       "service": "user-service",
       "kind": "standalone",
@@ -338,6 +344,12 @@
     },
     {
       "name": "BadConstructor",
+      "service": "user-service",
+      "kind": "class",
+      "layer": "data"
+    },
+    {
+      "name": "Base",
       "service": "user-service",
       "kind": "class",
       "layer": "data"
@@ -379,9 +391,21 @@
       "layer": "data"
     },
     {
+      "name": "createPostIfAuthorMissing",
+      "service": "user-service",
+      "kind": "standalone",
+      "layer": "data"
+    },
+    {
       "name": "createWidgetWithAudit",
       "service": "user-service",
       "kind": "standalone",
+      "layer": "data"
+    },
+    {
+      "name": "Dog",
+      "service": "user-service",
+      "kind": "class",
       "layer": "data"
     },
     {
@@ -439,6 +463,12 @@
       "layer": "data"
     },
     {
+      "name": "runLs",
+      "service": "user-service",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "scope-bugs",
       "service": "user-service",
       "kind": "standalone",
@@ -461,6 +491,12 @@
       "service": "user-service",
       "kind": "standalone",
       "layer": "api"
+    },
+    {
+      "name": "Subject",
+      "service": "user-service",
+      "kind": "class",
+      "layer": "data"
     },
     {
       "name": "TokenService",

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/db/missing-unique-constraint-author-row.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/db/missing-unique-constraint-author-row.ts
@@ -1,0 +1,19 @@
+// Fresh negative case: classic check-then-insert race on a non-unique
+// scoping column (`post.authorId` is NOT @unique in schema.prisma). The
+// `findFirst` is inside the if condition and the body inserts into the
+// same table with the same column, so a UNIQUE constraint really is the
+// fix.
+
+declare const prisma: {
+  post: {
+    findFirst: (o: { where: { authorId: string } }) => Promise<{ id: string } | null>;
+    create: (o: { data: { authorId: string; title: string } }) => Promise<{ id: string }>;
+  };
+};
+
+// VIOLATION: database/deterministic/missing-unique-constraint
+export async function createPostIfAuthorMissing(authorId: string, title: string) {
+  if (!(await prisma.post.findFirst({ where: { authorId } }))) {
+    await prisma.post.create({ data: { authorId, title } });
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/models/missing-super-call-extends-with-implements.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/models/missing-super-call-extends-with-implements.ts
@@ -1,0 +1,28 @@
+// Fresh negative case: a derived class that ALSO `implements` an interface,
+// whose constructor uses `this` before calling super(). The presence of an
+// `implements` clause must not mask the missing super() call when the class
+// also extends a base.
+
+class Base {
+  public id: string;
+  constructor(id: string) {
+    this.id = id;
+  }
+}
+
+interface Tagged {
+  tag: string;
+}
+
+// VIOLATION: bugs/deterministic/missing-super-call
+export class Subject extends Base implements Tagged {
+  public tag: string;
+
+  constructor(id: string, tag: string) {
+    // Missing super(id) — derived constructor must call super() first.
+    // @ts-ignore
+    this.tag = tag;
+    // @ts-ignore
+    this.id = id;
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/models/regex-anchor-precedence-mixed.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/models/regex-anchor-precedence-mixed.ts
@@ -1,0 +1,7 @@
+// Fresh negative case: mixed anchoring across alternatives. `^foo|bar$`
+// matches strings that *start with* "foo" OR strings that *end with* "bar",
+// which is almost certainly not what the author intended. The fix is to
+// wrap the alternation in a group.
+
+// VIOLATION: code-quality/deterministic/regex-anchor-precedence
+export const mixedAnchors = /^foo|bar$/;

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/models/this-before-super-extends-out-of-order.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/models/this-before-super-extends-out-of-order.ts
@@ -1,0 +1,19 @@
+// Fresh negative case: a derived class whose constructor accesses `this`
+// before calling super(). The call to super() exists (so missing-super-call
+// does not fire), but the ordering bug is exactly what this-before-super
+// targets and a real ReferenceError at runtime.
+
+class Animal {
+  constructor(public readonly name: string) {}
+}
+
+// VIOLATION: bugs/deterministic/this-before-super
+export class Dog extends Animal {
+  public breed: string;
+
+  constructor(name: string, breed: string) {
+    // @ts-ignore
+    this.breed = breed;
+    super(name);
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/security/os-command-injection-named-import.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/security/os-command-injection-named-import.ts
@@ -1,0 +1,14 @@
+// Fresh negative case: bare-identifier `exec(...)` call where `exec` is
+// imported from `child_process` via an ESM named import. This is a real
+// command injection if the input is attacker-controlled.
+
+import { exec } from 'child_process';
+
+// VIOLATION: security/deterministic/os-command-injection
+export function runLs(target: string): void {
+  exec(`ls ${target}`, (err) => {
+    if (err) {
+      throw err;
+    }
+  });
+}

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/models/missing-super-call-implements-only.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/models/missing-super-call-implements-only.ts
@@ -1,0 +1,25 @@
+// FP shape for `bugs/deterministic/missing-super-call`: a class that
+// `implements` an interface but does not extend any base class. There is no
+// super constructor to call (and `super()` would be a TS error), so the rule
+// must not treat the `implements` clause as triggering the derived-class
+// requirement.
+
+export interface Coord {
+  readonly x: number;
+  readonly y: number;
+  readonly timestamp: number;
+}
+
+export class Sample implements Coord {
+  constructor(
+    public readonly x: number,
+    public readonly y: number,
+    public readonly timestamp: number = 0,
+  ) {
+    // Parameter-property assignments are emitted by TS — no body needed.
+  }
+
+  public distanceTo(other: Coord): number {
+    return Math.sqrt((other.x - this.x) ** 2 + (other.y - this.y) ** 2);
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/models/regex-anchor-precedence-consistent.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/models/regex-anchor-precedence-consistent.ts
@@ -1,0 +1,16 @@
+// FP shapes for `regex-anchor-precedence`: (1) each alternative is anchored
+// independently (so the anchor is correctly applied to every branch) and
+// (2) the `|` characters live inside a character class, where they are
+// literals, not alternation.
+
+// Shape 1: top-level alternation where every alternative carries its own
+// start anchor. The intent is fully expressed — no precedence ambiguity.
+export const blocklistedPathsRegex = /^\/api\/|^\/__/u;
+
+// Shape 2: an email-style regex with `|` literal inside a character class.
+// The rule must not interpret class-internal `|` as alternation.
+export const emailLooseRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/u;
+
+// Shape 3: every alternative is end-anchored consistently — symmetric to
+// Shape 1 but on the trailing side.
+export const trailingAnchorRegex = /foo$|bar$/u;

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/models/this-before-super-implements-only.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/models/this-before-super-implements-only.ts
@@ -1,0 +1,29 @@
+// FP shape for `bugs/deterministic/this-before-super`: a class that
+// `implements` an interface but does not extend any base class. `this` may
+// be used freely inside the constructor — there is no super() to come
+// before because there is no super class.
+
+interface Transport<T> {
+  send(payload: T): Promise<void>;
+}
+
+interface Options {
+  apiKey: string;
+  endpoint: string;
+}
+
+export class MailchannelsLikeTransport implements Transport<string> {
+  private readonly options: Options;
+
+  constructor(options: Partial<Options>) {
+    const { apiKey = '', endpoint = '' } = options;
+    this.options = { apiKey, endpoint };
+  }
+
+  public async send(payload: string): Promise<void> {
+    if (this.options.apiKey.length === 0) {
+      throw new Error('Missing API key');
+    }
+    await Promise.resolve(payload);
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/repositories/missing-unique-constraint-write-shape-mismatch.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/repositories/missing-unique-constraint-write-shape-mismatch.ts
@@ -1,0 +1,80 @@
+// Two FP shapes for `missing-unique-constraint`. Both have a `findFirst`
+// inside an `if` block on a non-unique column (which is what the rule looks
+// for), and the enclosing function does perform ORM writes — but no write is
+// an actual insert into the queried table, so a UNIQUE constraint would not
+// be the fix.
+
+import type { Post } from '@prisma/client';
+
+interface MockPostClient {
+  post: {
+    findFirst: (opts: {
+      where: { authorId: string; id?: string };
+      select?: unknown;
+    }) => Promise<Pick<Post, 'id' | 'title'> | null>;
+    update: (opts: { where: { id: string }; data: { published: boolean } }) => Promise<Post>;
+    deleteMany: (opts: { where: { authorId: string; published: boolean } }) => Promise<{ count: number }>;
+  };
+  comment: {
+    create: (opts: { data: { body: string; post_id: string } }) => Promise<{ id: string }>;
+  };
+}
+
+declare const db: MockPostClient;
+
+// Shape 1: find on `post` inside an if-block, then `create` on a different
+// table (`comment`). There is no check-then-insert uniqueness pattern across
+// these two unrelated tables.
+export async function attachCommentToAuthoredPost(
+  authorId: string,
+  preferredPostId: string,
+): Promise<{ commentId: string; postTitle: string }> {
+  let target: Pick<Post, 'id' | 'title'> | null = null;
+  if (preferredPostId !== '') {
+    target = await db.post.findFirst({
+      where: {
+        authorId,
+        id: preferredPostId,
+      },
+      select: { id: true, title: true },
+    });
+    if (target === null) {
+      throw new Error('Post not found');
+    }
+  }
+
+  const created = await db.comment.create({
+    data: { body: 'note', post_id: target === null ? '' : target.id },
+  });
+  return { commentId: created.id, postTitle: target === null ? '' : target.title };
+}
+
+// Shape 2: throttle / rotate pattern. Find on `post` inside an if-block by
+// a non-unique scoping column; the function only `update`s and `deleteMany`s
+// — it never inserts. There is no race-prone insert that a UNIQUE constraint
+// would defend against.
+export async function rotateMostRecentAuthoredPost(
+  authorId: string,
+  cutoff: string,
+): Promise<{ rotatedId: string | null }> {
+  if (cutoff.length > 0) {
+    const mostRecent = await db.post.findFirst({
+      where: { authorId },
+      select: { id: true, title: true },
+    });
+
+    if (mostRecent === null) {
+      return { rotatedId: null };
+    }
+
+    await db.post.update({
+      where: { id: mostRecent.id },
+      data: { published: true },
+    });
+    await db.post.deleteMany({
+      where: { authorId, published: false },
+    });
+    return { rotatedId: mostRecent.id };
+  }
+  return { rotatedId: null };
+}

--- a/tests/fixtures/sample-js-project-positive/services/user-service/src/services/os-command-injection-local-helper.ts
+++ b/tests/fixtures/sample-js-project-positive/services/user-service/src/services/os-command-injection-local-helper.ts
@@ -1,0 +1,31 @@
+// FP shape for `security/deterministic/os-command-injection`: a locally
+// defined async helper named `exec`, called fire-and-forget. The file does
+// not import `child_process`, so a bare identifier call `exec(...)` is the
+// local helper, not a shell command.
+
+interface Search {
+  open: boolean;
+  triggerOnFocus: boolean;
+  query: string;
+  fetchOptions: (term: string) => Promise<readonly string[]>;
+}
+
+export async function runScheduledSearch(s: Search): Promise<readonly string[]> {
+  let results: readonly string[] = [];
+
+  const exec = async (): Promise<void> => {
+    if (!s.open) {
+      return;
+    }
+    if (s.triggerOnFocus) {
+      results = await s.fetchOptions(s.query);
+      return;
+    }
+    if (s.query.length > 0) {
+      results = await s.fetchOptions(s.query);
+    }
+  };
+
+  await exec();
+  return results;
+}


### PR DESCRIPTION
Closes #184
Closes #185
Closes #186
Closes #187
Closes #188

## Fixes

| rule_key | issue | positive fixture | negative fixture |
|---|---|---|---|
| `database/deterministic/missing-unique-constraint` | #184 | [`missing-unique-constraint-write-shape-mismatch.ts`](../blob/claude/fp-fix/batch-202605212245/tests/fixtures/sample-js-project-positive/services/user-service/src/repositories/missing-unique-constraint-write-shape-mismatch.ts) | [`missing-unique-constraint-author-row.ts`](../blob/claude/fp-fix/batch-202605212245/tests/fixtures/sample-js-project-negative/services/user-service/src/db/missing-unique-constraint-author-row.ts) |
| `security/deterministic/os-command-injection` | #185 | [`os-command-injection-local-helper.ts`](../blob/claude/fp-fix/batch-202605212245/tests/fixtures/sample-js-project-positive/services/user-service/src/services/os-command-injection-local-helper.ts) | [`os-command-injection-named-import.ts`](../blob/claude/fp-fix/batch-202605212245/tests/fixtures/sample-js-project-negative/services/user-service/src/security/os-command-injection-named-import.ts) |
| `bugs/deterministic/missing-super-call` | #186 | [`missing-super-call-implements-only.ts`](../blob/claude/fp-fix/batch-202605212245/tests/fixtures/sample-js-project-positive/services/user-service/src/models/missing-super-call-implements-only.ts) | [`missing-super-call-extends-with-implements.ts`](../blob/claude/fp-fix/batch-202605212245/tests/fixtures/sample-js-project-negative/services/user-service/src/models/missing-super-call-extends-with-implements.ts) |
| `bugs/deterministic/this-before-super` | #187 | [`this-before-super-implements-only.ts`](../blob/claude/fp-fix/batch-202605212245/tests/fixtures/sample-js-project-positive/services/user-service/src/models/this-before-super-implements-only.ts) | [`this-before-super-extends-out-of-order.ts`](../blob/claude/fp-fix/batch-202605212245/tests/fixtures/sample-js-project-negative/services/user-service/src/models/this-before-super-extends-out-of-order.ts) |
| `code-quality/deterministic/regex-anchor-precedence` | #188 | [`regex-anchor-precedence-consistent.ts`](../blob/claude/fp-fix/batch-202605212245/tests/fixtures/sample-js-project-positive/services/user-service/src/models/regex-anchor-precedence-consistent.ts) | [`regex-anchor-precedence-mixed.ts`](../blob/claude/fp-fix/batch-202605212245/tests/fixtures/sample-js-project-negative/services/user-service/src/models/regex-anchor-precedence-mixed.ts) |

## database/deterministic/missing-unique-constraint (#184)

OSS samples:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/auth/create-passkey-authentication-options.ts#L31`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/user/verify-email.ts#L39

Narrowed the rule from "any ORM write in the enclosing function body" to "an *insert-style* call (`create` / `insert` / `upsert` / `createMany` / `bulkCreate` / `save`) targeting the *same table* as the find". `update` / `delete` / `updateMany` / `deleteMany` cannot race-create rows, so check-then-update or check-then-delete is not the pattern this rule targets. Cross-table writes (find on table A, create on table B) also do not constitute a uniqueness pattern. A new `extractWriteTable()` helper handles both Prisma/Sequelize callee chains (`prisma.users.create(...)`) and Drizzle's `db.insert(table).values(...)` first-argument form.

Positive fixture covers both FP shapes (cross-table write, update-only body). Negative fixture asserts the classic check-then-create-on-same-non-unique-column TP still fires.

## security/deterministic/os-command-injection (#185)

OSS samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/multiselect.tsx#L305
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/multiselect.tsx#L277

Bare-identifier `exec(...)` calls are now verified against the file's imports before flagging. The name `exec` is commonly reused for local async helpers (`const exec = async () => {...}; void exec();`), so we require evidence that it was imported from `child_process` — either via ESM named import or `const { exec } = require('child_process')`. `execSync` is left as-is since it is almost exclusively the child_process binding.

Positive fixture: a local async helper named `exec` invoked fire-and-forget, with no `child_process` import. Negative fixture: ESM `import { exec } from 'child_process'` followed by a bare `exec(...)` call — a genuine command-injection risk that must still fire.

## bugs/deterministic/missing-super-call (#186)

OSS samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/signature-pad/point.ts#L24
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/transports/mailchannels.ts#L38

`class_heritage` in TypeScript covers both `extends` and `implements`, but only `extends` brings a super constructor. The rule now requires an actual `extends_clause` in the heritage before flagging. Classes that *only* implement an interface are exempt — `super()` would be a TypeScript error there.

Positive fixture: `class Sample implements Coord` with parameter-property constructor. Negative fixture: `class Subject extends Base implements Tagged` whose constructor never calls `super()`.

## bugs/deterministic/this-before-super (#187)

OSS samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/signature-pad/point.ts#L25
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/transports/mailchannels.ts#L41

Same root cause as #186. The heritage check now requires an `extends_clause`. Positive fixture: an `implements`-only transport class that uses `this` freely in its constructor (no super exists to come before). Negative fixture: a derived class whose constructor accesses `this.breed` before calling `super(name)` — a real `ReferenceError` at runtime.

## code-quality/deterministic/regex-anchor-precedence (#188)

OSS samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/context.ts#L63
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/utils/zod.ts#L12

Top-level alternation detection now tracks character classes (`[...]`) and group depth, so a `|` inside `[a|b]` is treated as a literal. After splitting into top-level alternatives, the rule fires only when *some* alternatives are anchored and others aren't — `^a|^b` (both start-anchored) and `a$|b$` (both end-anchored) are correctly anchored on every branch, while `^a|b$` is the real precedence bug the rule targets.

Positive fixture covers three FP shapes: per-alternative start anchors, an email regex with class-internal `|`, and per-alternative end anchors. Negative fixture: `^foo|bar$` — mixed anchoring across alternatives.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAcvgDHBHttADTZKyWAdMx)_