### PR TITLE
Fix #44, dashboard port conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,14 @@ CLAUDE_CODE_MODEL=                    # Claude Code --model flag (empty = defaul
 CLAUDE_CODE_TIMEOUT_MS=120000         # per-call timeout (ms)
 CLAUDE_CODE_MAX_RETRIES=2             # retry attempts on parse/validation failure
 CLAUDE_CODE_MAX_CONCURRENCY=10        # max concurrent `claude` processes per run
+PORT=47821                            # dashboard server port (auto-picked if unset)
 ```
+
+### Dashboard port
+
+By default `truecourse dashboard` probes for a free TCP port (starting at `47821`) before launching the server. Service-mode installs persist the chosen port to `~/.truecourse/.env` so subsequent starts use the same one. Set `PORT=` explicitly if you want to pin a specific port.
+
+**Windows users:** Hyper-V and Docker Desktop reserve dynamic port ranges via WinNAT, and these ranges shift between reboots. If you see `EACCES` / `EADDRINUSE` on launch, the auto-probe will fall through to the next candidate; you can inspect reserved ranges with `netsh interface ipv4 show excludedportrange protocol=tcp`.
 
 **`CLAUDE_CODE_MAX_CONCURRENCY`** caps how many Claude CLI processes TrueCourse spawns in parallel during a single analyze. Default `10`. Raise it on CI runners with spare headroom; lower it on resource-constrained machines (e.g. 8 GB laptops, shared VMs) to avoid OOM on large repos. Must be a positive integer.
 
@@ -261,7 +268,7 @@ Patterns are anchored to the file's location, so `src/generated/` matches the to
 git clone https://github.com/truecourse-ai/truecourse.git
 cd truecourse
 pnpm install
-pnpm dev                # Start dashboard at http://localhost:3000 (server on :3001, Vite on :3000)
+pnpm dev                # Start dashboard at http://localhost:3000 (Vite on :3000, server on :$PORT or :47821 by default)
 pnpm test               # Run tests
 pnpm build              # Build all packages
 ```

--- a/apps/dashboard/client/src/lib/server-url.ts
+++ b/apps/dashboard/client/src/lib/server-url.ts
@@ -1,16 +1,11 @@
 /**
  * Returns the API server URL.
  *
- * - Production (packaged): frontend is served by Express on the same origin → ''
- * - Development: Next.js runs on port 3000, Express on 3001 → derive from hostname
+ * Always same-origin. In packaged production the Express server serves the
+ * static frontend, so the API lives at the same origin. In dev, Vite proxies
+ * `/api` and `/socket.io` to the backend (see vite.config.ts), so the browser
+ * still talks to its own origin.
  */
 export function getServerUrl(): string {
-  if (typeof window === 'undefined') return '';
-  // When frontend runs on its own port (dev or local prod via `pnpm start`),
-  // API is on port 3001. When served by Express (npm package), same origin.
-  const port = window.location.port;
-  if (port && port !== '3001') {
-    return `http://${window.location.hostname}:3001`;
-  }
   return '';
 }

