### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/deep-callback-nesting.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/deep-callback-nesting.ts
@@ -1,5 +1,30 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+
+/**
+ * Count only DIRECT callback nesting. A callback chain looks like
+ *   outerCall(arg, function () { innerCall(function () { ... }) })
+ * where each function is the immediate argument of a call. Functions
+ * buried inside object/array literals (config DSLs, ts-pattern `.with()`
+ * chains, options bags, mappers) are not real callback nesting — they
+ * are structural property values — so they don't increment depth.
+ */
+function isDirectCallbackArg(fn: SyntaxNode): SyntaxNode | null {
+  let p: SyntaxNode | null = fn.parent
+  while (p?.type === 'parenthesized_expression') p = p.parent
+  return p?.type === 'arguments' ? p : null
+}
+
+function findEnclosingFn(start: SyntaxNode | null): SyntaxNode | null {
+  let n = start
+  while (n) {
+    if (n.type === 'arrow_function' || n.type === 'function_expression') return n
+    if (n.type === 'function_declaration' || n.type === 'method_definition' || n.type === 'program') return null
+    n = n.parent
+  }
+  return null
+}
 
 export const deepCallbackNestingVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/deep-callback-nesting',
@@ -7,25 +32,26 @@ export const deepCallbackNestingVisitor: CodeRuleVisitor = {
   nodeTypes: ['function_expression', 'arrow_function'],
   visit(node, filePath, sourceCode) {
     let depth = 0
-    let parent = node.parent
+    let current: SyntaxNode = node
 
-    while (parent) {
-      if (parent.type === 'arguments') {
-        depth++
-        if (depth >= 4) {
-          return makeViolation(
-            this.ruleKey, node, filePath, 'medium',
-            'Deep callback nesting',
-            `Callback nested ${depth} levels deep — refactor using async/await or named functions.`,
-            sourceCode,
-            'Extract nested callbacks into named functions or use async/await to flatten the nesting.',
-          )
-        }
+    while (true) {
+      const argsNode = isDirectCallbackArg(current)
+      if (!argsNode) break
+      depth++
+      if (depth >= 4) {
+        return makeViolation(
+          this.ruleKey, node, filePath, 'medium',
+          'Deep callback nesting',
+          `Callback nested ${depth} levels deep — refactor using async/await or named functions.`,
+          sourceCode,
+          'Extract nested callbacks into named functions or use async/await to flatten the nesting.',
+        )
       }
-
-      if ((parent.type === 'function_declaration') || parent.type === 'program') break
-
-      parent = parent.parent
+      const callExpr = argsNode.parent
+      if (!callExpr) break
+      const enclosing = findEnclosingFn(callExpr.parent)
+      if (!enclosing) break
+      current = enclosing
     }
     return null
   },

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/no-empty-function.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/no-empty-function.ts
@@ -41,6 +41,25 @@ export const jsNoEmptyFunctionVisitor: CodeRuleVisitor = {
       if (op?.text === '||' || op?.text === '??') return null
     }
 
+    // Skip private/protected empty constructors — the singleton and
+    // abstract-base patterns rely on `private constructor() {}` or
+    // `protected constructor() {}` to block instantiation. The empty
+    // body is the whole point.
+    if (node.type === 'method_definition') {
+      let isConstructor = false
+      let hasRestrictedAccess = false
+      for (let i = 0; i < node.childCount; i++) {
+        const child = node.child(i)
+        if (!child) continue
+        if (child.type === 'property_identifier' && child.text === 'constructor') isConstructor = true
+        if (child.type === 'accessibility_modifier') {
+          const txt = child.text.trim()
+          if (txt === 'private' || txt === 'protected') hasRestrictedAccess = true
+        }
+      }
+      if (isConstructor && hasRestrictedAccess) return null
+    }
+
     const nameNode = node.childForFieldName('name')
     const name = nameNode?.text || 'anonymous'
 

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/promise-all-no-error-handling.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/promise-all-no-error-handling.ts
@@ -20,9 +20,12 @@ export const promiseAllNoErrorHandlingVisitor: CodeRuleVisitor = {
     if (isInsideTryCatch(node)) return null
     if (hasCatchChain(node)) return null
 
-    // Check if result is awaited inside try/catch
+    // Skip if the result is awaited: a rejection becomes a thrown exception
+    // that propagates to the caller (framework boundary, transaction wrapper,
+    // …) where error handling lives. The bug pattern this rule catches is
+    // strictly fire-and-forget: `Promise.all(...)` whose rejection vanishes.
     const parent = node.parent
-    if (parent?.type === 'await_expression' && isInsideTryCatch(parent)) return null
+    if (parent?.type === 'await_expression') return null
 
     // Skip Next.js page/layout files — errors are handled by error.tsx boundary
     if (/\/app\/.*(?:page|layout)\.[tj]sx?$/.test(filePath)) return null

--- a/packages/analyzer/src/rules/security/visitors/javascript/disabled-auto-escaping.ts
+++ b/packages/analyzer/src/rules/security/visitors/javascript/disabled-auto-escaping.ts
@@ -10,6 +10,15 @@ export const disabledAutoEscapingVisitor: CodeRuleVisitor = {
     if (node.type === 'jsx_attribute') {
       const name = node.namedChildren[0]
       if (name && name.text === 'dangerouslySetInnerHTML') {
+        // Reach into `{{ __html: <expr> }}` and reuse the same safety
+        // analysis we use for `el.innerHTML = …`. Static strings and
+        // values produced by recognized escape/sanitize helpers are
+        // not XSS sinks.
+        const htmlValue = extractDangerouslyHtmlValue(node)
+        if (htmlValue) {
+          if (isStaticStringLiteral(htmlValue)) return null
+          if (isFullyEscapedRhs(htmlValue)) return null
+        }
         return makeViolation(
           this.ruleKey, node, filePath, 'high',
           'Disabled auto-escaping',
@@ -53,6 +62,31 @@ export const disabledAutoEscapingVisitor: CodeRuleVisitor = {
 
     return null
   },
+}
+
+/**
+ * Given a `dangerouslySetInnerHTML={{ __html: <expr> }}` attribute node,
+ * return the `<expr>` node — or null if the attribute doesn't follow the
+ * canonical inline-object shape (which is the only shape this visitor
+ * understands; references to a precomputed object are conservatively
+ * left as violations).
+ */
+function extractDangerouslyHtmlValue(
+  attr: import('web-tree-sitter').Node,
+): import('web-tree-sitter').Node | null {
+  // jsx_attribute > (property_identifier, jsx_expression)
+  const jsxExpr = attr.namedChildren.find((c) => c?.type === 'jsx_expression')
+  if (!jsxExpr) return null
+  const obj = jsxExpr.namedChildren.find((c) => c?.type === 'object')
+  if (!obj) return null
+  for (let i = 0; i < obj.namedChildCount; i++) {
+    const pair = obj.namedChild(i)
+    if (pair?.type !== 'pair') continue
+    const key = pair.childForFieldName('key')
+    if (key?.text !== '__html') continue
+    return pair.childForFieldName('value')
+  }
+  return null
 }
 
 function isStaticStringLiteral(node: import('web-tree-sitter').Node): boolean {

--- a/packages/analyzer/src/rules/security/visitors/javascript/timing-attack-comparison.ts
+++ b/packages/analyzer/src/rules/security/visitors/javascript/timing-attack-comparison.ts
@@ -24,6 +24,32 @@ function isLengthAccess(node: SyntaxNode): boolean {
   return prop?.text === 'length'
 }
 
+const ENUM_CONSTANT_PATTERN = /^[A-Z][A-Z0-9_]*$/
+
+/**
+ * Return true if the node is a clearly non-secret constant: a boolean
+ * literal, null/undefined, an UPPER_SNAKE_CASE identifier (typical enum
+ * value), or a member access whose final property is UPPER_SNAKE_CASE
+ * (e.g. `FieldType.SIGNATURE`). Timing attacks require both sides to be
+ * unknown to the attacker; when one side is a publicly-known constant,
+ * the compare leaks nothing.
+ */
+function isClearConstantValue(node: SyntaxNode): boolean {
+  if (node.type === 'true' || node.type === 'false') return true
+  if (node.type === 'null') return true
+  if (node.type === 'undefined') return true
+  if (node.type === 'identifier') {
+    if (node.text === 'undefined') return true
+    if (ENUM_CONSTANT_PATTERN.test(node.text)) return true
+    return false
+  }
+  if (node.type === 'member_expression') {
+    const prop = node.childForFieldName('property')
+    if (prop?.text && ENUM_CONSTANT_PATTERN.test(prop.text)) return true
+  }
+  return false
+}
+
 /**
  * Return the most specific identifier on this side of a comparison — the
  * variable name for a plain identifier, the final property segment for a
@@ -66,6 +92,11 @@ export const timingAttackComparisonVisitor: CodeRuleVisitor = {
 
     // Skip comparisons against numeric literals (length / count checks).
     if (left.type === 'number' || right.type === 'number') return null
+
+    // Skip when one side is a clear public constant — boolean literal,
+    // null/undefined, or an UPPER_SNAKE_CASE enum value. A timing attack
+    // requires both sides to be secret to the attacker.
+    if (isClearConstantValue(left) || isClearConstantValue(right)) return null
 
     // Apply the sensitive-name check against the leaf identifier so that
     // member access paths like `decodedToken.scope` are recognized by

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -85,6 +85,18 @@
       "layer": "api"
     },
     {
+      "name": "EventHandler",
+      "service": "api-gateway",
+      "kind": "class",
+      "layer": "api"
+    },
+    {
+      "name": "handleEvent",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "api"
+    },
+    {
       "name": "handleParse",
       "service": "api-gateway",
       "kind": "standalone",
@@ -109,6 +121,12 @@
       "layer": "service"
     },
     {
+      "name": "loadUserPyramid",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "logger",
       "service": "api-gateway",
       "kind": "standalone",
@@ -122,6 +140,12 @@
     },
     {
       "name": "performance",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "promise-all-no-error-handling",
       "service": "api-gateway",
       "kind": "standalone",
       "layer": "service"
@@ -575,6 +599,12 @@
       "service": "user-service",
       "kind": "standalone",
       "layer": "data"
+    },
+    {
+      "name": "verifyWebhook",
+      "service": "user-service",
+      "kind": "standalone",
+      "layer": "service"
     },
     {
       "name": "Aliaser",
@@ -1150,6 +1180,12 @@
       "name": "CompletelyUnrelatedWidget",
       "service": "web",
       "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "DangerouslyUserContent",
+      "service": "web",
+      "kind": "standalone",
       "layer": "service"
     },
     {

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/deep-callback-nesting-chained.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/deep-callback-nesting-chained.ts
@@ -1,0 +1,21 @@
+// True bug: four nested callbacks, each a direct argument to the next
+// call — the classic pyramid-of-doom shape that the rule is designed
+// to catch. Refactor with async/await or named functions.
+
+declare function fetchUser(id: string, cb: (user: { id: string }) => void): void;
+declare function fetchOrders(uid: string, cb: (orders: { id: string }[]) => void): void;
+declare function fetchItems(oid: string, cb: (items: unknown[]) => void): void;
+declare function logAll(items: unknown[], cb: () => void): void;
+
+export function loadUserPyramid(id: string): void {
+  fetchUser(id, (user) => {
+    fetchOrders(user.id, (orders) => {
+      fetchItems(orders[0].id, (items) => {
+        // VIOLATION: code-quality/deterministic/deep-callback-nesting
+        logAll(items, () => {
+          return;
+        });
+      });
+    });
+  });
+}

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/no-empty-function-public-handler.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/no-empty-function-public-handler.ts
@@ -1,0 +1,12 @@
+// True bug: an empty public function body that callers may legitimately
+// rely on to do something. Without a comment explaining the intentional
+// no-op, this looks like a forgotten implementation.
+
+export function handleEvent(event: { id: string }): void {
+  void event;
+}
+
+export class EventHandler {
+  // VIOLATION: code-quality/deterministic/no-empty-function
+  public handle(event: { id: string }): void {}
+}

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/promise-all-no-error-handling.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/promise-all-no-error-handling.ts
@@ -1,0 +1,17 @@
+// True bug: fire-and-forget Promise.all — the call is neither awaited
+// nor given a .catch(), so a single rejecting item produces an
+// unhandled rejection that never surfaces to the caller.
+//
+// Not exported on purpose — the visitor fires per-file, and we don't
+// want to grow the module graph for the negative-fixture snapshot.
+
+function warmCaches(keys: readonly string[]): void {
+  // VIOLATION: reliability/deterministic/promise-all-no-error-handling
+  Promise.all(keys.map((key) => warmCache(key)));
+}
+
+async function warmCache(key: string): Promise<void> {
+  void key;
+}
+
+void warmCaches;

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/reliability.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/reliability.ts
@@ -54,9 +54,11 @@ export async function commitWithoutAwait() {
 }
 
 // VIOLATION: reliability/deterministic/promise-all-no-error-handling
-export async function fetchAll(urls: string[]) {
-  const results = await Promise.all(urls.map((url) => fetch(url)));
-  return results;
+// True bug: not awaited, no .catch — a rejecting item produces an
+// unhandled rejection. `await Promise.all(...)` is fine because the
+// rejection propagates to the caller; this is the fire-and-forget shape.
+export function refreshAll(urls: string[]) {
+  Promise.all(urls.map((url) => fetch(url)));
 }
 
 // VIOLATION: reliability/deterministic/missing-error-event-handler

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/timing-attack-webhook-hmac.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/timing-attack-webhook-hmac.ts
@@ -1,0 +1,9 @@
+// True bug: HMAC signature verification with a plain `===` compare is
+// vulnerable to timing attacks. The attacker can guess the signature
+// byte-by-byte by measuring how long the compare takes to fail. Use
+// a constant-time comparison helper instead.
+
+export function verifyWebhook(providedSignature: string, expectedSignature: string): boolean {
+  // VIOLATION: security/deterministic/timing-attack-comparison
+  return providedSignature === expectedSignature;
+}

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/DangerouslyUserContent.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/DangerouslyUserContent.tsx
@@ -1,0 +1,18 @@
+// True bug: untrusted, unescaped HTML rendered via
+// `dangerouslySetInnerHTML`. The `bannerHtml` prop comes from a CMS
+// field that admins can edit — any HTML/script they paste flows
+// straight into the DOM, bypassing React's auto-escaping.
+
+type DangerouslyUserContentProps = {
+  bannerHtml: string;
+};
+
+export function DangerouslyUserContent({ bannerHtml }: DangerouslyUserContentProps): JSX.Element {
+  return (
+    <div
+      className="banner"
+      // VIOLATION: security/deterministic/disabled-auto-escaping
+      dangerouslySetInnerHTML={{ __html: bannerHtml }}
+    />
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/deep-callback-nesting-config-dsl.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/deep-callback-nesting-config-dsl.ts
@@ -1,0 +1,35 @@
+// Positive: code-quality/deterministic/deep-callback-nesting
+//
+// Config-DSL shapes — arrow functions used as object property values
+// inside a nested options bag — read top-to-bottom as data, not as
+// chained callbacks. The rule should only count DIRECT callback
+// nesting (callback inside a callback inside a callback), not arrow
+// functions buried in structural object literals.
+
+type Driver = { name: string };
+type Adapter = { kind: string };
+type Introspector = { db: unknown };
+type QueryCompiler = { run: () => string };
+type Dialect = {
+  createAdapter: () => Adapter;
+  createDriver: () => Driver;
+  createIntrospector: (db: unknown) => Introspector;
+  createQueryCompiler: () => QueryCompiler;
+};
+
+declare function buildDialect(opts: { dialect: Dialect }): { dialect: Dialect };
+declare function withExtension<T>(builder: (driver: Driver) => T): T;
+declare function defineClient<T>(name: string, factory: () => T): T;
+
+export const client = defineClient('client', () =>
+  withExtension((driver) =>
+    buildDialect({
+      dialect: {
+        createAdapter: () => ({ kind: 'postgres' }),
+        createDriver: () => driver,
+        createIntrospector: (db) => ({ db }),
+        createQueryCompiler: () => ({ run: () => 'SELECT 1' }),
+      },
+    }),
+  ),
+);

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/no-empty-function-private-constructor.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/no-empty-function-private-constructor.ts
@@ -1,0 +1,21 @@
+// Positive: code-quality/deterministic/no-empty-function
+//
+// `private constructor() {}` and `protected constructor() {}` are the
+// canonical singleton / abstract-base patterns — the empty body is the
+// whole point (block direct instantiation, force callers to go through
+// the static factory). The rule must not flag them as a missing
+// implementation.
+
+export class Singleton {
+  private constructor() {}
+
+  static create(): Singleton {
+    return new Singleton();
+  }
+}
+
+export abstract class BaseLogger {
+  protected constructor() {}
+
+  abstract log(message: string): void;
+}

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/promise-all-no-error-handling.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/promise-all-no-error-handling.ts
@@ -1,0 +1,32 @@
+// Positive: reliability/deterministic/promise-all-no-error-handling
+//
+// `await Promise.all(...)` inside an async function is not fire-and-forget —
+// any rejection becomes a thrown exception that propagates to the caller
+// (route handler, transaction wrapper, job runner, …) where the framework's
+// error boundary takes over. The rule should only flag Promise.all calls
+// whose rejection truly vanishes.
+
+export async function loadDashboard(ids: readonly string[]): Promise<{ entries: number[]; total: number }> {
+  const [entries, total] = await Promise.all([
+    fetchEntries(ids),
+    countEntries(ids),
+  ]);
+  return { entries, total };
+}
+
+export async function fetchAllRecords(keys: readonly string[]): Promise<readonly number[]> {
+  const records = await Promise.all(keys.map((key) => fetchRecord(key)));
+  return records.slice();
+}
+
+function fetchEntries(ids: readonly string[]): Promise<number[]> {
+  return Promise.resolve(ids.map((_, i) => i));
+}
+
+function countEntries(ids: readonly string[]): Promise<number> {
+  return Promise.resolve(ids.length);
+}
+
+function fetchRecord(key: string): Promise<number> {
+  return Promise.resolve(key.length);
+}

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/timing-attack-enum-and-boolean.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/timing-attack-enum-and-boolean.ts
@@ -1,0 +1,36 @@
+// Positive: security/deterministic/timing-attack-comparison
+//
+// `===`/`!==` comparisons where one side is a clear non-secret value —
+// an enum constant (`FieldType.SIGNATURE`), a boolean literal, `null`,
+// or `undefined` — cannot leak secret information through timing because
+// the constant side is publicly known. The rule must not flag these
+// just because the other side's identifier happens to contain a word
+// like "signature" or "token".
+
+const enum FieldType {
+  SIGNATURE = 'SIGNATURE',
+  FREE_SIGNATURE = 'FREE_SIGNATURE',
+  TEXT = 'TEXT',
+}
+
+type SignatureFieldOptions = {
+  type: FieldType;
+  typedSignatureEnabled: boolean | null;
+  signature: string | null;
+};
+
+export function isSignatureField(opts: SignatureFieldOptions): boolean {
+  return opts.type === FieldType.SIGNATURE || opts.type === FieldType.FREE_SIGNATURE;
+}
+
+export function isTypedSignatureAllowed(opts: SignatureFieldOptions): boolean {
+  return opts.typedSignatureEnabled !== false;
+}
+
+export function isSignatureMissing(opts: SignatureFieldOptions): boolean {
+  return opts.signature === null;
+}
+
+export function isTokenUnset(token: string | undefined): boolean {
+  return token === undefined;
+}

--- a/tests/fixtures/sample-js-project-positive/services/web/app/routes/disabled-auto-escaping-static.tsx
+++ b/tests/fixtures/sample-js-project-positive/services/web/app/routes/disabled-auto-escaping-static.tsx
@@ -1,0 +1,35 @@
+// Positive: security/deterministic/disabled-auto-escaping
+//
+// `dangerouslySetInnerHTML` with a static string or template (no
+// substitutions) cannot inject untrusted content — the HTML is fully
+// known at compile time. Same goes for values that go through a
+// recognized escape/sanitize helper. The rule should not flag these.
+//
+// Lives under `/app/` so it's treated as a server component — the
+// orthogonal `inline-object-in-jsx-prop` perf rule (which fires on the
+// inline `{{ __html: … }}` shape) does not apply to server components.
+
+declare function escapeHtml(s: string): string;
+declare function sanitize(s: string): string;
+
+export function NoFlashStyles(): JSX.Element {
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: `*, *::before, *::after { animation: none !important; transition: none !important; }`,
+      }}
+    />
+  );
+}
+
+export function AboutBlurb(): JSX.Element {
+  return <p dangerouslySetInnerHTML={{ __html: '<strong>About</strong> us' }} />;
+}
+
+export function UserBio({ raw }: { raw: string }): JSX.Element {
+  return <div dangerouslySetInnerHTML={{ __html: sanitize(raw) }} />;
+}
+
+export function GreetingBanner({ name }: { name: string }): JSX.Element {
+  return <span dangerouslySetInnerHTML={{ __html: `Hi, ${escapeHtml(name)}!` }} />;
+}


### PR DESCRIPTION
Closes #271
Closes #272
Closes #273
Closes #274
Closes #275

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `reliability/deterministic/promise-all-no-error-handling` | #271 | `tests/fixtures/sample-js-project-positive/services/api-gateway/src/promise-all-no-error-handling.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/promise-all-no-error-handling.ts` |
| `security/deterministic/timing-attack-comparison` | #272 | `tests/fixtures/sample-js-project-positive/services/api-gateway/src/timing-attack-enum-and-boolean.ts` | `tests/fixtures/sample-js-project-negative/services/user-service/src/timing-attack-webhook-hmac.ts` |
| `code-quality/deterministic/no-empty-function` | #273 | `tests/fixtures/sample-js-project-positive/services/api-gateway/src/no-empty-function-private-constructor.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/no-empty-function-public-handler.ts` |
| `code-quality/deterministic/deep-callback-nesting` | #274 | `tests/fixtures/sample-js-project-positive/services/api-gateway/src/deep-callback-nesting-config-dsl.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/deep-callback-nesting-chained.ts` |
| `security/deterministic/disabled-auto-escaping` | #275 | `tests/fixtures/sample-js-project-positive/services/web/app/routes/disabled-auto-escaping-static.tsx` | `tests/fixtures/sample-js-project-negative/services/web/src/components/DangerouslyUserContent.tsx` |

## reliability/deterministic/promise-all-no-error-handling

OSS sources (FP shape — `await Promise.all(...)` inside a framework-managed async function):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/document/send-document.ts#L216
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/envelope-router/find-envelope-audit-logs.ts#L53
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/docs/src/app/llms-full.txt/route.ts#L7
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/admin/admin-find-documents.ts#L50
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/document/search-documents-with-keyword.ts#L21

Positive fixture (must NOT fire) — paraphrased FP shape:

```ts
// `await Promise.all(...)` propagates rejection to the caller (framework
// boundary, transaction wrapper, route handler) where error handling lives.
export async function loadDashboard(ids: readonly string[]): Promise<{ entries: number[]; total: number }> {
  const [entries, total] = await Promise.all([
    fetchEntries(ids),
    countEntries(ids),
  ]);
  return { entries, total };
}
```

Negative fixture (MUST fire) — true bug, fire-and-forget:

```ts
// VIOLATION: reliability/deterministic/promise-all-no-error-handling
function warmCaches(keys: readonly string[]): void {
  Promise.all(keys.map((key) => warmCache(key)));
}
```

Visitor summary: skip the rule whenever `Promise.all(...)` is the operand of an `await_expression`. An awaited rejection becomes a normal thrown exception that propagates to the caller (tRPC procedure, Next.js route, prisma transaction wrapper), so error handling exists — it just lives one frame up. Previously the rule only skipped when the await was inside an explicit try/catch in the same function, which produced FPs on essentially every framework-managed async handler. The bug pattern the rule still catches — `Promise.all(...)` not awaited, not `.catch()`-chained, not in try/catch — produces a silent unhandled rejection.

## security/deterministic/timing-attack-comparison

OSS sources (FP shape — comparing against an enum value or boolean literal):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/utils/field-signing/signature-field.ts#L22
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/document/validate-field-auth.ts#L29
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/organisation-router/update-organisation-settings.ts#L114`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/guards/is-signature-field.ts#L8
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/team-router/update-team-settings.ts#L70

Positive fixture (must NOT fire):

```ts
const enum FieldType { SIGNATURE = 'SIGNATURE', FREE_SIGNATURE = 'FREE_SIGNATURE', TEXT = 'TEXT' }

export function isSignatureField(opts: { type: FieldType }): boolean {
  return opts.type === FieldType.SIGNATURE || opts.type === FieldType.FREE_SIGNATURE;
}

export function isTypedSignatureAllowed(opts: { typedSignatureEnabled: boolean | null }): boolean {
  return opts.typedSignatureEnabled !== false;
}

export function isTokenUnset(token: string | undefined): boolean {
  return token === undefined;
}
```

Negative fixture (MUST fire) — true bug:

```ts
export function verifyWebhook(providedSignature: string, expectedSignature: string): boolean {
  // VIOLATION: security/deterministic/timing-attack-comparison
  return providedSignature === expectedSignature;
}
```

Visitor summary: skip the comparison when either side is a clear public constant — a boolean literal, `null`/`undefined`, an `UPPER_SNAKE_CASE` identifier, or a member access whose final property is `UPPER_SNAKE_CASE` (e.g. `FieldType.SIGNATURE`). A timing attack only leaks information when both sides are unknown to the attacker; a publicly-known enum tag or boolean on one side reduces the compare to a "shape" check that leaks nothing. The previous logic only filtered out `typeof`, `.length`, and number literals, so any `field.type === FieldType.SIGNATURE` fired purely because the leaf identifier `SIGNATURE` matched the sensitive-name regex.

## code-quality/deterministic/no-empty-function

OSS sources (FP shape — singleton `private constructor() {}`):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/license/license-client.ts#L33
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/telemetry/telemetry-client.ts#L35

Positive fixture (must NOT fire):

```ts
export class Singleton {
  private constructor() {}

  static create(): Singleton {
    return new Singleton();
  }
}

export abstract class BaseLogger {
  protected constructor() {}

  abstract log(message: string): void;
}
```

Negative fixture (MUST fire) — true bug, empty public handler with no `// noop` rationale:

```ts
export class EventHandler {
  // VIOLATION: code-quality/deterministic/no-empty-function
  public handle(event: { id: string }): void {}
}
```

Visitor summary: skip `method_definition` nodes whose name is `constructor` and whose `accessibility_modifier` is `private` or `protected`. The empty body is the whole point of the singleton / abstract-base pattern (block direct `new`, force callers through a static factory) — there's no missing implementation to add. Public empty functions and other empty methods still fire as before.

## code-quality/deterministic/deep-callback-nesting

OSS sources (FP shape — arrow functions nested inside config-DSL object literals, ts-pattern `.with()` chains, etc.):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/index.ts#L31
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/api/v1/implementation.ts#L1404
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/team-router/update-team-member.ts#L161
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/envelope/find-envelopes.ts#L172
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/template/create-document-from-direct-template.ts#L566`

Positive fixture (must NOT fire) — config-DSL with arrow values nested in an options object, not real callback chains:

```ts
export const client = defineClient('client', () =>
  withExtension((driver) =>
    buildDialect({
      dialect: {
        createAdapter: () => ({ kind: 'postgres' }),
        createDriver: () => driver,
        createIntrospector: (db) => ({ db }),
        createQueryCompiler: () => ({ run: () => 'SELECT 1' }),
      },
    }),
  ),
);
```

Negative fixture (MUST fire) — classic pyramid-of-doom:

```ts
export function loadUserPyramid(id: string): void {
  fetchUser(id, (user) => {
    fetchOrders(user.id, (orders) => {
      fetchItems(orders[0].id, (items) => {
        // VIOLATION: code-quality/deterministic/deep-callback-nesting
        logAll(items, () => { return; });
      });
    });
  });
}
```

Visitor summary: count only DIRECT callback nesting. Walking up from a `function_expression`/`arrow_function`, only count `arguments` ancestors where the function is an immediate argument of a call (`parent.type === 'arguments'`, possibly through `parenthesized_expression`). When the next callback is found, jump to its enclosing function and repeat. Arrow functions nested via `object`/`pair`/`array` literals — config DSLs, options bags, ts-pattern `.with()` chains, mapper definitions — are structural property values, not callback chains, so they no longer inflate depth. The pyramid-of-doom shape the rule is designed to catch still fires unchanged.

## security/deterministic/disabled-auto-escaping

OSS sources (FP shape — `dangerouslySetInnerHTML` with static content or recognized escape helpers):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/root.tsx#L139
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/docs/src/components/mdx/mermaid.tsx#L65
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/root.tsx#L175
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/forms/2fa/enable-authenticator-app-dialog.tsx#L199`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_internal+/[__htmltopdf]+/certificate.tsx#L371

Positive fixture (must NOT fire) — static CSS reset, static fragment, sanitized input, template with escape helper:

```tsx
export function NoFlashStyles(): JSX.Element {
  return (
    <style
      dangerouslySetInnerHTML={{
        __html: `*, *::before, *::after { animation: none !important; transition: none !important; }`,
      }}
    />
  );
}

export function UserBio({ raw }: { raw: string }): JSX.Element {
  return <div dangerouslySetInnerHTML={{ __html: sanitize(raw) }} />;
}

export function GreetingBanner({ name }: { name: string }): JSX.Element {
  return <span dangerouslySetInnerHTML={{ __html: `Hi, ${escapeHtml(name)}!` }} />;
}
```

Negative fixture (MUST fire) — true bug, untrusted admin-controlled HTML straight to the DOM:

```tsx
export function DangerouslyUserContent({ bannerHtml }: { bannerHtml: string }): JSX.Element {
  return (
    <div
      className="banner"
      // VIOLATION: security/deterministic/disabled-auto-escaping
      dangerouslySetInnerHTML={{ __html: bannerHtml }}
    />
  );
}
```

Visitor summary: for `dangerouslySetInnerHTML={{ __html: <expr> }}`, reach into the inline JSX object literal, pull out the `__html` value, and run it through the same safety predicates the rule already uses for `el.innerHTML = …` — `isStaticStringLiteral` (string / template with no substitutions) and `isFullyEscapedRhs` (every dynamic operand is a recognized escape/sanitize helper). Static CSS resets, static HTML fragments, and properly sanitized values stop firing. Non-inline shapes (`dangerouslySetInnerHTML={someVar}`) and inline objects with un-sanitized dynamic content (`{{ __html: bannerHtml }}`) still fire.

## FP-count delta (vs `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f` on `documenso/documenso`)

Measured by re-running `pnpm build:dist` and then `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` against the same target ref.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `reliability/deterministic/promise-all-no-error-handling` | 147 | 2 | -145 |
| `security/deterministic/timing-attack-comparison` | 71 | 20 | -51 |
| `code-quality/deterministic/no-empty-function` | 2 | 0 | -2 |
| `code-quality/deterministic/deep-callback-nesting` | 92 | 17 | -75 |
| `security/deterministic/disabled-auto-escaping` | 6 | 5 | -1 |
| **Total (these 5 rules)** | **318** | **44** | **-274** |
| **All-rules total on target** | **51062** | **50788** | **-274** |

No regressions in other rules — the all-rules delta equals the subtotal for the five fixed rules.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvAS9GZyaCBFuhyR4sP1JN)_