### PR TITLE
Avoid reserved default dashboard port

### DIFF
--- a/apps/dashboard/server/src/index.ts
+++ b/apps/dashboard/server/src/index.ts
@@ -7,7 +7,7 @@ import { stopAllWatchers } from './services/watcher.service.js';
 import { wipeLegacyPostgresData, getLogDir } from '@truecourse/core/config/paths';
 import { closeLogger, configureLogger, log } from '@truecourse/core/lib/logger';
 
-const port = parseInt(process.env.PORT || '3001', 10);
+const port = parseInt(process.env.PORT || '3211', 10);
 
 async function main() {
   // 0. Route all internal diagnostics to the dashboard log file. When running


### PR DESCRIPTION
My PR changes the dashboard server default port from 3001 to 3211 to avoid conflicts with ports commonly reserved by Docker/Hyper-V environments.

Validation:
- pnpm.cmd --filter @truecourse/dashboard-server build
- pnpm.cmd exec vitest run tests/dashboard-server/dashboard-routes.test.ts
- Verified the dashboard server starts with a custom PORT value

Note:
The full test suite has unrelated Windows path/fixture failures locally, but the dashboard server build and dashboard route tests pass.