### PR TITLE
Fix: Change default dashboard port from 3001 to 5555 (Issue #44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Patterns are anchored to the file's location, so `src/generated/` matches the to
 git clone https://github.com/truecourse-ai/truecourse.git
 cd truecourse
 pnpm install
-pnpm dev                # Start dashboard at http://localhost:3000 (server on :3001, Vite on :3000)
+pnpm dev                # Start dashboard at http://localhost:3000 (server on :5555, Vite on :3000)
 pnpm test               # Run tests
 pnpm build              # Build all packages
 ```

--- a/apps/dashboard/client/src/lib/server-url.ts
+++ b/apps/dashboard/client/src/lib/server-url.ts
@@ -2,15 +2,15 @@
  * Returns the API server URL.
  *
  * - Production (packaged): frontend is served by Express on the same origin → ''
- * - Development: Next.js runs on port 3000, Express on 3001 → derive from hostname
+ * - Development: Next.js runs on port 3000, Express on 5555 → derive from hostname
  */
 export function getServerUrl(): string {
   if (typeof window === 'undefined') return '';
   // When frontend runs on its own port (dev or local prod via `pnpm start`),
-  // API is on port 3001. When served by Express (npm package), same origin.
+  // API is on port 5555. When served by Express (npm package), same origin.
   const port = window.location.port;
-  if (port && port !== '3001') {
-    return `http://${window.location.hostname}:3001`;
+  if (port && port !== '5555') {
+    return `http://${window.location.hostname}:5555`;
   }
   return '';
 }

--- a/apps/dashboard/server/src/index.ts
+++ b/apps/dashboard/server/src/index.ts
@@ -7,7 +7,7 @@ import { stopAllWatchers } from './services/watcher.service.js';
 import { wipeLegacyPostgresData, getLogDir } from '@truecourse/core/config/paths';
 import { closeLogger, configureLogger, log } from '@truecourse/core/lib/logger';
 
