### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/architecture/checker.ts
+++ b/packages/analyzer/src/rules/architecture/checker.ts
@@ -194,6 +194,22 @@ function buildSameFileCalls(fileAnalyses?: FileAnalysis[]): Map<string, Set<stri
 const GOD_MODULE_THRESHOLD = 15
 
 /**
+ * Modules that exist purely to support tests — Jest `__tests__/__mocks__`
+ * directories, `.test`/`.spec` files, and Playwright/Cypress e2e helper
+ * files — are expected to collect many helper methods (Page Object Model,
+ * shared fixtures, etc.). Flagging them as god-modules is a false positive.
+ */
+function isTestSupportModulePath(filePath: string): boolean {
+  const lower = filePath.toLowerCase()
+  return (
+    /[\\/]__tests__[\\/]/.test(lower) ||
+    /[\\/]__mocks__[\\/]/.test(lower) ||
+    /\.(?:test|spec)\.(?:[mc]?[jt]sx?)$/.test(lower) ||
+    /[\\/](?:e2e|playwright|cypress)[\\/]/.test(lower)
+  )
+}
+
+/**
  * Check deterministic module-level rules and return violations.
  */
 export function checkModuleRules(
@@ -337,6 +353,7 @@ export function checkModuleRules(
   // God module
   if (ruleKeys.has('architecture/deterministic/god-module')) {
     for (const mod of modules) {
+      if (isTestSupportModulePath(mod.filePath)) continue
       if (mod.methodCount > GOD_MODULE_THRESHOLD) {
         violations.push({
           ruleKey: 'architecture/deterministic/god-module',

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/element-overwrite.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/element-overwrite.ts
@@ -3,6 +3,15 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { JS_LANGUAGES } from './_helpers.js'
 
+function containsAwait(stmt: SyntaxNode): boolean {
+  if (stmt.type === 'await_expression') return true
+  for (let i = 0; i < stmt.namedChildCount; i++) {
+    const child = stmt.namedChild(i)
+    if (child && containsAwait(child)) return true
+  }
+  return false
+}
+
 export const elementOverwriteVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/element-overwrite',
   languages: JS_LANGUAGES,
@@ -43,14 +52,23 @@ export const elementOverwriteVisitor: CodeRuleVisitor = {
         const prev = assigns.get(key)!
         // Check if the key was read between the two assignments
         let wasRead = false
+        let hasAwait = false
         for (let j = prev.idx + 1; j < i; j++) {
           const between = statements[j]
           if (between.text.includes(obj.text)) {
             wasRead = true
             break
           }
+          if (!hasAwait && containsAwait(between)) hasAwait = true
         }
-        if (!wasRead) {
+        // React useRef lock idiom: `xRef.current = true; await ...; xRef.current = false`.
+        // The await yields the event loop, so re-entrant callers can observe
+        // the first assignment via the ref's shared `.current`. Skip the
+        // violation when an intervening await crosses the two assignments and
+        // the property is the React `.current` accessor.
+        const isRefCurrent =
+          left.type === 'member_expression' && indexOrProp.text === 'current'
+        if (!wasRead && !(isRefCurrent && hasAwait)) {
           return makeViolation(
             this.ruleKey, expr, filePath, 'high',
             'Element overwritten before read',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/missing-env-validation.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/missing-env-validation.ts
@@ -31,6 +31,14 @@ export const missingEnvValidationVisitor: CodeRuleVisitor = {
         || t === 'logical_expression') {
         return null
       }
+      // `!process.env.X` / `!!process.env.X` (and the `Boolean()` cast form
+      // it expands to) coerce undefined to a boolean — that IS the
+      // validation the rule wants to see.
+      if (t === 'unary_expression') {
+        const op = ancestor.childForFieldName('operator')?.text
+          ?? ancestor.child(0)?.text
+        if (op === '!') return null
+      }
       ancestor = ancestor.parent
       depth++
     }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/no-script-url.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/no-script-url.ts
@@ -26,6 +26,12 @@ export const noScriptUrlVisitor: CodeRuleVisitor = {
       // Skip in if conditions (comparison context)
       if (parent?.type === 'binary_expression') return null
 
+      // Skip when the string is a member of a literal denylist/allowlist —
+      // e.g. `const BLOCKED = ['javascript:', 'data:']` inside a sanitizer.
+      // The intent is the opposite of the rule: code is preventing the
+      // pattern, not introducing one.
+      if (parent?.type === 'array') return null
+
       return makeViolation(
         this.ruleKey, node, filePath, 'medium',
         'Script URL',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-empty-repetition.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-empty-repetition.ts
@@ -10,7 +10,12 @@ export const regexEmptyRepetitionVisitor: CodeRuleVisitor = {
     const src = getRegexSource(node)
     if (!src) return null
 
-    if (/\([^)]*[*+][^)]*\)[*+]/.test(src)) {
+    // Catastrophic backtracking requires the inner group to be able to match
+    // the empty string. Two shapes count: an empty group `(?:)`/`()`, or a
+    // group whose trailing atom is itself a zero-or-more (`*`, `?`,
+    // `{0,…}`). A trailing `+` requires content, so `(?:[-_][a-z0-9]+)*`
+    // is safe even though `+` appears inside.
+    if (/\((?:\?[:!=]|\?<[!=])?(?:[^)]*(?:[*?]|\{0,\d*\}))?\)[*+]/.test(src)) {
       return makeViolation(
         this.ruleKey, node, filePath, 'low',
         'Empty string repetition in regex',

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -55,6 +55,12 @@
       "layer": "api"
     },
     {
+      "name": "attachOpener",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "attachUserMiddleware",
       "service": "api-gateway",
       "kind": "standalone",
@@ -65,6 +71,12 @@
       "service": "api-gateway",
       "kind": "standalone",
       "layer": "api"
+    },
+    {
+      "name": "buildAuthHeader",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "service"
     },
     {
       "name": "error-handler",
@@ -325,6 +337,12 @@
       "layer": "data"
     },
     {
+      "name": "applyConfig",
+      "service": "user-service",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "array-bugs",
       "service": "user-service",
       "kind": "standalone",
@@ -503,6 +521,12 @@
       "service": "user-service",
       "kind": "class",
       "layer": "data"
+    },
+    {
+      "name": "TaskHandlers",
+      "service": "user-service",
+      "kind": "class",
+      "layer": "api"
     },
     {
       "name": "TokenService",

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/missing-env-validation-raw.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/missing-env-validation-raw.ts
@@ -1,0 +1,8 @@
+// True bug: env var read raw, no coercion, no guard. `apiKey` is just
+// `string | undefined` and the caller uses it as a string.
+
+export function buildAuthHeader(): string {
+  // VIOLATION: code-quality/deterministic/missing-env-validation
+  const apiKey = process.env.SAMPLE_API_TOKEN;
+  return `Bearer ${apiKey}`;
+}

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/no-script-url-anchor.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/no-script-url-anchor.ts
@@ -1,0 +1,9 @@
+// True bug: assigning `javascript:` URL to an anchor's href — equivalent
+// to `eval` and a known XSS vector.
+
+type AnchorStub = { href: string };
+
+export function attachOpener(anchor: AnchorStub): void {
+  // VIOLATION: code-quality/deterministic/no-script-url
+  anchor.href = 'javascript:openDialog()';
+}

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/regex-empty-repetition-nested.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/regex-empty-repetition-nested.ts
@@ -1,0 +1,5 @@
+// True bug: `(a*)*` lets each outer iteration consume zero characters,
+// causing catastrophic backtracking on a non-matching input.
+
+// VIOLATION: code-quality/deterministic/regex-empty-repetition
+export const NESTED_STAR = /^(a*)*$/;

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/services/element-overwrite-config.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/services/element-overwrite-config.ts
@@ -1,0 +1,12 @@
+// True bug: two back-to-back assignments to the same property, with
+// nothing observing the first one (no await, no read). The first assignment
+// is dead code.
+
+type Config = { retries: number };
+
+export function applyConfig(config: Config): Config {
+  // VIOLATION: bugs/deterministic/element-overwrite
+  config.retries = 1;
+  config.retries = 3;
+  return config;
+}

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/services/god-module-task-handlers.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/services/god-module-task-handlers.ts
@@ -1,0 +1,89 @@
+// VIOLATION: architecture/deterministic/god-module
+// Service class with too many unrelated responsibilities. Should be split
+// into smaller focused services (CRUD, lifecycle, notifications, etc.).
+
+type Task = { id: string; title: string; status: string; ownerId: string };
+type Store = Map<string, Task>;
+
+export class TaskHandlers {
+  constructor(private readonly store: Store) {}
+
+  createTask(id: string, title: string, ownerId: string): Task {
+    const task: Task = { id, title, status: 'open', ownerId };
+    this.store.set(id, task);
+    return task;
+  }
+
+  getTask(id: string): Task | undefined {
+    return this.store.get(id);
+  }
+
+  updateTitle(id: string, title: string): void {
+    const t = this.store.get(id);
+    if (t) t.title = title;
+  }
+
+  deleteTask(id: string): void {
+    this.store.delete(id);
+  }
+
+  closeTask(id: string): void {
+    const t = this.store.get(id);
+    if (t) t.status = 'closed';
+  }
+
+  reopenTask(id: string): void {
+    const t = this.store.get(id);
+    if (t) t.status = 'open';
+  }
+
+  archiveTask(id: string): void {
+    const t = this.store.get(id);
+    if (t) t.status = 'archived';
+  }
+
+  assignOwner(id: string, ownerId: string): void {
+    const t = this.store.get(id);
+    if (t) t.ownerId = ownerId;
+  }
+
+  listOpen(): Task[] {
+    return [...this.store.values()].filter(t => t.status === 'open');
+  }
+
+  listClosed(): Task[] {
+    return [...this.store.values()].filter(t => t.status === 'closed');
+  }
+
+  listArchived(): Task[] {
+    return [...this.store.values()].filter(t => t.status === 'archived');
+  }
+
+  listByOwner(ownerId: string): Task[] {
+    return [...this.store.values()].filter(t => t.ownerId === ownerId);
+  }
+
+  countOpen(): number {
+    return this.listOpen().length;
+  }
+
+  countClosed(): number {
+    return this.listClosed().length;
+  }
+
+  countArchived(): number {
+    return this.listArchived().length;
+  }
+
+  exportAll(): Task[] {
+    return [...this.store.values()];
+  }
+
+  importAll(tasks: Task[]): void {
+    for (const t of tasks) this.store.set(t.id, t);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/missing-env-validation-bool-coerce.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/missing-env-validation-bool-coerce.ts
@@ -1,0 +1,6 @@
+// `!!process.env.X` and `!process.env.X` coerce undefined to a boolean,
+// which IS validation — the resulting value is well-defined whether the
+// env var is set or not.
+
+export const HAS_LICENSE_KEY = !!process.env.SAMPLE_LICENSE_KEY;
+export const IS_DEBUG_DISABLED = !process.env.SAMPLE_DEBUG;

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/no-script-url-denylist.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/no-script-url-denylist.ts
@@ -1,0 +1,13 @@
+// CSS/URL sanitizer denylist. The string `'javascript:'` here is in a
+// blocked-value substring list — the code is rejecting the pattern, not
+// introducing one. Flagging this is a false positive.
+
+const BLOCKED_VALUE_SUBSTRINGS = ['url(', 'expression(', '@import', 'javascript:'];
+
+export function isBlocked(value: string): boolean {
+  const lower = value.toLowerCase();
+  for (const substring of BLOCKED_VALUE_SUBSTRINGS) {
+    if (lower.includes(substring)) return true;
+  }
+  return false;
+}

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/regex-empty-repetition-bounded.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/regex-empty-repetition-bounded.ts
@@ -1,0 +1,5 @@
+// Inner group `[-_][a-z0-9]+` cannot match the empty string — it requires
+// at least one separator AND one alphanumeric. The outer `*` is safe; no
+// catastrophic backtracking is possible.
+
+export const URL_SLUG = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/u;

--- a/tests/fixtures/sample-js-project-positive/services/web/e2e/fixtures/god-module-page-object.ts
+++ b/tests/fixtures/sample-js-project-positive/services/web/e2e/fixtures/god-module-page-object.ts
@@ -1,0 +1,95 @@
+// Playwright-style end-to-end Page Object Model. POMs intentionally collect
+// many helper methods (open, fill, submit, assert, ...) because that's their
+// whole purpose — the rule must not flag them as god-modules.
+
+type PageStub = {
+  goto(url: string): Promise<void>;
+  click(selector: string): Promise<void>;
+  fill(selector: string, value: string): Promise<void>;
+  waitForSelector(selector: string): Promise<void>;
+  textContent(selector: string): Promise<string | null>;
+  isVisible(selector: string): Promise<boolean>;
+};
+
+export class DocumentEditorPage {
+  private readonly page: PageStub;
+  private readonly baseUrl: string;
+
+  constructor(page: PageStub, baseUrl: string) {
+    this.page = page;
+    this.baseUrl = baseUrl;
+  }
+
+  async openNewDocument(): Promise<void> {
+    await this.page.goto(`${this.baseUrl}/documents/new`);
+  }
+
+  async openExistingDocument(id: string): Promise<void> {
+    await this.page.goto(`${this.baseUrl}/documents/${id}`);
+  }
+
+  async fillTitle(value: string): Promise<void> {
+    await this.page.fill('input[name="title"]', value);
+  }
+
+  async fillDescription(value: string): Promise<void> {
+    await this.page.fill('textarea[name="description"]', value);
+  }
+
+  async clickSaveDraft(): Promise<void> {
+    await this.page.click('button[data-action="save-draft"]');
+  }
+
+  async clickPublish(): Promise<void> {
+    await this.page.click('button[data-action="publish"]');
+  }
+
+  async clickAddRecipient(): Promise<void> {
+    await this.page.click('button[data-action="add-recipient"]');
+  }
+
+  async fillRecipientEmail(value: string): Promise<void> {
+    await this.page.fill('input[name="recipient-email"]', value);
+  }
+
+  async fillRecipientName(value: string): Promise<void> {
+    await this.page.fill('input[name="recipient-name"]', value);
+  }
+
+  async clickRemoveRecipient(index: number): Promise<void> {
+    await this.page.click(`button[data-recipient-index="${index}"]`);
+  }
+
+  async waitForToastSuccess(): Promise<void> {
+    await this.page.waitForSelector('[data-toast="success"]');
+  }
+
+  async waitForToastError(): Promise<void> {
+    await this.page.waitForSelector('[data-toast="error"]');
+  }
+
+  readTitle(): Promise<string | null> {
+    return this.page.textContent('input[name="title"]');
+  }
+
+  isPublishEnabled(): Promise<boolean> {
+    return this.page.isVisible('button[data-action="publish"]:not([disabled])');
+  }
+
+  async clickSettingsTab(): Promise<void> {
+    await this.page.click('[role="tab"][data-tab="settings"]');
+  }
+
+  async clickPreviewTab(): Promise<void> {
+    await this.page.click('[role="tab"][data-tab="preview"]');
+  }
+
+  async clickRecipientsTab(): Promise<void> {
+    await this.page.click('[role="tab"][data-tab="recipients"]');
+  }
+
+  async expectStatus(value: string): Promise<boolean> {
+    const actual = await this.page.textContent('[data-document-status]');
+    return actual === value;
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/services/web/src/hooks/element-overwrite-async-lock.ts
+++ b/tests/fixtures/sample-js-project-positive/services/web/src/hooks/element-overwrite-async-lock.ts
@@ -1,0 +1,20 @@
+// React `useRef` "lock" pattern: setting the ref's `.current` flag, awaiting
+// some work, then clearing it. The first assignment is observable by
+// re-entrant async callers via the ref's shared mutable state, so this is
+// not a wasted overwrite.
+
+type RefStub<T> = { current: T };
+
+export async function runOnce<T>(
+  lockRef: RefStub<boolean>,
+  queueRef: RefStub<T[]>,
+  handle: (items: readonly T[]) => Promise<void>,
+): Promise<void> {
+  if (lockRef.current || queueRef.current.length === 0) return;
+
+  lockRef.current = true;
+  const pending = queueRef.current;
+  queueRef.current = [];
+  await handle(pending);
+  lockRef.current = false;
+}


### PR DESCRIPTION
Resolves 5 false positives surfaced by the documenso/documenso campaign
at ref `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f`.

Closes #201
Closes #202
Closes #203
Closes #204
Closes #205

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
| --- | --- | --- | --- |
| `architecture/deterministic/god-module` | #201 | `tests/fixtures/sample-js-project-positive/services/web/e2e/fixtures/god-module-page-object.ts` | `tests/fixtures/sample-js-project-negative/services/user-service/src/services/god-module-task-handlers.ts` |
| `bugs/deterministic/element-overwrite` | #202 | `tests/fixtures/sample-js-project-positive/services/web/src/hooks/element-overwrite-async-lock.ts` | `tests/fixtures/sample-js-project-negative/services/user-service/src/services/element-overwrite-config.ts` |
| `code-quality/deterministic/missing-env-validation` | #203 | `tests/fixtures/sample-js-project-positive/services/api-gateway/src/missing-env-validation-bool-coerce.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/missing-env-validation-raw.ts` |
| `code-quality/deterministic/no-script-url` | #204 | `tests/fixtures/sample-js-project-positive/services/api-gateway/src/no-script-url-denylist.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/no-script-url-anchor.ts` |
| `code-quality/deterministic/regex-empty-repetition` | #205 | `tests/fixtures/sample-js-project-positive/services/api-gateway/src/regex-empty-repetition-bounded.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/regex-empty-repetition-nested.ts` |

## architecture/deterministic/god-module

- Source FP: https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/app-tests/e2e/fixtures/envelope-editor.ts#L1
- The flagged file is a Playwright Page Object Model (POM) under `packages/app-tests/e2e/fixtures/`. POMs by design collect many helper methods (open, fill, click, assert, ...). They're test scaffolding, not production "god classes."

Positive fixture (Playwright-style POM in `e2e/fixtures/` — should not fire):
```diff
+++ b/tests/fixtures/sample-js-project-positive/services/web/e2e/fixtures/god-module-page-object.ts
+export class DocumentEditorPage {
+  constructor(page, baseUrl) { this.page = page; this.baseUrl = baseUrl; }
+  async openNewDocument() { ... }
+  async openExistingDocument(id) { ... }
+  async fillTitle(value) { ... }
+  async fillDescription(value) { ... }
+  async clickSaveDraft() { ... }
+  async clickPublish() { ... }
+  // …18 methods total
+}
```

Negative fixture (production service class — should fire):
```diff
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/services/god-module-task-handlers.ts
+// VIOLATION: architecture/deterministic/god-module
+export class TaskHandlers {
+  createTask(...) {...}
+  getTask(...) {...}
+  updateTitle(...) {...}
+  // …18 methods total
+}
```

Visitor change: added `isTestSupportModulePath()` to `packages/analyzer/src/rules/architecture/checker.ts`. The god-module loop skips modules whose file path matches `__tests__/`, `__mocks__/`, `.test.*` / `.spec.*`, or sits inside an `e2e/`, `playwright/`, or `cypress/` directory. Test-support modules intentionally collect many helper methods.

## bugs/deterministic/element-overwrite

- Source FP: https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/hooks/use-autosave.ts#L33
- `isProcessingRef.current = true; await …; isProcessingRef.current = false` is the React `useRef` lock idiom. The two assignments bracket an awaited region, and the intermediate `true` value is observed by reentrant async callers via the ref's shared `.current`.

Positive fixture (React useRef lock — should not fire):
```diff
+++ b/tests/fixtures/sample-js-project-positive/services/web/src/hooks/element-overwrite-async-lock.ts
+export async function runOnce<T>(
+  lockRef: RefStub<boolean>,
+  queueRef: RefStub<T[]>,
+  handle: (items: readonly T[]) => Promise<void>,
+): Promise<void> {
+  if (lockRef.current || queueRef.current.length === 0) return;
+
+  lockRef.current = true;
+  const pending = queueRef.current;
+  queueRef.current = [];
+  await handle(pending);
+  lockRef.current = false;
+}
```

Negative fixture (consecutive overwrite with nothing observing first — should fire):
```diff
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/services/element-overwrite-config.ts
+export function applyConfig(config: Config): Config {
+  // VIOLATION: bugs/deterministic/element-overwrite
+  config.retries = 1;
+  config.retries = 3;
+  return config;
+}
```

Visitor change: in `packages/analyzer/src/rules/bugs/visitors/javascript/element-overwrite.ts`, added a `containsAwait()` descendant scan and skip the violation when (a) the LHS property is `.current` and (b) any intervening statement contains an `await_expression`. The await yield exposes the first assignment to re-entrant async callers via the ref's mutable `.current`.

## code-quality/deterministic/missing-env-validation

- Source FP: https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/telemetry/telemetry-client.ts#L13
- `const HAS_LICENSE_KEY = !!process.env.X` IS validation — `!!` coerces undefined to `false`. The rule already exempts `if`, `binary_expression`, `ternary_expression`, and `logical_expression`, but not unary `!`.

Positive fixture (boolean-coerced env access — should not fire):
```diff
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/missing-env-validation-bool-coerce.ts
+export const HAS_LICENSE_KEY = !!process.env.SAMPLE_LICENSE_KEY;
+export const IS_DEBUG_DISABLED = !process.env.SAMPLE_DEBUG;
```

Negative fixture (raw env, no validation — should fire):
```diff
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/missing-env-validation-raw.ts
+export function buildAuthHeader(): string {
+  // VIOLATION: code-quality/deterministic/missing-env-validation
+  const apiKey = process.env.SAMPLE_API_TOKEN;
+  return `Bearer ${apiKey}`;
+}
```

Visitor change: in `packages/analyzer/src/rules/code-quality/visitors/javascript/missing-env-validation.ts`, the ancestor-walk now also matches `unary_expression` whose operator is `!`. Both `!process.env.X` and `!!process.env.X` are treated as validation contexts.

## code-quality/deterministic/no-script-url

- Source FP: https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/utils/sanitize-branding-css.ts#L61
- The string `'javascript:'` lives inside `BLOCKED_VALUE_SUBSTRINGS`, a denylist used by a CSS sanitizer. The code is rejecting the pattern, not introducing one.

Positive fixture (literal in a sanitizer denylist — should not fire):
```diff
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/no-script-url-denylist.ts
+const BLOCKED_VALUE_SUBSTRINGS = ['url(', 'expression(', '@import', 'javascript:'];
+export function isBlocked(value: string): boolean {
+  const lower = value.toLowerCase();
+  for (const substring of BLOCKED_VALUE_SUBSTRINGS) {
+    if (lower.includes(substring)) return true;
+  }
+  return false;
+}
```

Negative fixture (anchor href assigned a `javascript:` URL — should fire):
```diff
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/no-script-url-anchor.ts
+export function attachOpener(anchor: AnchorStub): void {
+  // VIOLATION: code-quality/deterministic/no-script-url
+  anchor.href = 'javascript:openDialog()';
+}
```

Visitor change: in `packages/analyzer/src/rules/code-quality/visitors/javascript/no-script-url.ts`, also bail when the string's tree-sitter parent is an `array` literal — literal denylist/allowlist entries are the opposite of the rule's intent.

## code-quality/deterministic/regex-empty-repetition

- Source FP: https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/team-router/schema.ts#L30
- The regex is `/^[a-z0-9]+(?:[-_][a-z0-9]+)*$/`. The inner group `[-_][a-z0-9]+` requires at least one separator AND one alphanumeric — it cannot match the empty string, so the outer `*` cannot drive catastrophic backtracking. The old matcher fired on any `*` or `+` anywhere inside the group, which is far too broad.

Positive fixture (bounded inner pattern — should not fire):
```diff
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/regex-empty-repetition-bounded.ts
+export const URL_SLUG = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/u;
```

Negative fixture (`(a*)*` — true catastrophic backtracking — should fire):
```diff
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/regex-empty-repetition-nested.ts
+// VIOLATION: code-quality/deterministic/regex-empty-repetition
+export const NESTED_STAR = /^(a*)*$/;
```

Visitor change: in `packages/analyzer/src/rules/code-quality/visitors/javascript/regex-empty-repetition.ts`, tightened the detection regex to `\((?:\?[:!=]|\?<[!=])?(?:[^)]*(?:[*?]|\{0,\d*\}))?\)[*+]`. The inner group only counts as "can match empty" when it is itself empty, or its trailing atom is a zero-or-more quantifier (`*`, `?`, or `{0,…}`). A trailing `+` requires content and no longer triggers.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vsb5dfLKgRnRDRU92qgQtU)_