### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/argument-type-mismatch.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/argument-type-mismatch.ts
@@ -2,6 +2,17 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { TS_LANGUAGES } from './_helpers.js'
 
+// Narrow the diagnostic gate to TS error codes that actually mean
+// "argument doesn't match the parameter type". Generic semantic errors —
+// unresolved modules, missing names, JSX intrinsic gaps — would otherwise
+// dominate the result set whenever a target's third-party types aren't
+// fully resolvable. Codes from the TS compiler diagnostic table:
+//   2345 — Argument of type X is not assignable to parameter of type Y
+//   2769 — No overload matches this call
+//   2554 — Expected N arguments, but got M (arity mismatch)
+//   2555 — Expected at least N arguments, but got M
+const ARGUMENT_MISMATCH_CODES = new Set<number>([2345, 2769, 2554, 2555])
+
 /**
  * Detect: Arguments to built-in functions that don't match documented types.
  * Corresponds to sonarjs S3782 (argument-type).
@@ -20,7 +31,7 @@ export const argumentTypeMismatchVisitor: CodeRuleVisitor = {
     // overloads, and complex type inference that TypeScript handles correctly.
     const startLine = node.startPosition.row
     const endLine = node.endPosition.row
-    const hasError = typeQuery.hasTypeErrorInRange(filePath, startLine, endLine)
+    const hasError = typeQuery.hasTypeErrorInRange(filePath, startLine, endLine, ARGUMENT_MISMATCH_CODES)
     if (!hasError) return null
 
     // There's a real TS type error at this call site — get details for the message

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/missing-error-boundary.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/missing-error-boundary.ts
@@ -20,13 +20,18 @@ export const missingErrorBoundaryVisitor: CodeRuleVisitor = {
     // Only check files that look like React components
     if (!sourceCode.includes('React') && !sourceCode.includes('react') && !sourceCode.includes('jsx')) return null
 
-    // Check for data-fetching patterns
-    // Only flag patterns where ErrorBoundary can actually catch errors:
-    // useQuery/useSWR throw during render (catchable), Suspense uses error boundaries.
-    // useEffect+fetch is NOT flagged — errors in useEffect are async and cannot be caught by ErrorBoundary.
+    // Check for data-fetching patterns. Bare useQuery/useSWR may throw
+    // during render (depending on options) so they remain a signal — but
+    // we exclude member-expression calls like `trpc.x.useQuery(...)`,
+    // which delegate to TanStack Query under abstractions that surface
+    // errors via the returned `error`/`isError` state (no boundary
+    // required). Suspense and the suspense-* query variants always throw
+    // during render and need a boundary upstream.
     const hasAsyncData =
-      /\buseQuery\b/.test(sourceCode) ||
-      /\buseSWR\b/.test(sourceCode) ||
+      /(?<![.\w])useQuery\b/.test(sourceCode) ||
+      /(?<![.\w])useSWR\b/.test(sourceCode) ||
+      /\buseSuspenseQuery\b/.test(sourceCode) ||
+      /\buseSuspenseInfiniteQuery\b/.test(sourceCode) ||
       /\bSuspense\b/.test(sourceCode)
 
     if (!hasAsyncData) return null

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/elseif-without-else.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/elseif-without-else.ts
@@ -2,6 +2,45 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 
+const LITERAL_NODE_TYPES = new Set([
+  'string', 'number', 'null', 'undefined', 'true', 'false',
+])
+
+/**
+ * Identify the variable being narrowed by `condition`, if the condition has
+ * one of the shapes used in discriminated-union narrowing. Returns the
+ * identifier text, or `null` if the condition doesn't match those shapes.
+ *
+ * Shapes recognised:
+ *   - `foo`                       (truthy check on a single identifier)
+ *   - `foo === <literal>`         (equality narrowing — strict & loose)
+ *   - `typeof foo === '<literal>'`(typeof narrowing)
+ */
+function narrowedIdentifier(condition: SyntaxNode | null): string | null {
+  if (!condition) return null
+  while (condition?.type === 'parenthesized_expression') {
+    condition = condition.namedChildren[0] ?? null
+  }
+  if (!condition) return null
+  if (condition.type === 'identifier') return condition.text
+  if (condition.type !== 'binary_expression') return null
+  const op = condition.childForFieldName('operator')?.text
+  if (op !== '===' && op !== '!==' && op !== '==' && op !== '!=') return null
+  const left = condition.childForFieldName('left')
+  const right = condition.childForFieldName('right')
+  if (!left || !right) return null
+  const leftLit = LITERAL_NODE_TYPES.has(left.type)
+  const rightLit = LITERAL_NODE_TYPES.has(right.type)
+  if (leftLit === rightLit) return null
+  const operand = leftLit ? right : left
+  if (operand.type === 'identifier') return operand.text
+  if (operand.type === 'unary_expression' && operand.firstChild?.text === 'typeof') {
+    const inner = operand.namedChildren[0]
+    if (inner?.type === 'identifier') return inner.text
+  }
+  return null
+}
+
 export const elseifWithoutElseVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/elseif-without-else',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -15,9 +54,11 @@ export const elseifWithoutElseVisitor: CodeRuleVisitor = {
 
     let hasElseIf = false
     let hasElse = false