-const port = parseInt(process.env.PORT || '3001', 10);
+const port = parseInt(process.env.PORT || '5555', 10);
 
 async function main() {
   // 0. Route all internal diagnostics to the dashboard log file. When running

--- a/dev-output.txt
+++ b/dev-output.txt
@@ -1,0 +1,56 @@
+
+> truecourse@ dev C:\Users\mefel\truecourse
+> turbo dev
+
+• turbo 2.8.16
+• Packages in scope: @truecourse/analyzer, @truecourse/core, @truecourse/dashboard-client, @truecourse/dashboard-server, @truecourse/landing, @truecourse/shared, truecourse
+• Running dev in 7 packages
+• Remote caching disabled
+@truecourse/shared:dev: cache bypass, force executing a49998ff0b206497
+@truecourse/analyzer:dev: cache bypass, force executing 65f2d414ed7e3c63
+@truecourse/dashboard-server:dev: cache bypass, force executing f496d7ac7a7e273e
+@truecourse/landing:dev: cache bypass, force executing c4e83d7ed8b70a36
+@truecourse/dashboard-client:dev: cache bypass, force executing ee33afcea0d41ad9
+truecourse:dev: cache bypass, force executing 9e004efe4cf53e71
+truecourse:dev: 
+truecourse:dev: > truecourse@0.5.12 dev C:\Users\mefel\truecourse\tools\cli
+truecourse:dev: > echo 'CLI is not used in dev mode'
+truecourse:dev: 
+@truecourse/dashboard-server:dev: 
+@truecourse/dashboard-server:dev: > @truecourse/dashboard-server@0.5.12 dev C:\Users\mefel\truecourse\apps\dashboard\server
+@truecourse/dashboard-server:dev: > TRUECOURSE_DEV=1 tsx watch src/index.ts
+@truecourse/dashboard-server:dev: 
+@truecourse/landing:dev: 
+@truecourse/landing:dev: > @truecourse/landing@0.1.0 dev C:\Users\mefel\truecourse\apps\landing
+@truecourse/landing:dev: > vite --port 3100
+@truecourse/landing:dev: 
+@truecourse/analyzer:dev: 
+@truecourse/dashboard-client:dev: 
+@truecourse/analyzer:dev: > @truecourse/analyzer@0.1.0 dev C:\Users\mefel\truecourse\packages\analyzer
+@truecourse/dashboard-client:dev: > @truecourse/dashboard-client@0.1.0 dev C:\Users\mefel\truecourse\apps\dashboard\client
+@truecourse/analyzer:dev: > tsc --watch
+@truecourse/dashboard-client:dev: > vite --port 3000
+@truecourse/analyzer:dev: 
+@truecourse/dashboard-client:dev: 
+@truecourse/shared:dev: 
+@truecourse/shared:dev: > @truecourse/shared@0.1.0 dev C:\Users\mefel\truecourse\packages\shared
+@truecourse/shared:dev: > tsc --watch
+@truecourse/shared:dev: 
+truecourse:dev: 'CLI is not used in dev mode'
+@truecourse/dashboard-server:dev: 'TRUECOURSE_DEV' is not recognized as an internal or external command,
+@truecourse/dashboard-server:dev: operable program or batch file.
+@truecourse/dashboard-server:dev:  ELIFECYCLE  Command failed with exit code 1.
+@truecourse/shared:dev: [2J[3J[H5:29:08 PM - Starting compilation in watch mode...
+@truecourse/shared:dev: 
+@truecourse/analyzer:dev: [2J[3J[H5:29:08 PM - Starting compilation in watch mode...
+@truecourse/analyzer:dev: 
+@truecourse/dashboard-server:dev: ERROR: command finished with error: command (C:\Users\mefel\truecourse\apps\dashboard\server) C:\Users\mefel\AppData\Local\pnpm\store\v11\links\@\pnpm\9.15.0\dabcd8222099706e9d5613e2bbde82a6ffe5e77c8ba18b78fcd77c3eac869433\bin\pnpm.CMD run dev exited (1)
+@truecourse/dashboard-server#dev: command (C:\Users\mefel\truecourse\apps\dashboard\server) C:\Users\mefel\AppData\Local\pnpm\store\v11\links\@\pnpm\9.15.0\dabcd8222099706e9d5613e2bbde82a6ffe5e77c8ba18b78fcd77c3eac869433\bin\pnpm.CMD run dev exited (1)
+
+ Tasks:    1 successful, 6 total
+Cached:    0 cached, 6 total
+  Time:    779ms 
+Failed:    @truecourse/dashboard-server#dev
+
+ ERROR  run failed: command  exited (1)
+ ELIFECYCLE  Command failed with exit code 1.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -419,7 +419,7 @@ npx truecourse        # subsequent runs: just start
 
 - `npx truecourse add` — registers the current working directory as a repo
 - Detects cwd, calls `POST /api/repos` with the path
-- Prints the URL to open the repo graph (e.g., `http://localhost:3001/repos/<id>`)
+- Prints the URL to open the repo graph (e.g., `http://localhost:5555/repos/<id>`)
 - Requires the server to be running (shows helpful error if not)
 
 ### Verification (Phase 1)
@@ -988,7 +988,7 @@ When `runMode` is `service`, `truecourse start` installs and starts the service 
 1. `pnpm build:dist` → build completes successfully
 2. `truecourse setup` → select "Background service" → verify `~/.truecourse/config.json` has `"runMode": "service"`
 3. `truecourse start` → installs launchd plist and starts the service, prints URL
-4. Close terminal → `http://localhost:3001` still accessible
+4. Close terminal → `http://localhost:5555` still accessible
 5. `truecourse service status` → shows running with PID
 6. `truecourse service logs` → tails log output
 7. `truecourse service stop` → service stops, URL no longer accessible
@@ -2139,7 +2139,7 @@ An MCP server that wraps the TrueCourse REST API, giving Claude direct structure
 
 - Node.js MCP server using `@modelcontextprotocol/sdk`
 - Lives in `truecourse-plugin/mcp-server/`
-- Connects to TrueCourse server at `http://localhost:{PORT}` (reads PORT from `~/.truecourse/.env` or defaults to 3001)
+- Connects to TrueCourse server at `http://localhost:{PORT}` (reads PORT from `~/.truecourse/.env` or defaults to 5555)
 - Each tool maps directly to one REST endpoint — thin wrapper, no business logic
 - Returns raw JSON for Claude to reason over
 

--- a/tools/cli/src/commands/helpers.ts
+++ b/tools/cli/src/commands/helpers.ts
@@ -10,7 +10,7 @@ import { createHash } from "node:crypto";
 import { resolveRepoDir } from "@truecourse/core/config/paths";
 import { getProjectByPath, registerProject } from "@truecourse/core/config/registry";
 
-const DEFAULT_PORT = 3001;
+const DEFAULT_PORT = 5555;
 
 // --- Config utilities ---
 


### PR DESCRIPTION
## Issue
Default port 3001 is reserved/used by Docker and hypervisors, causing port conflicts.

## Solution
Changed default port to 5555, which:
- Is not reserved by Docker or hypervisors
- Avoids common development port conflicts
- Still allows PORT=3001 override for backward compatibility

## Changes
- Dashboard server: default port 3001 → 5555
- CLI helpers: default port 3001 → 5555
- Frontend: port detection updated
- Documentation: all references updated