### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/_helpers.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/_helpers.ts
@@ -43,6 +43,69 @@ export function getRegexSource(node: SyntaxNode): string | null {
   return null
 }
 
+// Framework route conventions whose return type is fixed by the framework
+// contract and almost never annotated in real codebases. Covers:
+//   - Next.js App Router HTTP-method handlers and config exports.
+//   - Remix / React Router v7 route module exports.
+// Used by `missing-boundary-types` and `missing-return-type` to suppress
+// FPs on framework-dictated names.
+export const FRAMEWORK_ROUTE_EXPORT_NAMES: ReadonlySet<string> = new Set([
+  // HTTP-method route handlers (Next.js App Router).
+  'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS',
+  // Remix / React Router v7 route module exports.
+  'loader', 'action', 'clientLoader', 'clientAction',
+  'meta', 'links', 'headers', 'shouldRevalidate',
+  'HydrateFallback', 'ErrorBoundary',
+  // Next.js App Router metadata / static-params helpers.
+  'generateMetadata', 'generateStaticParams',
+  'generateImageMetadata', 'generateViewport',
+  'middleware',
+])
+
+// True when a `function_declaration` or `arrow_function` node belongs to
+// an `export default` statement (e.g. Remix / Next.js page components).
+export function isDefaultExportedFunction(node: SyntaxNode): boolean {
+  const exportNode = node.parent
+  if (!exportNode || exportNode.type !== 'export_statement') return false
+  for (let i = 0; i < exportNode.childCount; i++) {
+    if (exportNode.child(i)?.type === 'default') return true
+  }
+  return false
+}
+
+// True when a function body returns a JSX element / fragment. Used to skip
+// React component default exports — TS infers `JSX.Element` and codebases
+// almost never annotate it.
+export function functionReturnsJsx(node: SyntaxNode): boolean {
+  const JSX_NODE_TYPES = new Set(['jsx_element', 'jsx_self_closing_element', 'jsx_fragment'])
+  const body = getFunctionBody(node)
+  if (!body) return false
+  // Arrow function with a JSX expression body (no statement_block).
+  if (JSX_NODE_TYPES.has(body.type)) return true
+
+  let found = false
+  function walk(n: SyntaxNode) {
+    if (found) return
+    // Don't cross into nested functions.
+    if (n.id !== node.id && JS_FUNCTION_TYPES.includes(n.type)) return
+    if (n.type === 'return_statement') {
+      for (let i = 0; i < n.namedChildCount; i++) {
+        const c = n.namedChild(i)
+        if (c && (JSX_NODE_TYPES.has(c.type) || (c.type === 'parenthesized_expression' && c.namedChild(0) && JSX_NODE_TYPES.has(c.namedChild(0)!.type)))) {
+          found = true
+          return
+        }
+      }
+    }
+    for (let i = 0; i < n.namedChildCount; i++) {
+      const c = n.namedChild(i)
+      if (c) walk(c)
+    }
+  }
+  walk(body)
+  return found
+}
+
 // Magic numbers: exclude very common / obviously safe literals
 export const MAGIC_NUMBER_WHITELIST = new Set([0, 1, 2, -1, 100, 1000])
 

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/confusing-void-expression.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/confusing-void-expression.ts
@@ -35,21 +35,44 @@ export const confusingVoidExpressionVisitor: CodeRuleVisitor = {
     if (!isVoid) return null
 
     // Check that the containing function doesn't have void return type itself
-    // (returning void from void function is fine, it's shorthand)
+    // (returning void from void function is fine, it's shorthand).
     let parent = node.parent
+    let containingFn: typeof node | null = null
     while (parent) {
       if (parent.type === 'arrow_function') {
         // Arrow functions with expression body: `() => voidFn()` — this is fine
         if (parent.childForFieldName('body')?.type !== 'statement_block') {
           return null
         }
+        containingFn = parent
         break
       }
       if (parent.type === 'function_declaration' || parent.type === 'function_expression' ||
           parent.type === 'method_definition') {
+        containingFn = parent
         break
       }
       parent = parent.parent
+    }
+
+    // Mirrors `@typescript-eslint/no-confusing-void-expression`'s
+    // `ignoreVoidReturningFunctions` option for the common framework-handler
+    // shape: an *arrow* whose return type resolves to `void` / `Promise<void>`
+    // / `undefined`. tRPC mutation handlers, Express middlewares etc. use
+    // `return await voidFn()` to forward the void result — not confusing
+    // when the outer signature is itself void. Restricting to arrows keeps
+    // the existing function-declaration coverage intact.
+    if (containingFn?.type === 'arrow_function') {
+      const fnReturnType = typeQuery.getReturnType(
+        filePath,
+        containingFn.startPosition.row,
+        containingFn.startPosition.column,
+        containingFn.endPosition.row,
+        containingFn.endPosition.column,
+      )
+      if (fnReturnType && /^(void|undefined|Promise<\s*(void|undefined)\s*>)$/.test(fnReturnType)) {
+        return null
+      }
     }
 
     return makeViolation(

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/filename-class-mismatch.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/filename-class-mismatch.ts
@@ -11,6 +11,28 @@ const CONVENTIONAL_DEFAULT_NAMES = new Set([
   'app', 'router', 'route', 'handler', 'server', 'config', 'default', 'middleware', 'plugin',
 ])
 
+/**
+ * Conventional role-suffixes appended to a filename-derived name to form
+ * the export. Stripped (case-insensitively, post-normalization) so that
+ * `document-rejected.tsx` exporting `DocumentRejectedEmail` matches,
+ * `user-card.tsx` exporting `UserCardComponent` matches, etc.
+ */
+const ROLE_SUFFIXES = [
+  // React-y / UI
+  'component', 'page', 'view', 'layout', 'form', 'dialog', 'modal', 'card',
+  'panel', 'sheet', 'drawer', 'toolbar', 'header', 'footer', 'sidebar',
+  'list', 'item', 'row', 'cell', 'menu', 'icon', 'button', 'badge',
+  'provider', 'context', 'wrapper', 'container', 'renderer',
+  // Backend / shared
+  'service', 'controller', 'resolver', 'handler', 'manager', 'factory',
+  'helper', 'helpers', 'util', 'utils', 'client', 'adapter', 'repository',
+  'store', 'model', 'schema', 'config', 'options', 'plugin', 'middleware',
+  // Email/template specific
+  'email', 'template', 'mail', 'message', 'notification',
+  // Hooks / functional
+  'hook', 'use',
+]
+
 export const filenameClassMismatchVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/filename-class-mismatch',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -66,6 +88,14 @@ export const filenameClassMismatchVisitor: CodeRuleVisitor = {
     const normalizeFileName = (s: string) => s.toLowerCase().replace(/[-_.]/g, '')
     const normFile = normalizeFileName(fileBase)
     const normClass = normalizeFileName(exportedName)
+
+    // Allow `<filename><RoleSuffix>` pattern (e.g. `document-rejected.tsx`
+    // exporting `DocumentRejectedEmail`). The file describes the topic, the
+    // suffix the role — a stable convention across many codebases.
+    if (normFile && normClass.startsWith(normFile)) {
+      const tail = normClass.slice(normFile.length)
+      if (tail === '' || ROLE_SUFFIXES.includes(tail)) return null
+    }
 
     if (normFile && normClass && normFile !== normClass) {
       return makeViolation(

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/missing-boundary-types.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/missing-boundary-types.ts
@@ -1,5 +1,13 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { FRAMEWORK_ROUTE_EXPORT_NAMES, functionReturnsJsx } from './_helpers.js'
+
+function isDefaultExport(exportNode: import('web-tree-sitter').Node): boolean {
+  for (let i = 0; i < exportNode.childCount; i++) {
+    if (exportNode.child(i)?.type === 'default') return true
+  }
+  return false
+}
 
 export const missingBoundaryTypesVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/missing-boundary-types',
@@ -27,6 +35,17 @@ export const missingBoundaryTypesVisitor: CodeRuleVisitor = {
 
     const nameNode = funcNode.childForFieldName('name')
     const name = nameNode?.text ?? 'function'
+
+    // Skip framework route conventions (Next.js route handlers, Remix route
+    // module exports, Next.js metadata helpers). The framework defines the
+    // signature so explicit return types are rarely added and not helpful.
+    if (FRAMEWORK_ROUTE_EXPORT_NAMES.has(name)) return null
+
+    // Skip default-exported React components (Remix / Next.js page modules):
+    // TS infers `JSX.Element` and codebases almost never annotate it. Named
+    // JSX-returning exports still get flagged — they're part of a public API
+    // surface where stable return types matter.
+    if (isDefaultExport(node) && functionReturnsJsx(funcNode)) return null
 
     return makeViolation(
       this.ruleKey, funcNode, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/missing-return-type.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/missing-return-type.ts
@@ -1,5 +1,6 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { FRAMEWORK_ROUTE_EXPORT_NAMES, functionReturnsJsx, isDefaultExportedFunction } from './_helpers.js'
 
 export const missingReturnTypeVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/missing-return-type',
@@ -18,6 +19,15 @@ export const missingReturnTypeVisitor: CodeRuleVisitor = {
 
     // Skip constructors
     if (name === 'constructor') return null
+
+    // Skip framework route conventions (Next.js route handlers, Remix route
+    // module exports, Next.js metadata helpers). The framework dictates the
+    // signature, so explicit return types are rarely added in practice.
+    if (FRAMEWORK_ROUTE_EXPORT_NAMES.has(name)) return null
+
+    // Skip default-exported React components (Remix / Next.js page modules):
+    // TS infers `JSX.Element` and codebases almost never annotate it.
+    if (isDefaultExportedFunction(node) && functionReturnsJsx(node)) return null
 
     return makeViolation(
       this.ruleKey, nameNode, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/star-import.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/star-import.ts
@@ -28,6 +28,17 @@ export const jsStarImportVisitor: CodeRuleVisitor = {
       if (namespaceLibs.some((lib) => sourceText === lib || sourceText.startsWith(lib + '/') || sourceText.startsWith(lib + '-'))) {
         return null
       }
+      // Skip libraries whose API is designed around a namespace alias:
+      //   - `zod` is built for `import * as z from 'zod'` → `z.object(...)`.
+      //   - `@react-email/*` and `fumadocs-ui/components/*` expose many
+      //     individually-imported components that read more cleanly under
+      //     a single namespace alias.
+      if (sourceText === 'zod'
+        || sourceText.startsWith('@react-email/')
+        || sourceText.startsWith('fumadocs-ui/')
+        || sourceText.startsWith('fumadocs-core/')) {
+        return null
+      }
       // Relative imports (./foo, ../bar) — namespace imports for local modules are a valid pattern
       if (sourceText.startsWith('./') || sourceText.startsWith('../')) return null
 
@@ -39,6 +50,13 @@ export const jsStarImportVisitor: CodeRuleVisitor = {
         const root = node.tree.rootNode
         const jsxPattern = nsName + '.'
         if (root.text.includes('<' + jsxPattern)) return null
+
+        // Skip when the namespace is referenced many times — the alias is
+        // load-bearing and collapsing it into named imports would just
+        // produce a sprawling import list.
+        const escaped = nsName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        const matches = root.text.match(new RegExp(`\\b${escaped}\\.`, 'g'))
+        if (matches && matches.length >= 5) return null
       }
 
       return makeViolation(

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/missing-null-check-after-find.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/missing-null-check-after-find.ts
@@ -23,6 +23,16 @@ export const missingNullCheckAfterFindVisitor: CodeRuleVisitor = {
     const prop = fn.childForFieldName('property')
     if (prop?.text !== 'find') return null
 
+    // Selector-style `.find(stringLiteral)` is never `Array.prototype.find`
+    // (whose only argument is a predicate callback). Konva, jQuery, Cheerio,
+    // Playwright locators etc. all use string selectors. Skip syntactically
+    // — works even without resolved type info (e.g. node_modules absent).
+    const args = node.childForFieldName('arguments')
+    const firstArg = args?.namedChild(0)
+    if (firstArg && (firstArg.type === 'string' || firstArg.type === 'template_string')) {
+      return null
+    }
+
     // Not every `.find()` is `Array.prototype.find`. Konva's `Node.find`,
     // jQuery's `$.find`, Cheerio's selector `.find` etc. all return arrays
     // — there's no possibility of `undefined`, so chained access is safe.
@@ -45,12 +55,14 @@ export const missingNullCheckAfterFindVisitor: CodeRuleVisitor = {
     // Skip if optional chaining is used: arr.find(...)?.property
     if (parent.type === 'optional_chain_expression') return null
 
-    // Skip when the parent is a member_expression using optional chaining (?.)
+    // Skip when the parent is a member_expression using optional chaining (?.).
+    // tree-sitter-typescript inserts an `optional_chain` child between the
+    // object and the property; that's whitespace-insensitive (handles wrapped
+    // chains like `arr.find(cb)\n  ?.prop`).
     if (parent.type === 'member_expression' && parent.childForFieldName('object')?.id === node.id) {
-      const parentText = parent.text
-      const findCallEnd = node.endIndex - parent.startIndex
-      const afterFind = parentText.slice(findCallEnd)
-      if (afterFind.startsWith('?.')) return null
+      for (let i = 0; i < parent.namedChildCount; i++) {
+        if (parent.namedChild(i)?.type === 'optional_chain') return null
+      }
     }
 
     // If result is used in member access immediately: arr.find(...).property

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -607,6 +607,12 @@
       "layer": "service"
     },
     {
+      "name": "buildRecordLabel",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "Calculator",
       "service": "utils",
       "kind": "class",
@@ -704,6 +710,12 @@
     },
     {
       "name": "computeDefaultTimeout",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "confusing-void-expression-non-void-caller",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"
@@ -919,9 +931,21 @@
       "layer": "service"
     },
     {
+      "name": "readGreeting",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "ReassignableClass",
       "service": "utils",
       "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "recipientNameFor",
+      "service": "utils",
+      "kind": "standalone",
       "layer": "service"
     },
     {
@@ -1114,6 +1138,12 @@
       "name": "WrongNameClass",
       "service": "utils",
       "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "BillingDashboard",
+      "service": "web",
+      "kind": "class",
       "layer": "service"
     },
     {

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/filename-class-mismatch-divergent-topic.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/filename-class-mismatch-divergent-topic.tsx
@@ -1,0 +1,13 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/filename-class-mismatch.
+ *
+ * The filename and the default export's topic genuinely diverge — no
+ * `<Topic><Role>` relationship between them, just a renamed file or a
+ * copy-paste that was never cleaned up. Importers see a path that says
+ * one thing and a symbol that says another.
+ */
+
+// VIOLATION: code-quality/deterministic/filename-class-mismatch
+export default class BillingDashboard {
+  readonly id = 'billing-dashboard';
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/confusing-void-expression-non-void-caller.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/confusing-void-expression-non-void-caller.ts
@@ -1,0 +1,18 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/confusing-void-expression.
+ *
+ * The arrow's return type is `Promise<unknown>` (not void), so returning
+ * a void-typed value silently coerces to `undefined`. The call site
+ * looks like it's forwarding a real value when it isn't — the case the
+ * rule is meant to catch.
+ */
+
+function notifyAuditLog(): void {
+  // pretend to enqueue an audit-log event
+}
+
+// VIOLATION: code-quality/deterministic/confusing-void-expression
+export const submitTask = async (): Promise<unknown> => {
+  const result = notifyAuditLog();
+  return result;
+};

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/missing-boundary-types-plain-helper.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/missing-boundary-types-plain-helper.ts
@@ -1,0 +1,12 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/missing-boundary-types.
+ *
+ * A regular exported utility — no framework convention, no JSX. The
+ * boundary genuinely needs an explicit return type so the public shape
+ * is stable.
+ */
+
+// VIOLATION: code-quality/deterministic/missing-boundary-types
+export function buildRecordLabel(prefix: string, id: number) {
+  return `${prefix}-${id}`;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/missing-null-check-after-find-array-predicate.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/missing-null-check-after-find-array-predicate.ts
@@ -1,0 +1,20 @@
+/**
+ * Paraphrased true-bug for reliability/deterministic/missing-null-check-after-find.
+ *
+ * `Array.prototype.find` returns `T | undefined`. Accessing a property
+ * straight on its result without an optional-chain or guard will throw
+ * when no element matches.
+ */
+
+interface Recipient {
+  readonly id: number;
+  readonly displayName: string;
+}
+
+export function recipientNameFor(
+  recipients: ReadonlyArray<Recipient>,
+  recipientId: number,
+): string {
+  // VIOLATION: reliability/deterministic/missing-null-check-after-find
+  return recipients.find((r) => r.id === recipientId).displayName;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/star-import-sparse-namespace.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/star-import-sparse-namespace.ts
@@ -1,0 +1,15 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/star-import.
+ *
+ * `import * as fs from 'node:fs'` pulls the entire fs module's runtime
+ * surface, but the caller only references one or two functions. A
+ * named import is strictly better for tree-shaking and readability;
+ * the rule should still fire here.
+ */
+
+// VIOLATION: code-quality/deterministic/star-import
+import * as fileSystem from 'node:fs';
+
+export function readGreeting(path: string): string {
+  return fileSystem.readFileSync(path, 'utf-8');
+}

--- a/tests/fixtures/sample-js-project-positive/externals.d.ts
+++ b/tests/fixtures/sample-js-project-positive/externals.d.ts
@@ -119,6 +119,30 @@ declare module 'sample-crypto-shim' {
   export function hashLegacy(input: string, rounds: number): string;
 }
 
+declare module 'zod' {
+  type ZodTypeAny = unknown;
+  interface ZodString { uuid(): ZodString; min(n: number): ZodString }
+  interface ZodNumber { int(): ZodNumber; nonnegative(): ZodNumber }
+  interface ZodObject<T> { parse(input: unknown): T }
+  export function string(): ZodString;
+  export function number(): ZodNumber;
+  export function object<T = unknown>(shape: Record<string, ZodTypeAny>): ZodObject<T>;
+  export type infer<T> = T extends ZodObject<infer U> ? U : never;
+}
+
+declare module '@react-email/render' {
+  export function render(node: unknown): Promise<string>;
+}
+
+declare module 'big-math-toolkit-fake' {
+  export function sum(values: ReadonlyArray<number>): number;
+  export function mean(values: ReadonlyArray<number>): number;
+  export function median(values: ReadonlyArray<number>): number;
+  export function stdev(values: ReadonlyArray<number>): number;
+  export function min(values: ReadonlyArray<number>): number;
+  export function max(values: ReadonlyArray<number>): number;
+}
+
 declare module '@sample/shared-utils' {
   export const logger: {
     info(message: string): void;

--- a/tests/fixtures/sample-js-project-positive/src/confusing-void-expression-void-returning-handler.ts
+++ b/tests/fixtures/sample-js-project-positive/src/confusing-void-expression-void-returning-handler.ts
@@ -1,0 +1,37 @@
+/**
+ * Positive fixture for code-quality/deterministic/confusing-void-expression.
+ *
+ * `return voidFn()` is the idiomatic shorthand for framework handlers
+ * whose own signature already returns `void` / `Promise<void>` — tRPC
+ * mutation handlers, Express middleware, etc. Matches
+ * `@typescript-eslint/no-confusing-void-expression`'s
+ * `ignoreVoidReturningFunctions` option: the outer void return means no
+ * "looks like the value matters" confusion is possible.
+ *
+ * The `return await voidFn()` shape from the upstream samples triggers
+ * `no-return-await` (a separate rule) outside a `try`, so the async
+ * branch wraps the call in `try` to exercise just this rule.
+ */
+
+function recordAuditEvent(): void {
+  // no-op
+}
+
+async function flushTaskQueue(): Promise<void> {
+  await Promise.resolve();
+}
+
+// Sync arrow returning `void` — `return voidFn()` is the shorthand.
+export const runAuditHandler: () => void = () => {
+  return recordAuditEvent();
+};
+
+// Async arrow returning `Promise<void>` — `return await voidFn()` inside
+// `try` is the production pattern.
+export const runFlushHandler: () => Promise<void> = async () => {
+  try {
+    return await flushTaskQueue();
+  } catch {
+    return;
+  }
+};

--- a/tests/fixtures/sample-js-project-positive/src/filename-class-mismatch-role-suffix.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/filename-class-mismatch-role-suffix.tsx
@@ -1,0 +1,19 @@
+/**
+ * Positive fixture for code-quality/deterministic/filename-class-mismatch.
+ *
+ * A common convention across email-template, React-component, and
+ * service codebases: the file describes the *topic* in kebab-case, and
+ * the exported symbol is `<TopicInPascalCase><RoleSuffix>` (e.g.
+ * `Email`, `Component`, `Service`). The rule previously normalised both
+ * names and compared them for equality, flagging every suffixed export
+ * as a mismatch. Once the suffix tail is recognised as a conventional
+ * role marker, the comparison should accept it.
+ */
+
+import * as React from 'react';
+
+export function FilenameClassMismatchRoleSuffixComponent(): React.ReactElement {
+  return <div>topic + role suffix</div>;
+}
+
+export default FilenameClassMismatchRoleSuffixComponent;

--- a/tests/fixtures/sample-js-project-positive/src/missing-boundary-types-framework-handlers.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/missing-boundary-types-framework-handlers.tsx
@@ -1,0 +1,63 @@
+/**
+ * Positive fixture for code-quality/deterministic/missing-boundary-types.
+ *
+ * Framework route conventions (HTTP-method handlers, React Router /
+ * Remix route module exports, Next.js App Router exports) and React
+ * component default exports rarely carry explicit return types in real
+ * codebases — the framework defines the contract, and TS infers
+ * `JSX.Element` for components. Flagging these as "boundary types
+ * missing" produced a steady stream of FPs on Remix / Next.js routes.
+ *
+ * `missing-return-type` is the sibling rule with the same matching shape
+ * (named `function_declaration`s without a return-type annotation), so
+ * the framework-convention skip lands in both visitors.
+ */
+
+// React Router / Remix route module conventions: `loader`, `action`,
+// `meta`, `links`, `headers`, `clientLoader`, `clientAction`,
+// `shouldRevalidate`, `HydrateFallback`, `ErrorBoundary`.
+export function loader({ request }: { request: Request }) {
+  const url = new URL(request.url);
+  return { path: url.pathname };
+}
+
+export function action({ request }: { request: Request }) {
+  return { ok: request.method === 'POST' };
+}
+
+export function meta() {
+  return [{ title: 'Settings' }];
+}
+
+export function links() {
+  return [{ rel: 'stylesheet', href: '/styles.css' }];
+}
+
+// Next.js App Router route handlers (HTTP methods).
+export function GET(request: Request) {
+  const url = new URL(request.url);
+  return new Response(JSON.stringify({ path: url.pathname }));
+}
+
+export function OPTIONS(_request: Request) {
+  return new Response(null, { status: 204 });
+}
+
+// Next.js metadata / static params helpers.
+export function generateMetadata({ params }: { params: { slug: string } }) {
+  return { title: params.slug };
+}
+
+export function generateStaticParams() {
+  return [{ slug: 'home' }, { slug: 'about' }];
+}
+
+// Default-exported React component — TS infers `JSX.Element`; codebases
+// almost never annotate this.
+export default function SettingsPage() {
+  return (
+    <div className="settings">
+      <h1>Settings</h1>
+    </div>
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/src/missing-null-check-after-find-string-selector.ts
+++ b/tests/fixtures/sample-js-project-positive/src/missing-null-check-after-find-string-selector.ts
@@ -1,0 +1,74 @@
+/**
+ * Positive fixture for reliability/deterministic/missing-null-check-after-find.
+ *
+ * Selector-style `.find(stringSelector)` APIs (Konva, jQuery, Cheerio,
+ * Playwright locators, etc.) commonly return a non-array collection-like
+ * type whose return string does NOT match `T[]` or `Array<T>`. When type
+ * resolution is unavailable (e.g. analyzing without node_modules) the
+ * return is `any`, so the array-shape skip never triggers. In both cases
+ * the rule was firing on what was clearly a selector call — the first
+ * argument is a string literal, which `Array.prototype.find` (whose only
+ * argument is a predicate callback) cannot accept.
+ *
+ * Also covers the multi-line optional-chain shape:
+ *   `arr.find(cb)\n  ?.prop` — the `?.` is on the next physical line.
+ * The previous text-based check required `?.` to immediately follow the
+ * call with no whitespace in between, so wrapped chains were flagged.
+ */
+
+interface CanvasNode {
+  readonly id: string;
+  destroy(): void;
+  size(): number;
+}
+
+interface CanvasNodeCollection {
+  // Selector-style: returns another collection. NOT an array — the
+  // returned string type does not match `T[]` / `Array<T>`.
+  find(selector: string): CanvasNodeCollection;
+  filter(pred: (n: CanvasNode) => boolean): CanvasNodeCollection;
+  forEach(cb: (n: CanvasNode) => void): void;
+  sort(cmp: (a: CanvasNode, b: CanvasNode) => number): CanvasNodeCollection;
+  readonly length: number;
+}
+
+export function clearGroups(stage: CanvasNodeCollection): void {
+  // Was flagged: `.find('Group')` chained into `.forEach(...)` — but the
+  // string-literal first argument means this can't be Array.prototype.find.
+  stage.find('Group').forEach((node) => {
+    node.destroy();
+  });
+}
+
+export function countShapes(stage: CanvasNodeCollection): number {
+  // Was flagged: `.find('Shape').length` — same reasoning, string selector.
+  return stage.find('Shape').length;
+}
+
+export function sortedChildren(stage: CanvasNodeCollection): CanvasNodeCollection {
+  // Chained `.find('...').sort(...)` — still a selector call.
+  return stage.find('.tile').sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function filteredHandles(stage: CanvasNodeCollection): CanvasNodeCollection {
+  // Chained `.find('...').filter(...)` — still a selector call.
+  return stage.find('.handle').filter((node) => node.size() > 0);
+}
+
+interface Entry {
+  readonly id: number;
+  readonly tags: ReadonlyArray<{ readonly kind: string }>;
+}
+
+export function firstTagFor(
+  entries: ReadonlyArray<Entry>,
+  entryId: number,
+): { readonly kind: string } | undefined {
+  // Optional-chain split across a line break. The result of `Array.find`
+  // (which CAN be undefined) is safely accessed via `?.tags.find(...)`.
+  // The rule must recognise the `?.` even when whitespace/newlines sit
+  // between the call's closing `)` and the `?.`.
+  return entries
+    .find((entry) => entry.id === entryId)
+    ?.tags.find((tag) => tag.kind === 'primary');
+}

--- a/tests/fixtures/sample-js-project-positive/src/star-import-idiomatic-namespace.ts
+++ b/tests/fixtures/sample-js-project-positive/src/star-import-idiomatic-namespace.ts
@@ -1,0 +1,44 @@
+/**
+ * Positive fixture for code-quality/deterministic/star-import.
+ *
+ * Some libraries' APIs are explicitly designed around a namespace alias
+ * (zod's `z.` schema builders are the canonical case) or expose so many
+ * top-level helpers that a `*-as-alias` import is dramatically clearer
+ * than dragging in twenty named imports.
+ *
+ * The rule should skip these:
+ *   - well-known idiomatic-namespace packages (`zod`, `@react-email/*`,
+ *     `fumadocs-*`), regardless of use count.
+ *   - any other module where the namespace alias is referenced ≥ 5
+ *     times in the file — the alias is load-bearing.
+ */
+
+import * as z from 'zod';
+import * as ReactEmail from '@react-email/render';
+import * as bigmath from 'big-math-toolkit-fake';
+
+// `z.*` — canonical zod schema builder, namespace-aliased by design.
+export const UserSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  age: z.number().int().nonnegative(),
+});
+
+export type User = z.infer<typeof UserSchema>;
+
+// `ReactEmail.*` — @react-email/render's API is namespace-shaped.
+export function renderTemplate(node: unknown): Promise<string> {
+  return ReactEmail.render(node);
+}
+
+// `bigmath` is a fake library, so it's not on the whitelist — instead it
+// passes via the ≥ 5-references threshold. Six member accesses below.
+export function summarise(values: ReadonlyArray<number>): number {
+  const sum = bigmath.sum(values);
+  const mean = bigmath.mean(values);
+  const median = bigmath.median(values);
+  const stdev = bigmath.stdev(values);
+  const min = bigmath.min(values);
+  const max = bigmath.max(values);
+  return sum + mean + median + stdev + min + max;
+}


### PR DESCRIPTION
Closes #256
Closes #258
Closes #259
Closes #260
Closes #261

## Fixes

| Rule | Issue | Positive fixture | Negative fixture |
|---|---|---|---|
| `reliability/deterministic/missing-null-check-after-find` | #256 | `tests/fixtures/sample-js-project-positive/src/missing-null-check-after-find-string-selector.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/missing-null-check-after-find-array-predicate.ts` |
| `code-quality/deterministic/missing-boundary-types` | #258 | `tests/fixtures/sample-js-project-positive/src/missing-boundary-types-framework-handlers.tsx` | `tests/fixtures/sample-js-project-negative/shared/utils/src/missing-boundary-types-plain-helper.ts` |
| `code-quality/deterministic/filename-class-mismatch` | #259 | `tests/fixtures/sample-js-project-positive/src/filename-class-mismatch-role-suffix.tsx` | `tests/fixtures/sample-js-project-negative/services/web/src/components/filename-class-mismatch-divergent-topic.tsx` |
| `code-quality/deterministic/confusing-void-expression` | #260 | `tests/fixtures/sample-js-project-positive/src/confusing-void-expression-void-returning-handler.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/confusing-void-expression-non-void-caller.ts` |
| `code-quality/deterministic/star-import` | #261 | `tests/fixtures/sample-js-project-positive/src/star-import-idiomatic-namespace.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/star-import-sparse-namespace.ts` |

## reliability/deterministic/missing-null-check-after-find

Upstream sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/universal/field-renderer/render-grid-lines.ts#L43
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/envelope-editor/envelope-generic-page-renderer.tsx#L142`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_internal+/[__htmltopdf]+/certificate.tsx#L199
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/universal/field-renderer/render-grid-lines.ts#L73
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/app-tests/e2e/fixtures/konva.ts#L14

Positive fixture (new):
```ts
export function clearGroups(stage: CanvasNodeCollection): void {
  // string-literal first argument → not Array.prototype.find
  stage.find('Group').forEach((node) => node.destroy());
}

export function firstTagFor(entries, entryId) {
  // multi-line optional chain — `?.` lives on the next line
  return entries
    .find((entry) => entry.id === entryId)
    ?.tags.find((tag) => tag.kind === 'primary');
}
```

Negative fixture (new):
```ts
// VIOLATION: reliability/deterministic/missing-null-check-after-find
return recipients.find((r) => r.id === recipientId).displayName;
```

Visitor change: skip when the first argument is a string / template literal (selector-style APIs like Konva, jQuery, Cheerio, Playwright cannot be `Array.prototype.find`, whose only argument is a predicate callback). Also replaced the text-based optional-chain heuristic with an AST scan for an `optional_chain` child of the parent `member_expression`, so wrapped chains like `arr.find(cb)\n  ?.prop` are recognised.

## code-quality/deterministic/missing-boundary-types

Upstream sources:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings._layout.tsx#L21`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/openpage-api/app/growth/route.ts#L15
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/openpage-api/app/github/stars/route.ts#L3
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_recipient+/d.$token+/_index.tsx#L162
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/openpage-api/app/github/issues/route.ts#L21

Positive fixture (new):
```tsx
export function loader({ request }) { /* Remix loader */ }
export function GET(request) { /* Next.js route handler */ }
export function generateMetadata({ params }) { /* Next metadata */ }
export default function SettingsPage() { return <div>...</div>; }
```

Negative fixture (new):
```ts
// VIOLATION: code-quality/deterministic/missing-boundary-types
export function buildRecordLabel(prefix: string, id: number) {
  return `${prefix}-${id}`;
}
```

Visitor change: added a shared `FRAMEWORK_ROUTE_EXPORT_NAMES` whitelist covering Next.js App Router HTTP-method handlers (`GET`/`POST`/…), Next.js metadata helpers (`generateMetadata`, `generateStaticParams`, …), and Remix / React Router v7 route-module exports (`loader`, `action`, `meta`, `links`, `headers`, …). Also added an `isDefaultExportedFunction` + JSX-return check so `export default function Page() { return <…/> }` (Remix/Next page modules) is skipped — but **named** JSX-returning exports keep firing (the existing `Links.tsx` negative coverage still passes). Same skip applied to the sibling `missing-return-type` rule since both match the same shape and the fixture would otherwise still trigger it.

## code-quality/deterministic/filename-class-mismatch

Upstream sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/templates/document-rejected.tsx#L66
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/templates/organisation-delete.tsx#L75
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/templates/reset-password.tsx#L83
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/templates/organisation-join.tsx#L72
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/templates/forgot-password.tsx#L55

Positive fixture (new) — file `filename-class-mismatch-role-suffix.tsx`:
```tsx
export function FilenameClassMismatchRoleSuffixComponent(): React.ReactElement {
  return <div>topic + role suffix</div>;
}
export default FilenameClassMismatchRoleSuffixComponent;
```

Negative fixture (new) — file `filename-class-mismatch-divergent-topic.tsx`:
```tsx
// VIOLATION: code-quality/deterministic/filename-class-mismatch
export default class BillingDashboard {
  readonly id = 'billing-dashboard';
}
```

Visitor change: accept the `<FileTopic><RoleSuffix>` convention — when the normalised export name starts with the normalised filename and the remaining tail is one of a curated set of role suffixes (`email`, `component`, `page`, `service`, `handler`, `provider`, `hook`, …), it's treated as a match. `document-rejected.tsx` exporting `DocumentRejectedEmail` (topic + `email`) now matches; entirely-divergent topics still get flagged.

## code-quality/deterministic/confusing-void-expression

Upstream sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/team-router/create-team-members.ts#L27
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/admin-router/reset-two-factor-authentication.ts#L19

Positive fixture (new):
```ts
// outer arrow returns void / Promise<void> → forwarding a void value is the idiom
export const runAuditHandler: () => void = () => {
  return recordAuditEvent();
};

export const runFlushHandler: () => Promise<void> = async () => {
  try {
    return await flushTaskQueue();
  } catch {
    return;
  }
};
```

Negative fixture (new):
```ts
// VIOLATION: code-quality/deterministic/confusing-void-expression
export const submitTask = async (): Promise<unknown> => {
  const result = notifyAuditLog();
  return result;
};
```

Visitor change: mirrors `@typescript-eslint/no-confusing-void-expression`'s `ignoreVoidReturningFunctions` option, scoped to arrow functions. When the enclosing arrow's resolved return type is `void` / `undefined` / `Promise<void>` / `Promise<undefined>`, returning a void-typed value via `return voidFn()` / `return await voidFn()` is the idiomatic framework-handler pattern (tRPC mutation handlers, Express middleware, etc.). Restricting to arrows keeps the existing `function`-declaration negative coverage intact.

## code-quality/deterministic/star-import

Upstream sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/envelope-distribute-dialog.tsx#L39
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/cert/cert-status.ts#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/signing/transports/local.ts#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/render.tsx#L4
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/template-use-dialog.tsx#L39

Positive fixture (new):
```ts
import * as z from 'zod';                        // canonical zod namespace
import * as ReactEmail from '@react-email/render';
import * as bigmath from 'big-math-toolkit-fake'; // 6 member accesses → load-bearing alias
```

Negative fixture (new):
```ts
// VIOLATION: code-quality/deterministic/star-import
import * as fileSystem from 'node:fs';
export function readGreeting(path: string): string {
  return fileSystem.readFileSync(path, 'utf-8');
}
```

Visitor change: extended the idiomatic-namespace whitelist with `zod`, `@react-email/*`, and `fumadocs-ui/*` / `fumadocs-core/*` (libraries whose API is designed around a single alias). Added a usage-count heuristic — when the namespace alias is referenced ≥ 5 times in the file, the alias is load-bearing and breaking it into named imports would just produce a sprawling import list. Sparse `import * as fs` calls with 1–2 references continue to fire.

## Skipped this batch

- #257 — `code-quality/deterministic/cognitive-complexity`: the issue's own `why_fp` flags most samples as real complexity, not FPs (`validate-checkbox.ts:6`, `seal-document.handler.ts:344`, `verify-embedding-presign-token.ts:12` genuinely exceed the 15-point threshold). The two JSX-renderer FPs require retuning the core complexity-counting walk (Sonar's first-of-each-unique-operator-per-sequence rule, or excluding JSX-expression operators) plus the threshold against the existing negative cases — a refactor, not a single-skip tightening. Marked `fp-blocked` for human review of the rule's overall formula.

## FP-count delta (vs `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f` on `documenso/documenso`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| reliability/deterministic/missing-null-check-after-find | 12 | 1 | -11 |
| code-quality/deterministic/missing-boundary-types | 338 | 59 | -279 |
| code-quality/deterministic/filename-class-mismatch | 27 | 16 | -11 |
| code-quality/deterministic/confusing-void-expression | 2 | 0 | -2 |
| code-quality/deterministic/star-import | 10 | 4 | -6 |
| **Total (these 5 rules)** | **389** | **80** | **-309** |
| **All-rules total on target** | **51710** | **51122** | **-588** |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtJH5g9AUAdWiAQ5QtVDh6)_