### PR TITLE
fix(fp): resolve 3 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/index-of-positive-check.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/index-of-positive-check.ts
@@ -22,31 +22,41 @@ export const indexOfPositiveCheckVisitor: CodeRuleVisitor = {
       return prop?.text === 'indexOf' || prop?.text === 'lastIndexOf'
     }
 
-    // Flag any comparison to a non-negative integer (0 or positive) — only -1 is meaningful
-    function isNonNegativeNumber(n: SyntaxNode): boolean {
-      if (n.type !== 'number') return false
+    function asNonNegativeInt(n: SyntaxNode): number | null {
+      if (n.type !== 'number') return null
       const val = Number(n.text)
-      return Number.isInteger(val) && val >= 0
+      return Number.isInteger(val) && val >= 0 ? val : null
     }
 
-    if (isIndexOfCall(left) && isNonNegativeNumber(right)) {
-      return makeViolation(
-        this.ruleKey, node, filePath, 'medium',
-        'indexOf compared to positive number',
-        `\`indexOf()\` returns -1 when not found. Comparing to \`${right.text}\` misses the case where the element is at index 0. Use \`!== -1\` to check if found.`,
-        sourceCode,
-        'Compare to -1: use `indexOf(x) !== -1` (found) or `indexOf(x) === -1` (not found).',
-      )
+    // Only flag operator/value combinations that exclude valid array
+    // indexes from a "found" check. `indexOf(x) >= 0` and `indexOf(x) < 0`
+    // are the correct found / not-found idioms and must not fire here.
+    const op = operator.text
+
+    if (isIndexOfCall(left)) {
+      const val = asNonNegativeInt(right)
+      if (val !== null && ((op === '>' && val === 0) || (op === '>=' && val >= 1))) {
+        return makeViolation(
+          this.ruleKey, node, filePath, 'medium',
+          'indexOf compared to positive number',
+          `\`indexOf()\` returns -1 when not found. Comparing to \`${right.text}\` misses the case where the element is at index 0. Use \`!== -1\` to check if found.`,
+          sourceCode,
+          'Compare to -1: use `indexOf(x) !== -1` (found) or `indexOf(x) === -1` (not found).',
+        )
+      }
     }
 
-    if (isIndexOfCall(right) && isNonNegativeNumber(left)) {
-      return makeViolation(
-        this.ruleKey, node, filePath, 'medium',
-        'indexOf compared to positive number',
-        `\`indexOf()\` returns -1 when not found. Comparing to \`${left.text}\` misses the case where the element is at index 0. Use \`!== -1\` to check if found.`,
-        sourceCode,
-        'Compare to -1: use `indexOf(x) !== -1` (found) or `indexOf(x) === -1` (not found).',
-      )
+    if (isIndexOfCall(right)) {
+      const val = asNonNegativeInt(left)
+      if (val !== null && ((op === '<' && val === 0) || (op === '<=' && val >= 1))) {
+        return makeViolation(
+          this.ruleKey, node, filePath, 'medium',
+          'indexOf compared to positive number',
+          `\`indexOf()\` returns -1 when not found. Comparing to \`${left.text}\` misses the case where the element is at index 0. Use \`!== -1\` to check if found.`,
+          sourceCode,
+          'Compare to -1: use `indexOf(x) !== -1` (found) or `indexOf(x) === -1` (not found).',
+        )
+      }
     }
 
     return null

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/useless-constructor.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/useless-constructor.ts
@@ -9,6 +9,12 @@ export const uselessConstructorVisitor: CodeRuleVisitor = {
     const nameNode = node.childForFieldName('name')
     if (nameNode?.text !== 'constructor') return null
 
+    // `private`/`protected` constructors aren't useless — they restrict
+    // instantiation (e.g. singleton pattern). Removing them would expose
+    // the default public constructor and change observable behavior.
+    const modifier = node.namedChildren.find((c) => c.type === 'accessibility_modifier')
+    if (modifier && (modifier.text === 'private' || modifier.text === 'protected')) return null
+
     const body = node.namedChildren.find((c) => c.type === 'statement_block')
     if (!body) return null
 

--- a/packages/analyzer/src/rules/performance/visitors/javascript/_helpers.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/_helpers.ts
@@ -173,6 +173,34 @@ export function isLikelyServerComponent(filePath: string, sourceCode: string): b
   return true
 }
 
+/**
+ * Heuristic: is the file a one-off script (CLI, seed, build tool) rather
+ * than long-running server code? "In handler" performance rules don't
+ * apply to scripts that run once and exit.
+ *
+ * A file is considered script-like if:
+ *   1. The basename starts with `seed-` / `seed.` (e.g. `seed-database.ts`).
+ *   2. The basename has a `.cli.` / `.script.` infix (`run.cli.ts`).
+ *   3. Any ancestor directory is `scripts`, `bin`, `tools`, `cli`,
+ *      `cmd`, `seed`, or `seeds`.
+ */
+export function isScriptLikeJsFile(filePath: string): boolean {
+  const segments = filePath.split('/')
+  const fileName = (segments[segments.length - 1] ?? '').toLowerCase()
+
+  if (/^seed[-.]/.test(fileName)) return true
+  if (/\.(cli|script)\.[cm]?[tj]sx?$/.test(fileName)) return true
+
+  for (let i = 0; i < segments.length - 1; i++) {
+    const dir = segments[i]?.toLowerCase()
+    if (dir === 'scripts' || dir === 'bin' || dir === 'tools' ||
+        dir === 'cli' || dir === 'cmd' || dir === 'seed' || dir === 'seeds') {
+      return true
+    }
+  }
+  return false
+}
+
 export function findContainingStatement(node: SyntaxNode): SyntaxNode | null {
   let current: SyntaxNode | null = node
   while (current) {

--- a/packages/analyzer/src/rules/performance/visitors/javascript/sync-require-in-handler.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/sync-require-in-handler.ts
@@ -1,6 +1,6 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
-import { isInsideAsyncFunctionOrHandler } from './_helpers.js'
+import { isInsideAsyncFunctionOrHandler, isScriptLikeJsFile } from './_helpers.js'
 
 export const syncRequireInHandlerVisitor: CodeRuleVisitor = {
   ruleKey: 'performance/deterministic/sync-require-in-handler',
@@ -9,6 +9,11 @@ export const syncRequireInHandlerVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     const fn = node.childForFieldName('function')
     if (!fn || fn.type !== 'identifier' || fn.text !== 'require') return null
+
+    // CLI / seed / build scripts run once and exit; the "in handler" perf
+    // concern doesn't apply, and dynamic `require(path)` is the standard
+    // way to iterate over a directory of script modules.
+    if (isScriptLikeJsFile(filePath)) return null
 
     if (!isInsideAsyncFunctionOrHandler(node)) return null
 

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -85,6 +85,12 @@
       "layer": "api"
     },
     {
+      "name": "handleParse",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "api"
+    },
+    {
       "name": "HealthService",
       "service": "api-gateway",
       "kind": "class",
@@ -583,6 +589,12 @@
       "layer": "service"
     },
     {
+      "name": "BaseHandler",
+      "service": "utils",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "Builder",
       "service": "utils",
       "kind": "class",
@@ -596,6 +608,12 @@
     },
     {
       "name": "CaseHelpers",
+      "service": "utils",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "ChildHandler",
       "service": "utils",
       "kind": "class",
       "layer": "service"
@@ -776,6 +794,12 @@
     },
     {
       "name": "http-call-no-timeout-external",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "isSelectedBuggy",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/sync-require-in-handler-server-route.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/sync-require-in-handler-server-route.ts
@@ -1,0 +1,11 @@
+// True-bug shape: a synchronous `require()` inside an async server-side
+// request handler blocks the event loop on first call. The lib should be
+// imported at module top instead.
+
+declare function require(id: string): { parse: (s: string) => unknown };
+
+export async function handleParse(req: { body: string }, res: { send: (v: unknown) => void }) {
+  // VIOLATION: performance/deterministic/sync-require-in-handler
+  const parser = require('big-parser-lib');
+  res.send(parser.parse(req.body));
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/index-of-positive-check-misses-zero.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/index-of-positive-check-misses-zero.ts
@@ -1,0 +1,10 @@
+// True-bug shape: `indexOf(x) > 0` misses the case where the element is at
+// index 0 (it returns false for the first item). The correct found-check is
+// `>= 0` or `!== -1`.
+
+type Node = { id: string };
+
+export function isSelectedBuggy(selected: Node[], node: Node): boolean {
+  // VIOLATION: bugs/deterministic/index-of-positive-check
+  return selected.indexOf(node) > 0;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/useless-constructor-passthrough.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/useless-constructor-passthrough.ts
@@ -1,0 +1,14 @@
+// True-bug shape: a public constructor that only forwards its args to
+// `super()` is redundant — the parent constructor would be inherited
+// automatically.
+
+class BaseHandler {
+  constructor(public name: string) {}
+}
+
+export class ChildHandler extends BaseHandler {
+  // VIOLATION: code-quality/deterministic/useless-constructor
+  constructor(name: string) {
+    super(name);
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/scripts/seed-database-require-loop.js
+++ b/tests/fixtures/sample-js-project-positive/scripts/seed-database-require-loop.js
@@ -1,0 +1,20 @@
+// Paraphrased FP shape for performance/deterministic/sync-require-in-handler.
+//
+// CLI seed scripts run once and exit — they have no request-handler latency
+// to protect. Dynamic `require(path)` inside an async top-level driver is
+// the idiomatic way to iterate over a directory of seed modules.
+
+const files = ['users.js', 'documents.js'];
+
+const runAll = async () => {
+  for (const file of files) {
+    const mod = require(`${__dirname}/seed/${file}`);
+    if (mod && typeof mod.run === 'function') {
+      await mod.run();
+    }
+  }
+};
+
+runAll().catch((err) => {
+  console.error(err);
+});

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/index-of-positive-check-found-idiom.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/index-of-positive-check-found-idiom.ts
@@ -1,0 +1,19 @@
+// Paraphrased FP shape for bugs/deterministic/index-of-positive-check.
+//
+// `lastIndexOf(x) >= 0` and `lastIndexOf(x) < 0` are the correct
+// found / not-found idioms — both include index 0 in the "found" set.
+// The rule should only flag patterns that exclude valid array indexes
+// (e.g. `> 0`, `>= 1`).
+//
+// Uses `lastIndexOf` to demonstrate the same visitor branch without
+// colliding with the prefer-includes rule (which only flags `indexOf`).
+
+type Node = { id: string };
+
+export function isLastSelected(selected: ReadonlyArray<Node>, node: Node): boolean {
+  return selected.lastIndexOf(node) >= 0;
+}
+
+export function isLastUnselected(selected: ReadonlyArray<Node>, node: Node): boolean {
+  return selected.lastIndexOf(node) < 0;
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/useless-constructor-singleton.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/useless-constructor-singleton.ts
@@ -1,0 +1,28 @@
+// Paraphrased FP shape for code-quality/deterministic/useless-constructor.
+//
+// A `private` constructor is NOT useless — it prevents external
+// instantiation (e.g. singleton pattern, sealed factories). A
+// `protected` constructor restricts construction to subclasses.
+// Removing either would expose the default public constructor and
+// break that contract.
+
+abstract class BaseProvider {
+  protected ready = false;
+}
+
+export class SealedProvider extends BaseProvider {
+  private constructor() {
+    super();
+  }
+
+  static create(): SealedProvider {
+    return new SealedProvider();
+  }
+}
+
+export class SubclassableBase extends BaseProvider {
+  protected constructor(label: string) {
+    super();
+    this.ready = label.length > 0;
+  }
+}


### PR DESCRIPTION
Closes #206
Closes #207
Closes #208

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
| --- | --- | --- | --- |
| bugs/deterministic/index-of-positive-check | #206 | `tests/fixtures/sample-js-project-positive/shared/utils/src/index-of-positive-check-found-idiom.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/index-of-positive-check-misses-zero.ts` |
| code-quality/deterministic/useless-constructor | #207 | `tests/fixtures/sample-js-project-positive/shared/utils/src/useless-constructor-singleton.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/useless-constructor-passthrough.ts` |
| performance/deterministic/sync-require-in-handler | #208 | `tests/fixtures/sample-js-project-positive/scripts/seed-database-require-loop.js` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/sync-require-in-handler-server-route.ts` |

## bugs/deterministic/index-of-positive-check

OSS source:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx#L369`

Positive fixture (`tests/fixtures/sample-js-project-positive/shared/utils/src/index-of-positive-check-found-idiom.ts`):

```diff
+// Paraphrased FP shape for bugs/deterministic/index-of-positive-check.
+//
+// `lastIndexOf(x) >= 0` and `lastIndexOf(x) < 0` are the correct
+// found / not-found idioms — both include index 0 in the "found" set.
+// The rule should only flag patterns that exclude valid array indexes
+// (e.g. `> 0`, `>= 1`).
+//
+// Uses `lastIndexOf` to demonstrate the same visitor branch without
+// colliding with the prefer-includes rule (which only flags `indexOf`).
+
+type Node = { id: string };
+
+export function isLastSelected(selected: ReadonlyArray<Node>, node: Node): boolean {
+  return selected.lastIndexOf(node) >= 0;
+}
+
+export function isLastUnselected(selected: ReadonlyArray<Node>, node: Node): boolean {
+  return selected.lastIndexOf(node) < 0;
+}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/index-of-positive-check-misses-zero.ts`):

```diff
+// True-bug shape: `indexOf(x) > 0` misses the case where the element is at
+// index 0 (it returns false for the first item). The correct found-check is
+// `>= 0` or `!== -1`.
+
+type Node = { id: string };
+
+export function isSelectedBuggy(selected: Node[], node: Node): boolean {
+  // VIOLATION: bugs/deterministic/index-of-positive-check
+  return selected.indexOf(node) > 0;
+}
```

Visitor change: narrowed the visitor to only flag operator/value combinations that exclude valid array indexes from a "found" check — specifically `indexOf > 0` and `indexOf >= 1` (and their reversed forms). The correct idioms `>= 0`, `< 0`, `!== -1`, `=== -1` no longer fire. Reverse comparisons (`0 < indexOf`, `1 <= indexOf`) are still flagged.

## code-quality/deterministic/useless-constructor

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/local.ts#L47

Positive fixture (`tests/fixtures/sample-js-project-positive/shared/utils/src/useless-constructor-singleton.ts`):

```diff
+// Paraphrased FP shape for code-quality/deterministic/useless-constructor.
+//
+// A `private` constructor is NOT useless — it prevents external
+// instantiation (e.g. singleton pattern, sealed factories). A
+// `protected` constructor restricts construction to subclasses.
+// Removing either would expose the default public constructor and
+// break that contract.
+
+abstract class BaseProvider {
+  protected ready = false;
+}
+
+export class SealedProvider extends BaseProvider {
+  private constructor() {
+    super();
+  }
+
+  static create(): SealedProvider {
+    return new SealedProvider();
+  }
+}
+
+export class SubclassableBase extends BaseProvider {
+  protected constructor(label: string) {
+    super();
+    this.ready = label.length > 0;
+  }
+}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/useless-constructor-passthrough.ts`):

```diff
+// True-bug shape: a public constructor that only forwards its args to
+// `super()` is redundant — the parent constructor would be inherited
+// automatically.
+
+class BaseHandler {
+  constructor(public name: string) {}
+}
+
+export class ChildHandler extends BaseHandler {
+  // VIOLATION: code-quality/deterministic/useless-constructor
+  constructor(name: string) {
+    super(name);
+  }
+}
```

Visitor change: skip the visitor when the constructor has a `private` or `protected` accessibility modifier — those modifiers restrict visibility, so the constructor is not removable without changing observable behavior.

## performance/deterministic/sync-require-in-handler

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/seed-database.ts#L12

Positive fixture (`tests/fixtures/sample-js-project-positive/scripts/seed-database-require-loop.js`):

```diff
+// Paraphrased FP shape for performance/deterministic/sync-require-in-handler.
+//
+// CLI seed scripts run once and exit — they have no request-handler latency
+// to protect. Dynamic `require(path)` inside an async top-level driver is
+// the idiomatic way to iterate over a directory of seed modules.
+
+const files = ['users.js', 'documents.js'];
+
+const runAll = async () => {
+  for (const file of files) {
+    const mod = require(`${__dirname}/seed/${file}`);
+    if (mod && typeof mod.run === 'function') {
+      await mod.run();
+    }
+  }
+};
+
+runAll().catch((err) => {
+  console.error(err);
+});
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/sync-require-in-handler-server-route.ts`):

```diff
+// True-bug shape: a synchronous `require()` inside an async server-side
+// request handler blocks the event loop on first call. The lib should be
+// imported at module top instead.
+
+declare function require(id: string): { parse: (s: string) => unknown };
+
+export async function handleParse(req: { body: string }, res: { send: (v: unknown) => void }) {
+  // VIOLATION: performance/deterministic/sync-require-in-handler
+  const parser = require('big-parser-lib');
+  res.send(parser.parse(req.body));
+}
```

Visitor change: added an `isScriptLikeJsFile` helper that flags files whose basename starts with `seed-`/`seed.`, has a `.cli.`/`.script.` infix, or sits under an ancestor directory named `scripts`, `bin`, `tools`, `cli`, `cmd`, `seed`, or `seeds`. The `sync-require-in-handler` visitor short-circuits on these — CLI/seed scripts have no request-handler latency to protect.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6fcRWyh2uGMk356LcMDZo)_