### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-complexity.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-complexity.ts
@@ -9,6 +9,13 @@ export const regexComplexityVisitor: CodeRuleVisitor = {
   languages: ['typescript', 'tsx', 'javascript'],
   nodeTypes: ['regex'],
   visit(node, filePath, sourceCode) {
+    // Skip build/runtime config files (vite.config.ts, vitest.config.ts,
+    // webpack.config.js, etc.) — regexes there typically match well-known
+    // build-tool conventions (query params, virtual-module specifiers,
+    // bundler internals) and are config, not application logic.
+    const lowerPath = filePath.toLowerCase()
+    if (/\.config\.[cm]?[jt]sx?$/.test(lowerPath)) return null
+
     const patternNode = node.namedChildren.find((c) => c.type === 'regex_pattern')
     if (!patternNode) return null
 

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/star-import.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/star-import.ts
@@ -10,6 +10,12 @@ export const jsStarImportVisitor: CodeRuleVisitor = {
       (c) => c.type === 'import_clause' && c.namedChildren.some((cc) => cc.type === 'namespace_import')
     )
     if (hasNamespaceImport) {
+      // Skip type-only namespace imports: `import type * as X from 'pkg'`.
+      // The `type` keyword causes the entire import to be erased at compile
+      // time, so tree-shaking / runtime-load concerns don't apply.
+      const isTypeOnly = node.children.some((c) => !c.isNamed && c.type === 'type')
+      if (isTypeOnly) return null
+
       // Skip well-known namespace imports that are idiomatic
       const source = node.namedChildren.find((c) => c.type === 'string')
       const sourceText = source?.text?.slice(1, -1) ?? ''

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unnecessary-type-assertion.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unnecessary-type-assertion.ts
@@ -37,6 +37,14 @@ export const unnecessaryTypeAssertionVisitor: CodeRuleVisitor = {
     // Skip when source type is `any` — narrowing from any is a meaningful assertion
     if (exprType === 'any') return null
 
+    // Skip the inner `X as unknown` step of a `X as unknown as Y` laundering
+    // chain. The intermediate cast to `unknown` is forced by TypeScript when
+    // the original and final types are not assignable to each other; removing
+    // it would make the outer cast illegal.
+    if (typeAnnotation.text === 'unknown' && node.parent?.type === 'as_expression') {
+      return null
+    }
+
     if (exprType && targetType && exprType === targetType) {
       // Skip narrowing via keyof — `key as keyof T` provides a useful type constraint
       // even when TS resolves both sides to the same type (e.g. string)

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unused-expression.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unused-expression.ts
@@ -24,6 +24,14 @@ export const unusedExpressionVisitor: CodeRuleVisitor = {
     }
     if (expr.type === 'template_string') return null
     if (expr.type === 'new_expression') return null
+    // Skip TypeScript namespace / module declarations. Tree-sitter wraps
+    // `namespace Foo { ... }` (and the older `module Foo { ... }` syntax)
+    // in an expression_statement, but these are type-level constructs —
+    // commonly used inside `declare global { ... }` or
+    // `declare module 'x' { ... }` to augment ambient types — and have no
+    // runtime side-effect concern of their own.
+    if (expr.type === 'internal_module') return null
+    if (expr.type === 'module') return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'medium',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/useless-escape.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/useless-escape.ts
@@ -10,6 +10,15 @@ export const uselessEscapeVisitor: CodeRuleVisitor = {
     const quoteChar = text[0]
     if (quoteChar !== '"' && quoteChar !== "'") return null
 
+    // Skip strings that are the value of a JSX `pattern` attribute on a
+    // form input. The HTML `pattern` attribute is a regex parsed by the
+    // browser, so `\d`, `\w`, `\s`, etc. are correct regex shorthand and
+    // the backslash is required.
+    if (node.parent?.type === 'jsx_attribute') {
+      const propId = node.parent.namedChildren.find((c) => c.type === 'property_identifier')
+      if (propId?.text === 'pattern') return null
+    }
+
     const validEscapes = new Set(['n', 'r', 't', 'b', 'f', 'v', '0', '\\', quoteChar, 'u', 'x', '\n'])
 
     let i = 1

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -661,6 +661,12 @@
       "layer": "service"
     },
     {
+      "name": "consumeCounter",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "Container",
       "service": "utils",
       "kind": "class",
@@ -727,6 +733,18 @@
       "layer": "service"
     },
     {
+      "name": "getParser",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "greetLength",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "http-call-no-timeout-external",
       "service": "utils",
       "kind": "standalone",
@@ -764,6 +782,12 @@
     },
     {
       "name": "logger",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "looksLikeRoute",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/regex-complexity.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/regex-complexity.ts
@@ -1,0 +1,12 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/regex-complexity.
+ *
+ * A long inline regex with many capture groups and lookaheads embedded in
+ * an arbitrary application file — the rule should fire and ask for it to
+ * be extracted to a documented named constant.
+ */
+
+export function looksLikeRoute(input: string): boolean {
+  // VIOLATION: code-quality/deterministic/regex-complexity
+  return /^(?=\/)(?!\/(?:api|admin))\/([a-z][\w-]*)(?:\/([a-z][\w-]*))?(?:\/([a-z][\w-]*))?$/i.test(input);
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/star-import.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/star-import.ts
@@ -1,0 +1,14 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/star-import.
+ *
+ * A namespace import of a value module (not type-only) pulls the entire
+ * module's runtime surface. The caller only needs one helper, so a named
+ * import is strictly better for tree-shaking and readability.
+ */
+
+// VIOLATION: code-quality/deterministic/star-import
+import * as csvParser from 'csv-parser';
+
+export function getParser(): unknown {
+  return csvParser;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-assertion.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-assertion.ts
@@ -1,0 +1,12 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/unnecessary-type-assertion.
+ *
+ * Asserting `as string` on a value already typed as `string` is a no-op
+ * that adds noise. The rule should fire and the assertion should be
+ * removed.
+ */
+
+export function greetLength(name: string): number {
+  // VIOLATION: code-quality/deterministic/unnecessary-type-assertion
+  return (name as string).length;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unused-expression.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unused-expression.ts
@@ -1,0 +1,12 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/unused-expression.
+ *
+ * A plain identifier reference as an expression statement is a no-op —
+ * almost always a forgotten assignment or call.
+ */
+
+export function consumeCounter(counter: number): number {
+  // VIOLATION: code-quality/deterministic/unused-expression
+  counter;
+  return counter + 1;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/useless-escape.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/useless-escape.ts
@@ -1,0 +1,10 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/useless-escape.
+ *
+ * `\p` is not a recognized JavaScript string escape — the backslash is
+ * silently dropped at parse time. Almost always a typo for an intended
+ * literal character, or a misplaced regex shorthand.
+ */
+
+// VIOLATION: code-quality/deterministic/useless-escape
+export const greeting = 'sto\p';

--- a/tests/fixtures/sample-js-project-positive/src/regex-complexity-build-config.config.ts
+++ b/tests/fixtures/sample-js-project-positive/src/regex-complexity-build-config.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Positive fixture for code-quality/deterministic/regex-complexity.
+ *
+ * Build-tool config files (anything matching `*.config.{ts,js,…}`)
+ * commonly contain regexes that match bundler conventions — virtual
+ * modules, query suffixes, asset paths. These are not application logic
+ * that benefits from being extracted further, so the rule should skip
+ * config files entirely.
+ */
+
+type BundlerOptions = {
+  excludeQueries?: RegExp;
+};
+
+declare function defineBundler(options: BundlerOptions): BundlerOptions;
+
+export default defineBundler({
+  excludeQueries: /\?(?:inline|raw|url|no-inline|import(?:&(?:inline|raw|url|no-inline))?)$/u,
+});

--- a/tests/fixtures/sample-js-project-positive/src/star-import-type-only.ts
+++ b/tests/fixtures/sample-js-project-positive/src/star-import-type-only.ts
@@ -1,0 +1,16 @@
+/**
+ * Positive fixture for code-quality/deterministic/star-import.
+ *
+ * `import type * as X from 'pkg'` is a type-only namespace import. The
+ * `type` keyword causes the entire import to be erased at compile time,
+ * so there is no runtime module load and no tree-shaking implication.
+ * The rule should not fire on type-only namespace imports.
+ */
+
+import type * as PrismaShapes from '@prisma/client';
+
+export type FieldRow = PrismaShapes.Field;
+
+export function describePage(field: FieldRow): string {
+  return `${field.id}:page-${field.page}`;
+}

--- a/tests/fixtures/sample-js-project-positive/src/unnecessary-type-assertion-launder.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unnecessary-type-assertion-launder.ts
@@ -1,0 +1,20 @@
+/**
+ * Positive fixture for code-quality/deterministic/unnecessary-type-assertion.
+ *
+ * `value as unknown as T` is the standard "launder through unknown"
+ * pattern. The intermediate `as unknown` step is required by TypeScript
+ * when the source type and the final target type are not assignable to
+ * each other — a direct `value as T` would be rejected by the compiler.
+ *
+ * Even when TypeScript infers the inner expression's type to be `unknown`
+ * (e.g. a callback whose parameter is typed `unknown`), the explicit
+ * `as unknown` step is not redundant — it is the only legal way to set
+ * up the subsequent assertion to a concrete type.
+ */
+
+const knownStatuses: readonly string[] = ['draft', 'sent', 'completed'];
+
+type ValueGuard = (value: unknown) => boolean;
+
+export const isKnownStatus: ValueGuard = (value) =>
+  knownStatuses.includes(value as unknown as string);

--- a/tests/fixtures/sample-js-project-positive/src/unused-expression-ambient-namespace.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unused-expression-ambient-namespace.ts
@@ -1,0 +1,20 @@
+/**
+ * Positive fixture for code-quality/deterministic/unused-expression.
+ *
+ * `namespace X { ... }` is a TypeScript type-level construct, not a
+ * runtime expression. It is commonly used inside `declare global { ... }`
+ * or `declare module '...' { ... }` to augment ambient or module-scoped
+ * types. Tree-sitter wraps the namespace declaration in an
+ * `expression_statement`, but it has no runtime side-effect concern — the
+ * rule should not fire.
+ */
+
+type TFlags = { admin: boolean; viewer: boolean };
+
+declare global {
+  namespace AppJson {
+    type Flags = TFlags;
+  }
+}
+
+export type { TFlags };

--- a/tests/fixtures/sample-js-project-positive/src/useless-escape-jsx-pattern.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/useless-escape-jsx-pattern.tsx
@@ -1,0 +1,26 @@
+/**
+ * Positive fixture for code-quality/deterministic/useless-escape.
+ *
+ * The HTML `pattern` attribute on `<input>` is a regular expression
+ * parsed by the browser, not a JavaScript string literal. Escape
+ * sequences like `\d`, `\w`, `\s` are valid regex shorthand and the
+ * backslash is required for correct semantics. The rule should not
+ * flag escapes inside a JSX `pattern` attribute value.
+ */
+
+import * as React from 'react';
+
+interface Props {
+  readonly defaultValue?: string;
+}
+
+export function DigitsOnlyInput({ defaultValue }: Props): React.ReactElement {
+  return (
+    <input
+      type="text"
+      inputMode="numeric"
+      pattern="^\d+$"
+      defaultValue={defaultValue}
+    />
+  );
+}


### PR DESCRIPTION
Closes #189
Closes #190
Closes #191
Closes #192
Closes #194

## Fixes

| rule_key | issue | positive fixture | negative fixture |
|---|---|---|---|
| code-quality/deterministic/star-import | #189 | `tests/fixtures/sample-js-project-positive/src/star-import-type-only.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/star-import.ts` |
| code-quality/deterministic/unnecessary-type-assertion | #190 | `tests/fixtures/sample-js-project-positive/src/unnecessary-type-assertion-launder.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-assertion.ts` |
| code-quality/deterministic/unused-expression | #191 | `tests/fixtures/sample-js-project-positive/src/unused-expression-ambient-namespace.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unused-expression.ts` |
| code-quality/deterministic/regex-complexity | #192 | `tests/fixtures/sample-js-project-positive/src/regex-complexity-build-config.config.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/regex-complexity.ts` |
| code-quality/deterministic/useless-escape | #194 | `tests/fixtures/sample-js-project-positive/src/useless-escape-jsx-pattern.tsx` | `tests/fixtures/sample-js-project-negative/shared/utils/src/useless-escape.ts` |

## code-quality/deterministic/star-import (#189)

OSS source: [documenso/documenso@8f6be47 apps/docs/src/lib/source.ts L2](https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/docs/src/lib/source.ts#L2), [apps/docs/src/app/docs/layout.tsx L3](https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/docs/src/app/docs/layout.tsx#L3)

Positive fixture (`tests/fixtures/sample-js-project-positive/src/star-import-type-only.ts`):

```ts
/**
 * Positive fixture for code-quality/deterministic/star-import.
 *
 * `import type * as X from 'pkg'` is a type-only namespace import. The
 * `type` keyword causes the entire import to be erased at compile time,
 * so there is no runtime module load and no tree-shaking implication.
 * The rule should not fire on type-only namespace imports.
 */

import type * as PrismaShapes from '@prisma/client';

export type FieldRow = PrismaShapes.Field;

export function describePage(field: FieldRow): string {
  return `${field.id}:page-${field.page}`;
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/star-import.ts`):

```ts
/**
 * Paraphrased true-bug for code-quality/deterministic/star-import.
 *
 * A namespace import of a value module (not type-only) pulls the entire
 * module's runtime surface. The caller only needs one helper, so a named
 * import is strictly better for tree-shaking and readability.
 */

// VIOLATION: code-quality/deterministic/star-import
import * as csvParser from 'csv-parser';

export function getParser(): unknown {
  return csvParser;
}
```

Visitor change: skip type-only namespace imports (`import type * as X from 'pkg'`). Tree-sitter represents the `type` keyword as an anonymous child of `import_statement`, so a single `node.children.some(c => !c.isNamed && c.type === 'type')` check is enough to identify them. The `type` keyword erases the entire import at compile time, so the rule's tree-shaking and runtime-load concerns do not apply.

## code-quality/deterministic/unnecessary-type-assertion (#190)

OSS source: [documenso/documenso@8f6be47 template-page-view-documents-table.tsx L178](`https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/template/template-page-view-documents-table.tsx#L178),` [template-page-view-documents-table.tsx L196](`https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/template/template-page-view-documents-table.tsx#L196)`

Positive fixture (`tests/fixtures/sample-js-project-positive/src/unnecessary-type-assertion-launder.ts`):

```ts
/**
 * Positive fixture for code-quality/deterministic/unnecessary-type-assertion.
 *
 * `value as unknown as T` is the standard "launder through unknown"
 * pattern. The intermediate `as unknown` step is required by TypeScript
 * when the source type and the final target type are not assignable to
 * each other — a direct `value as T` would be rejected by the compiler.
 *
 * Even when TypeScript infers the inner expression's type to be `unknown`
 * (e.g. a callback whose parameter is typed `unknown`), the explicit
 * `as unknown` step is not redundant — it is the only legal way to set
 * up the subsequent assertion to a concrete type.
 */

const knownStatuses: readonly string[] = ['draft', 'sent', 'completed'];

type ValueGuard = (value: unknown) => boolean;

export const isKnownStatus: ValueGuard = (value) =>
  knownStatuses.includes(value as unknown as string);
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-assertion.ts`):

```ts
/**
 * Paraphrased true-bug for code-quality/deterministic/unnecessary-type-assertion.
 *
 * Asserting `as string` on a value already typed as `string` is a no-op
 * that adds noise. The rule should fire and the assertion should be
 * removed.
 */

export function greetLength(name: string): number {
  // VIOLATION: code-quality/deterministic/unnecessary-type-assertion
  return (name as string).length;
}
```

Visitor change: skip the inner `as unknown` step of a `X as unknown as Y` laundering chain. Detected by `typeAnnotation.text === 'unknown' && node.parent?.type === 'as_expression'`. TypeScript requires the intermediate `as unknown` when the source and final target types are not assignable to each other, so removing it would make the outer cast illegal — it is not a no-op.

## code-quality/deterministic/unused-expression (#191)

OSS source: [documenso/documenso@8f6be47 packages/prisma/types/types.d.ts L14](https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/types/types.d.ts#L14), [packages/lib/server-only/stripe/stripe.d.ts L2](https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/stripe/stripe.d.ts#L2)

Positive fixture (`tests/fixtures/sample-js-project-positive/src/unused-expression-ambient-namespace.ts`):

```ts
/**
 * Positive fixture for code-quality/deterministic/unused-expression.
 *
 * `namespace X { ... }` is a TypeScript type-level construct, not a
 * runtime expression. It is commonly used inside `declare global { ... }`
 * or `declare module '...' { ... }` to augment ambient or module-scoped
 * types. Tree-sitter wraps the namespace declaration in an
 * `expression_statement`, but it has no runtime side-effect concern — the
 * rule should not fire.
 */

type TFlags = { admin: boolean; viewer: boolean };

declare global {
  namespace AppJson {
    type Flags = TFlags;
  }
}

export type { TFlags };
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/unused-expression.ts`):

```ts
/**
 * Paraphrased true-bug for code-quality/deterministic/unused-expression.
 *
 * A plain identifier reference as an expression statement is a no-op —
 * almost always a forgotten assignment or call.
 */

export function consumeCounter(counter: number): number {
  // VIOLATION: code-quality/deterministic/unused-expression
  counter;
  return counter + 1;
}
```

Visitor change: skip when the expression statement wraps an `internal_module` (TypeScript `namespace X { ... }`) or the older `module X { ... }` AST node. Tree-sitter parses these as `expression_statement → internal_module/module`, but they are type-level constructs — commonly used inside `declare global { ... }` or `declare module 'x' { ... }` to augment ambient types — and have no runtime side-effect concern of their own.

## code-quality/deterministic/regex-complexity (#192)

OSS source: [documenso/documenso@8f6be47 apps/remix/vite.config.ts L62](https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/vite.config.ts#L62)

Positive fixture (`tests/fixtures/sample-js-project-positive/src/regex-complexity-build-config.config.ts`):

```ts
/**
 * Positive fixture for code-quality/deterministic/regex-complexity.
 *
 * Build-tool config files (anything matching `*.config.{ts,js,…}`)
 * commonly contain regexes that match bundler conventions — virtual
 * modules, query suffixes, asset paths. These are not application logic
 * that benefits from being extracted further, so the rule should skip
 * config files entirely.
 */

type BundlerOptions = {
  excludeQueries?: RegExp;
};

declare function defineBundler(options: BundlerOptions): BundlerOptions;

export default defineBundler({
  excludeQueries: /\?(?:inline|raw|url|no-inline|import(?:&(?:inline|raw|url|no-inline))?)$/u,
});
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/regex-complexity.ts`):

```ts
/**
 * Paraphrased true-bug for code-quality/deterministic/regex-complexity.
 *
 * A long inline regex with many capture groups and lookaheads embedded in
 * an arbitrary application file — the rule should fire and ask for it to
 * be extracted to a documented named constant.
 */

export function looksLikeRoute(input: string): boolean {
  // VIOLATION: code-quality/deterministic/regex-complexity
  return /^(?=\/)(?!\/(?:api|admin))\/([a-z][\w-]*)(?:\/([a-z][\w-]*))?(?:\/([a-z][\w-]*))?$/i.test(input);
}
```

Visitor change: skip files whose path matches `*.config.{ts,tsx,js,jsx,cts,mts,cjs,mjs}`. Build/runtime config files (Vite, Vitest, webpack, rollup, etc.) commonly contain regexes that match bundler conventions (query suffixes, virtual modules, asset paths). These are config artifacts, not application logic that would benefit from further extraction.

## code-quality/deterministic/useless-escape (#194)

OSS source: [documenso/documenso@8f6be47 access-auth-2fa-form.tsx L240](`https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document-signing/access-auth-2fa-form.tsx#L240)`

Positive fixture (`tests/fixtures/sample-js-project-positive/src/useless-escape-jsx-pattern.tsx`):

```tsx
/**
 * Positive fixture for code-quality/deterministic/useless-escape.
 *
 * The HTML `pattern` attribute on `<input>` is a regular expression
 * parsed by the browser, not a JavaScript string literal. Escape
 * sequences like `\d`, `\w`, `\s` are valid regex shorthand and the
 * backslash is required for correct semantics. The rule should not
 * flag escapes inside a JSX `pattern` attribute value.
 */

import * as React from 'react';

interface Props {
  readonly defaultValue?: string;
}

export function DigitsOnlyInput({ defaultValue }: Props): React.ReactElement {
  return (
    <input
      type="text"
      inputMode="numeric"
      pattern="^\d+$"
      defaultValue={defaultValue}
    />
  );
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/useless-escape.ts`):

```ts
/**
 * Paraphrased true-bug for code-quality/deterministic/useless-escape.
 *
 * `\p` is not a recognized JavaScript string escape — the backslash is
 * silently dropped at parse time. Almost always a typo for an intended
 * literal character, or a misplaced regex shorthand.
 */

// VIOLATION: code-quality/deterministic/useless-escape
export const greeting = 'sto\p';
```

Visitor change: skip strings that are the value of a JSX `pattern` attribute (`node.parent?.type === 'jsx_attribute'` with a `property_identifier` of `pattern`). The HTML `pattern` attribute is a regex parsed by the browser, so escapes like `\d`, `\w`, `\s` are valid regex shorthand and the backslash is required for correct semantics.

## Skipped this batch

- #193 (`code-quality/deterministic/no-empty-function`) — FP no longer reproduces at `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f`. The sample at `field-item-advanced-settings.tsx#L181` is `useAutoSave(onAutoSave || (async () => {}))`, which is already covered by the existing `||` / `??` fallback skip path in the visitor. The two remaining violations of this rule on the target are the singleton private-constructor cases that the issue body itself flagged as borderline.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01PT2tkmXZ7xedHFLxUN3WBN)_