### PR TITLE
Refresh expired Discord invite link

### DIFF
--- a/apps/landing/src/components/Footer.tsx
+++ b/apps/landing/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import { Github, Mail } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { DiscordIcon } from './DiscordIcon';
 
-const DISCORD_URL = 'https://discord.gg/8AYwf26A';
+const DISCORD_URL = 'https://discord.gg/TanxB63arz';
 
 export function Footer() {
   return (

--- a/apps/landing/src/components/Header.tsx
+++ b/apps/landing/src/components/Header.tsx
@@ -4,7 +4,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { cn } from '@/lib/cn';
 import { DiscordIcon } from './DiscordIcon';
 
-const DISCORD_URL = 'https://discord.gg/8AYwf26A';
+const DISCORD_URL = 'https://discord.gg/TanxB63arz';
 
 type NavItem = { href: string; label: string; external?: boolean };
 

--- a/tools/cli/src/community-prompts.ts
+++ b/tools/cli/src/community-prompts.ts
@@ -15,7 +15,7 @@ import path from "node:path";
 import { getGlobalDir } from "@truecourse/core/config/paths";
 import { isInteractive } from "./commands/helpers.js";
 
-const DISCORD_URL = "https://discord.gg/8AYwf26A";
+const DISCORD_URL = "https://discord.gg/TanxB63arz";
 const GITHUB_URL = "https://github.com/truecourse-ai/truecourse";
 
 // OSC 8 hyperlinks would be ideal but width measurement counts the escape


### PR DESCRIPTION
## Summary
- The previous Discord invite (`discord.gg/8AYwf26A`) was created with **no expiry** but is now reported as expired by Discord's API (`code 50270`).
- Replaced the URL in all three places it lives:
  - `apps/landing/src/components/Header.tsx`
  - `apps/landing/src/components/Footer.tsx`
  - `tools/cli/src/community-prompts.ts` (shown after a user's first analyze)
- New invite `discord.gg/TanxB63arz` validated via Discord API: `expires_at: null`, points at TrueCourse #general.

## Test plan
- [ ] Open the landing page; click Discord in the header and the footer — both should land on the TrueCourse server.
- [ ] Run a first analyze in a fresh repo on a clean machine (or wipe `~/.truecourse/community-prompts.json`) and confirm the printed Discord link is the new one and works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)