### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/conditional-hook.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/conditional-hook.ts
@@ -13,13 +13,24 @@ function isHookCall(node: SyntaxNode): boolean {
   return HOOK_NAMES.test(fn.text)
 }
 
-// Check if the node is inside a conditional block (if/else/ternary/loop)
+// Check if `inner` lies inside `outer`'s subtree by byte range.
+function isWithin(outer: SyntaxNode, inner: SyntaxNode): boolean {
+  return inner.startIndex >= outer.startIndex && inner.endIndex <= outer.endIndex
+}
+
+// Check if the node is inside a conditional block (if/else/ternary/loop).
+// A hook that sits in the `condition` of an if/ternary is always evaluated
+// exactly once, so it does not violate Rules of Hooks; only hooks in the
+// consequence/alternative or any loop body are conditional.
 function getConditionalAncestor(node: SyntaxNode): SyntaxNode | null {
   let current: SyntaxNode | null = node.parent
   while (current) {
-    if (
-      current.type === 'if_statement' ||
-      current.type === 'ternary_expression' ||
+    if (current.type === 'if_statement' || current.type === 'ternary_expression') {
+      const cond = current.childForFieldName('condition')
+      if (!cond || !isWithin(cond, node)) {
+        return current
+      }
+    } else if (
       current.type === 'for_statement' ||
       current.type === 'for_in_statement' ||
       current.type === 'for_of_statement' ||

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/unsafe-type-assertion.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/unsafe-type-assertion.ts
@@ -21,6 +21,11 @@ export const unsafeTypeAssertionVisitor: CodeRuleVisitor = {
     const typeAnnotation = node.namedChildren[1]
     if (!expr || !typeAnnotation) return null
 
+    // Skip: `[] as T[]` — widening an empty-array `never[]` initializer to its
+    // intended element type. This is a safe, idiomatic workaround for TS
+    // inferring `never[]` in object-literal accumulators, reduce seeds, etc.
+    if (expr.type === 'array' && expr.namedChildren.length === 0) return null
+
     const exprType = typeQuery.getTypeAtPosition(
       filePath,
       expr.startPosition.row,

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/default-case-in-switch.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/default-case-in-switch.ts
@@ -1,5 +1,31 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+
+function statementTerminates(node: SyntaxNode): boolean {
+  switch (node.type) {
+    case 'return_statement':
+    case 'throw_statement':
+    case 'break_statement':
+    case 'continue_statement':
+      return true
+    case 'statement_block': {
+      // A block terminates iff its last statement terminates.
+      const stmts = node.namedChildren
+      if (stmts.length === 0) return false
+      return statementTerminates(stmts[stmts.length - 1])
+    }
+    case 'if_statement': {
+      const cons = node.childForFieldName('consequence')
+      const alt = node.childForFieldName('alternative')
+      if (!cons || !alt) return false
+      // `if/else` terminates iff both branches terminate.
+      return statementTerminates(cons) && statementTerminates(alt)
+    }
+    default:
+      return false
+  }
+}
 
 export const defaultCaseInSwitchVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/default-case-in-switch',
@@ -15,14 +41,14 @@ export const defaultCaseInSwitchVisitor: CodeRuleVisitor = {
     const cases = body.namedChildren.filter((c) => c.type === 'switch_case')
     if (cases.length === 0) return null
 
-    // Skip exhaustive switches — all case clauses end with return, throw, or break
+    // Skip exhaustive switches — every case must end with a terminating
+    // statement (return / throw / break / continue), or with a block / if-else
+    // whose own terminating-suffix recursively satisfies the same shape.
     const allCasesTerminate = cases.every((caseNode) => {
       const caseChildren = caseNode.namedChildren
       if (caseChildren.length === 0) return false
       const lastChild = caseChildren[caseChildren.length - 1]
-      return lastChild.type === 'return_statement' ||
-        lastChild.type === 'throw_statement' ||
-        lastChild.type === 'break_statement'
+      return statementTerminates(lastChild)
     })
     if (allCasesTerminate) return null
 

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/too-many-breaks.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/too-many-breaks.ts
@@ -3,6 +3,27 @@ import { makeViolation } from '../../../types.js'
 import { JS_FUNCTION_TYPES, getFunctionBody, getFunctionName } from './_helpers.js'
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 
+const LOOP_NODE_TYPES = new Set([
+  'for_statement',
+  'for_in_statement',
+  'for_of_statement',
+  'while_statement',
+  'do_statement',
+])
+
+// A `break` inside a `switch` is required syntax for non-fallthrough cases,
+// not a control-flow exit from the surrounding function. Only loop breaks
+// represent the kind of branching this rule is meant to discourage.
+function breakTargetsLoop(breakNode: SyntaxNode, functionNode: SyntaxNode): boolean {
+  let current: SyntaxNode | null = breakNode.parent
+  while (current && current.id !== functionNode.id) {
+    if (current.type === 'switch_statement') return false
+    if (LOOP_NODE_TYPES.has(current.type)) return true
+    current = current.parent
+  }
+  return false
+}
+
 export const tooManyBreaksVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/too-many-breaks',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -15,7 +36,7 @@ export const tooManyBreaksVisitor: CodeRuleVisitor = {
 
     function walk(n: SyntaxNode) {
       if (JS_FUNCTION_TYPES.includes(n.type) && n.id !== node.id) return
-      if (n.type === 'break_statement') breakCount++
+      if (n.type === 'break_statement' && breakTargetsLoop(n, node)) breakCount++
       for (let i = 0; i < n.childCount; i++) {
         const child = n.child(i)
         if (child) walk(child)

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/missing-next-on-error.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/missing-next-on-error.ts
@@ -23,9 +23,13 @@ export const missingNextOnErrorVisitor: CodeRuleVisitor = {
       return nameNode.text.replace(/:.+/, '').trim()
     })
 
-    // Must have a next-like param (usually 3rd or 4th param)
+    // Must have an Express-shaped signature: (req, res, next) or (err, req, res, next).
+    // Hono and Koa middleware are (ctx, next) with only two params and use
+    // exception propagation rather than next(error); they must not be flagged.
     const hasNext = paramNames.some((n) => n === 'next')
-    if (!hasNext) return null
+    const hasReq = paramNames.some((n) => n === 'req' || n === 'request')
+    const hasRes = paramNames.some((n) => n === 'res' || n === 'response')
+    if (!hasNext || !hasReq || !hasRes) return null
 
     // Check the catch body for next(
     const body = node.childForFieldName('body')

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -55,6 +55,12 @@
       "layer": "api"
     },
     {
+      "name": "attachUserMiddleware",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "api"
+    },
+    {
       "name": "authMiddleware",
       "service": "api-gateway",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/missing-next-on-error.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/missing-next-on-error.ts
@@ -1,0 +1,27 @@
+/**
+ * Negative fixture for reliability/deterministic/missing-next-on-error.
+ *
+ * Express-shaped middleware with `(req, res, next)`. The catch block must
+ * forward the error via `next(err)` to reach Express's error handler;
+ * sending a 500 response and returning is not equivalent because downstream
+ * error middleware never runs.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+
+const decodeAuthToken = (raw: string): { sub: string } => {
+  if (!raw) throw new Error('empty token');
+  return { sub: raw };
+};
+
+// VIOLATION: reliability/deterministic/missing-next-on-error
+export function attachUserMiddleware(req: Request, res: Response, next: NextFunction) {
+  try {
+    const token = (req.headers['authorization'] ?? '').replace(/^Bearer\s+/, '');
+    const claims = decodeAuthToken(token);
+    (req as Request & { user?: { sub: string } }).user = claims;
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'unauthorized' });
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/ReactBugs.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/ReactBugs.tsx
@@ -13,6 +13,14 @@ export function ConditionalHook({ show }: { show: boolean }) {
   return <div>Hidden</div>;
 }
 
+// VIOLATION: bugs/deterministic/conditional-hook
+// Hook sits in the consequence branch of a ternary — only called when the
+// condition is truthy, so the number of hook calls per render varies.
+export function TernaryBranchHook({ show }: { show: boolean }) {
+  const label = show ? useState('on')[0] : 'off';
+  return <span>{label}</span>;
+}
+
 // VIOLATION: bugs/deterministic/usestate-object-mutation
 export function StateMutation() {
   const [state, setState] = useState({ items: [] as string[], count: 0 });

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-complexity.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-complexity.ts
@@ -196,6 +196,26 @@ export function lotsOfBreaks(items: string[]) {
   return 'done';
 }
 
+// VIOLATION: code-quality/deterministic/too-many-breaks
+// Nested loop with six early-exit breaks — all of them target the inner
+// loop (not a switch), so the rule should still fire after the
+// switch-break exclusion.
+export function scanMatrix(rows: ReadonlyArray<ReadonlyArray<number>>): number {
+  let hits = 0;
+  for (const row of rows) {
+    for (const value of row) {
+      if (value === 1) break;
+      if (value === 2) break;
+      if (value === 3) break;
+      if (value === 4) break;
+      if (value === 5) break;
+      if (value === 6) break;
+      hits += 1;
+    }
+  }
+  return hits;
+}
+
 // VIOLATION: code-quality/deterministic/too-many-return-statements
 export function manyReturns(x: number) {
   if (x === 1) return 'one';

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts
@@ -53,6 +53,23 @@ export function noDefault(action: string) {
   }
 }
 
+// VIOLATION: code-quality/deterministic/default-case-in-switch
+// Open `string` parameter (not a discriminated union) with a non-terminating
+// case body — `count = 0` falls through to whatever follows the switch, and
+// any unexpected `kind` is silently ignored.
+export function tallyByKind(kind: string): number {
+  let count = 0;
+  switch (kind) {
+    case 'small':
+      count = 1;
+      break;
+    case 'large': {
+      count = 10;
+    }
+  }
+  return count;
+}
+
 // VIOLATION: code-quality/deterministic/dot-notation-enforcement
 export function bracketAccess(obj: Record<string, any>) {
   return obj['name'];

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/misc-bugs.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/misc-bugs.ts
@@ -196,6 +196,14 @@ export function broadAssert(input: unknown) {
   return input as string;
 }
 
+// VIOLATION: bugs/deterministic/unsafe-type-assertion
+// Numeric-to-string cast where the source has a concrete incompatible type
+// (number is not assignable to string in either direction). Distinct from
+// the safe `[] as T[]` widening shape that the positive fixture covers.
+export function castNumberToString(n: number): string {
+  return n as string;
+}
+
 // VIOLATION: bugs/deterministic/unsafe-unary-minus
 export function negateNonNumber() {
   const x = '5';

--- a/tests/fixtures/sample-js-project-positive/src/conditional-hook-ternary-condition.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/conditional-hook-ternary-condition.tsx
@@ -1,0 +1,31 @@
+/**
+ * Positive fixture for bugs/deterministic/conditional-hook.
+ *
+ * The hook call sits in the *condition* of a ternary expression, not in one
+ * of its branches. The condition is always evaluated exactly once per render,
+ * so the hook is called unconditionally — this does not violate Rules of
+ * Hooks. Only hook calls inside the consequence/alternative of an if/ternary
+ * (or inside any loop body) are conditional.
+ */
+
+import * as React from 'react';
+
+function useHasMounted(): boolean {
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  return mounted;
+}
+
+type DeferUntilMountedProps = {
+  render: () => React.ReactNode;
+  placeholder?: React.ReactNode;
+};
+
+export const DeferUntilMounted = ({
+  render,
+  placeholder = null,
+}: DeferUntilMountedProps) => {
+  return useHasMounted() ? render() : placeholder;
+};

--- a/tests/fixtures/sample-js-project-positive/src/default-case-in-switch-block-bodied-reducer.ts
+++ b/tests/fixtures/sample-js-project-positive/src/default-case-in-switch-block-bodied-reducer.ts
@@ -1,0 +1,32 @@
+/**
+ * Positive fixture for code-quality/deterministic/default-case-in-switch.
+ *
+ * A reducer over a discriminated union — TypeScript already enforces
+ * exhaustiveness statically, so a `default` case is unreachable. The
+ * visitor's "all cases terminate" check has to peer inside block-bodied
+ * cases (`case 'X': { … return Y; }`) for this to be recognised — that's
+ * a common pattern when one branch needs to introduce a local `const`.
+ */
+
+type NoticeAction =
+  | { type: 'append'; item: { id: string; label: string } }
+  | { type: 'drop'; id: string }
+  | { type: 'reset' };
+
+type NoticeState = { items: Array<{ id: string; label: string }> };
+
+export function noticeReducer(state: NoticeState, action: NoticeAction): NoticeState {
+  switch (action.type) {
+    case 'append':
+      return { items: [...state.items, action.item] };
+
+    case 'drop': {
+      const { id } = action;
+      return { items: state.items.filter((it) => it.id !== id) };
+    }
+
+    case 'reset': {
+      return { items: [] };
+    }
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/src/missing-next-on-error-hono-middleware.ts
+++ b/tests/fixtures/sample-js-project-positive/src/missing-next-on-error-hono-middleware.ts
@@ -1,0 +1,43 @@
+/**
+ * Positive fixture for reliability/deterministic/missing-next-on-error.
+ *
+ * Hono-style middleware takes `(c, next)` — a context object plus a `next`
+ * callback that takes no arguments. Errors propagate via exception, so there
+ * is no `next(error)` convention here. The catch block intentionally falls
+ * back to a sentinel value and the middleware keeps running.
+ *
+ * The rule should only fire on Express-shaped middleware with `(req, res,
+ * next)`, not on Hono / Koa-style `(c, next)` middleware.
+ */
+
+type HonoContext = {
+  header: (key: string, value: string) => void;
+  req: { raw: Request };
+};
+
+type HonoMiddleware = (
+  c: HonoContext,
+  next: () => Promise<void>,
+) => Promise<Response | void>;
+
+const readClientTag = (raw: Request): string => {
+  const tag = raw.headers.get('x-client-tag');
+  if (!tag) throw new Error('missing tag header');
+  return tag;
+};
+
+export const createClientTagMiddleware = (): HonoMiddleware => {
+  return async (c, next) => {
+    let tag: string;
+
+    try {
+      tag = readClientTag(c.req.raw);
+    } catch {
+      tag = 'anonymous';
+    }
+
+    c.header('X-Client-Tag', tag);
+
+    await next();
+  };
+};

--- a/tests/fixtures/sample-js-project-positive/src/too-many-breaks-switch-six-cases.ts
+++ b/tests/fixtures/sample-js-project-positive/src/too-many-breaks-switch-six-cases.ts
@@ -1,0 +1,35 @@
+/**
+ * Positive fixture for code-quality/deterministic/too-many-breaks.
+ *
+ * A standard non-fallthrough `switch` over six labels has six `break;`
+ * statements — one per case — purely as required syntax. None of them
+ * represent the kind of control-flow branching the rule is meant to
+ * discourage; the rule should only count breaks that target a surrounding
+ * loop.
+ */
+
+type StatusKind = 'unsigned' | 'opened' | 'waiting' | 'completed' | 'rejected';
+
+export function classNameForStatus(kind: StatusKind): string {
+  let className = 'tone-muted';
+  switch (kind) {
+    case 'unsigned':
+      className = 'tone-neutral';
+      break;
+    case 'opened':
+      className = 'tone-warning';
+      break;
+    case 'waiting':
+      className = 'tone-info';
+      break;
+    case 'completed':
+      className = 'tone-success';
+      break;
+    case 'rejected':
+      className = 'tone-danger';
+      break;
+    default:
+      break;
+  }
+  return className;
+}

--- a/tests/fixtures/sample-js-project-positive/src/unsafe-type-assertion-empty-array-widening.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unsafe-type-assertion-empty-array-widening.ts
@@ -1,0 +1,41 @@
+/**
+ * Positive fixture for bugs/deterministic/unsafe-type-assertion.
+ *
+ * `[] as T[]` is a safe widening assertion used to give an empty-array
+ * initializer the element type the caller intended. Without it, TypeScript
+ * infers `never[]` (most commonly for reduce seeds and object-literal
+ * accumulators), which then rejects every later push/concat. The rule should
+ * skip this exact shape — `[] as Foo[]` with no items in the array literal.
+ */
+
+type Outcome = { ok: boolean; errors: string[] };
+
+export function collectOutcome(events: ReadonlyArray<{ message?: string }>): Outcome {
+  const out: Outcome = {
+    ok: true,
+    errors: [] as string[],
+  };
+
+  for (const ev of events) {
+    if (ev.message !== undefined) {
+      out.ok = false;
+      out.errors.push(ev.message);
+    }
+  }
+
+  return out;
+}
+
+export function partitionByLabel<T extends { label: string }>(
+  items: readonly T[],
+  label: string,
+): { matched: T[]; rest: T[] } {
+  return items.reduce(
+    (acc, item) => {
+      if (item.label === label) acc.matched.push(item);
+      else acc.rest.push(item);
+      return acc;
+    },
+    { matched: [] as T[], rest: [] as T[] },
+  );
+}


### PR DESCRIPTION
Closes #195
Closes #196
Closes #198
Closes #199
Closes #200

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `reliability/deterministic/missing-next-on-error` | #195 | `tests/fixtures/sample-js-project-positive/src/missing-next-on-error-hono-middleware.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/missing-next-on-error.ts` |
| `bugs/deterministic/conditional-hook` | #196 | `tests/fixtures/sample-js-project-positive/src/conditional-hook-ternary-condition.tsx` | `tests/fixtures/sample-js-project-negative/services/web/src/components/ReactBugs.tsx` (`TernaryBranchHook`) |
| `bugs/deterministic/unsafe-type-assertion` | #198 | `tests/fixtures/sample-js-project-positive/src/unsafe-type-assertion-empty-array-widening.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/misc-bugs.ts` (`castNumberToString`) |
| `code-quality/deterministic/default-case-in-switch` | #199 | `tests/fixtures/sample-js-project-positive/src/default-case-in-switch-block-bodied-reducer.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts` (`tallyByKind`) |
| `code-quality/deterministic/too-many-breaks` | #200 | `tests/fixtures/sample-js-project-positive/src/too-many-breaks-switch-six-cases.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-complexity.ts` (`scanMatrix`) |

## reliability/deterministic/missing-next-on-error

Upstream FP: https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/rate-limit/rate-limit-middleware.ts#L32

Positive fixture (Hono `(c, next)` middleware — should not fire):
```ts
type HonoMiddleware = (
  c: HonoContext,
  next: () => Promise<void>,
) => Promise<Response | void>;

export const createClientTagMiddleware = (): HonoMiddleware => {
  return async (c, next) => {
    let tag: string;
    try {
      tag = readClientTag(c.req.raw);
    } catch {
      tag = 'anonymous';
    }
    c.header('X-Client-Tag', tag);
    await next();
  };
};
```

Negative fixture (Express `(req, res, next)` middleware — should still fire):
```ts
// VIOLATION: reliability/deterministic/missing-next-on-error
export function attachUserMiddleware(req: Request, res: Response, next: NextFunction) {
  try {
    const token = (req.headers['authorization'] ?? '').replace(/^Bearer\s+/, '');
    const claims = decodeAuthToken(token);
    (req as Request & { user?: { sub: string } }).user = claims;
    next();
  } catch (err) {
    res.status(401).json({ error: 'unauthorized' });
  }
}
```

Visitor change: the rule used to fire on any function with a `next`-named parameter whose catch block didn't call `next(`. That conflated Hono / Koa middleware (`(c, next)` — two params, `await next()`, exception propagation) with Express middleware (`(req, res, next)` — three params, `next(error)` convention). The fix now also requires `req`/`request` AND `res`/`response` parameters to be present, so only Express-shaped signatures trigger.

## bugs/deterministic/conditional-hook

Upstream FP: https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/components/client-only.tsx#L9

Positive fixture (hook is the ternary's `condition` — always evaluated once):
```tsx
export const DeferUntilMounted = ({
  render,
  placeholder = null,
}: DeferUntilMountedProps) => {
  return useHasMounted() ? render() : placeholder;
};
```

Negative fixture (hook in the consequence branch — really conditional):
```tsx
// VIOLATION: bugs/deterministic/conditional-hook
export function TernaryBranchHook({ show }: { show: boolean }) {
  const label = show ? useState('on')[0] : 'off';
  return <span>{label}</span>;
}
```

Visitor change: `getConditionalAncestor` returned the surrounding `if_statement` / `ternary_expression` unconditionally. Now it checks the byte range of the ancestor's `condition` field — a hook sitting inside that field is always evaluated exactly once, so it does not violate Rules of Hooks. Only hooks in the consequence/alternative (or any loop body) count.

## bugs/deterministic/unsafe-type-assertion

Upstream FP: https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/bulk-send-template.handler.ts#L77

Positive fixture (`[] as T[]` widening of an empty-array initializer):
```ts
export function collectOutcome(events: ReadonlyArray<{ message?: string }>): Outcome {
  const out: Outcome = {
    ok: true,
    errors: [] as string[],
  };
  // …
}
```

Negative fixture (`number as string` — concrete incompatible cast):
```ts
// VIOLATION: bugs/deterministic/unsafe-type-assertion
export function castNumberToString(n: number): string {
  return n as string;
}
```

Visitor change: added an early-skip for the `[] as T[]` shape — an empty-array literal asserted to an array type. TypeScript otherwise infers `never[]` for empty-array initializers (reduce seeds, accumulator object fields, etc.), so this widening is a safe, idiomatic workaround rather than an unsafe cast. Other incompatible casts (e.g. `n as string`) still fire.

## code-quality/deterministic/default-case-in-switch

Upstream FP: https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/use-toast.ts#L73

Positive fixture (reducer over a discriminated union with block-bodied cases):
```ts
export function noticeReducer(state: NoticeState, action: NoticeAction): NoticeState {
  switch (action.type) {
    case 'append':
      return { items: [...state.items, action.item] };
    case 'drop': {
      const { id } = action;
      return { items: state.items.filter((it) => it.id !== id) };
    }
    case 'reset': {
      return { items: [] };
    }
  }
}
```

Negative fixture (open `string` parameter with a non-terminating case):
```ts
// VIOLATION: code-quality/deterministic/default-case-in-switch
export function tallyByKind(kind: string): number {
  let count = 0;
  switch (kind) {
    case 'small':
      count = 1;
      break;
    case 'large': {
      count = 10;
    }
  }
  return count;
}
```

Visitor change: the terminate-check only looked at each case's last *direct* child. If a case body was wrapped in `{ … }` it saw a `statement_block` and gave up, so reducers that needed a local `const` in one branch (the shadcn / Radix toast pattern) tripped the rule even when every branch returned. Added a small recursive `statementTerminates` helper that peers into block-bodied cases and into if/else where both branches terminate.

## code-quality/deterministic/too-many-breaks

Upstream FP: https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/stack-avatar.tsx#L19

Positive fixture (single switch with five labels + default — six `break;` purely as required syntax):
```ts
export function classNameForStatus(kind: StatusKind): string {
  let className = 'tone-muted';
  switch (kind) {
    case 'unsigned':
      className = 'tone-neutral';
      break;
    case 'opened':
      className = 'tone-warning';
      break;
    case 'waiting':
      className = 'tone-info';
      break;
    case 'completed':
      className = 'tone-success';
      break;
    case 'rejected':
      className = 'tone-danger';
      break;
    default:
      break;
  }
  return className;
}
```

Negative fixture (nested loop with six early-exit breaks — all target a loop):
```ts
// VIOLATION: code-quality/deterministic/too-many-breaks
export function scanMatrix(rows: ReadonlyArray<ReadonlyArray<number>>): number {
  let hits = 0;
  for (const row of rows) {
    for (const value of row) {
      if (value === 1) break;
      if (value === 2) break;
      if (value === 3) break;
      if (value === 4) break;
      if (value === 5) break;
      if (value === 6) break;
      hits += 1;
    }
  }
  return hits;
}
```

Visitor change: every `break` was counted uniformly. `break` inside a `switch` is required syntax for non-fallthrough cases, not a control-flow exit from the surrounding function. Now only breaks whose nearest enclosing structure is a loop count — the switch-case break-per-case pattern no longer trips a function-wide limit.

## Skipped this batch

- #197 — `bugs/deterministic/shared-mutable-module-state`: `fp-blocked`. The same React-hook FP shape (`let memoryState = {…}` in a `from 'react'` file) is also flagged by `architecture/deterministic/declarations-in-global-scope`. Fixing one rule leaves the positive fixture tripping the other, so a clean fix needs both visitors to share React-client-code detection — that's two-rule scope and outside this routine's per-issue contract.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01EALhcXBGjnZ9bt7D3uQ9NG)_