+    const narrowedIds: Array<string | null> = []
 
     let currentNode: SyntaxNode | null = node
     while (currentNode?.type === 'if_statement') {
+      narrowedIds.push(narrowedIdentifier(currentNode.childForFieldName('condition')))
       const elseClause: import('web-tree-sitter').Node | undefined = currentNode.children.find((c) => c.type === 'else_clause')
       if (!elseClause) break
 
@@ -34,6 +75,13 @@ export const elseifWithoutElseVisitor: CodeRuleVisitor = {
     }
 
     if (hasElseIf && !hasElse) {
+      // Skip the discriminated-union narrowing idiom: every branch tests a
+      // different literal value (or typeof tag) of the same identifier. The
+      // missing `else` here is "unreachable on a closed union" — adding one
+      // is dead code, not a defensive guard.
+      const first = narrowedIds[0]
+      if (first !== null && narrowedIds.every((id) => id !== null && id === first)) return null
+
       return makeViolation(
         this.ruleKey, node, filePath, 'low',
         'else-if chain without final else',

--- a/packages/analyzer/src/rules/performance/visitors/javascript/missing-usememo-expensive.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/missing-usememo-expensive.ts
@@ -16,8 +16,22 @@ export const missingUseMemoExpensiveVisitor: CodeRuleVisitor = {
     const prop = fn.childForFieldName('property')
     if (!prop || !EXPENSIVE_ARRAY_METHODS.has(prop.text)) return null
 
-    // Skip when chained on Object.entries/keys/values — these produce small arrays
     const obj = fn.childForFieldName('object')
+
+    // .filter() is O(n) and cheap on its own — only worth memoizing when it
+    // appears in a multi-stage chain (e.g. .filter().map().filter()) where
+    // the work compounds. Plain .filter(Boolean) at the tail of any chain is
+    // the standard null-removal idiom and never warrants useMemo.
+    if (prop.text === 'filter') {
+      const args = node.childForFieldName('arguments')
+      if (args && args.namedChildCount === 1) {
+        const arg = args.namedChild(0)
+        if (arg?.type === 'identifier' && arg.text === 'Boolean') return null
+      }
+      if (obj?.type !== 'call_expression') return null
+    }
+
+    // Skip when chained on Object.entries/keys/values — these produce small arrays
     if (obj?.type === 'call_expression') {
       const objFn = obj.childForFieldName('function')
       if (objFn?.type === 'member_expression') {

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/express-async-no-wrapper.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/express-async-no-wrapper.ts
@@ -34,6 +34,14 @@ export const expressAsyncNoWrapperVisitor: CodeRuleVisitor = {
 
     if (!isAsyncHandler) return null
 
+    // Hono handlers take a single Context argument — `async (c) => ...` — and
+    // Hono natively awaits the returned promise and routes errors through its
+    // own `onError`. Express handlers take `(req, res)` or `(req, res, next)`.
+    // Distinguish by arity so we only flag the Express-shaped signature this
+    // rule is actually about.
+    const params = lastArg.childForFieldName('parameters')
+    if (params && params.namedChildCount === 1) return null
+
     // Check if the async handler body has a try/catch wrapping its contents
     const body = lastArg.childForFieldName('body')
     if (body) {

--- a/packages/analyzer/src/ts-compiler.ts
+++ b/packages/analyzer/src/ts-compiler.ts
@@ -262,8 +262,11 @@ export interface TypeQueryService {
   getParameterTypes(filePath: string, line: number, column: number, endLine?: number, endColumn?: number): Array<{ name: string; type: string }> | null
   /** Check if two positions have compatible types */
   areTypesCompatible(filePath: string, line1: number, col1: number, line2: number, col2: number): boolean
-  /** Check if the TS compiler reports a type error in a line range */
-  hasTypeErrorInRange(filePath: string, startLine: number, endLine: number): boolean
+  /** Check if the TS compiler reports a type error in a line range. If
+   * `errorCodes` is provided, only diagnostics whose `code` matches are
+   * considered — used to ignore unrelated diagnostics (unresolved modules,
+   * missing names) that aren't actual argument-type mismatches. */
+  hasTypeErrorInRange(filePath: string, startLine: number, endLine: number, errorCodes?: ReadonlySet<number>): boolean
 }
 
 /**
@@ -537,7 +540,7 @@ export function createTypeQueryService(
       return sp.checker.isTypeAssignableTo(type1, type2) || sp.checker.isTypeAssignableTo(type2, type1)
     },
 
-    hasTypeErrorInRange(filePath, startLine, endLine) {
+    hasTypeErrorInRange(filePath, startLine, endLine, errorCodes) {
       const sp = getProgramForFile(filePath)
       if (!sp) return false
       const sf = sp.program.getSourceFile(filePath)
@@ -546,6 +549,7 @@ export function createTypeQueryService(
         const diagnostics = sp.program.getSemanticDiagnostics(sf)
         for (const d of diagnostics) {
           if (d.start === undefined || d.file !== sf) continue
+          if (errorCodes && !errorCodes.has(d.code)) continue
           const diagLine = sf.getLineAndCharacterOfPosition(d.start).line
           if (diagLine >= startLine && diagLine <= endLine) return true
         }

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -649,6 +649,12 @@
       "layer": "service"
     },
     {
+      "name": "classifyRequest",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "clear-text-protocol-hardcoded-host",
       "service": "utils",
       "kind": "standalone",
@@ -1021,6 +1027,12 @@
       "layer": "service"
     },
     {
+      "name": "summarize",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "todoHandler",
       "service": "utils",
       "kind": "standalone",
@@ -1147,6 +1159,12 @@
       "layer": "service"
     },
     {
+      "name": "MultiStageChain",
+      "service": "web",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "NotificationList",
       "service": "web",
       "kind": "standalone",
@@ -1166,6 +1184,12 @@
     },
     {
       "name": "RemainingReact",
+      "service": "web",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "SuspenseQueryView",
       "service": "web",
       "kind": "standalone",
       "layer": "service"

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/express-async-no-wrapper-express-pattern.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/express-async-no-wrapper-express-pattern.ts
@@ -1,0 +1,20 @@
+// Paraphrased TP for reliability/deterministic/express-async-no-wrapper.
+//
+// Classic Express signature (`(req, res, next)` or `(req, res)`). Without a
+// try/catch or async wrapper, a thrown error from the async handler ends
+// up as an unhandled rejection — Express never sees it.
+
+interface ExpressReq { params: Record<string, string>; }
+interface ExpressRes { json(value: unknown): void; status(code: number): ExpressRes; }
+interface ExpressApp {
+  get(path: string, handler: (req: ExpressReq, res: ExpressRes) => Promise<void>): void;
+}
+
+declare const app: ExpressApp;
+declare function loadUser(id: string): Promise<{ id: string; name: string }>;
+
+// VIOLATION: reliability/deterministic/express-async-no-wrapper
+app.get('/users/:id', async (req, res) => {
+  const user = await loadUser(req.params.id);
+  res.json(user);
+});

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/MissingErrorBoundarySuspense.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/MissingErrorBoundarySuspense.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+declare function useSuspenseQuery<T>(opts: { queryKey: string[]; queryFn: () => Promise<T> }): { data: T };
+
+// VIOLATION: bugs/deterministic/missing-error-boundary
+export function SuspenseQueryView() {
+  const { data } = useSuspenseQuery<{ title: string }>({
+    queryKey: ['x'],
+    queryFn: () => fetch('/api/x').then((r) => r.json() as Promise<{ title: string }>),
+  });
+  return <h1>{data.title}</h1>;
+}

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/MissingUsememoExpensiveChain.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/MissingUsememoExpensiveChain.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+type Entry = { id: number; active: boolean; tag: string; priority: number };
+
+// VIOLATION: performance/deterministic/missing-usememo-expensive
+export function MultiStageChain({ entries }: { entries: Entry[] }) {
+  const result = entries
+    .filter((e) => e.active)
+    .map((e) => ({ key: e.tag, weight: e.priority }))
+    .filter((e) => e.weight > 0);
+  return <ul>{result.map((r) => <li key={r.key}>{r.weight}</li>)}</ul>;
+}

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/ReactPerformance.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/ReactPerformance.tsx
@@ -61,8 +61,11 @@ export function BatchUpdate({ items }: { items: string[] }) {
 
 // VIOLATION: performance/deterministic/missing-usememo-expensive
 export function ExpensiveFilter({ items }: { items: Array<{ active: boolean; name: string }> }) {
-  const activeItems = items.filter((item) => item.active);
-  return <ul>{activeItems.map((i) => <li key={i.name}>{i.name}</li>)}</ul>;
+  const activeItems = items
+    .filter((item) => item.active)
+    .map((i) => ({ key: i.name, on: true }))
+    .filter((i) => i.on);
+  return <ul>{activeItems.map((i) => <li key={i.key}>{i.key}</li>)}</ul>;
 }
 
 // VIOLATION: performance/deterministic/unnecessary-context-provider

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/UserForm.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/UserForm.tsx
@@ -27,7 +27,10 @@ export function UserForm({ initialUser, onSubmit, onCancel, roles }: UserFormPro
   const [submitting, setSubmitting] = useState(false);
 
   // VIOLATION: performance/deterministic/missing-usememo-expensive
-  const filteredRoles = roles.filter((r) => r !== 'superadmin');
+  const filteredRoles = roles
+    .filter((r) => r !== 'superadmin')
+    .map((r) => r.toUpperCase())
+    .filter((r) => r.length > 0);
 
   // VIOLATION: code-quality/deterministic/missing-return-type
   function validate() {

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/argument-type-mismatch-overload.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/argument-type-mismatch-overload.ts
@@ -1,0 +1,19 @@
+// Paraphrased TP example for bugs/deterministic/argument-type-mismatch.
+//
+// Real argument-type / overload-resolution mismatch — TypeScript emits
+// TS2345 (or TS2769 on overloaded signatures), which is exactly the
+// signal this rule is meant to surface.
+
+interface Recipient {
+  readonly id: number;
+  readonly displayName: string;
+}
+
+function describeRecipient(name: string): string {
+  return `recipient: ${name}`;
+}
+
+export function summarize(r: Recipient): string {
+  // VIOLATION: bugs/deterministic/argument-type-mismatch
+  return describeRecipient(r.id);
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/elseif-without-else-distinct-conditions.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/elseif-without-else-distinct-conditions.ts
@@ -1,0 +1,20 @@
+// Paraphrased TP example for code-quality/deterministic/elseif-without-else.
+//
+// The chain mixes conditions on different variables — the missing else is
+// a real silent-fallthrough hazard, not a closed-union narrowing.
+
+interface Request {
+  readonly userId: number | null;
+  readonly anonymous: boolean;
+}
+
+// VIOLATION: code-quality/deterministic/elseif-without-else
+export function classifyRequest(req: Request): string {
+  let label = 'unknown';
+  if (req.anonymous) {
+    label = 'anonymous';
+  } else if (req.userId !== null) {
+    label = 'authenticated';
+  }
+  return label;
+}

--- a/tests/fixtures/sample-js-project-positive/src/argument-type-mismatch-unresolved-method.ts
+++ b/tests/fixtures/sample-js-project-positive/src/argument-type-mismatch-unresolved-method.ts
@@ -1,0 +1,47 @@
+// Paraphrased FP for bugs/deterministic/argument-type-mismatch.
+//
+// In the wild, complex third-party generics and barrel-exported helpers
+// often emit unrelated TS diagnostics on the same line as a call expression
+// (e.g. TS2339 property-not-found, TS2304 cannot-find-name). The old rule
+// treated any in-range diagnostic as an argument-type mismatch and fired
+// even when the argument types were fine. The fix narrows the gate to
+// TS2345/2769/2554/2555 (real argument-type / arity mismatches).
+//
+// The patterns below are the shapes flagged by the in-wild FPs (variadic
+// class-name builder, raw-bytes constructor, validator parse, regex
+// constructor). They are well-typed here and must not be reported.
+
+function joinClassNames(...parts: ReadonlyArray<string | false | null | undefined>): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+interface Validator<T> {
+  parse(input: unknown): T;
+}
+
+interface Recipient {
+  readonly id: number;
+  readonly displayName: string;
+}
+
+const recipientValidator: Validator<Recipient> = {
+  parse(input: unknown): Recipient {
+    return input as Recipient;
+  },
+};
+
+export function variadicClassNames(active: boolean, label: string | undefined): string {
+  return joinClassNames('base', active && 'is-active', label);
+}
+
+export function decodeBytes(raw: Uint8Array): Uint8Array {
+  return Uint8Array.from(raw);
+}
+
+export function validateRecipient(input: unknown): Recipient {
+  return recipientValidator.parse(input);
+}
+
+export function compilePattern(prefix: string, suffix: string): RegExp {
+  return new RegExp(`(${prefix})(${suffix})$`);
+}

--- a/tests/fixtures/sample-js-project-positive/src/elseif-without-else-union-narrowing.ts
+++ b/tests/fixtures/sample-js-project-positive/src/elseif-without-else-union-narrowing.ts
@@ -1,0 +1,30 @@
+// Paraphrased FP for code-quality/deterministic/elseif-without-else.
+//
+// Discriminated-union narrowing — every branch tests a different literal
+// of the same variable. The missing `else` is unreachable because the
+// union is closed; adding one would be dead code, not a defensive guard.
+
+type Mode = 'checked' | 'value';
+
+interface Row {
+  checked: boolean;
+  value: string;
+}
+
+export function applyUpdate(row: Row, mode: Mode, raw: unknown): void {
+  if (mode === 'checked') {
+    row.checked = Boolean(raw);
+  } else if (mode === 'value') {
+    row.value = String(raw);
+  }
+}
+
+export function normalizeCss(brandingCss: string | null): string | null {
+  let out: string | null | undefined;
+  if (brandingCss === null) {
+    out = null;
+  } else if (typeof brandingCss === 'string') {
+    out = brandingCss.trim() === '' ? null : brandingCss;
+  }
+  return out ?? null;
+}

--- a/tests/fixtures/sample-js-project-positive/src/express-async-no-wrapper-hono-handler.ts
+++ b/tests/fixtures/sample-js-project-positive/src/express-async-no-wrapper-hono-handler.ts
@@ -1,0 +1,41 @@
+// Paraphrased FP for reliability/deterministic/express-async-no-wrapper.
+//
+// Hono handlers take a single Context argument — `async (c) => ...` — and
+// Hono itself awaits the returned promise and dispatches errors through
+// its `onError` middleware. The Express-shaped wrapper concern does not
+// apply, so the rule must not flag single-arg async handlers on
+// `.get/.post/.use/...` calls. The Express shape (`(req, res)` /
+// `(req, res, next)`) still fires — see the negative fixture.
+
+interface HonoContext {
+  json(value: unknown, status?: number): Response;
+  req: { valid(part: 'param'): Record<string, string> };
+}
+
+interface HonoApp {
+  get(path: string, handler: (c: HonoContext) => Promise<Response>): void;
+  use(path: string, handler: (c: HonoContext) => Promise<Response>): void;
+}
+
+declare const app: HonoApp;
+declare const router: HonoApp;
+declare const route: HonoApp;
+
+declare function fetchDocument(id: string): Promise<{ payload: string }>;
+
+app.get('/api/docs/:id', async (c) => {
+  const { id } = c.req.valid('param');
+  const doc = await fetchDocument(id);
+  return c.json(doc);
+});
+
+router.use('/api/v2/*', async (c) => {
+  const data = await fetchDocument('latest');
+  return c.json(data);
+});
+
+route.get('/token/:token/data', async (c) => {
+  const { token } = c.req.valid('param');
+  const doc = await fetchDocument(token);
+  return c.json(doc);
+});

--- a/tests/fixtures/sample-js-project-positive/src/missing-error-boundary-trpc-query.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/missing-error-boundary-trpc-query.tsx
@@ -1,0 +1,32 @@
+// Paraphrased FP for bugs/deterministic/missing-error-boundary.
+//
+// Member-expression query calls like `trpc.x.y.useQuery(...)` go through
+// abstractions (tRPC, generated SDKs) where TanStack Query is configured
+// to surface errors via the returned `error`/`isError` state rather than
+// throw during render. An ErrorBoundary further up the tree is not
+// required to keep the UI from crashing. The fix narrows the trigger to
+// bare `useQuery(...)` / `useSWR(...)` calls and the Suspense variants.
+
+interface InviteRow {
+  readonly id: number;
+  readonly email: string;
+}
+
+interface TrpcInviteApi {
+  readonly find: {
+    useQuery(input: { organisationId: number }): {
+      data: ReadonlyArray<InviteRow> | undefined;
+      isLoading: boolean;
+      isLoadingError: boolean;
+    };
+  };
+}
+
+declare const inviteApi: TrpcInviteApi;
+
+export function InvitesPanel({ organisationId }: { organisationId: number }): JSX.Element {
+  const { data, isLoading, isLoadingError } = inviteApi.find.useQuery({ organisationId });
+  if (isLoadingError) return <span>error</span>;
+  if (isLoading) return <span>loading</span>;
+  return <ul>{data?.map((row) => <li key={row.id}>{row.email}</li>)}</ul>;
+}

--- a/tests/fixtures/sample-js-project-positive/src/missing-usememo-expensive-single-filter.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/missing-usememo-expensive-single-filter.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+type Member = {
+  readonly id: number;
+  readonly priority: number;
+  readonly active: boolean;
+  readonly tag: string;
+};
+
+interface PanelProps {
+  readonly members: Member[];
+  readonly current: Member;
+}
+
+export function MemberPanel({ members, current }: PanelProps): JSX.Element {
+  const [searchTerm] = useState('');
+
+  // Single-stage .filter() on a regular array — O(n) and cheap. Wrapping in
+  // useMemo would be over-engineering and should not be flagged.
+  const subsequent = members.filter((m) => m.priority > current.priority);
+
+  // Chained .map(...).filter(Boolean) — the trailing filter(Boolean) is the
+  // standard null-removal idiom and should not be flagged.
+  const validTags = members.map((m) => m.tag).filter(Boolean);
+
+  const matches = members.filter((m) => m.id !== current.id);
+
+  return (
+    <div>
+      <span>{searchTerm}</span>
+      <span>{subsequent.length}</span>
+      <span>{validTags.length}</span>
+      <span>{matches.length}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #251
Closes #252
Closes #253
Closes #254
Closes #255

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `performance/deterministic/missing-usememo-expensive` | #251 | `tests/fixtures/sample-js-project-positive/src/missing-usememo-expensive-single-filter.tsx` | `tests/fixtures/sample-js-project-negative/services/web/src/components/MissingUsememoExpensiveChain.tsx` |
| `bugs/deterministic/argument-type-mismatch` | #252 | `tests/fixtures/sample-js-project-positive/src/argument-type-mismatch-unresolved-method.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/argument-type-mismatch-overload.ts` |
| `bugs/deterministic/missing-error-boundary` | #253 | `tests/fixtures/sample-js-project-positive/src/missing-error-boundary-trpc-query.tsx` | `tests/fixtures/sample-js-project-negative/services/web/src/components/MissingErrorBoundarySuspense.tsx` |
| `code-quality/deterministic/elseif-without-else` | #254 | `tests/fixtures/sample-js-project-positive/src/elseif-without-else-union-narrowing.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/elseif-without-else-distinct-conditions.ts` |
| `reliability/deterministic/express-async-no-wrapper` | #255 | `tests/fixtures/sample-js-project-positive/src/express-async-no-wrapper-hono-handler.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/express-async-no-wrapper-express-pattern.ts` |

## performance/deterministic/missing-usememo-expensive

OSS sources:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document-signing/envelope-signing-provider.tsx#L277`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx#L86`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/components/recipient/recipient-action-auth-select.tsx#L49
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx#L27`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document-signing/document-signing-auth-dialog.tsx#L45`

Positive fixture (new — should not fire):
```tsx
import { useState } from 'react';

type Member = { readonly id: number; readonly priority: number; readonly active: boolean; readonly tag: string };
interface PanelProps { readonly members: Member[]; readonly current: Member }

export function MemberPanel({ members, current }: PanelProps): JSX.Element {
  const [searchTerm] = useState('');
  const subsequent = members.filter((m) => m.priority > current.priority);
  const validTags = members.map((m) => m.tag).filter(Boolean);
  const matches = members.filter((m) => m.id !== current.id);
  return (
    <div>
      <span>{searchTerm}</span>
      <span>{subsequent.length}</span>
      <span>{validTags.length}</span>
      <span>{matches.length}</span>
    </div>
  );
}
```

Negative fixture (new — should fire on the trailing chained filter):
```tsx
import React from 'react';
type Entry = { id: number; active: boolean; tag: string; priority: number };
// VIOLATION: performance/deterministic/missing-usememo-expensive
export function MultiStageChain({ entries }: { entries: Entry[] }) {
  const result = entries
    .filter((e) => e.active)
    .map((e) => ({ key: e.tag, weight: e.priority }))
    .filter((e) => e.weight > 0);
  return <ul>{result.map((r) => <li key={r.key}>{r.weight}</li>)}</ul>;
}
```

Visitor change: a single `.filter()` on a plain array is O(n) and rarely worth wrapping in `useMemo`. The fix skips `.filter()` whose receiver isn't itself a call expression (i.e. not part of a chain) and also skips the trailing `.filter(Boolean)` idiom even when chained. `.sort`/`.reduce`/`.flatMap`/`.flat` are still flagged because those operations are inherently more expensive. Existing inline negatives in `ReactPerformance.tsx` and `UserForm.tsx` (which used single `.filter()` to demonstrate the rule) were updated to chained shapes to stay consistent with the new firing rule.

## bugs/deterministic/argument-type-mismatch

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/pdf/normalize-pdf.ts#L33
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/lib/recipient-colors.ts#L84
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/alert-dialog.tsx#L61
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/signature-pad/signature-pad-color-picker.tsx#L19
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx#L191`

Positive fixture (new — should not fire):
```ts
// paraphrased shapes from the issue's samples (variadic class-name builder,
// raw-bytes constructor, validator parse, regex constructor)
function joinClassNames(...parts: ReadonlyArray<string | false | null | undefined>): string {
  return parts.filter((p): p is string => Boolean(p)).join(' ');
}
interface Validator<T> { parse(input: unknown): T; }
interface Recipient { readonly id: number; readonly displayName: string; }
const recipientValidator: Validator<Recipient> = { parse(input: unknown): Recipient { return input as Recipient; } };
export function variadicClassNames(active: boolean, label: string | undefined): string {
  return joinClassNames('base', active && 'is-active', label);
}
export function decodeBytes(raw: Uint8Array): Uint8Array { return Uint8Array.from(raw); }
export function validateRecipient(input: unknown): Recipient { return recipientValidator.parse(input); }
export function compilePattern(prefix: string, suffix: string): RegExp { return new RegExp(`(${prefix})(${suffix})$`); }
```

Negative fixture (new — should fire on TS2345):
```ts
interface Recipient { readonly id: number; readonly displayName: string; }
function describeRecipient(name: string): string { return `recipient: ${name}`; }
export function summarize(r: Recipient): string {
  // VIOLATION: bugs/deterministic/argument-type-mismatch
  return describeRecipient(r.id);
}
```

Visitor change: the rule used the TypeScript compiler's full semantic diagnostic stream and treated any in-range error as an argument-type mismatch. In the wild that catches unrelated noise — TS2304 cannot-find-name, TS2307 cannot-find-module, TS2339 property-not-found, JSX intrinsic gaps — whenever third-party generic-heavy types don't resolve cleanly. The fix narrows the gate to TS2345 (argument-of-type-X-not-assignable), TS2769 (no-overload-matches), TS2554 and TS2555 (arity), via a new optional `errorCodes` filter on `hasTypeErrorInRange`. Resolution noise no longer leaks into this rule.

## bugs/deterministic/missing-error-boundary

OSS sources:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/tables/organisation-member-invites-table.tsx#L1`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/tables/inbox-table.tsx#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/forms/email-preferences-form.tsx#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/tables/documents-table-sender-filter.tsx#L1
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/tables/organisation-billing-invoices-table.tsx#L1`

Positive fixture (new — should not fire on `trpc.x.y.useQuery`):
```tsx
interface InviteRow { readonly id: number; readonly email: string; }
interface TrpcInviteApi { readonly find: { useQuery(input: { organisationId: number }): { data: ReadonlyArray<InviteRow> | undefined; isLoading: boolean; isLoadingError: boolean } } }
declare const inviteApi: TrpcInviteApi;
export function InvitesPanel({ organisationId }: { organisationId: number }): JSX.Element {
  const { data, isLoading, isLoadingError } = inviteApi.find.useQuery({ organisationId });
  if (isLoadingError) return <span>error</span>;
  if (isLoading) return <span>loading</span>;
  return <ul>{data?.map((row) => <li key={row.id}>{row.email}</li>)}</ul>;
}
```

Negative fixture (new — should fire on suspense-* variants):
```tsx
import React from 'react';
declare function useSuspenseQuery<T>(opts: { queryKey: string[]; queryFn: () => Promise<T> }): { data: T };
// VIOLATION: bugs/deterministic/missing-error-boundary
export function SuspenseQueryView() {
  const { data } = useSuspenseQuery<{ title: string }>({
    queryKey: ['x'], queryFn: () => fetch('/api/x').then((r) => r.json() as Promise<{ title: string }>),
  });
  return <h1>{data.title}</h1>;
}
```

Visitor change: the rule's `useQuery` regex matched everywhere — including `trpc.x.y.useQuery(...)` member-expression calls, where TanStack Query (under abstractions like tRPC) surfaces errors via the returned `error`/`isError` state rather than throwing during render. The fix tightens the regex to `(?<[.\w])useQuery\b` / `(?<[.\w])useSWR\b` so member-expression calls are excluded. `useSuspenseQuery`, `useSuspenseInfiniteQuery`, and bare `Suspense` (which all throw during render) still trigger the boundary check.

## code-quality/deterministic/elseif-without-else

OSS sources:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx#L371`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/team-router/update-team-settings.ts#L141
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/docs/src/lib/merge-refs.ts#L6
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/document-flow/field-items-advanced-settings/checkbox-field.tsx#L105`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/utils/document-audit-logs.ts#L604

Positive fixture (new — discriminated-union narrowing should not fire):
```ts
type Mode = 'checked' | 'value';
interface Row { checked: boolean; value: string }
export function applyUpdate(row: Row, mode: Mode, raw: unknown): void {
  if (mode === 'checked') { row.checked = Boolean(raw); }
  else if (mode === 'value') { row.value = String(raw); }
}
export function normalizeCss(brandingCss: string | null): string | null {
  let out: string | null | undefined;
  if (brandingCss === null) { out = null; }
  else if (typeof brandingCss === 'string') { out = brandingCss.trim() === '' ? null : brandingCss; }
  return out ?? null;
}
```

Negative fixture (new — distinct conditions should still fire):
```ts
interface Request { readonly userId: number | null; readonly anonymous: boolean }
// VIOLATION: code-quality/deterministic/elseif-without-else
export function classifyRequest(req: Request): string {
  let label = 'unknown';
  if (req.anonymous) { label = 'anonymous'; }
  else if (req.userId !== null) { label = 'authenticated'; }
  return label;
}
```

Visitor change: collect the identifier being narrowed by each branch's condition (using shapes `x`, `x === <literal>`, `typeof x === '<literal>'`) and skip the violation when every branch in the chain narrows the same identifier — that's the discriminated-union idiom where the missing `else` is unreachable on a closed union. Chains with different conditions per branch still fire.

## reliability/deterministic/express-async-no-wrapper

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/router.ts#L125
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/files/routes/get-envelope-item-pdf-by-token.ts#L23
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/router.ts#L79
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/router.ts#L135
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/files/routes/get-envelope-item-pdf.ts#L31

Positive fixture (new — Hono single-context handlers should not fire):
```ts
declare const app: HonoApp; declare const router: HonoApp; declare const route: HonoApp;
declare function fetchDocument(id: string): Promise<{ payload: string }>;
app.get('/api/docs/:id', async (c) => { const { id } = c.req.valid('param'); const doc = await fetchDocument(id); return c.json(doc); });
router.use('/api/v2/*', async (c) => { const data = await fetchDocument('latest'); return c.json(data); });
route.get('/token/:token/data', async (c) => { const { token } = c.req.valid('param'); const doc = await fetchDocument(token); return c.json(doc); });
```

Negative fixture (new — Express `(req, res)` should fire):
```ts
declare const app: ExpressApp;
declare function loadUser(id: string): Promise<{ id: string; name: string }>;
// VIOLATION: reliability/deterministic/express-async-no-wrapper
app.get('/users/:id', async (req, res) => {
  const user = await loadUser(req.params.id);
  res.json(user);
});
```

Visitor change: Hono handlers take a single `Context` argument — `async (c) => ...` — and Hono natively awaits the returned promise and routes errors through its own `onError`. The Express-shaped wrapper concern doesn't apply. The fix skips async handlers whose `formal_parameters` has exactly one named child. Express `(req, res)` / `(req, res, next)` signatures still fire.

## FP-count delta (vs `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f` on `documenso/documenso`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `performance/deterministic/missing-usememo-expensive` | 51 | 7 | -44 |
| `bugs/deterministic/argument-type-mismatch` | 3915 | 21 | -3894 |
| `bugs/deterministic/missing-error-boundary` | 88 | 3 | -85 |
| `code-quality/deterministic/elseif-without-else` | 23 | 19 | -4 |
| `reliability/deterministic/express-async-no-wrapper` | 5 | 1 | -4 |
| **Total (these 5 rules)** | **4082** | **51** | **-4031** |
| **All-rules total on target** | **55741** | **51710** | **-4031** |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_014wDm5RJQWsfjvBrYTR5mh8)_