### PR TITLE
fix: auto-select next available port when default is reserved by Dock…

### DIFF
--- a/apps/dashboard/server/src/index.ts
+++ b/apps/dashboard/server/src/index.ts
@@ -1,13 +1,17 @@
 import { createServer } from 'http';
+import fs from 'node:fs';
 import path from 'node:path';
 import '@truecourse/core/config/env';
 import { setupSocket } from './socket/index.js';
 import { createApp } from './app.js';
 import { stopAllWatchers } from './services/watcher.service.js';
-import { wipeLegacyPostgresData, getLogDir } from '@truecourse/core/config/paths';
+import { wipeLegacyPostgresData, getLogDir, getServerPortFilePath } from '@truecourse/core/config/paths';
 import { closeLogger, configureLogger, log } from '@truecourse/core/lib/logger';
 
-const port = parseInt(process.env.PORT || '3001', 10);
+const DEFAULT_PORT = 3001;
+const MAX_PORT_ATTEMPTS = 10;
+const userSpecifiedPort = !!process.env.PORT;
+const startPort = parseInt(process.env.PORT || String(DEFAULT_PORT), 10);
 
 async function main() {
   // 0. Route all internal diagnostics to the dashboard log file. When running
@@ -33,41 +37,77 @@ async function main() {
   const httpServer = createServer(app);
   setupSocket(httpServer);
 
-  // 3. Start listening
-  await new Promise<void>((resolve, reject) => {
-    httpServer.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code === 'EADDRINUSE') {
-        reject(new Error(
-          `Port ${port} is already in use. Is another TrueCourse instance running?\n` +
-          `Stop it first, or set PORT to use a different port.`
-        ));
-      } else {
-        reject(err);
-      }
+  // 3. Start listening — auto-selects the next free port if the default is
+  //    reserved (common when Docker or a hypervisor has claimed it). If the
+  //    user explicitly set PORT we respect that and fail immediately.
+  let actualPort = startPort;
+  for (let attempt = 0; attempt < MAX_PORT_ATTEMPTS; attempt++) {
+    const candidate = startPort + attempt;
+    const bound = await new Promise<boolean>((resolve, reject) => {
+      const onError = (err: NodeJS.ErrnoException) => {
+        httpServer.removeListener('error', onError);
+        httpServer.removeListener('listening', onListening);
+        if (err.code === 'EADDRINUSE') {
+          resolve(false);
+        } else {
+          reject(err);
+        }
+      };
+      const onListening = () => {
+        httpServer.removeListener('error', onError);
+        resolve(true);
+      };
+      httpServer.once('error', onError);
+      httpServer.once('listening', onListening);
+      httpServer.listen(candidate);
     });
-    httpServer.listen(port, () => {
-      log.banner([
-        '',
-        '         _|_',
-        '        /_|_\\',
-        '          |',
-        '         /|',
-        '        / |',
-        '       /  |',
-        '      /   |',
-        '     /    |',
-        '    /_____|_____\\',
-        '    \\__________|',
-        '     \\_________/',
-        '   ~~~~~~~~~~~~~~',
-        '',
-        '   Charting your course...',
-        '',
-      ]);
-      log.info(`[Server] Listening on port ${port}`);
-      resolve();
-    });
-  });
+
+    if (bound) {
+      actualPort = candidate;
+      break;
+    }
+
+    if (userSpecifiedPort) {
+      throw new Error(
+        `Port ${candidate} is already in use.\n` +
+        `Stop whatever is using it, or unset PORT to allow automatic port selection.`
+      );
+    }
+
+    if (attempt === MAX_PORT_ATTEMPTS - 1) {
+      throw new Error(
+        `No available port found in range ${startPort}–${startPort + MAX_PORT_ATTEMPTS - 1}.\n` +
+        `Set PORT to specify a different port.`
+      );
+    }
+
+    log.warn(`[Server] Port ${candidate} is in use (possibly reserved by Docker or a hypervisor), trying ${candidate + 1}...`);
+  }
+
+  log.banner([
+    '',
+    '         _|_',
+    '        /_|_\\',
+    '          |',
+    '         /|',
+    '        / |',
+    '       /  |',
+    '      /   |',
+    '     /    |',
+    '    /_____|_____\\',
+    '    \\__________|',
+    '     \\_________/',
+    '   ~~~~~~~~~~~~~~',
+    '',
+    '   Charting your course...',
+    '',
+  ]);
+  log.info(`[Server] Listening on port ${actualPort}`);
+
+  // Write the actual port so the CLI can discover it when auto-selection fired
+  const portFile = getServerPortFilePath();
+  fs.mkdirSync(path.dirname(portFile), { recursive: true });
+  fs.writeFileSync(portFile, String(actualPort), 'utf-8');
 
   // Graceful shutdown
   async function shutdown() {
@@ -75,6 +115,7 @@ async function main() {
     stopAllWatchers();
     httpServer.closeAllConnections();
     httpServer.close();
+    try { fs.unlinkSync(getServerPortFilePath()); } catch { /* already gone */ }
     log.info('[Server] Closed');
     await closeLogger();
     process.exit(0);

--- a/packages/core/src/config/paths.ts
+++ b/packages/core/src/config/paths.ts
@@ -30,6 +30,10 @@ export function getLogDir(): string {
   return path.join(getGlobalDir(), 'logs');
 }
 
+export function getServerPortFilePath(): string {
+  return path.join(getGlobalDir(), 'server.port');
+}
+
 // ---------------------------------------------------------------------------
 // Per-repo paths
 // ---------------------------------------------------------------------------

--- a/tools/cli/src/commands/dashboard.ts
+++ b/tools/cli/src/commands/dashboard.ts
@@ -30,11 +30,11 @@ function resolveServerEntry(): string | null {
   return candidates.find((p) => fs.existsSync(p)) ?? null;
 }
 
-async function waitForHealth(url: string, timeoutMs = 30_000): Promise<boolean> {
+async function waitForHealth(getUrl: () => string, timeoutMs = 30_000): Promise<boolean> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
-      const res = await fetch(`${url}/api/health`);
+      const res = await fetch(`${getUrl()}/api/health`);
       if (res.ok) return true;
     } catch {
       // keep polling
@@ -67,8 +67,6 @@ async function promptRunMode(): Promise<TrueCourseConfig["runMode"]> {
 }
 
 async function runConsoleMode(serverEntry: string): Promise<void> {
-  const url = getServerUrl();
-
   p.log.step("Starting dashboard server...");
   const serverProcess = spawn(process.execPath, [serverEntry], {
     stdio: "inherit",
@@ -90,13 +88,14 @@ async function runConsoleMode(serverEntry: string): Promise<void> {
     process.exit(code ?? 0);
   });
 
-  const healthy = await waitForHealth(url);
+  const healthy = await waitForHealth(getServerUrl);
   if (!healthy) {
     p.log.error("Server did not become healthy in time.");
     forward("SIGTERM");
     process.exit(1);
   }
 
+  const url = getServerUrl();
   const target = targetUrlFor(url);
   openInBrowser(target);
   p.log.success(`Dashboard open at ${target}`);
@@ -107,7 +106,6 @@ async function runServiceMode(serverEntry: string): Promise<void> {
   const platform = getPlatform();
   const logDir = getLogDir();
   const logPath = getLogPath();
-  const url = getServerUrl();
 
   rotateLogs(logDir);
 
@@ -123,7 +121,7 @@ async function runServiceMode(serverEntry: string): Promise<void> {
     }
   }
 
-  const healthy = await waitForHealth(url);
+  const healthy = await waitForHealth(getServerUrl);
   if (!healthy) {
     p.log.warn("Service started but server hasn't responded on the health endpoint.");
     p.log.info(`Log dir: ${logDir}`);
@@ -137,7 +135,7 @@ async function runServiceMode(serverEntry: string): Promise<void> {
     process.exit(1);
   }
 
-  const target = targetUrlFor(url);
+  const target = targetUrlFor(getServerUrl());
   openInBrowser(target);
   p.log.success(`Dashboard open at ${target}`);
   p.log.info("Stop the dashboard with: truecourse dashboard stop");

--- a/tools/cli/src/commands/helpers.ts
+++ b/tools/cli/src/commands/helpers.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
-import { resolveRepoDir } from "@truecourse/core/config/paths";
+import { resolveRepoDir, getServerPortFilePath } from "@truecourse/core/config/paths";
 import { getProjectByPath, registerProject } from "@truecourse/core/config/registry";
 
 const DEFAULT_PORT = 3001;
@@ -44,6 +44,12 @@ export function writeConfig(partial: Partial<TrueCourseConfig>): void {
 }
 
 export function getServerUrl(): string {
+  const portFile = getServerPortFilePath();
+  if (fs.existsSync(portFile)) {
+    const raw = fs.readFileSync(portFile, 'utf-8').trim();
+    const port = parseInt(raw, 10);
+    if (!isNaN(port) && port > 0) return `http://localhost:${port}`;
+  }
   const port = process.env.PORT || DEFAULT_PORT;
   return `http://localhost:${port}`;
 }


### PR DESCRIPTION
Problem
Port 3001 (the default) can be reserved by Docker or Windows Hyper-V, causing the server to fail immediately with a misleading "Is another TrueCourse instance running?" error even when no TrueCourse instance is running.

Fix

The server now automatically tries ports 3001–3010 on startup if the default is taken
The chosen port is written to ~/.truecourse/server.port so the CLI can discover it
The CLI health poller re-evaluates the URL on every attempt so it picks up the port file once the server writes it
If the user explicitly set PORT, we respect that and fail fast with a clear error