### PR TITLE
fp-automation: re-discovery continues in-session + TG rollup for issue bursts

### DIFF
--- a/.github/workflows/notify-routine-activity.yml
+++ b/.github/workflows/notify-routine-activity.yml
@@ -18,6 +18,11 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: read
+  contents: read
+  pull-requests: read
+
 jobs:
   notify-pr:
     if: >
@@ -45,12 +50,74 @@ jobs:
             --data-urlencode "text=${MESSAGE}" \
             > /dev/null
 
-  notify-issue:
+  # Bursts of fp-fix issues (fp-discover initial filing, fp-next-fix
+  # re-discovery filing) used to produce one TG message per issue —
+  # 30+ messages in a row. Debounce with concurrency: each new fp-fix
+  # `issues.opened` event cancels the prior in-progress run, so only
+  # the last event's run survives. That run sleeps to let the burst
+  # settle, queries all fp-fix issues opened in the last 10 minutes,
+  # and sends ONE rollup message with the count.
+  notify-fp-fix-burst:
     if: >
       github.event_name == 'issues' &&
-      (contains(github.event.issue.labels.*.name, 'fp-fix') ||
-       contains(github.event.issue.labels.*.name, 'fp-blocked') ||
-       startsWith(github.event.issue.title, '[fp-campaign-close]'))
+      contains(github.event.issue.labels.*.name, 'fp-fix')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: fp-fix-burst
+      cancel-in-progress: true
+    steps:
+      - name: Wait for burst to settle
+        run: sleep 60
+
+      - name: Send rollup Telegram message
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+            echo "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID secret not set — skipping notification."
+            exit 0
+          fi
+
+          since=$(date -u -d '10 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')
+          issues_json=$(gh issue list \
+            --repo "$REPO" \
+            --label fp-fix \
+            --state open \
+            --search "created:>${since}" \
+            --json number,title \
+            --limit 200)
+
+          count=$(echo "$issues_json" | jq 'length')
+          if [ "$count" -eq 0 ]; then
+            echo "No fp-fix issues opened in window — nothing to roll up."
+            exit 0
+          fi
+
+          sample=$(echo "$issues_json" | jq -r '.[0:5][] | "• #\(.number) \(.title)"')
+          first_num=$(echo "$issues_json" | jq -r '.[0].number')
+          first_url="https://github.com/${REPO}/issues/${first_num}"
+
+          if [ "$count" -eq 1 ]; then
+            MESSAGE=$(printf "📋 1 new fp-fix issue filed\n\n%s\n\n%s" \
+              "$sample" "$first_url")
+          else
+            MESSAGE=$(printf "📋 %s new fp-fix issues filed\n\n%s\n\n%s" \
+              "$count" "$sample" "$first_url")
+          fi
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" \
+            > /dev/null
+
+  # Campaign-close failure issues are filed individually and are rare —
+  # no rollup, fire per-issue.
+  notify-campaign-close-failure:
+    if: >
+      github.event_name == 'issues' &&
+      startsWith(github.event.issue.title, '[fp-campaign-close]')
     runs-on: ubuntu-latest
     steps:
       - name: Send Telegram message
@@ -65,7 +132,7 @@ jobs:
             echo "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID secret not set — skipping notification."
             exit 0
           fi
-          MESSAGE=$(printf "🔔 New routine issue #%s\n%s\n\n%s" \
+          MESSAGE=$(printf "⚠️ fp-campaign-close failure: #%s\n%s\n\n%s" \
             "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_URL")
           curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -369,9 +369,20 @@ far in this session:
 6. **If `tp_rate < 0.90`** — campaign continues. File one new fp-fix
    issue per rule with FPs (same shape as discovery). Leave the
    campaign's `status` as `in_progress`. **Do not** open a
-   campaign-close PR; no release is cut. The next fp-fix PR merge
-   will refire fp-next-fix to keep working through the new issues.
-   End.
+   campaign-close PR; no release is cut.
+
+   **Then continue into the per-issue loop in this same session** —
+   the target clone, dist build, `before_counts`, and counters are
+   all still valid; only the issue list needs re-fetching. Process
+   the freshly-filed issues with the remaining `successes`/`attempts`
+   budget. If the budget allows at least one success, the session
+   will end with a normal batched PR (which carries the FP-count
+   delta and fires Trigger B on merge).
+
+   The rationale: this path used to end here and require a manual
+   "Run now" click to kick the loop. Continuing in-session removes
+   that hand-off — the session that filed the new issues immediately
+   starts processing them.
 
 If the queue empties during the per-issue loop **after** at least one
 success, go to "Open the batched PR" with what you have — don't run


### PR DESCRIPTION
Two small QoL fixes for the fp-automation chain, bundled because they're both small and orthogonal.

## 1. fp-next-fix re-discovery continues in-session (was: stalled)

**Symptom**: a fp-next-fix session hit the queue-empty path (all open `fp-fix` issues blocked), re-analyzed, found `tp_rate < 0.90`, filed new `fp-fix` issues, and ended. The chain stalled because Trigger B fires on `fp-fix` PR merge — not on issue creation — so nothing re-fired fp-next-fix without you clicking **Run now**.

**Fix**: after filing the new issues, the session now re-enters the per-issue loop with the same target clone, dist build, `before_counts`, and counters. The session ends with a normal batched PR (or no-PR if no successes), and Trigger B fires on its merge as usual. No manual kick required.

## 2. TG rollup for fp-fix issue bursts (was: 30+ messages per campaign start)

**Symptom**: when fp-discover (or fp-next-fix re-discovery) files ~30 issues, the workflow sends one TG message per issue.

**Fix**: new `notify-fp-fix-burst` job uses `concurrency: cancel-in-progress` on group `fp-fix-burst`. Each new `issues.opened` event cancels the prior in-flight run. Only the last issue's run survives, sleeps 60s for the burst to settle, queries all fp-fix issues opened in the last 10 min, and sends ONE rollup message:

```
📋 30 new fp-fix issues filed

• #301 [fp-fix] bugs/foo in documenso/documenso
• #302 [fp-fix] bugs/bar in documenso/documenso
• #303 [fp-fix] code-quality/baz in documenso/documenso
• #304 ...

https://github.com/truecourse-ai/truecourse/issues/301
```

Single-issue bursts get the singular form. `[fp-campaign-close]` failure issues keep their per-issue notifications (rare, one-off, no rollup needed). Dead `fp-blocked` filter branch dropped (that label is added post-creation, never present at `issues.opened`).

## Test plan

- [ ] Merge.
- [ ] Watch the next fp-discover session: confirm one rollup TG arrives ~60s after the burst settles.
- [ ] When fp-next-fix next hits the re-discovery path (all-blocked queue + TP < 90%), confirm it continues processing in the same session and opens a batched PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_