### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/javascript/duplicate-import.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/javascript/duplicate-import.ts
@@ -23,6 +23,14 @@ export const duplicateImportVisitor: CodeRuleVisitor = {
         const currentIsTypeOnly = imp.text.includes('import type')
         if (prevIsTypeOnly !== currentIsTypeOnly) continue
 
+        // Skip when one import is a side-effect-only import (`import 'x'`)
+        // and the other pulls bindings. The bare form is intentional — it
+        // documents that the module is loaded for its side effects — and
+        // mechanically merging into the named import erases that intent.
+        const prevIsSideEffectOnly = isSideEffectOnly(prevImp)
+        const currentIsSideEffectOnly = isSideEffectOnly(imp)
+        if (prevIsSideEffectOnly !== currentIsSideEffectOnly) continue
+
         return makeViolation(
           this.ruleKey, imp, filePath, 'low',
           'Duplicate import',
@@ -37,3 +45,14 @@ export const duplicateImportVisitor: CodeRuleVisitor = {
     return null
   },
 }
+
+// `import 'foo'` — no import_clause, just the source string. Used to trigger
+// a module's top-level side effects (polyfills, CSS bundling, registration
+// calls). Distinct intent from `import { x } from 'foo'`.
+function isSideEffectOnly(imp: SyntaxNode): boolean {
+  for (const child of imp.namedChildren) {
+    if (child.type === 'import_clause') return false
+  }
+  return true
+}
+

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/duplicate-import.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/duplicate-import.ts
@@ -1,3 +1,4 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { JS_LANGUAGES } from './_helpers.js'
@@ -7,7 +8,7 @@ export const duplicateImportVisitor: CodeRuleVisitor = {
   languages: JS_LANGUAGES,
   nodeTypes: ['program'],
   visit(node, filePath, sourceCode) {
-    const seenSources = new Map<string, import('web-tree-sitter').Node>()
+    const seenSources = new Map<string, SyntaxNode>()
 
     for (const child of node.namedChildren) {
       if (child.type === 'import_statement') {
@@ -21,6 +22,11 @@ export const duplicateImportVisitor: CodeRuleVisitor = {
             const prevIsType = prev.text.startsWith('import type ')
             const currIsType = child.text.startsWith('import type ')
             if (prevIsType !== currIsType) continue
+
+            // Side-effect-only (`import 'x'`) paired with a bindings import
+            // is intentional — the bare form documents that the module is
+            // loaded for its top-level effects. Merging them erases intent.
+            if (isSideEffectOnly(prev) !== isSideEffectOnly(child)) continue
 
             return makeViolation(
               this.ruleKey, child, filePath, 'medium',
@@ -37,4 +43,11 @@ export const duplicateImportVisitor: CodeRuleVisitor = {
 
     return null
   },
+}
+
+function isSideEffectOnly(imp: SyntaxNode): boolean {
+  for (const child of imp.namedChildren) {
+    if (child.type === 'import_clause') return false
+  }
+  return true
 }

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/generic-error-message.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/generic-error-message.ts
@@ -1,3 +1,4 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { JS_LANGUAGES } from './_helpers.js'
@@ -13,23 +14,85 @@ const GENERIC_MESSAGES = [
   'please try again',
 ]
 
+// Object-literal keys that label a short headline shown to a user.
+const TITLE_KEYS = new Set(['title', 'heading', 'header', 'name', 'summary', 'label'])
+// Object-literal keys that carry the longer, actionable detail to pair with a title.
+const DESCRIPTION_KEYS = new Set([
+  'description', 'detail', 'details', 'body', 'subtitle', 'content', 'message',
+])
+
 export const genericErrorMessageVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/generic-error-message',
   languages: JS_LANGUAGES,
   nodeTypes: ['string', 'template_string'],
   visit(node, filePath, sourceCode) {
     const text = node.text.toLowerCase().replace(/['"` ]/g, '').trim()
+    let matched = false
     for (const msg of GENERIC_MESSAGES) {
       if (text === msg.replace(/ /g, '')) {
-        return makeViolation(
-          this.ruleKey, node, filePath, 'low',
-          'Generic error message',
-          `Error message "${node.text}" is too vague to be actionable. Include an error code or specific detail to help with debugging.`,
-          sourceCode,
-          'Replace with a specific error message that includes an error code or actionable detail.',
-        )
+        matched = true
+        break
       }
     }
-    return null
+    if (!matched) return null
+
+    // Toast/notification-style UIs commonly pair a vague title with a useful
+    // description in the same object literal (`{ title: 'Something went wrong',
+    // description: 'Failed to save…' }`). The user does see actionable detail,
+    // so flagging the title is noise. Skip when a sibling description-like
+    // property is present.
+    if (isLabeledWithDescriptionSibling(node)) return null
+
+    return makeViolation(
+      this.ruleKey, node, filePath, 'low',
+      'Generic error message',
+      `Error message "${node.text}" is too vague to be actionable. Include an error code or specific detail to help with debugging.`,
+      sourceCode,
+      'Replace with a specific error message that includes an error code or actionable detail.',
+    )
   },
+}
+
+function isLabeledWithDescriptionSibling(node: SyntaxNode): boolean {
+  const pair = findContainingPair(node)
+  if (!pair) return false
+
+  const keyNode = pair.childForFieldName('key')
+  if (!keyNode) return false
+  const keyName = keyNode.text.replace(/['"`]/g, '')
+  if (!TITLE_KEYS.has(keyName)) return false
+
+  const obj = pair.parent
+  if (!obj || obj.type !== 'object') return false
+
+  for (const child of obj.namedChildren) {
+    if (child.id === pair.id || child.type !== 'pair') continue
+    const k = child.childForFieldName('key')
+    if (!k) continue
+    const kn = k.text.replace(/['"`]/g, '')
+    if (DESCRIPTION_KEYS.has(kn)) return true
+  }
+  return false
+}
+
+// Walk up until we find a `pair` ancestor where `node` is inside the value
+// subtree (not the key subtree). Returns null if the node is a key, or if
+// there's no enclosing pair before the function/program boundary.
+function findContainingPair(node: SyntaxNode): SyntaxNode | null {
+  let cur: SyntaxNode | null = node.parent
+  while (cur) {
+    if (cur.type === 'pair') {
+      const value = cur.childForFieldName('value')
+      if (!value) return null
+      // Confirm node lives under the value branch.
+      let walker: SyntaxNode | null = node
+      while (walker && walker.id !== cur.id) {
+        if (walker.id === value.id) return cur
+        walker = walker.parent
+      }
+      return null
+    }
+    cur = cur.parent
+  }
+  return null
 }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/deeply-nested-functions.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/deeply-nested-functions.ts
@@ -1,3 +1,4 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { getFunctionName } from './_helpers.js'
@@ -12,9 +13,11 @@ export const deeplyNestedFunctionsVisitor: CodeRuleVisitor = {
     while (parent) {
       if (parent.type === 'function_declaration' || parent.type === 'function_expression'
         || parent.type === 'arrow_function' || parent.type === 'method_definition') {
-        // Don't count arrow functions passed as callback arguments as nesting levels
-        const isCallbackArrow = parent.type === 'arrow_function' && parent.parent?.type === 'arguments'
-        if (!isCallbackArrow) {
+        // Inline callback-position arrows (call args, JSX attribute values like
+        // `onChange={(v) => ...}`, render props) aren't real nesting — they're
+        // the idiomatic shape for event handlers / map predicates / etc. Skip
+        // them so the rule only fires on actual nested-helper definitions.
+        if (!isInlineCallbackArrow(parent)) {
           depth++
         }
       }
@@ -33,4 +36,22 @@ export const deeplyNestedFunctionsVisitor: CodeRuleVisitor = {
     }
     return null
   },
+}
+
+function isInlineCallbackArrow(fn: SyntaxNode): boolean {
+  if (fn.type !== 'arrow_function') return false
+  const parent = fn.parent
+  if (!parent) return false
+  // Call argument: `foo(() => …)` / `arr.map(x => …)`
+  if (parent.type === 'arguments') return true
+  // JSX attribute expression: `<C onClick={() => …} />`, `<F render={…} />`
+  if (parent.type === 'jsx_expression') return true
+  // Object literal value: `{ onClick: () => … }` — but only when it's not the
+  // top-level object of a const declaration (which is a real definition).
+  if (parent.type === 'pair') {
+    const obj = parent.parent
+    if (obj?.type === 'object' && obj.parent?.type === 'arguments') return true
+    if (obj?.type === 'object' && obj.parent?.type === 'jsx_expression') return true
+  }
+  return false
 }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unknown-catch-variable.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unknown-catch-variable.ts
@@ -5,12 +5,29 @@ export const unknownCatchVariableVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/unknown-catch-variable',
   languages: ['typescript', 'tsx'],
   nodeTypes: ['catch_clause'],
-  visit(node, filePath, sourceCode) {
+  needsTypeQuery: true,
+  visit(node, filePath, sourceCode, _dataFlow, typeQuery) {
     const param = node.childForFieldName('parameter')
     if (!param) return null
 
     const typeAnnotation = node.childForFieldName('type')
     if (typeAnnotation) return null
+
+    // When tsconfig has `useUnknownInCatchVariables: true` (the default under
+    // `strict: true`), the compiler already gives `e` the type `unknown`, so
+    // the explicit annotation is redundant — flagging here is a false
+    // positive. Only flag when the effective type is something else (i.e. the
+    // tsconfig explicitly opts back into `any`).
+    if (typeQuery) {
+      const t = typeQuery.getTypeString(
+        filePath,
+        param.startPosition.row,
+        param.startPosition.column,
+        param.endPosition.row,
+        param.endPosition.column,
+      )
+      if (t === 'unknown') return null
+    }
 
     const paramName = param.text
     return makeViolation(

--- a/packages/analyzer/src/rules/performance/visitors/javascript/sync-fs-in-request-handler.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/sync-fs-in-request-handler.ts
@@ -1,3 +1,4 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { SYNC_FS_METHODS, isInsideAsyncFunctionOrHandler } from './_helpers.js'
@@ -8,6 +9,13 @@ import { SYNC_FS_METHODS, isInsideAsyncFunctionOrHandler } from './_helpers.js'
 // `seed` or ending in `-seed`/`.seed` (etc.) — same shape used by
 // bugs/await-in-loop.
 const SEED_FILE_PATH_PATTERN = /(?:^|[\\/])(?:seed|seeds)[\\/]|(?:^|[\\/])seed[^\\/]*\.(?:ts|tsx|js|jsx|mjs|cjs)$|[-_.](?:seed|seeds)\.(?:ts|tsx|js|jsx|mjs|cjs)$/i
+
+// Factory / init-style function names that typically run once at startup —
+// transports, signers, clients, etc. Sync FS inside them blocks once at boot,
+// not on a hot request path, so flagging is noise. Conservative on purpose:
+// generic prefixes like `load` / `make` / `build` are too ambiguous (could
+// equally name per-request code) and stay out of the set.
+const INIT_NAME_PATTERN = /^(create|init|initialize|setup|bootstrap|configure|register)([A-Z_]|$)/
 
 export const syncFsInRequestHandlerVisitor: CodeRuleVisitor = {
   ruleKey: 'performance/deterministic/sync-fs-in-request-handler',
@@ -34,6 +42,9 @@ export const syncFsInRequestHandlerVisitor: CodeRuleVisitor = {
 
     if (!isInsideAsyncFunctionOrHandler(node)) return null
 
+    const enclosingName = findEnclosingFunctionName(node)
+    if (enclosingName && INIT_NAME_PATTERN.test(enclosingName)) return null
+
     return makeViolation(
       this.ruleKey, node, filePath, 'high',
       'Synchronous filesystem call in async context',
@@ -42,4 +53,37 @@ export const syncFsInRequestHandlerVisitor: CodeRuleVisitor = {
       `Replace ${methodName}() with its async counterpart (e.g., fs.promises.readFile()).`,
     )
   },
+}
+
+// Walks up to the nearest enclosing function and returns its name. For arrow
+// functions / function expressions assigned to a const or property, returns
+// the binding name (e.g. `createGoogleCloudSigner`). Returns null when no
+// name can be recovered.
+function findEnclosingFunctionName(node: SyntaxNode): string | null {
+  let current: SyntaxNode | null = node.parent
+  while (current) {
+    if (current.type === 'function_declaration' || current.type === 'method_definition') {
+      return current.childForFieldName('name')?.text ?? null
+    }
+    if (current.type === 'arrow_function' || current.type === 'function') {
+      const parent = current.parent
+      if (parent?.type === 'variable_declarator') {
+        return parent.childForFieldName('name')?.text ?? null
+      }
+      if (parent?.type === 'pair') {
+        const k = parent.childForFieldName('key')
+        return k?.text?.replace(/['"`]/g, '') ?? null
+      }
+      if (parent?.type === 'assignment_expression') {
+        const left = parent.childForFieldName('left')
+        if (left?.type === 'identifier') return left.text
+        if (left?.type === 'member_expression') {
+          return left.childForFieldName('property')?.text ?? null
+        }
+      }
+      return null
+    }
+    current = current.parent
+  }
+  return null
 }

--- a/tests/fixtures/sample-js-project-negative/packages/loose-catch-config/index.ts
+++ b/tests/fixtures/sample-js-project-negative/packages/loose-catch-config/index.ts
@@ -1,0 +1,13 @@
+// This package's tsconfig sets `useUnknownInCatchVariables: false`, so the
+// catch parameter below is implicitly `any` — that's the bug the rule is
+// meant to catch, because callers can dereference arbitrary properties on an
+// untyped error without any compiler help.
+
+export function parseJsonOrNull(input: string): unknown {
+  try {
+    return JSON.parse(input);
+  // VIOLATION: code-quality/deterministic/unknown-catch-variable
+  } catch (err) {
+    return null;
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/packages/loose-catch-config/tsconfig.json
+++ b/tests/fixtures/sample-js-project-negative/packages/loose-catch-config/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "useUnknownInCatchVariables": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/arch-violations.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/arch-violations.ts
@@ -12,6 +12,9 @@ const apiVersion = 'v1';
 
 // VIOLATION: architecture/deterministic/duplicate-import
 import { Request as Req } from 'express';
+// Two named imports from the same source — the classic mistake.
+// VIOLATION: architecture/deterministic/duplicate-import
+import { z as zod } from 'zod';
 
 const router = Router();
 

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/sync-fs-in-request-handler-async.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/sync-fs-in-request-handler-async.ts
@@ -13,3 +13,10 @@ export async function serveTemplate(templatePath: string): Promise<string> {
   const buffer = fs.readFileSync(templatePath);
   return buffer.toString('utf-8');
 }
+
+// Per-request handler — read on every call blocks the event loop.
+async function handleAvatarRequest(userId: string): Promise<Buffer> {
+  // VIOLATION: performance/deterministic/sync-fs-in-request-handler
+  return fs.readFileSync(`/var/data/avatars/${userId}.png`);
+}
+void handleAvatarRequest;

--- a/tests/fixtures/sample-js-project-negative/services/notification-service/src/queue-worker.ts
+++ b/tests/fixtures/sample-js-project-negative/services/notification-service/src/queue-worker.ts
@@ -154,3 +154,13 @@ export function adjustPriority(a: number, b: number) {
   // VIOLATION: bugs/deterministic/confusing-increment-decrement
   return a + b++;
 }
+
+// Single-key error object with no description sibling — the receiver gets no
+// actionable detail beyond the generic phrase.
+// VIOLATION: code-quality/deterministic/missing-return-type
+// VIOLATION: code-quality/deterministic/missing-boundary-types
+function buildFailureResponse() {
+  // VIOLATION: bugs/deterministic/generic-error-message
+  return { error: 'Internal Server Error' };
+}
+void buildFailureResponse;

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-complexity.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-complexity.ts
@@ -336,3 +336,18 @@ export class Container {
     return 0;
   }
 }
+
+// Genuinely nested helper functions (not inline callbacks) — these should be
+// pulled out to module scope.
+function deepNestArrows() {
+  const outer = () => {
+    const middle = () => {
+      // VIOLATION: code-quality/deterministic/deeply-nested-functions
+      const inner = () => 'too deep';
+      return inner();
+    };
+    return middle();
+  };
+  return outer();
+}
+void deepNestArrows;

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-typescript.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-typescript.ts
@@ -41,15 +41,6 @@ export function anyConstraint<T extends unknown>(x: T): T {
 // VIOLATION: code-quality/deterministic/useless-empty-export
 export {};
 
-// VIOLATION: code-quality/deterministic/unknown-catch-variable
-export function catchUntyped() {
-  try {
-    throw new Error('test');
-  } catch (e) {
-    console.error(e);
-  }
-}
-
 // VIOLATION: code-quality/deterministic/redundant-template-expression
 export function templateString(x: string) {
   return `${x}`;

--- a/tests/fixtures/sample-js-project-positive/deeply-nested-functions-inline-callbacks.ts
+++ b/tests/fixtures/sample-js-project-positive/deeply-nested-functions-inline-callbacks.ts
@@ -1,0 +1,39 @@
+// Object-literal handler configs (`api({ onSuccess: (x) => ... })`) and
+// inline JSX-prop arrows are the idiomatic shape for event handlers and
+// data-flow callbacks. Nesting them isn't a "deeply nested function" bug —
+// the closures only exist for the lifetime of the parent invocation.
+
+interface SubscriberConfig<T> {
+  readonly onSuccess: (data: T) => void;
+  readonly onError: (err: Error) => void;
+}
+
+declare function subscribe<T>(opts: SubscriberConfig<T>): void;
+
+export function configureSubscribers(): void {
+  subscribe<number>({
+    onSuccess: (outerValue) => {
+      subscribe<string>({
+        onSuccess: (innerValue) => {
+          subscribe<boolean>({
+            onSuccess: (finalValue) => {
+              const total = String(finalValue) + innerValue + String(outerValue);
+              if (total.length === 0) {
+                throw new Error('unexpected empty payload');
+              }
+            },
+            onError: (err) => {
+              console.warn('inner failure', err.message);
+            },
+          });
+        },
+        onError: (err) => {
+          console.error('middle failure', err.stack);
+        },
+      });
+    },
+    onError: (err) => {
+      console.info('outer failure', err.name);
+    },
+  });
+}

--- a/tests/fixtures/sample-js-project-positive/duplicate-import-side-effect.ts
+++ b/tests/fixtures/sample-js-project-positive/duplicate-import-side-effect.ts
@@ -1,0 +1,11 @@
+// A bare side-effect import documents that the module is loaded for its
+// top-level effects (polyfills, registrations, time-zone tables). Pairing it
+// with a named import from the same module is intentional and distinct from
+// a real "duplicate import" mistake — the two lines carry different intent.
+
+import '@sample/shared-utils';
+import { validateEmail } from '@sample/shared-utils';
+
+export function isValidContact(email: string): boolean {
+  return validateEmail(email);
+}

--- a/tests/fixtures/sample-js-project-positive/generic-error-message-toast.ts
+++ b/tests/fixtures/sample-js-project-positive/generic-error-message-toast.ts
@@ -1,0 +1,27 @@
+// Toast-style notifications routinely pair a short, vague title ("Something
+// went wrong") with a longer description that gives the user actionable
+// detail. The title alone isn't a real "uninformative error" because the
+// description is shown alongside it.
+
+declare const showToast: (opts: {
+  title: string;
+  description: string;
+  variant?: string;
+}) => void;
+
+declare const tag: (strings: TemplateStringsArray) => string;
+
+export function notifyDeleteFailed(): void {
+  showToast({
+    title: 'Something went wrong',
+    description: 'The document could not be deleted right now. Please try again in a moment.',
+    variant: 'destructive',
+  });
+}
+
+export function notifyCopyFailed(): void {
+  showToast({
+    title: tag`Something went wrong`,
+    description: tag`The sharing link could not be created at this time. Please try again.`,
+  });
+}

--- a/tests/fixtures/sample-js-project-positive/sync-fs-in-request-handler-init-factory.ts
+++ b/tests/fixtures/sample-js-project-positive/sync-fs-in-request-handler-init-factory.ts
@@ -1,0 +1,32 @@
+// Factory-style functions named `create*` / `init*` are invoked once at
+// server bootstrap, not on per-request hot paths. Sync filesystem calls here
+// block the boot sequence (which is fine) — not the request loop.
+
+import fs from 'node:fs';
+
+interface SignerConfig {
+  cert: Buffer;
+  key: Buffer;
+}
+
+export const createCryptoSigner = async (
+  certPath: string,
+  keyPath: string,
+): Promise<SignerConfig> => {
+  if (!fs.existsSync(certPath)) {
+    throw new Error('cert missing');
+  }
+  const cert = fs.readFileSync(certPath);
+  const key = fs.readFileSync(keyPath);
+  await registerWithRemote(cert);
+  return { cert, key };
+};
+
+export async function initRemoteSigner(configPath: string): Promise<void> {
+  const config = fs.readFileSync(configPath);
+  await registerWithRemote(config);
+}
+
+async function registerWithRemote(_config: Buffer): Promise<void> {
+  await Promise.resolve();
+}

--- a/tests/fixtures/sample-js-project-positive/unknown-catch-variable-strict-default.ts
+++ b/tests/fixtures/sample-js-project-positive/unknown-catch-variable-strict-default.ts
@@ -1,0 +1,29 @@
+// Strict-mode tsconfig (the project root) has `useUnknownInCatchVariables: true`
+// implicitly. The compiler already types `e` as `unknown`, so requiring an
+// explicit `: unknown` annotation here would be redundant noise.
+
+class DomainError extends Error {}
+
+function performStep(): void {
+  throw new DomainError('boom');
+}
+
+export function runJob(): string {
+  try {
+    performStep();
+    return 'ok';
+  } catch (error) {
+    if (error instanceof DomainError) {
+      throw error;
+    }
+    return 'failed';
+  }
+}
+
+export function parseJsonOrDefault<T>(input: string, fallback: T): T | unknown {
+  try {
+    return JSON.parse(input);
+  } catch (err) {
+    return fallback;
+  }
+}


### PR DESCRIPTION
Closes #276
Closes #277
Closes #278
Closes #279
Closes #280

## Fixes

| Rule | Issue | Positive fixture | Negative fixture |
|---|---|---|---|
| `code-quality/deterministic/unknown-catch-variable` | #276 | `tests/fixtures/sample-js-project-positive/unknown-catch-variable-strict-default.ts` | `tests/fixtures/sample-js-project-negative/packages/loose-catch-config/index.ts` |
| `bugs/deterministic/generic-error-message` | #277 | `tests/fixtures/sample-js-project-positive/generic-error-message-toast.ts` | `tests/fixtures/sample-js-project-negative/services/notification-service/src/queue-worker.ts` (new `buildFailureResponse` case) |
| `performance/deterministic/sync-fs-in-request-handler` | #278 | `tests/fixtures/sample-js-project-positive/sync-fs-in-request-handler-init-factory.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/sync-fs-in-request-handler-async.ts` (new `handleAvatarRequest` case) |
| `architecture/deterministic/duplicate-import` | #279 | `tests/fixtures/sample-js-project-positive/duplicate-import-side-effect.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/services/arch-violations.ts` (new `import { z as zod } from 'zod'` case) |
| `code-quality/deterministic/deeply-nested-functions` | #280 | `tests/fixtures/sample-js-project-positive/deeply-nested-functions-inline-callbacks.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-complexity.ts` (new `deepNestArrows` case) |

## code-quality/deterministic/unknown-catch-variable

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/embedding-router/apply-multi-sign-signature.ts#L89
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/embed/embed-document-signing-page-v1.tsx#L232
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/forms/signin.tsx#L260
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/folder-create-dialog.tsx#L68
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/embed/authoring/configure-document-upload.tsx#L64`

Positive fixture (`unknown-catch-variable-strict-default.ts`):
```ts
// Strict-mode tsconfig (the project root) has `useUnknownInCatchVariables: true`
// implicitly. The compiler already types `e` as `unknown`, so requiring an
// explicit `: unknown` annotation here would be redundant noise.

class DomainError extends Error {}

function performStep(): void {
  throw new DomainError('boom');
}

export function runJob(): string {
  try {
    performStep();
    return 'ok';
  } catch (error) {
    if (error instanceof DomainError) {
      throw error;
    }
    return 'failed';
  }
}

export function parseJsonOrDefault<T>(input: string, fallback: T): T | unknown {
  try {
    return JSON.parse(input);
  } catch (err) {
    return fallback;
  }
}
```

Negative fixture (`packages/loose-catch-config/index.ts` + sub-`tsconfig.json` with `useUnknownInCatchVariables: false`):
```ts
export function parseJsonOrNull(input: string): unknown {
  try {
    return JSON.parse(input);
  // VIOLATION: code-quality/deterministic/unknown-catch-variable
  } catch (err) {
    return null;
  }
}
```

Visitor change: the rule now queries the effective catch-variable type via `TypeQueryService` and skips when the compiler already treats it as `unknown` (i.e. `useUnknownInCatchVariables=true`, the default under `strict: true`). It continues to fire when a tsconfig opts back into `any`.

## bugs/deterministic/generic-error-message

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/files/files.ts#L242
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/envelope-delete-dialog.tsx#L78
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/envelope-duplicate-dialog.tsx#L62
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/team-inherit-member-disable-dialog.tsx#L38`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/components/document/document-share-button.tsx#L45

Positive fixture (`generic-error-message-toast.ts`):
```ts
declare const showToast: (opts: { title: string; description: string; variant?: string; }) => void;
declare const tag: (strings: TemplateStringsArray) => string;

export function notifyDeleteFailed(): void {
  showToast({
    title: 'Something went wrong',
    description: 'The document could not be deleted right now. Please try again in a moment.',
    variant: 'destructive',
  });
}

export function notifyCopyFailed(): void {
  showToast({
    title: tag`Something went wrong`,
    description: tag`The sharing link could not be created at this time. Please try again.`,
  });
}
```

Negative fixture (appended to `queue-worker.ts`):
```ts
function buildFailureResponse() {
  // VIOLATION: bugs/deterministic/generic-error-message
  return { error: 'Internal Server Error' };
}
```

Visitor change: walks up to the containing `pair` and skips when a vague title-like property (`title`/`heading`/`summary`/...) is paired with a sibling description-like property (`description`/`detail`/`body`/...) in the same object literal — the toast pattern shows actionable detail to the user. Bare strings and single-key error objects still fire as TPs.

## performance/deterministic/sync-fs-in-request-handler

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/signing/transports/google-cloud.ts#L59
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/signing/transports/google-cloud.ts#L15
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/signing/transports/google-cloud.ts#L62
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/signing/transports/google-cloud.ts#L27
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/pdf/render-certificate.ts#L581 (borderline TP per the issue)

Positive fixture (`sync-fs-in-request-handler-init-factory.ts`):
```ts
import fs from 'node:fs';

interface SignerConfig { cert: Buffer; key: Buffer; }

export const createCryptoSigner = async (certPath: string, keyPath: string): Promise<SignerConfig> => {
  if (!fs.existsSync(certPath)) { throw new Error('cert missing'); }
  const cert = fs.readFileSync(certPath);
  const key = fs.readFileSync(keyPath);
  await registerWithRemote(cert);
  return { cert, key };
};

export async function initRemoteSigner(configPath: string): Promise<void> {
  const config = fs.readFileSync(configPath);
  await registerWithRemote(config);
}

async function registerWithRemote(_config: Buffer): Promise<void> { await Promise.resolve(); }
```

Negative fixture (appended to `sync-fs-in-request-handler-async.ts`):
```ts
// Per-request handler — read on every call blocks the event loop.
async function handleAvatarRequest(userId: string): Promise<Buffer> {
  // VIOLATION: performance/deterministic/sync-fs-in-request-handler
  return fs.readFileSync(`/var/data/avatars/${userId}.png`);
}
void handleAvatarRequest;
```

Visitor change: looks up the enclosing function's name (including const-assigned arrow functions and object-pair methods) and skips when it matches a conservative init prefix set — `create|init|initialize|setup|bootstrap|configure|register`. Ambiguous prefixes (`load`/`make`/`build`) intentionally stay out so they continue to fire when used in per-request code.

## architecture/deterministic/duplicate-import

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/api/v1/implementation.ts#L8 (the actual FP — side-effect + named import combo)
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/document-flow/document-flow-root.tsx#L7
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/multiselect.tsx#L4
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/components/document/document-share-button.tsx#L11

Positive fixture (`duplicate-import-side-effect.ts`):
```ts
import '@sample/shared-utils';
import { validateEmail } from '@sample/shared-utils';

export function isValidContact(email: string): boolean {
  return validateEmail(email);
}
```

Negative fixture (appended to `arch-violations.ts`):
```ts
// Two named imports from the same source — the classic mistake.
// VIOLATION: architecture/deterministic/duplicate-import
import { z as zod } from 'zod';
```

Visitor change: `import 'x'` (no specifiers) carries different intent from `import { y } from 'x'` — the bare form is an explicit marker the developer added for side effects (polyfills, registrations, table initialization). The rules now skip the duplicate check in that combination, mirroring the existing handling for type-only + value imports. Applied to both the `architecture/deterministic` and `bugs/deterministic` versions of the rule, which share the heuristic.

## code-quality/deterministic/deeply-nested-functions

OSS sources:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.groups.$id.tsx#L257`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/envelope-signing/envelope-signer-page-renderer.tsx#L209`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/document-flow/add-signers.tsx#L728
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/envelope-editor/envelope-editor-upload-page.tsx#L590`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/envelope-signing/envelope-signer-page-renderer.tsx#L238`

Positive fixture (`deeply-nested-functions-inline-callbacks.ts`):
```ts
export function configureSubscribers(): void {
  subscribe<number>({
    onSuccess: (outerValue) => {
      subscribe<string>({
        onSuccess: (innerValue) => {
          subscribe<boolean>({
            onSuccess: (finalValue) => {
              const total = String(finalValue) + innerValue + String(outerValue);
              if (total.length === 0) { throw new Error('unexpected empty payload'); }
            },
            onError: (err) => { console.warn('inner failure', err.message); },
          });
        },
        onError: (err) => { console.error('middle failure', err.stack); },
      });
    },
    onError: (err) => { console.info('outer failure', err.name); },
  });
}
```

Negative fixture (appended to `code-quality-complexity.ts`):
```ts
function deepNestArrows() {
  const outer = () => {
    const middle = () => {
      // VIOLATION: code-quality/deterministic/deeply-nested-functions
      const inner = () => 'too deep';
      return inner();
    };
    return middle();
  };
  return outer();
}
```

Visitor change: extended the "inline callback position" exemption beyond direct call arguments to also include JSX attribute values (`jsx_expression` parent) and object-literal handler properties (`pair` in an object passed as an argument or as a JSX expression). Both shapes are inline handlers, not nested helpers. Genuine nested function declarations still flag.

## FP-count delta (vs `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f` on `documenso/documenso`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/unknown-catch-variable` | 286 | 252 | -34 |
| `bugs/deterministic/generic-error-message` | 70 | 10 | -60 |
| `performance/deterministic/sync-fs-in-request-handler` | 5 | 3 | -2 |
| `architecture/deterministic/duplicate-import` | 4 | 3 | -1 |
| `code-quality/deterministic/deeply-nested-functions` | 91 | 33 | -58 |
| **Total (these 5 rules)** | 456 | 301 | -155 |
| **All-rules total on target** | 50788 | 50632 | -156 |

(The 156th delta comes from the `bugs/deterministic/duplicate-import` companion rule, which received the same side-effect-import fix as the architecture version.)

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ut9sGJYJvi6M9D1rzZVSk7)_