### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/architecture/checker.ts
+++ b/packages/analyzer/src/rules/architecture/checker.ts
@@ -767,6 +767,48 @@ export function checkModuleRules(
           }
         }
 
+        // Skip when the source file imports the target through a "deep
+        // bare specifier" — a package import with a sub-path beyond the
+        // package name (e.g. `@scope/pkg/primitives/dialog`). Sub-path
+        // imports only work because the target package exposed that path
+        // via its `files`/`exports` field (or imposed no restriction at
+        // all), so the path is part of the package's published API
+        // surface, not internal reach-through. Without this skip,
+        // monorepo packages with subpath exports
+        // (`@documenso/ui/primitives/*`, shadcn-style kits) flood with FPs.
+        if (dep.sourceFilePath && dep.targetFilePath) {
+          const importSources = fileImportSources.get(dep.sourceFilePath)
+          if (importSources) {
+            const tgtStem = dep.targetFilePath.replace(/\.(?:tsx?|jsx?|mjs|cjs|d\.ts)$/, '')
+            const importedViaPublicSubpath = [...importSources].some((src) => {
+              if (
+                src.startsWith('.') ||
+                src.startsWith('/') ||
+                src.startsWith('@/') ||
+                src.startsWith('~/')
+              ) return false
+              // Split package portion (scoped: `@scope/name`, unscoped:
+              // `name`) from the sub-path; require at least one sub-path
+              // segment.
+              let subPath: string | null = null
+              if (src.startsWith('@')) {
+                const segs = src.split('/')
+                if (segs.length >= 3) subPath = segs.slice(2).join('/')
+              } else {
+                const slash = src.indexOf('/')
+                if (slash > 0 && slash < src.length - 1) subPath = src.slice(slash + 1)
+              }
+              if (!subPath) return false
+              // Confirm this import is the one that resolved to this
+              // dep's target file (its stem ends with the sub-path, or
+              // with `<sub-path>/index` for directory imports).
+              return tgtStem.endsWith('/' + subPath) ||
+                     tgtStem.endsWith('/' + subPath + '/index')
+            })
+            if (importedViaPublicSubpath) continue
+          }
+        }
+
         violations.push({
           ruleKey: 'architecture/deterministic/cross-service-internal-import',
           title: `Cross-service internal import: \`${srcMod.name}\` → \`${tgtMod.name}\``,

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/loose-boolean-expression.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/loose-boolean-expression.ts
@@ -63,6 +63,18 @@ export const looseBooleanExpressionVisitor: CodeRuleVisitor = {
       const baseType = typeStr.replace(/\s*\|.*/, '') // first type in union
       if (/^[A-Z]/.test(baseType) && !['Number', 'String', 'Boolean'].includes(baseType)) return null
 
+      // Only fire when a *falsy literal* sits inside the union — that's
+      // the case where the truthy check silently collapses a meaningful
+      // value (the empty string, `0`, `0n`) with the "missing" reading
+      // the rest of the union represents. `if (value)` on `string`,
+      // `number`, `boolean`, or any `T | null | undefined` of those is
+      // the idiomatic null-or-empty guard; the @typescript-eslint
+      // strict-boolean-expressions stricter reading floods FPs with no
+      // observed bug payoff.
+      const parts = typeStr.split('|').map(p => p.trim())
+      const FALSY_LITERAL = /^(?:""|''|0|0n)$/
+      if (!parts.some(p => FALSY_LITERAL.test(p))) return null
+
       return makeViolation(
         this.ruleKey, node, filePath, 'medium',
         'Non-boolean in boolean context',

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/useeffect-missing-deps.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/useeffect-missing-deps.ts
@@ -6,9 +6,18 @@ import { JS_LANGUAGES } from './_helpers.js'
 // Detect: useEffect(() => { uses variable X }, []) where X is not in deps array
 // Simple heuristic: useEffect with empty deps array but callback references identifiers
 
-function collectIdentifiers(node: SyntaxNode, skip: Set<string>): Set<string> {
+function collectIdentifiers(node: SyntaxNode, baseSkip: Set<string>): Set<string> {
   const ids = new Set<string>()
-  function walk(n: SyntaxNode) {
+
+  function collectParamNames(params: SyntaxNode, into: Set<string>): void {
+    if (params.type === 'identifier') into.add(params.text)
+    for (let i = 0; i < params.childCount; i++) {
+      const child = params.child(i)
+      if (child) collectParamNames(child, into)
+    }
+  }
+
+  function walk(n: SyntaxNode, skip: Set<string>) {
     if (n.type === 'identifier' && !skip.has(n.text)) {
       // Only include identifiers that are in a value position
       const parent = n.parent
@@ -22,13 +31,37 @@ function collectIdentifiers(node: SyntaxNode, skip: Set<string>): Set<string> {
       }
       ids.add(n.text)
     }
-    // Don't recurse into nested function scopes' parameter bindings
+    // Entering a nested function scope: extend the skip set with that
+    // function's parameter bindings before recursing. Without this, args
+    // of callbacks defined inside the effect (e.g. `setMessages((prev) =>
+    // …)`, `arr.map((item) => …)`) leak out as "missing closure deps".
+    let childSkip = skip
+    if (
+      n !== node &&
+      (n.type === 'arrow_function' ||
+        n.type === 'function_expression' ||
+        n.type === 'function' ||
+        n.type === 'function_declaration' ||
+        n.type === 'method_definition')
+    ) {
+      const params = n.childForFieldName('parameters') ?? n.childForFieldName('parameter')
+      if (params) {
+        const nested = new Set(skip)
+        collectParamNames(params, nested)
+        // Function-declaration own name is also bound in the nested scope.
+        if (n.type === 'function_declaration') {
+          const nameNode = n.childForFieldName('name')
+          if (nameNode?.type === 'identifier') nested.add(nameNode.text)
+        }
+        childSkip = nested
+      }
+    }
     for (let i = 0; i < n.childCount; i++) {
       const child = n.child(i)
-      if (child) walk(child)
+      if (child) walk(child, childSkip)
     }
   }
-  walk(node)
+  walk(node, baseSkip)
   return ids
 }
 

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/unchecked-array-access.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/unchecked-array-access.ts
@@ -20,8 +20,17 @@ export const uncheckedArrayAccessVisitor: CodeRuleVisitor = {
     if (index.type === 'number') return null
     // Skip string indexes (object property access)
     if (index.type === 'string') return null
-    // Skip when index is cast to string (property key access, not array indexing)
-    if (index.type === 'as_expression' && /\bas\s+string\b/.test(index.text)) return null
+    // Skip when index is cast to a string-keyed type. `as string` is the
+    // generic case; `as <Enum>` / `as <UnionAlias>` is the same pattern for
+    // a Record/Map exhaustively keyed by that enum or string-union — the
+    // cast IS the author's assertion that the lookup is total. Casts to
+    // numeric (`as number` / `as Number`) don't carry that meaning for
+    // arrays, so still fire.
+    if (index.type === 'as_expression') {
+      const castType = index.childForFieldName('type')?.text.trim() ?? ''
+      const isNumericCast = /^(?:number|Number)$/.test(castType)
+      if (!isNumericCast) return null
+    }
     // Skip when object is a Record/Map type assertion (property access, not array)
     if (object.type === 'parenthesized_expression' && object.text.includes('Record<')) return null
     if (object.type === 'as_expression' && object.text.includes('Record<')) return null
@@ -99,8 +108,21 @@ export const uncheckedArrayAccessVisitor: CodeRuleVisitor = {
     while (parent) {
       if (parent.type === 'if_statement') {
         const condition = parent.childForFieldName('condition')
-        if (condition && condition.text.includes('.length')) return null
-        if (condition && condition.text.includes(' in ') && condition.text.includes(indexText)) return null
+        if (condition) {
+          const condText = condition.text
+          if (condText.includes('.length')) return null
+          if (condText.includes(' in ') && condText.includes(indexText)) return null
+          // `findIndex`/`indexOf` return -1 on miss, so `idx !== -1`,
+          // `idx >= 0`, and `idx > -1` are canonical sentinel/bounds
+          // guards. Honor them when the if's condition names the same
+          // index variable used in the subscript.
+          if (
+            condText.includes(indexText) &&
+            (/!==?\s*-\s*1\b/.test(condText) ||
+              />=\s*0\b/.test(condText) ||
+              />\s*-\s*1\b/.test(condText))
+          ) return null
+        }
       }
       if (parent.type === 'ternary_expression' || parent.type === 'binary_expression') {
         if (parent.text.includes('.length')) return null

--- a/packages/analyzer/src/ts-compiler.ts
+++ b/packages/analyzer/src/ts-compiler.ts
@@ -451,7 +451,22 @@ export function createTypeQueryService(
       // Check if the type has a 'then' method (implements PromiseLike interface)
       // This catches thenables like drizzle-orm's PgRelationalQuery
       const thenProp = type.getProperty('then')
-      return !!thenProp
+      if (thenProp) return true
+      // A "value-or-promise" union (`Promise<T> | T`, often hidden behind
+      // an alias like `CopyValue`) is a legitimate `await` target — the
+      // promise branch unwraps and the value branch is a no-op. The
+      // string-head check above misses it whenever the compiler
+      // serializes the union with the non-promise branch first or whenever
+      // the alias replaces the expansion entirely; recurse into the
+      // union's constituent types so any promise-shaped member counts.
+      if (type.isUnion()) {
+        for (const t of type.types) {
+          const s = typeToString(filePath, t)
+          if (s.startsWith('Promise<') || s.includes('PromiseLike<')) return true
+          if (t.getProperty('then')) return true
+        }
+      }
+      return false
     },
 
     getReturnType(filePath, line, column, endLine?, endColumn?) {

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -133,6 +133,12 @@
       "layer": "api"
     },
     {
+      "name": "recordAuditEvent",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "redis",
       "service": "api-gateway",
       "kind": "standalone",
@@ -865,6 +871,12 @@
       "layer": "service"
     },
     {
+      "name": "nameAt",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "namespace-usage-internal-module",
       "service": "utils",
       "kind": "standalone",
@@ -982,6 +994,12 @@
       "name": "SetterNoReturn",
       "service": "utils",
       "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "shoutLabel",
+      "service": "utils",
+      "kind": "standalone",
       "layer": "service"
     },
     {
@@ -1105,6 +1123,12 @@
       "layer": "service"
     },
     {
+      "name": "Greeting",
+      "service": "web",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "IdenticalFunctionsBlockBody",
       "service": "web",
       "kind": "standalone",
@@ -1162,8 +1186,8 @@
   "moduleDependencies": [
     {
       "source": "assertEverything",
-      "target": "HealthService",
       "sourceService": "api-gateway",
+      "target": "HealthService",
       "targetService": "api-gateway",
       "importedNames": [
         "HealthService"
@@ -1171,17 +1195,26 @@
     },
     {
       "source": "assertEverything",
-      "target": "UserController",
       "sourceService": "api-gateway",
+      "target": "UserController",
       "targetService": "api-gateway",
       "importedNames": [
         "UserController"
       ]
     },
     {
-      "source": "UserController",
-      "target": "UserService",
+      "source": "recordAuditEvent",
       "sourceService": "api-gateway",
+      "target": "AuditLogRepository",
+      "targetService": "user-service",
+      "importedNames": [
+        "AuditLogRepository"
+      ]
+    },
+    {
+      "source": "UserController",
+      "sourceService": "api-gateway",
+      "target": "UserService",
       "targetService": "api-gateway",
       "importedNames": [
         "UserService"
@@ -1189,8 +1222,8 @@
     },
     {
       "source": "UserService",
-      "target": "formatters",
       "sourceService": "api-gateway",
+      "target": "formatters",
       "targetService": "utils",
       "importedNames": [
         "formatUser"
@@ -1198,8 +1231,8 @@
     },
     {
       "source": "NotificationProcessor",
-      "target": "EmailTemplates",
       "sourceService": "notification-service",
+      "target": "EmailTemplates",
       "targetService": "notification-service",
       "importedNames": [
         "EmailTemplates"
@@ -1207,8 +1240,8 @@
     },
     {
       "source": "NotificationProcessor",
-      "target": "sender",
       "sourceService": "notification-service",
+      "target": "sender",
       "targetService": "notification-service",
       "importedNames": [
         "sendEmail"
@@ -1216,8 +1249,8 @@
     },
     {
       "source": "src",
-      "target": "EmailTemplates",
       "sourceService": "notification-service",
+      "target": "EmailTemplates",
       "targetService": "notification-service",
       "importedNames": [
         "EmailTemplates"
@@ -1225,8 +1258,8 @@
     },
     {
       "source": "src",
-      "target": "NotificationProcessor",
       "sourceService": "notification-service",
+      "target": "NotificationProcessor",
       "targetService": "notification-service",
       "importedNames": [
         "NotificationProcessor"
@@ -1234,8 +1267,8 @@
     },
     {
       "source": "AuditLogRepository",
-      "target": "AuditEventsClient",
       "sourceService": "user-service",
+      "target": "AuditEventsClient",
       "targetService": "user-service",
       "importedNames": [
         "AuditEventsClient"
@@ -1243,8 +1276,8 @@
     },
     {
       "source": "src",
-      "target": "connection",
       "sourceService": "user-service",
+      "target": "connection",
       "targetService": "user-service",
       "importedNames": [
         "connectDatabase"
@@ -1252,8 +1285,8 @@
     },
     {
       "source": "user.handler",
-      "target": "UserService",
       "sourceService": "user-service",
+      "target": "UserService",
       "targetService": "user-service",
       "importedNames": [
         "UserService"
@@ -1261,8 +1294,8 @@
     },
     {
       "source": "user.handler",
-      "target": "validators",
       "sourceService": "user-service",
+      "target": "validators",
       "targetService": "utils",
       "importedNames": [
         "validateEmail"
@@ -1270,8 +1303,8 @@
     },
     {
       "source": "UserRepository",
-      "target": "user.handler",
       "sourceService": "user-service",
+      "target": "user.handler",
       "targetService": "user-service",
       "importedNames": [
         "getUsers"
@@ -1279,8 +1312,8 @@
     },
     {
       "source": "UserService",
-      "target": "UserRepository",
       "sourceService": "user-service",
+      "target": "UserRepository",
       "targetService": "user-service",
       "importedNames": [
         "UserRepository"
@@ -1288,8 +1321,8 @@
     },
     {
       "source": "Dashboard",
-      "target": "NotificationList",
       "sourceService": "web",
+      "target": "NotificationList",
       "targetService": "web",
       "importedNames": [
         "NotificationList"

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/cross-service-internal-import-relative-escape.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/cross-service-internal-import-relative-escape.ts
@@ -1,0 +1,13 @@
+// Reaching from one service into a sibling service's internal data-layer
+// module via a relative path that escapes the service directory bypasses
+// whatever public surface that sibling exposes. This is the bug pattern
+// cross-service-internal-import is meant to flag.
+
+// VIOLATION: architecture/deterministic/cross-service-internal-import
+import { AuditLogRepository } from '../../user-service/src/repositories/audit-log.repository';
+
+const repo = new AuditLogRepository();
+
+export function recordAuditEvent(userId: string, event: string): Promise<void> {
+  return repo.record(userId, event);
+}

--- a/tests/fixtures/sample-js-project-negative/services/notification-service/src/queue-worker.ts
+++ b/tests/fixtures/sample-js-project-negative/services/notification-service/src/queue-worker.ts
@@ -57,9 +57,12 @@ async function sendEmailJob(job: Job) {
 // VIOLATION: code-quality/deterministic/require-await
 // VIOLATION: code-quality/deterministic/missing-return-type
 async function sendSmsJob(job: Job) {
+  // `''` is a meaningful "not yet provided" state distinct from a
+  // delivered status, so `if (status)` collapses it together with the
+  // other states — the bug the rule should flag.
+  const status: '' | 'queued' | 'sent' = job.payload.status;
   // VIOLATION: bugs/deterministic/loose-boolean-expression
-  const recipient: string = job.payload.phone ?? '';
-  if (recipient) {
+  if (status) {
     return { jobId: job.id, sent: true };
   }
   return { jobId: job.id, sent: false };

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/UseEffectMissingDepsGreeting.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/UseEffectMissingDepsGreeting.tsx
@@ -1,0 +1,18 @@
+/**
+ * Negative fixture: a closure-captured prop (`name`) is referenced inside a
+ * useEffect with empty deps. The effect runs once on mount, so `message`
+ * never updates when `name` changes — a real stale-closure bug.
+ */
+
+import { useEffect, useState } from 'react';
+
+// VIOLATION: bugs/deterministic/useeffect-missing-deps
+export function Greeting({ name }: { name: string }): JSX.Element {
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    setMessage(`Hello, ${name}!`);
+  }, []);
+
+  return <p>{message}</p>;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/await-non-thenable-plain-value.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/await-non-thenable-plain-value.ts
@@ -1,0 +1,11 @@
+/**
+ * Negative fixture: `await` on a plainly-typed primitive does nothing —
+ * the `await` either masks a misplaced async/await intent or signals that
+ * the author misremembered the value's shape.
+ */
+
+export async function shoutLabel(value: string): Promise<string> {
+  // VIOLATION: bugs/deterministic/await-non-thenable
+  const resolved = await value;
+  return resolved.toUpperCase();
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unchecked-array-access-raw-index.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unchecked-array-access-raw-index.ts
@@ -1,0 +1,11 @@
+/**
+ * Negative fixture: a raw user-provided index used without a guard. The
+ * caller hands `position` in unchecked, and there's no length/sentinel/
+ * type-cast assertion that the slot exists.
+ */
+
+export function nameAt(roster: string[], position: number): string {
+  // VIOLATION: reliability/deterministic/unchecked-array-access
+  const candidate = roster[position];
+  return candidate.toUpperCase();
+}

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/cross-service-internal-import-public-subpath.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/cross-service-internal-import-public-subpath.ts
@@ -1,0 +1,11 @@
+// `primitives/` is listed in the `@sample/ui-kit` package's `files` field,
+// so `@sample/ui-kit/primitives/badge` is the package's published public
+// sub-path API — not internal reach-through. Flagging this import as
+// cross-service-internal-import is a false positive.
+
+import type { BadgeTone } from '@sample/ui-kit/primitives/badge';
+import { renderBadge } from '@sample/ui-kit/primitives/badge';
+
+export function describeBadge(label: string, tone: BadgeTone): string {
+  return renderBadge(label, tone);
+}

--- a/tests/fixtures/sample-js-project-positive/services/web/src/components/UseEffectMissingDepsNestedCallback.tsx
+++ b/tests/fixtures/sample-js-project-positive/services/web/src/components/UseEffectMissingDepsNestedCallback.tsx
@@ -1,0 +1,24 @@
+/**
+ * Positive fixture for bugs/deterministic/useeffect-missing-deps.
+ *
+ * The visitor previously walked into nested callbacks defined INSIDE the
+ * effect and collected their parameter names (e.g. `prev` in
+ * `setTicks((prev) => …)`, `item` in `arr.map((item) => …)`) as
+ * identifiers the closure was "missing". Callback args are not
+ * closure-captured deps — they're locally bound by the inner function.
+ */
+
+import { useEffect, useState } from 'react';
+
+export function Ticker(): JSX.Element {
+  const [ticks, setTicks] = useState<number[]>([]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setTicks((prev) => [...prev, prev.length]);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <div>{ticks.length}</div>;
+}

--- a/tests/fixtures/sample-js-project-positive/shared/ui-kit/package.json
+++ b/tests/fixtures/sample-js-project-positive/shared/ui-kit/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@sample/ui-kit",
+  "version": "1.0.0",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "files": [
+    "primitives/"
+  ],
+  "dependencies": {
+    "react": "^18.2.0"
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/shared/ui-kit/primitives/badge.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/ui-kit/primitives/badge.ts
@@ -1,0 +1,9 @@
+// `primitives/` is listed in this package's `files` field, so this module
+// is part of the package's published public surface — any consumer can
+// import `@sample/ui-kit/primitives/badge` as documented API.
+
+export type BadgeTone = 'neutral' | 'success' | 'warning';
+
+export function renderBadge(label: string, tone: BadgeTone = 'neutral'): string {
+  return `[${tone}] ${label}`;
+}

--- a/tests/fixtures/sample-js-project-positive/src/await-non-thenable-promise-or-value-union.ts
+++ b/tests/fixtures/sample-js-project-positive/src/await-non-thenable-promise-or-value-union.ts
@@ -1,0 +1,28 @@
+/**
+ * Positive fixture for bugs/deterministic/await-non-thenable.
+ *
+ * The "value-or-promise" union `Promise<T> | T` (often hidden behind an
+ * alias) is a perfectly legitimate `await` target — awaiting the value
+ * branch is a no-op, awaiting the promise branch unwraps it. The TS
+ * compiler is free to serialize the union with either side first and to
+ * print the alias name in place of the expansion, so the visitor must
+ * recurse into the union's constituent types rather than peek at the
+ * string head.
+ */
+
+type ClipboardPayload = Promise<string> | string;
+
+export const writeClipboard = async (
+  value: ClipboardPayload,
+  sink: (resolved: string) => void,
+): Promise<void> => {
+  sink(await value);
+};
+
+declare const fetchOrCached: () => Promise<number> | number;
+
+export const consumeCounter = async (
+  sink: (next: number) => void,
+): Promise<void> => {
+  sink(await fetchOrCached());
+};

--- a/tests/fixtures/sample-js-project-positive/src/loose-boolean-expression-primitive-truthiness.ts
+++ b/tests/fixtures/sample-js-project-positive/src/loose-boolean-expression-primitive-truthiness.ts
@@ -1,0 +1,47 @@
+/**
+ * Positive fixture for bugs/deterministic/loose-boolean-expression.
+ *
+ * `if (value)` on `string`, `number`, `boolean`, or any of these unioned
+ * with `null`/`undefined` is the idiomatic JS/TS null-or-empty guard. The
+ * canonical examples below all came back from
+ * @typescript-eslint/strict-boolean-expressions but flood codebases with
+ * noise without catching real bugs.
+ */
+
+export const allowExposed = (
+  exposedHeaders: readonly string[] | string | undefined,
+): string | null => {
+  const exposed = Array.isArray(exposedHeaders)
+    ? exposedHeaders.join(',')
+    : exposedHeaders;
+  if (exposed) {
+    return exposed;
+  }
+  return null;
+};
+
+export const firstNonEmptyHeader = (
+  headers: ReadonlyMap<string, string | null>,
+  names: readonly string[],
+): string | null => {
+  for (const name of names) {
+    const value = headers.get(name) ?? null;
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+};
+
+interface CorsOptions {
+  credentials?: boolean;
+}
+
+export const applyCredentials = (
+  opts: CorsOptions,
+  headers: Map<string, string>,
+): void => {
+  if (opts.credentials) {
+    headers.set('Access-Control-Allow-Credentials', 'true');
+  }
+};

--- a/tests/fixtures/sample-js-project-positive/src/unchecked-array-access-enum-cast-and-sentinel-guard.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unchecked-array-access-enum-cast-and-sentinel-guard.ts
@@ -1,0 +1,45 @@
+/**
+ * Two FP shapes the visitor previously flagged:
+ *
+ *  1. `MAP[x as Enum]` — a Record indexed by a value cast to the enum or
+ *     string-union the map is keyed by. The cast IS the author asserting
+ *     to the type system that the lookup is total over that union; the
+ *     visitor only honored an inline `as Record<…>` cast, not the
+ *     standard `MAP[k as KeyType]` shape.
+ *
+ *  2. `arr[idx]` after `if (idx !== -1)`. `Array.prototype.findIndex` and
+ *     `indexOf` return -1 on miss, so `idx !== -1` is the canonical bounds
+ *     guard for that pattern. The visitor only recognized `.length` and
+ *     `in` guards.
+ */
+
+type DocumentRole = 'OWNER' | 'EDITOR' | 'VIEWER';
+
+const ROLE_LABELS: Record<DocumentRole, string> = {
+  OWNER: 'Owner',
+  EDITOR: 'Editor',
+  VIEWER: 'Viewer',
+};
+
+export const describeRole = (raw: unknown): string => {
+  return ROLE_LABELS[raw as DocumentRole];
+};
+
+interface FieldRow {
+  id: string;
+  label: string;
+}
+
+const fieldRows: FieldRow[] = [];
+
+export const renameField = (
+  targetId: string,
+  nextLabel: string,
+): string | null => {
+  const fieldIndex = fieldRows.findIndex((f) => f.id === targetId);
+  if (fieldIndex !== -1) {
+    const current = fieldRows[fieldIndex];
+    return current.label === nextLabel ? current.label : nextLabel;
+  }
+  return null;
+};

--- a/tests/fixtures/sample-js-project-positive/tsconfig.json
+++ b/tests/fixtures/sample-js-project-positive/tsconfig.json
@@ -9,7 +9,8 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "paths": {
-      "@sample/shared-utils": ["./shared/utils/src/index.ts"]
+      "@sample/shared-utils": ["./shared/utils/src/index.ts"],
+      "@sample/ui-kit/*": ["./shared/ui-kit/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"]


### PR DESCRIPTION
## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `architecture/deterministic/cross-service-internal-import` | #246 | `tests/fixtures/sample-js-project-positive/services/api-gateway/src/cross-service-internal-import-public-subpath.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/cross-service-internal-import-relative-escape.ts` |
| `reliability/deterministic/unchecked-array-access` | #247 | `tests/fixtures/sample-js-project-positive/src/unchecked-array-access-enum-cast-and-sentinel-guard.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unchecked-array-access-raw-index.ts` |
| `bugs/deterministic/useeffect-missing-deps` | #248 | `tests/fixtures/sample-js-project-positive/services/web/src/components/UseEffectMissingDepsNestedCallback.tsx` | `tests/fixtures/sample-js-project-negative/services/web/src/components/UseEffectMissingDepsGreeting.tsx` |
| `bugs/deterministic/loose-boolean-expression` | #249 | `tests/fixtures/sample-js-project-positive/src/loose-boolean-expression-primitive-truthiness.ts` | `tests/fixtures/sample-js-project-negative/services/notification-service/src/queue-worker.ts` (updated) |
| `bugs/deterministic/await-non-thenable` | #250 | `tests/fixtures/sample-js-project-positive/src/await-non-thenable-promise-or-value-union.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/await-non-thenable-plain-value.ts` |

Closes #246
Closes #247
Closes #248
Closes #249
Closes #250

## `architecture/deterministic/cross-service-internal-import`

OSS sources (FP):
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document/document-recipient-link-copy-dialog.tsx#L1`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/default-recipients-multiselect-combobox.tsx#L1`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/folder-delete-dialog.tsx#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/passkey-create-dialog.tsx#L1
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/organisation-member-invite-dialog.tsx#L1`

Positive fixture (the FP that no longer fires):
```ts
import type { BadgeTone } from '@sample/ui-kit/primitives/badge';
import { renderBadge } from '@sample/ui-kit/primitives/badge';

export function describeBadge(label: string, tone: BadgeTone): string {
  return renderBadge(label, tone);
}
```
Plus a new workspace package `@sample/ui-kit` with `files: ["primitives/"]` so `primitives/` is the published public surface.

Negative fixture (the true bug that still fires):
```ts
// VIOLATION: architecture/deterministic/cross-service-internal-import
import { AuditLogRepository } from '../../user-service/src/repositories/audit-log.repository';
```

Visitor change: in `cross-service-internal-import`, after the existing path-alias skip, also skip when the source file imports the target through a "deep bare specifier" — a package import with a sub-path beyond the package name (e.g. `@scope/pkg/primitives/dialog`). Sub-path imports only work because the target package exposed that path via `files`/`exports` (or imposed no restriction), so the path is part of the package's API surface, not internal reach-through. The skip is anchored to the specific dep by matching the target file path's stem against the import's sub-path.

## `reliability/deterministic/unchecked-array-access`

OSS sources (FP):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/tables/admin-user-teams-table.tsx#L86
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/embed/authoring/configure-fields-view.tsx#L390
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents._index.tsx#L66`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/document-flow/add-signers.tsx#L440
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/document-flow/add-fields.tsx#L349

Positive fixture (the FP that no longer fires):
```ts
type DocumentRole = 'OWNER' | 'EDITOR' | 'VIEWER';
const ROLE_LABELS: Record<DocumentRole, string> = { /* … */ };
export const describeRole = (raw: unknown): string => ROLE_LABELS[raw as DocumentRole];

export const renameField = (targetId: string, nextLabel: string): string | null => {
  const fieldIndex = fieldRows.findIndex((f) => f.id === targetId);
  if (fieldIndex !== -1) {
    const current = fieldRows[fieldIndex];
    return current.label === nextLabel ? current.label : nextLabel;
  }
  return null;
};
```

Negative fixture (the true bug that still fires):
```ts
export function nameAt(roster: string[], position: number): string {
  // VIOLATION: reliability/deterministic/unchecked-array-access
  const candidate = roster[position];
  return candidate.toUpperCase();
}
```

Visitor change: broaden the `as_expression` index skip from `as string` only to "any cast except `as number`/`as Number`" — a `MAP[k as Enum]` cast is the canonical way to assert exhaustivity over a Record's keyset. Also recognise the `findIndex`/`indexOf` sentinel guards (`idx !== -1`, `idx >= 0`, `idx > -1`) in the enclosing-if walker alongside the existing `.length` and `in` patterns.

## `bugs/deterministic/useeffect-missing-deps`

OSS sources (FP — argument `prev` / `mod` of inner setters, not closure-captured):
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document-signing/document-signing-reject-dialog.tsx#L93`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document-signing/document-signing-dropdown-field.tsx#L151`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page.tsx#L137`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/settings+/_dynamic_personal_routes+/_layout.tsx#L35`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/embed+/playground.tsx#L182

Positive fixture (the FP that no longer fires):
```tsx
export function Ticker(): JSX.Element {
  const [ticks, setTicks] = useState<number[]>([]);
  useEffect(() => {
    const id = setInterval(() => {
      setTicks((prev) => [...prev, prev.length]);
    }, 1000);
    return () => clearInterval(id);
  }, []);
  return <div>{ticks.length}</div>;
}
```

Negative fixture (the true bug that still fires):
```tsx
// VIOLATION: bugs/deterministic/useeffect-missing-deps
export function Greeting({ name }: { name: string }): JSX.Element {
  const [message, setMessage] = useState('');
  useEffect(() => { setMessage(`Hello, ${name}!`); }, []);
  return <p>{message}</p>;
}
```

Visitor change: `collectIdentifiers` previously declared (in a comment) that it would not recurse into nested function scopes' parameter bindings — but it did. Threaded the skip set through `walk` and, when entering an `arrow_function` / `function_expression` / `function_declaration` / `method_definition`, augmented it with that inner function's parameter names (plus the function's own name for named function declarations). Callback args like `prev` in `setX((prev) => …)` and `event` in `addEventListener('m', (event) => …)` now stay local to their inner scope.

## `bugs/deterministic/loose-boolean-expression`

OSS sources (FP — idiomatic truthiness on primitives):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/openpage-api/lib/cors.ts#L104
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/universal/get-ip-address.ts#L27
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/tables/templates-table.tsx#L70
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx#L198`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/organisation-router/find-organisation-groups.ts#L90

Positive fixture (FPs that no longer fire — `if (exposed)` / `if (value)` / `if (opts.credentials)`):
```ts
export const allowExposed = (
  exposedHeaders: readonly string[] | string | undefined,
): string | null => {
  const exposed = Array.isArray(exposedHeaders)
    ? exposedHeaders.join(',')
    : exposedHeaders;
  if (exposed) { return exposed; }
  return null;
};
```

Negative fixture (the true bug that still fires — `''` collapses with the other states):
```ts
const status: '' | 'queued' | 'sent' = job.payload.status;
// VIOLATION: bugs/deterministic/loose-boolean-expression
if (status) { /* ... */ }
```

Visitor change: narrowed `loose-boolean-expression` to fire only when the union contains a falsy literal (`''`, `""`, `0`, `0n`). `if (value)` on `string`, `number`, `boolean`, `bigint`, or any of these unioned with `null`/`undefined` is the idiomatic null-or-empty guard and previously flooded the report with FPs. Literal unions that include a falsy member (`'' | 'queued' | 'sent'`, `0 | 1 | 2`) still fire because the truthy check there silently collapses a meaningful value.

## `bugs/deterministic/await-non-thenable`

OSS sources (FP):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/hooks/use-copy-to-clipboard.ts#L23
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/hooks/use-copy-to-clipboard.ts#L54

Positive fixture (the FP that no longer fires):
```ts
type ClipboardPayload = Promise<string> | string;
export const writeClipboard = async (
  value: ClipboardPayload,
  sink: (resolved: string) => void,
): Promise<void> => { sink(await value); };
```

Negative fixture (the true bug that still fires):
```ts
export async function shoutLabel(value: string): Promise<string> {
  // VIOLATION: bugs/deterministic/await-non-thenable
  const resolved = await value;
  return resolved.toUpperCase();
}
```

Visitor change: `isPromiseLike` previously matched on the type's string head (`startsWith('Promise<')` / `includes('PromiseLike<')`) and on a top-level `then` property. For a "value-or-promise" union `Promise<T> | T` (often hidden behind an alias like `CopyValue`), the compiler may print the alias name or order the non-promise branch first, and the union as a whole has no shared `then`. Added a recursion: when the head check and the `then` check both miss, walk each union constituent and let any promise-shaped member qualify the whole as promise-like.

## FP-count delta (vs `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f` on `documenso/documenso`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `architecture/deterministic/cross-service-internal-import` | 433 | 0 | -433 |
| `reliability/deterministic/unchecked-array-access` | 73 | 66 | -7 |
| `bugs/deterministic/useeffect-missing-deps` | 13 | 11 | -2 |
| `bugs/deterministic/loose-boolean-expression` | 97 | 0 | -97 |
| `bugs/deterministic/await-non-thenable` | 2 | 0 | -2 |
| **Total (these 5 rules)** | 618 | 77 | -541 |
| **All-rules total on target** | 56282 | 55741 | -541 |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMyC8hQ6LP8pLLaCgawbVH)_