### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/architecture/checker.ts
+++ b/packages/analyzer/src/rules/architecture/checker.ts
@@ -35,12 +35,14 @@ function isObjectLiteralMethod(filePath: string, methodName: string, startLine?:
   //   `<spaces><name>: function (args) {…}`      (function expression)
   //   `<spaces>async <name>(args) {…}`           (object-shorthand method)
   //   `<spaces><name>(args) {…}`                 (object-shorthand method)
+  //   `<spaces>get <name>() {…}`                 (object-literal getter)
+  //   `<spaces>set <name>(v) {…}`                (object-literal setter)
   // the value sits on the same line as the property key in normal code.
   const line = lines[startLine - 1]
   if (!line) return false
   const name = escapeRegex(methodName)
   const colonForm = new RegExp(`^\\s+${name}\\s*\\??\\s*:\\s*(?:async\\s+)?(?:function\\b|\\()`)
-  const shorthandForm = new RegExp(`^\\s+(?:async\\s+)?${name}\\s*\\(`)
+  const shorthandForm = new RegExp(`^\\s+(?:async\\s+|get\\s+|set\\s+)?${name}\\s*\\(`)
   if (!colonForm.test(line) && !shorthandForm.test(line)) return false
   // Reject top-level declarations that happen to share the indentation
   // pattern (`export function foo(`, `function foo(`, class methods inside
@@ -466,6 +468,10 @@ export function checkModuleRules(
         // e2e specs and CLI seed scripts which are excluded from analysis.
         if (SEED_PATH_PATTERN.test(method.filePath)) continue
 
+        // Skip Remix / React Router file-based route modules — consumed by
+        // the framework via filesystem convention, not source imports.
+        if (REMIX_ROUTE_PATH_PATTERN.test(method.filePath)) continue
+
         // Skip exports from shadcn/ui component library directories — these export all variants for consumer use
         if (/\/components\/ui\//.test(method.filePath)) continue
 
@@ -515,6 +521,9 @@ export function checkModuleRules(
     for (const mod of modules) {
       if (mod.kind === 'class' && mod.exportCount > 0 && !importedTargets.has(mod.name)) {
         if (entryPointFiles?.has(mod.filePath)) continue
+
+        if (SEED_PATH_PATTERN.test(mod.filePath)) continue
+        if (REMIX_ROUTE_PATH_PATTERN.test(mod.filePath)) continue
 
         // Skip classes used as type annotations (params, return types, superclasses)
         if (usedAsType.has(mod.name)) continue
@@ -844,8 +853,20 @@ const MIGRATION_PATH_PATTERN = /(?:alembic\/versions|\/migrations\/|\/seeds\/)\/
  * files are typically consumed by e2e specs (`*.spec.ts`, `*.test.ts`)
  * and CLI seed scripts — both excluded from analysis. Treating them as
  * unused-export produces a steady stream of FPs.
+ *
+ * Also matches Playwright / e2e fixture directories — those exports
+ * (custom fixtures, page-object helpers, `apiSignout`, etc.) are reached
+ * from `*.spec.ts` files that the analyzer doesn't traverse.
  */
-const SEED_PATH_PATTERN = /\/seed\//i
+const SEED_PATH_PATTERN = /\/(?:seed|e2e\/fixtures|app-tests\/[^/]+\/fixtures)\//i
+
+/**
+ * Matches Remix / React Router file-based route modules. The framework
+ * mounts these by filesystem convention (folder layout determines the
+ * URL); no source file imports the default export or named loaders/
+ * actions, so the static analyzer can't see the consumer.
+ */
+const REMIX_ROUTE_PATH_PATTERN = /\/app\/routes\//i
 
 /**
  * Check deterministic method-level rules and return violations.
@@ -1013,6 +1034,13 @@ export function checkMethodRules(
             classesWithImplements.add(cls.name)
             const modName = fa.filePath.split('/').pop()?.replace(/\.\w+$/, '')
             if (modName) classesWithImplements.add(modName)
+            // The parent class is an abstract / extensible base — its methods
+            // (including default `throw new Error('Not implemented')` stubs
+            // and `no-op` defaults) are reached polymorphically through the
+            // subclass's `super.method()` calls and through call sites typed
+            // as the parent. Without this, every override-by-design method
+            // on a base class shows up as dead-method.
+            classesWithImplements.add(cls.superClass)
           }
         }
         // Collect all exported names and imported names for cross-reference

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/readonly-parameter-types.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/readonly-parameter-types.ts
@@ -21,6 +21,17 @@ export const readonlyParameterTypesVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode, _dataFlow, typeQuery?: TypeQueryService) {
     if (!typeQuery) return null
 
+    // Rest parameters bind a fresh local array per call, so the caller
+    // cannot observe any mutation through them — readonly adds no safety.
+    if (isRestParameter(node)) return null
+
+    // Function-type signatures (e.g. `onChange: (xs: T[]) => void` on an
+    // interface or type-alias member) describe a callback contract. The
+    // parameter list is a type position, not an actual function being
+    // defined, so the readonly convention belongs on the implementation,
+    // not on the contract.
+    if (node.parent?.parent?.type === 'function_type') return null
+
     const typeAnnotation = node.childForFieldName('type')
     if (!typeAnnotation) return null
 
@@ -48,6 +59,11 @@ export const readonlyParameterTypesVisitor: CodeRuleVisitor = {
 
     return null
   },
+}
+
+function isRestParameter(node: SyntaxNode): boolean {
+  // `...args: T[]` parses as required_parameter wrapping a rest_pattern.
+  return node.namedChildren.some((c) => c.type === 'rest_pattern')
 }
 
 function isMutableArrayType(node: SyntaxNode): boolean {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/redundant-type-alias.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/redundant-type-alias.ts
@@ -13,6 +13,12 @@ import { makeViolation } from '../../../types.js'
 //       type ClaimFlags = TClaimFlags;       // ← required, not redundant
 //     }
 //   }
+const SEMANTIC_ALIAS_SUFFIX = /(?:Props|State|Settings|Options|Config|Context|Value|Data|Result|Response|Request|Action|Event|Handler|Provider)$/
+
+function hasSemanticSuffix(name: string): boolean {
+  return SEMANTIC_ALIAS_SUFFIX.test(name)
+}
+
 function isInsideNamespaceOrAmbient(node: SyntaxNode): boolean {
   let current: SyntaxNode | null = node.parent
   while (current) {
@@ -38,6 +44,20 @@ export const redundantTypeAliasVisitor: CodeRuleVisitor = {
 
     if (typeNode.type === 'type_identifier') {
       if (typeNode.text === nameNode.text) return null
+
+      // Exported aliases are semantic re-exports — the alias name is the
+      // public API of this module and exists to give consumers a stable
+      // import (e.g. `export type DocumentEmailSettings = TDocumentEmailSettings`).
+      // Collapsing to the source name would force every consumer to import
+      // through a deeper path, so the rename is meaningful, not redundant.
+      if (node.parent?.type === 'export_statement') return null
+
+      // React / TS structural-role suffixes (Props, State, Settings, ...)
+      // signal that the alias gives a domain-specific role to a generic
+      // type. The rename adds meaning even if the alias is local; flagging
+      // it adds noise without surfacing real cleanup wins.
+      if (hasSemanticSuffix(nameNode.text)) return null
+
       return makeViolation(
         this.ruleKey, node, filePath, 'low',
         'Redundant type alias',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/redundant-type-argument.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/redundant-type-argument.ts
@@ -55,8 +55,18 @@ export const redundantTypeArgumentVisitor: CodeRuleVisitor = {
         lastArg.startPosition.row,
         lastArg.startPosition.column,
       )
-      // If the type argument is `any` on generic utilities, it's often redundant
-      if (argType === 'any' && target.text && ['Array', 'Set', 'WeakSet', 'WeakMap'].includes(target.text)) {
+      // Only flag when the user actually wrote `any` literally. If the type
+      // text is something richer (`Field & { signature: ... }`,
+      // `InngestFunction<…, Handler.Any, Handler.Any>`) but `typeQuery`
+      // collapses it to `any` because an inner identifier didn't resolve,
+      // the argument is meaningful to the reader and removing it would
+      // erase intent.
+      if (
+        argType === 'any'
+        && lastArg.text.trim() === 'any'
+        && target.text
+        && ['Array', 'Set', 'WeakSet', 'WeakMap'].includes(target.text)
+      ) {
         return makeViolation(
           this.ruleKey, node, filePath, 'low',
           'Redundant type argument',

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-typescript.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-typescript.ts
@@ -14,6 +14,9 @@ export function forceNonNull(x: string | null) {
 // VIOLATION: code-quality/deterministic/redundant-type-alias
 type UserId = String;
 
+// VIOLATION: code-quality/deterministic/redundant-type-alias
+type SessionIdAlias = String;
+
 // VIOLATION: code-quality/deterministic/redundant-optional
 export interface OptionalUndef {
   name?: string | undefined;
@@ -94,6 +97,15 @@ export class Constants {
 // VIOLATION: code-quality/deterministic/reduce-type-cast
 export function reduceWithCast(arr: number[]) {
   return arr.reduce((acc, val) => [...acc, val], [] as number[]);
+}
+
+export function summarizeEntries(
+  // VIOLATION: code-quality/deterministic/readonly-parameter-types
+  entries: { key: string; value: number }[],
+): number {
+  let total = 0;
+  for (const entry of entries) total += entry.value;
+  return total;
 }
 
 // VIOLATION: code-quality/deterministic/redundant-overload

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-type-alias.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-type-alias.ts
@@ -1,11 +1,16 @@
 /**
  * Paraphrased true-bug for code-quality/deterministic/redundant-type-alias.
  *
- * A top-level type alias that just renames another type without adding
- * any structure — exactly the wrapper-without-meaning the rule is for.
+ * A local, non-exported type alias whose name carries no structural-role
+ * meaning (`Alias` suffix is generic) — exactly the wrapper-without-meaning
+ * the rule is for.
  */
 
 import type { TEmailSettings } from './redundant-type-alias-source';
 
 // VIOLATION: code-quality/deterministic/redundant-type-alias
-export type EmailSettingsValue = TEmailSettings;
+type EmailSettingsAlias = TEmailSettings;
+
+// Local re-use so the alias isn't unreachable.
+type _EmailAliasPair = [EmailSettingsAlias, EmailSettingsAlias];
+export type EmailAliasPair = _EmailAliasPair;

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/remaining-typescript.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/remaining-typescript.ts
@@ -31,6 +31,9 @@ import { type SideEffectType } from './side-effect-module';
 // VIOLATION: code-quality/deterministic/redundant-type-argument
 export const typedSet = new Set<any>();
 
+// VIOLATION: code-quality/deterministic/redundant-type-argument
+export const typedArray = new Array<any>();
+
 // VIOLATION: code-quality/deterministic/unnecessary-condition
 export function alwaysTruthySymbol(sym: symbol) {
   return sym ? 'has symbol' : 'no symbol';

--- a/tests/fixtures/sample-js-project-positive/services/web/app/routes/settings.billing.tsx
+++ b/tests/fixtures/sample-js-project-positive/services/web/app/routes/settings.billing.tsx
@@ -1,0 +1,21 @@
+/**
+ * Remix / React Router file-based route module.
+ *
+ * The framework consumes the default export (the page component) and the
+ * named `loader` / `action` by filesystem convention — no source file
+ * imports them. The unused-export rule should NOT fire here.
+ */
+
+import type * as React from 'react';
+
+interface BillingData {
+  planName: string;
+}
+
+export function loader(): BillingData {
+  return { planName: 'pro' };
+}
+
+export default function BillingSettingsPage(): React.ReactElement {
+  return <main>Billing settings</main>;
+}

--- a/tests/fixtures/sample-js-project-positive/services/web/e2e/fixtures/api-helpers.ts
+++ b/tests/fixtures/sample-js-project-positive/services/web/e2e/fixtures/api-helpers.ts
@@ -1,0 +1,13 @@
+/**
+ * Playwright e2e fixture helpers. Consumed by spec files
+ * (`*.spec.ts` / `*.test.ts`) which the analyzer doesn't traverse,
+ * so the unused-export rule should NOT fire on these exports.
+ */
+
+export function apiSignout(token: string): string {
+  return `signout:${token}`;
+}
+
+export function checkSessionValid(token: string): boolean {
+  return token.length > 0;
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/base-provider-polymorphism.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/base-provider-polymorphism.ts
@@ -1,0 +1,38 @@
+/**
+ * Abstract-by-convention base class. Its methods are overridden by
+ * subclasses and called polymorphically through the parent type, so the
+ * `architecture/deterministic/dead-method` rule should NOT flag them.
+ */
+
+export interface ProviderConfig {
+  endpoint: string;
+  scheduler: string;
+}
+
+export class BaseRemoteProvider {
+  protected readonly config: ProviderConfig;
+
+  constructor(config: ProviderConfig) {
+    this.config = config;
+  }
+
+  public registerHandler(name: string): string {
+    return `unregistered:${name}@${this.config.endpoint}`;
+  }
+
+  public startScheduler(): string {
+    return `${this.config.scheduler}:idle`;
+  }
+}
+
+export class WebhookRemoteProvider extends BaseRemoteProvider {
+  public registerHandler(name: string): string {
+    return `webhook:${name}@${this.config.endpoint}`;
+  }
+
+  public deliver(): string {
+    const handler = this.registerHandler('webhook');
+    const status = this.startScheduler();
+    return `${handler}|${status}`;
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/object-literal-accessors.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/object-literal-accessors.ts
@@ -1,0 +1,23 @@
+/**
+ * Object-literal getter accessors. They are accessed as properties
+ * (`response.statusCode`) by the calling framework, not invoked by
+ * name, so the `architecture/deterministic/dead-method` rule should
+ * NOT flag them.
+ */
+
+export interface ResponseLike {
+  statusCode: number;
+  setHeader(name: string, value: string): void;
+}
+
+export function createResponseStub(initial: number): ResponseLike {
+  const headers = new Map<string, string>();
+  return {
+    get statusCode(): number {
+      return initial;
+    },
+    setHeader(name: string, value: string): void {
+      headers.set(name, value);
+    },
+  };
+}

--- a/tests/fixtures/sample-js-project-positive/src/readonly-parameter-types-callback-types.ts
+++ b/tests/fixtures/sample-js-project-positive/src/readonly-parameter-types-callback-types.ts
@@ -1,0 +1,40 @@
+/**
+ * Rest parameters and callback function-type annotations.
+ *
+ * These should NOT trigger `code-quality/deterministic/readonly-parameter-types`:
+ *   - Rest parameters always bind a fresh local array, so the caller cannot
+ *     observe any mutation through them.
+ *   - Function-type annotations on object/interface properties describe a
+ *     contract for callbacks; the parameter list is a type position, not an
+ *     actual function being defined.
+ */
+
+interface ItemRecord {
+  id: string;
+  label: string;
+}
+
+export interface SelectionContract {
+  onChange: (items: ItemRecord[]) => void;
+  onPick: (ids: string[]) => void;
+}
+
+export type Listener = (events: ItemRecord[]) => void;
+
+export function logAll(...args: unknown[]): void {
+  for (const a of args) {
+    if (a !== undefined) {
+      JSON.stringify(a);
+    }
+  }
+}
+
+export function combine<T>(...lists: T[][]): T[] {
+  const out: T[] = [];
+  for (const list of lists) {
+    for (const item of list) out.push(item);
+  }
+  return out;
+}
+
+export type Reducer<S, A> = (state: S, actions: A[]) => S;

--- a/tests/fixtures/sample-js-project-positive/src/redundant-type-alias-semantic-rename.ts
+++ b/tests/fixtures/sample-js-project-positive/src/redundant-type-alias-semantic-rename.ts
@@ -1,0 +1,44 @@
+/**
+ * Type aliases that exist for semantic / API-stability reasons should
+ * NOT trigger `code-quality/deterministic/redundant-type-alias`:
+ *
+ *   - An EXPORTED alias is the public API of the module — collapsing it
+ *     forces every consumer to import a deeper path.
+ *   - A LOCAL alias whose name ends with a React/TS structural-role
+ *     suffix (Props, State, Settings, …) signals that the alias gives
+ *     a domain-specific role to a generic type.
+ */
+
+interface DocumentDraft {
+  id: string;
+  body: string;
+}
+
+interface SessionLike {
+  userId: string;
+}
+
+interface DocumentBrandingSnapshot {
+  themeColor: string;
+}
+
+// Exported semantic re-export
+export type DocumentDraftProps = DocumentDraft;
+
+// Exported re-export of a deeper internal type
+export type CurrentSession = SessionLike;
+
+// Local alias with a "Settings" semantic suffix — the alias names the role
+// (branding settings) even though it's the same shape as the snapshot.
+type BrandingSettings = DocumentBrandingSnapshot;
+
+export function describeBranding(s: BrandingSettings): string {
+  return s.themeColor;
+}
+
+// Local alias with a "Value" suffix — context value role
+type SessionProviderValue = SessionLike;
+
+export function readSession(s: SessionProviderValue): string {
+  return s.userId;
+}

--- a/tests/fixtures/sample-js-project-positive/src/redundant-type-argument-complex-inner.ts
+++ b/tests/fixtures/sample-js-project-positive/src/redundant-type-argument-complex-inner.ts
@@ -1,0 +1,24 @@
+/**
+ * `Array<...>` (and friends) with a non-`any` inner type — even if
+ * TypeScript's compiler can't fully resolve the inner type and falls
+ * back to `any` internally — should NOT trigger
+ * `code-quality/deterministic/redundant-type-argument`. The user wrote
+ * a concrete inner type and removing it would erase intent.
+ */
+
+interface SignatureMeta {
+  name: string;
+}
+
+interface RecipientRow {
+  id: string;
+  meta: SignatureMeta | null;
+}
+
+export const recipients: Array<
+  RecipientRow & {
+    extra: { tag: string };
+  }
+> = [];
+
+export const tags: Array<RecipientRow & { tag: string }> = [];


### PR DESCRIPTION
Closes #262
Closes #265
Closes #266
Closes #268
Closes #270

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/readonly-parameter-types` | #262 | `tests/fixtures/sample-js-project-positive/src/readonly-parameter-types-callback-types.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-typescript.ts` |
| `architecture/deterministic/unused-export` | #265 | `tests/fixtures/sample-js-project-positive/services/web/app/routes/settings.billing.tsx`, `tests/fixtures/sample-js-project-positive/services/web/e2e/fixtures/api-helpers.ts` | (existing `unused-export-truly-unused.ts`) |
| `code-quality/deterministic/redundant-type-argument` | #266 | `tests/fixtures/sample-js-project-positive/src/redundant-type-argument-complex-inner.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/remaining-typescript.ts` |
| `architecture/deterministic/dead-method` | #268 | `tests/fixtures/sample-js-project-positive/shared/utils/src/base-provider-polymorphism.ts`, `tests/fixtures/sample-js-project-positive/shared/utils/src/object-literal-accessors.ts` | (existing `unused-export-truly-unused.ts`) |
| `code-quality/deterministic/redundant-type-alias` | #270 | `tests/fixtures/sample-js-project-positive/src/redundant-type-alias-semantic-rename.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/redundant-type-alias.ts` |

## code-quality/deterministic/readonly-parameter-types

OSS source URLs (from issue #262):
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page.tsx#L110`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/_internal/job.ts#L54
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/app-tests/e2e/fixtures/api-seeds.ts#L322
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/organisation-groups-multiselect-combobox.tsx#L21`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/embed/authoring/configure-document-upload.tsx#L34`

Positive fixture (new file `…/src/readonly-parameter-types-callback-types.ts`):

```ts
export interface SelectionContract {
  onChange: (items: ItemRecord[]) => void;
  onPick: (ids: string[]) => void;
}

export type Listener = (events: ItemRecord[]) => void;

export function logAll(...args: unknown[]): void { … }
export function combine<T>(...lists: T[][]): T[] { … }
export type Reducer<S, A> = (state: S, actions: A[]) => S;
```

Negative fixture (added to `code-quality-typescript.ts`):

```ts
export function summarizeEntries(
  // VIOLATION: code-quality/deterministic/readonly-parameter-types
  entries: { key: string; value: number }[],
): number { … }
```

Visitor change: skip rest parameters (they bind a fresh local array per call, so the caller can't observe mutation through them) and skip parameters whose enclosing function is a `function_type` (callback signature in an interface/type member — a type position, not a real function definition).

## architecture/deterministic/unused-export

OSS source URLs (from issue #265):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/app-tests/e2e/fixtures/authentication.ts#L37
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated%2B/o.%24orgUrl.settings.branding.tsx#L29`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated%2B/o.%24orgUrl.settings.email.tsx#L16`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated%2B/t.%24teamUrl%2B/settings.tokens.tsx#L20`

Positive fixtures (new files):

```tsx
// services/web/app/routes/settings.billing.tsx
export function loader(): BillingData { … }
export default function BillingSettingsPage(): React.ReactElement { … }
```

```ts
// services/web/e2e/fixtures/api-helpers.ts
export function apiSignout(token: string): string { … }
export function checkSessionValid(token: string): boolean { … }
```

Checker change: extend `SEED_PATH_PATTERN` to also match `/e2e/fixtures/` and `/app-tests/<pkg>/fixtures/` (Playwright/Vitest fixture directories whose consumers are spec files the analyzer doesn't traverse); add a new `REMIX_ROUTE_PATH_PATTERN` (`/app/routes/`) that exempts Remix / React Router file-based route modules — the framework consumes the default export and named `loader` / `action` by filesystem convention, with no source-file import for the analyzer to see. Both exemptions apply to the method-level and the class-level unused-export checks.

## code-quality/deterministic/redundant-type-argument

OSS source URLs (from issue #266):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/inngest.ts#L14
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/tables/admin-document-recipient-item-table.tsx#L37`

Positive fixture (new file `…/src/redundant-type-argument-complex-inner.ts`):

```ts
export const recipients: Array<
  RecipientRow & {
    extra: { tag: string };
  }
> = [];

export const tags: Array<RecipientRow & { tag: string }> = [];
```

Negative fixture (added to `remaining-typescript.ts`):

```ts
// VIOLATION: code-quality/deterministic/redundant-type-argument
export const typedArray = new Array<any>();
```

Visitor change: tighten the trigger from `argType === 'any'` alone to `argType === 'any' && lastArg.text.trim() === 'any'`. The user wrote `any` literally only when the source text says `any` — when `typeQuery` collapses a complex inner type (`Field & { signature: ... }`, `InngestFunction<…, Handler.Any, Handler.Any>`) to `any` because an inner identifier didn't resolve, the argument is still meaningful to the reader and removing it would erase intent.

## architecture/deterministic/dead-method

OSS source URLs (from issue #268):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/base.ts#L26
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/client/base.ts#L16
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/utils/openapi-fetch-handler.ts#L182

Positive fixtures (new files):

```ts
// shared/utils/src/base-provider-polymorphism.ts
export class BaseRemoteProvider {
  public registerHandler(name: string): string { … }
  public startScheduler(): string { … }
}

export class WebhookRemoteProvider extends BaseRemoteProvider {
  public registerHandler(name: string): string { … }
  public deliver(): string {
    const handler = this.registerHandler('webhook');
    const status = this.startScheduler();
    return …;
  }
}
```

```ts
// shared/utils/src/object-literal-accessors.ts
export function createResponseStub(initial: number): ResponseLike {
  …
  return {
    get statusCode(): number { return initial; },
    setHeader(name: string, value: string): void { … },
  };
}
```

Checker change: when collecting `classesWithImplements` (the exemption set for class methods reachable via interface/inheritance), also add the parent class name when a class declares `extends X` — that exempts abstract-by-convention base methods (`BaseJobProvider.startCron` / `getApiHandler` / `defineJob`) that are reached polymorphically through the subclass. Separately, extend `isObjectLiteralMethod` to recognize `get name() { … }` and `set name(v) { … }` accessor forms, so getter/setter pairs returned from a factory function (`createOpenApiFetchHandler.statusCode`) are skipped the same way object-shorthand methods already are.

## code-quality/deterministic/redundant-type-alias

OSS source URLs (from issue #270):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/templates/document-self-signed.tsx#L10
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/providers/branding.tsx#L39
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/providers/team.tsx#L5
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/components/document/document-email-checkboxes.tsx#L10
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/components/template/template-type-select.tsx#L11

Positive fixture (new file `…/src/redundant-type-alias-semantic-rename.ts`):

```ts
// Exported semantic re-export
export type DocumentDraftProps = DocumentDraft;

// Exported re-export of a deeper internal type
export type CurrentSession = SessionLike;

// Local alias with a "Settings" semantic suffix
type BrandingSettings = DocumentBrandingSnapshot;

// Local alias with a "Value" suffix — context-value role
type SessionProviderValue = SessionLike;
```

Negative fixture (rewrite of `redundant-type-alias.ts`):

```ts
// VIOLATION: code-quality/deterministic/redundant-type-alias
type EmailSettingsAlias = TEmailSettings;

type _EmailAliasPair = [EmailSettingsAlias, EmailSettingsAlias];
export type EmailAliasPair = _EmailAliasPair;
```

(Also added a second negative case `type SessionIdAlias = String;` in `code-quality-typescript.ts`.)

Visitor change: skip aliases whose parent node is an `export_statement` (these are semantic re-exports — the alias name is the public API of the module, and collapsing it would force every consumer to import a deeper path) and skip aliases whose name ends with a React/TS structural-role suffix (Props, State, Settings, Options, Config, Context, Value, Data, Result, Response, Request, Action, Event, Handler, Provider) — those signal that the alias gives a domain-specific role to a generic type. The unit test in `tests/analyzer/code-quality-rules.test.ts` uses `type UserAlias = User;` (not exported, no semantic suffix), so the contract under test is preserved.

## Skipped this batch

- #263 — code-quality/deterministic/negated-condition — refactor-required: the natural fix (skip simple `!identifier` / `!member` negations) conflicts with `tests/analyzer/code-quality-rules.test.ts` asserting `if (!isReady) { fallback(); } else { proceed(); }` should fire. Tests outside `tests/fixtures/sample-*/` are off-limits to this routine.
- #264 — code-quality/deterministic/no-void — refactor-required: skipping `void <call>()` (the fire-and-forget idiom) conflicts with the unit test asserting `void someFunction();` should fire.
- #267 — code-quality/deterministic/require-unicode-regexp — refactor-required: skipping pure-ASCII patterns conflicts with the unit test asserting `/[a-z]+/` should fire.
- #269 — code-quality/deterministic/unnamed-regex-capture — refactor-required: skipping single-capture regexes conflicts with the unit test asserting `/(\d+)/` should fire.

## FP-count delta (vs `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f` on `documenso/documenso`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/readonly-parameter-types` | 121 | 82 | -39 |
| `architecture/deterministic/unused-export` | 26 | 18 | -8 |
| `code-quality/deterministic/redundant-type-argument` | 2 | 0 | -2 |
| `architecture/deterministic/dead-method` | 13 | 8 | -5 |
| `code-quality/deterministic/redundant-type-alias` | 6 | 0 | -6 |
| **Total (these 5 rules)** | 168 | 108 | **-60** |
| **All-rules total on target** | 51122 | 51062 | **-60** |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQZDn5Suj1CKMRAeGDjxKE)_