--- a/apps/dashboard/client/vite.config.ts
+++ b/apps/dashboard/client/vite.config.ts
@@ -2,11 +2,24 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 
+// In dev, `pnpm dev` should export PORT once at the turbo level so both the
+// dashboard server and this proxy agree. Default mirrors DEFAULT_PORT_CANDIDATES[0]
+// in @truecourse/core/lib/port for the case where PORT is unset.
+const apiPort = process.env.PORT || '47821';
+const apiTarget = `http://localhost:${apiPort}`;
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+    },
+  },
+  server: {
+    port: 3000,
+    proxy: {
+      '/api': { target: apiTarget, changeOrigin: true },
+      '/socket.io': { target: apiTarget, changeOrigin: true, ws: true },
     },
   },
   build: {

--- a/apps/dashboard/server/src/index.ts
+++ b/apps/dashboard/server/src/index.ts
@@ -6,8 +6,9 @@ import { createApp } from './app.js';
 import { stopAllWatchers } from './services/watcher.service.js';
 import { wipeLegacyPostgresData, getLogDir } from '@truecourse/core/config/paths';
 import { closeLogger, configureLogger, log } from '@truecourse/core/lib/logger';
+import { DEFAULT_PORT_CANDIDATES } from '@truecourse/core/lib/port';
 
-const port = parseInt(process.env.PORT || '3001', 10);
+const port = parseInt(process.env.PORT || String(DEFAULT_PORT_CANDIDATES[0]), 10);
 
 async function main() {
   // 0. Route all internal diagnostics to the dashboard log file. When running
@@ -36,10 +37,13 @@ async function main() {
   // 3. Start listening
   await new Promise<void>((resolve, reject) => {
     httpServer.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code === 'EADDRINUSE') {
+      if (err.code === 'EADDRINUSE' || err.code === 'EACCES') {
         reject(new Error(
-          `Port ${port} is already in use. Is another TrueCourse instance running?\n` +
-          `Stop it first, or set PORT to use a different port.`
+          `Port ${port} is already in use or reserved by the OS.\n` +
+          `On Windows this often means Hyper-V / Docker Desktop has reserved this port range\n` +
+          `(check: netsh interface ipv4 show excludedportrange protocol=tcp).\n` +
+          `Re-run \`truecourse dashboard\` so the CLI auto-picks a free port,\n` +
+          `or set PORT=xxxx explicitly to pin a different port.`
         ));
       } else {
         reject(err);

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -419,7 +419,7 @@ npx truecourse        # subsequent runs: just start
 
 - `npx truecourse add` — registers the current working directory as a repo
 - Detects cwd, calls `POST /api/repos` with the path
-- Prints the URL to open the repo graph (e.g., `http://localhost:3001/repos/<id>`)
+- Prints the URL to open the repo graph (e.g., `http://localhost:<port>/repos/<id>`, where `<port>` is auto-picked from `DEFAULT_PORT_CANDIDATES` or read from `PORT`)
 - Requires the server to be running (shows helpful error if not)
 
 ### Verification (Phase 1)
@@ -988,7 +988,7 @@ When `runMode` is `service`, `truecourse start` installs and starts the service 
 1. `pnpm build:dist` → build completes successfully
 2. `truecourse setup` → select "Background service" → verify `~/.truecourse/config.json` has `"runMode": "service"`
 3. `truecourse start` → installs launchd plist and starts the service, prints URL
-4. Close terminal → `http://localhost:3001` still accessible
+4. Close terminal → `http://localhost:<port>` still accessible (port persisted to `~/.truecourse/.env`)
 5. `truecourse service status` → shows running with PID
 6. `truecourse service logs` → tails log output
 7. `truecourse service stop` → service stops, URL no longer accessible
@@ -2139,7 +2139,7 @@ An MCP server that wraps the TrueCourse REST API, giving Claude direct structure
 
 - Node.js MCP server using `@modelcontextprotocol/sdk`
 - Lives in `truecourse-plugin/mcp-server/`
-- Connects to TrueCourse server at `http://localhost:{PORT}` (reads PORT from `~/.truecourse/.env` or defaults to 3001)
+- Connects to TrueCourse server at `http://localhost:{PORT}` (reads PORT from `~/.truecourse/.env` or falls back to the first entry of `DEFAULT_PORT_CANDIDATES` in `@truecourse/core/lib/port`)
 - Each tool maps directly to one REST endpoint — thin wrapper, no business logic
 - Returns raw JSON for Claude to reason over
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,6 +64,10 @@
       "types": "./dist/lib/cli-binary.d.ts",
       "import": "./dist/lib/cli-binary.js"
     },
+    "./lib/port": {
+      "types": "./dist/lib/port.d.ts",
+      "import": "./dist/lib/port.js"
+    },
     "./services/analyzer": {
       "types": "./dist/services/analyzer.service.d.ts",
       "import": "./dist/services/analyzer.service.js"

--- a/packages/core/src/lib/port.ts
+++ b/packages/core/src/lib/port.ts
@@ -1,0 +1,41 @@
+import net from 'node:net';
+
+export const DEFAULT_PORT_CANDIDATES = [47821, 47822, 47823, 8731, 8732, 9341];
+
+/**
+ * Try each candidate port in order; return the first one that binds cleanly
+ * on 127.0.0.1. Falls back to an OS-assigned port (listen on 0) if every
+ * candidate is taken or reserved.
+ *
+ * Why: on Windows, Hyper-V / Docker Desktop reserve dynamic TCP port ranges
+ * via WinNAT. Reserved ports surface as EACCES when you try to bind them,
+ * shifting between reboots. A pre-bind probe is the only way to observe the
+ * live reservation set.
+ */
+export async function findFreePort(candidates: number[] = DEFAULT_PORT_CANDIDATES): Promise<number> {
+  for (const p of candidates) {
+    const bound = await tryBind(p);
+    if (bound !== false) return bound;
+  }
+  const osPicked = await tryBind(0);
+  if (osPicked !== false) return osPicked;
+  throw new Error('Unable to find any free TCP port to bind on 127.0.0.1');
+}
+
+/**
+ * Attempt to bind a temporary server on 127.0.0.1 at `port` (0 means
+ * OS-assigned). Resolves to the bound port on success, or `false` on failure
+ * (EADDRINUSE / EACCES / etc). The probe socket is closed before resolving.
+ */
+export function tryBind(port: number): Promise<number | false> {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.once('error', () => resolve(false));
+    srv.listen({ port, host: '127.0.0.1', exclusive: true }, () => {
+      const addr = srv.address();
+      const actual = typeof addr === 'object' && addr ? addr.port : port;
+      srv.close(() => resolve(actual));
+    });
+  });
+}

--- a/tests/cli/env-write.test.ts
+++ b/tests/cli/env-write.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  parseEnvFile,
+  writeEnvVar,
+} from '../../tools/cli/src/commands/service/env';
+
+describe('writeEnvVar', () => {
+  let tmpDir: string;
+  let envPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-env-'));
+    envPath = path.join(tmpDir, '.env');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates the file and its parent directory when neither exists', () => {
+    const nested = path.join(tmpDir, 'nested', '.env');
+    writeEnvVar(nested, 'PORT', '47821');
+    const parsed = parseEnvFile(nested);
+    expect(parsed.PORT).toBe('47821');
+  });
+
+  it('replaces an existing key in-place and preserves other keys', () => {
+    fs.writeFileSync(envPath, 'PATH=/usr/local/bin\nPORT=3001\nTRUECOURSE_HOME=/tmp\n');
+    writeEnvVar(envPath, 'PORT', '47821');
+    const parsed = parseEnvFile(envPath);
+    expect(parsed.PORT).toBe('47821');
+    expect(parsed.PATH).toBe('/usr/local/bin');
+    expect(parsed.TRUECOURSE_HOME).toBe('/tmp');
+  });
+
+  it('appends a new key with a trailing newline when missing', () => {
+    fs.writeFileSync(envPath, 'PATH=/usr/local/bin');
+    writeEnvVar(envPath, 'PORT', '47821');
+    const content = fs.readFileSync(envPath, 'utf-8');
+    expect(content.endsWith('\n')).toBe(true);
+    expect(parseEnvFile(envPath).PORT).toBe('47821');
+  });
+
+  it('quotes values containing whitespace or hash characters', () => {
+    writeEnvVar(envPath, 'NOTE', 'hello world');
+    const raw = fs.readFileSync(envPath, 'utf-8');
+    expect(raw).toContain('NOTE="hello world"');
+    expect(parseEnvFile(envPath).NOTE).toBe('hello world');
+  });
+
+  it('does not falsely match keys with shared prefixes', () => {
+    fs.writeFileSync(envPath, 'PORT=3001\nPORT_EXTRA=9999\n');
+    writeEnvVar(envPath, 'PORT', '47821');
+    const parsed = parseEnvFile(envPath);
+    expect(parsed.PORT).toBe('47821');
+    expect(parsed.PORT_EXTRA).toBe('9999');
+  });
+});

--- a/tests/core/port.test.ts
+++ b/tests/core/port.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import net from 'node:net';
+import {
+  tryBind,
+  findFreePort,
+  DEFAULT_PORT_CANDIDATES,
+} from '../../packages/core/src/lib/port';
+
+function holdPort(port: number): Promise<{ server: net.Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once('error', reject);
+    server.listen({ port, host: '127.0.0.1', exclusive: true }, () => {
+      const addr = server.address();
+      const actual = typeof addr === 'object' && addr ? addr.port : port;
+      resolve({ server, port: actual });
+    });
+  });
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe('port utility', () => {
+  describe('tryBind', () => {
+    it('returns the bound port when port is free', async () => {
+      // Use port 0 to let the OS pick a guaranteed-free port for the assertion.
+      const result = await tryBind(0);
+      expect(result).not.toBe(false);
+      expect(typeof result).toBe('number');
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('returns false when port is already held', async () => {
+      const { server, port } = await holdPort(0);
+      try {
+        const result = await tryBind(port);
+        expect(result).toBe(false);
+      } finally {
+        await closeServer(server);
+      }
+    });
+  });
+
+  describe('findFreePort', () => {
+    it('returns the first candidate if it is free', async () => {
+      // Use port 0 as the sole candidate — guaranteed free, OS picks.
+      const port = await findFreePort([0]);
+      expect(port).toBeGreaterThan(0);
+    });
+
+    it('skips taken candidates and returns the next free one', async () => {
+      const { server, port: takenPort } = await holdPort(0);
+      try {
+        // First candidate is held; second is 0 (OS-assigned, always works).
+        const chosen = await findFreePort([takenPort, 0]);
+        expect(chosen).not.toBe(takenPort);
+        expect(chosen).toBeGreaterThan(0);
+      } finally {
+        await closeServer(server);
+      }
+    });
+
+    it('falls back to OS-assigned port when all candidates fail', async () => {
+      const { server, port: takenPort } = await holdPort(0);
+      try {
+        // Only candidate is held; should fall through to port 0 internally.
+        const chosen = await findFreePort([takenPort]);
+        expect(chosen).not.toBe(takenPort);
+        expect(chosen).toBeGreaterThan(0);
+      } finally {
+        await closeServer(server);
+      }
+    });
+  });
+
+  describe('DEFAULT_PORT_CANDIDATES', () => {
+    it('exposes a non-empty list of candidates', () => {
+      expect(DEFAULT_PORT_CANDIDATES.length).toBeGreaterThan(0);
+      for (const p of DEFAULT_PORT_CANDIDATES) {
+        expect(p).toBeGreaterThan(1023);
+        expect(p).toBeLessThan(65536);
+      }
+    });
+
+    it('does not include the legacy default port 3001', () => {
+      expect(DEFAULT_PORT_CANDIDATES).not.toContain(3001);
+    });
+  });
+});

--- a/tools/cli/src/commands/dashboard.ts
+++ b/tools/cli/src/commands/dashboard.ts
@@ -1,10 +1,12 @@
 import * as p from "@clack/prompts";
 import { spawn } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveRepoDir } from "@truecourse/core/config/paths";
 import { getProjectByPath, registerProject } from "@truecourse/core/config/registry";
+import { findFreePort, DEFAULT_PORT_CANDIDATES } from "@truecourse/core/lib/port";
 import {
   exitMissingNonInteractiveFlag,
   getConfigPath,
@@ -12,11 +14,13 @@ import {
   isInteractive,
   openInBrowser,
   readConfig,
+  resolveKnownPort,
   writeConfig,
   type TrueCourseConfig,
 } from "./helpers.js";
 import { getPlatform } from "./service/platform.js";
 import { rotateLogs, getLogDir, getLogPath, tailLogs, dumpLogTails } from "./service/logs.js";
+import { writeEnvVar } from "./service/env.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -66,13 +70,22 @@ async function promptRunMode(): Promise<TrueCourseConfig["runMode"]> {
   return choice;
 }
 
+async function resolveLaunchPort(): Promise<number> {
+  if (process.env.PORT) {
+    const parsed = Number(process.env.PORT);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return findFreePort(DEFAULT_PORT_CANDIDATES);
+}
+
 async function runConsoleMode(serverEntry: string): Promise<void> {
-  const url = getServerUrl();
+  const port = await resolveLaunchPort();
+  const url = `http://localhost:${port}`;
 
   p.log.step("Starting dashboard server...");
   const serverProcess = spawn(process.execPath, [serverEntry], {
     stdio: "inherit",
-    env: { ...process.env },
+    env: { ...process.env, PORT: String(port) },
   });
 
   const forward = (signal: NodeJS.Signals) => {
@@ -107,12 +120,17 @@ async function runServiceMode(serverEntry: string): Promise<void> {
   const platform = getPlatform();
   const logDir = getLogDir();
   const logPath = getLogPath();
-  const url = getServerUrl();
 
   rotateLogs(logDir);
 
   const installed = await platform.isInstalled();
   if (!installed) {
+    // Pick a free port BEFORE install so the chosen port is what the service
+    // wrapper sees on first start (and every subsequent start, via .env).
+    const port = await resolveLaunchPort();
+    const envFile = path.join(os.homedir(), ".truecourse", ".env");
+    writeEnvVar(envFile, "PORT", String(port));
+    p.log.info(`Service will listen on port ${port} (persisted to ${envFile}).`);
     p.log.step("Installing background service...");
     await platform.install(serverEntry, logPath);
   } else {
@@ -123,6 +141,7 @@ async function runServiceMode(serverEntry: string): Promise<void> {
     }
   }
 
+  const url = `http://localhost:${resolveKnownPort()}`;
   const healthy = await waitForHealth(url);
   if (!healthy) {
     p.log.warn("Service started but server hasn't responded on the health endpoint.");

--- a/tools/cli/src/commands/helpers.ts
+++ b/tools/cli/src/commands/helpers.ts
@@ -9,8 +9,8 @@ import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
 import { resolveRepoDir } from "@truecourse/core/config/paths";
 import { getProjectByPath, registerProject } from "@truecourse/core/config/registry";
-
-const DEFAULT_PORT = 3001;
+import { DEFAULT_PORT_CANDIDATES } from "@truecourse/core/lib/port";
+import { parseEnvFile } from "./service/env.js";
 
 // --- Config utilities ---
 
@@ -44,8 +44,33 @@ export function writeConfig(partial: Partial<TrueCourseConfig>): void {
 }
 
 export function getServerUrl(): string {
-  const port = process.env.PORT || DEFAULT_PORT;
-  return `http://localhost:${port}`;
+  return `http://localhost:${resolveKnownPort()}`;
+}
+
+/**
+ * Resolve the dashboard port the CLI should talk to. Order:
+ *   1. `process.env.PORT` if the user pinned one for this shell.
+ *   2. `PORT=` from `~/.truecourse/.env` — written by service-mode installs.
+ *   3. First default candidate as a pre-install fallback.
+ *
+ * Note: this does NOT probe for a free port. Probing happens in the dashboard
+ * launcher before spawning the server; here we just report the port we
+ * expect the server is (or will be) bound to.
+ */
+export function resolveKnownPort(): number {
+  if (process.env.PORT) {
+    const parsed = Number(process.env.PORT);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  const envFile = path.join(os.homedir(), ".truecourse", ".env");
+  if (existsSync(envFile)) {
+    const parsed = parseEnvFile(envFile);
+    if (parsed.PORT) {
+      const n = Number(parsed.PORT);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+  return DEFAULT_PORT_CANDIDATES[0];
 }
 
 /**

--- a/tools/cli/src/commands/service/env.ts
+++ b/tools/cli/src/commands/service/env.ts
@@ -1,4 +1,41 @@
 import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Set or replace a single key in a .env file, preserving any other keys,
+ * comments, and ordering. Creates the file (and its parent directory) if
+ * neither exists yet. Values containing whitespace or `#` are quoted.
+ */
+export function writeEnvVar(filePath: string, key: string, value: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+  const quoted = /[\s#"']/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value;
+  const newLine = `${key}=${quoted}`;
+  const keyPattern = new RegExp(`^\\s*${key.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\s*=`);
+
+  let content = "";
+  let replaced = false;
+
+  if (fs.existsSync(filePath)) {
+    const existing = fs.readFileSync(filePath, "utf-8");
+    const lines = existing.split("\n");
+    const updated = lines.map((line) => {
+      if (keyPattern.test(line)) {
+        replaced = true;
+        return newLine;
+      }
+      return line;
+    });
+    content = updated.join("\n");
+  }
+
+  if (!replaced) {
+    if (content && !content.endsWith("\n")) content += "\n";
+    content += `${newLine}\n`;
+  }
+
+  fs.writeFileSync(filePath, content, "utf-8");
+}
 
 /**
  * Parse a .env file into key-value pairs.

--- a/tools/cli/src/commands/service/windows.ts
+++ b/tools/cli/src/commands/service/windows.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import type { ServicePlatform } from "./platform.js";
+import { parseEnvFile } from "./env.js";
 
 // Display name shown in the Services UI.
 const SERVICE_DISPLAY_NAME = "TrueCourse";
@@ -32,6 +33,13 @@ export class WindowsService implements ServicePlatform {
     // `C:\Windows\System32\config\systemprofile`, so the server reads an
     // empty registry / config tree and the dashboard shows no projects.
     const truecourseHome = path.join(os.homedir(), ".truecourse");
+    const envFile = path.join(truecourseHome, ".env");
+
+    // Merge ~/.truecourse/.env into the service's environment block so
+    // service-mode installs honor PORT (and any future keys) the same way
+    // launchd/systemd do via their native env-file mechanisms.
+    const envFromFile = parseEnvFile(envFile);
+    const fileEntries = Object.entries(envFromFile).map(([name, value]) => ({ name, value }));
 
     return new Promise<void>((resolve, reject) => {
       const svc = new Service({
@@ -43,6 +51,7 @@ export class WindowsService implements ServicePlatform {
         // node-windows install dir, often inside an npx cache).
         logpath: logDir,
         env: [
+          ...fileEntries,
           { name: "TRUECOURSE_HOME", value: truecourseHome },
           { name: "TRUECOURSE_LOG_DIR", value: logDir },
         ],


### PR DESCRIPTION
This PR fixes the dashboard startup failure caused by hardcoded port usage.

Previously, the dashboard defaulted to port `3001`. On Windows, Hyper-V / Docker Desktop can reserve dynamic TCP port ranges, which may cause the dashboard server to fail with `EACCES` or `EADDRINUSE` when `3001` is unavailable or OS-reserved.

This PR updates the dashboard launch flow so the CLI probes for an actually available port before starting the server, then passes the selected port through the `PORT` environment variable.
