### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/async-void-function.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/async-void-function.ts
@@ -14,6 +14,15 @@ export const asyncVoidFunctionVisitor: CodeRuleVisitor = {
     const parent = node.parent
     if (!parent || parent.type !== 'expression_statement') return null
 
+    // Honor an explicit `// eslint-disable-next-line …no-floating-promises`
+    // on the line above the statement. The author has acknowledged the
+    // floating promise (e.g. application entrypoints that fire-and-forget).
+    const startRow = parent.startPosition.row
+    if (startRow > 0) {
+      const prevLine = sourceCode.split('\n')[startRow - 1] ?? ''
+      if (/eslint-disable-next-line[^\n]*no-floating-promises/.test(prevLine)) return null
+    }
+
     // Skip when the unhandled async call is inside a useEffect/useLayoutEffect callback.
     // Pattern: useEffect(() => { asyncFn(); }) — this is the standard React pattern.
     const grandparent = parent.parent // statement_block (callback body)

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/unhandled-promise.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/unhandled-promise.ts
@@ -16,6 +16,15 @@ export const unhandledPromiseVisitor: CodeRuleVisitor = {
     const expr = node.namedChildren[0]
     if (!expr) return null
 
+    // Honor an explicit `// eslint-disable-next-line …no-floating-promises`
+    // on the line above. The author has acknowledged the floating promise
+    // (e.g. application entrypoints that intentionally fire-and-forget).
+    const startRow = node.startPosition.row
+    if (startRow > 0) {
+      const prevLine = sourceCode.split('\n')[startRow - 1] ?? ''
+      if (/eslint-disable-next-line[^\n]*no-floating-promises/.test(prevLine)) return null
+    }
+
     // Skip if already handled: void expr, expr.catch(), await expr
     if (expr.type === 'await_expression') return null
     if (expr.type === 'void_expression') return null

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/duplicate-string.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/duplicate-string.ts
@@ -22,11 +22,29 @@ export const duplicateStringVisitor: CodeRuleVisitor = {
         // Skip TypeScript type keywords (e.g., `string` inside `predefined_type`)
         if (parent?.type === 'predefined_type') return
         if (parent?.type === 'import_statement' || parent?.type === 'call_expression') return
+        // Short kebab-case identifier-like tokens used as call/new arguments
+        // (e.g. `.toString('utf-8')`, `.with('invalid-token', …)`,
+        // `pingRegion('us-east-1')`) are framework / API tokens, not domain
+        // strings worth extracting. Restrict to ≤2 hyphens (≤3 segments) so
+        // longer kebab-spelled phrases still fire. Limit to the call-argument
+        // position so duplicated kebab strings stored in variables still fire.
+        if (parent?.type === 'arguments'
+          && (parent.parent?.type === 'call_expression' || parent.parent?.type === 'new_expression')
+          && /^[A-Za-z_$][A-Za-z0-9_$-]*$/.test(inner)
+          && (inner.match(/-/g)?.length ?? 0) <= 2) return
         // Skip JSX attribute values (SVG props, className, Tailwind classes)
         if (parent?.type === 'jsx_attribute') return
         // Skip type annotations and type contexts
         if (parent?.type === 'type_annotation' || parent?.type === 'type_alias_declaration'
           || parent?.type === 'property_signature' || parent?.type === 'literal_type') return
+        // Skip strings used as object literal property keys
+        // (e.g. `{ 'Content-Type': 'application/json' }`) — the key
+        // names the slot, it is not a domain string worth extracting.
+        if (parent?.type === 'pair' && parent.childForFieldName('key')?.id === n.id) return
+        // Skip dotted-identifier strings (e.g. `'Envelope.id'`,
+        // `'User.email'`) — these are schema column / namespaced
+        // identifier references, not domain strings.
+        if (/^[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)+$/.test(inner)) return
 
         const existing = stringCounts.get(content)
         if (existing) {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/expression-complexity.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/expression-complexity.ts
@@ -17,6 +17,30 @@ export const expressionComplexityVisitor: CodeRuleVisitor = {
     }
     if (!expr) return null
 
+    // Unwrap parentheses for the function / JSX shape checks below.
+    let target = expr
+    while (target.type === 'parenthesized_expression' && target.namedChildren[0]) {
+      target = target.namedChildren[0]
+    }
+
+    // Skip declarators / returns whose value is itself a function. The
+    // function body is visited as its own statements, so counting
+    // operators in the body at the outer declarator double-counts and
+    // inflates the score past the threshold for reasons unrelated to
+    // the declarator itself (e.g. `export const handler = (...) => {…}`).
+    if (target.type === 'arrow_function'
+      || target.type === 'function_expression'
+      || target.type === 'function_declaration'
+      || target.type === 'generator_function'
+      || target.type === 'generator_function_declaration') return null
+
+    // Skip JSX render returns. JSX naturally uses `&&` for conditional
+    // composition; counting those as boolean-expression operators reads
+    // declarative markup as tangled logic.
+    if (target.type === 'jsx_element'
+      || target.type === 'jsx_fragment'
+      || target.type === 'jsx_self_closing_element') return null
+
     let operatorCount = 0
     const BINARY_TYPES = new Set(['binary_expression', 'logical_expression'])
     // Don't recurse into nested function bodies. Each nested function's

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/magic-string.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/magic-string.ts
@@ -33,6 +33,24 @@ export const magicStringVisitor: CodeRuleVisitor = {
           // framework API tokens, typeof return values, or status/kind discriminants —
           // not magic strings worth extracting to a constant.
           if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(inner)) return
+          // Short kebab-case identifier-like tokens used as call/new arguments
+          // (e.g. `.toString('utf-8')`, `useState('method-selection')`) are
+          // framework / API tokens, not domain strings worth extracting.
+          // Restrict to ≤2 hyphens so longer kebab-spelled phrases still fire,
+          // and to the call-argument position so kebab strings stored in
+          // variables still fire.
+          if (n.parent?.type === 'arguments'
+            && (n.parent.parent?.type === 'call_expression' || n.parent.parent?.type === 'new_expression')
+            && /^[A-Za-z_$][A-Za-z0-9_$-]*$/.test(inner)
+            && (inner.match(/-/g)?.length ?? 0) <= 2) return
+          // Skip strings used as object literal property keys
+          // (e.g. `{ 'Content-Type': 'application/json' }`) — the key
+          // names the slot, it is not a magic string worth extracting.
+          if (n.parent?.type === 'pair' && n.parent.childForFieldName('key')?.id === n.id) return
+          // Skip dotted-identifier strings (e.g. `'Envelope.id'`,
+          // `'User.email'`) — these are schema column / namespaced
+          // identifier references, not magic strings.
+          if (/^[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)+$/.test(inner)) return
           // Only flag non-trivial strings
           if (inner.length >= MIN_LENGTH && /^[a-zA-Z]/.test(inner) && !inner.includes('${')) {
             const existing = counts.get(text) ?? []

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/prefer-const.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/prefer-const.ts
@@ -9,12 +9,25 @@ export const preferConstVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     if (!node.text.startsWith('let ')) return null
 
+    // Loop-header `let` (e.g. `for (let i = 0, max = len - 1; ...)`) —
+    // even when individual declarators (`max`) aren't reassigned, the
+    // single-declaration convention for loop locals is idiomatic.
+    if (node.parent?.type === 'for_statement') return null
+
     const declarators = node.namedChildren.filter((c) => c.type === 'variable_declarator')
     if (declarators.length === 0) return null
 
     for (const declarator of declarators) {
       const nameNode = declarator.childForFieldName('name')
       if (!nameNode) continue
+
+      // Destructured `let` (e.g. `let { width, height } = …`,
+      // `let [a, b] = …`) — the visitor's name-based reassignment
+      // check can't reliably tell whether an individual binding is
+      // reassigned later, and rewriting a destructured `let` to
+      // `const` is broken if any single binding is reassigned.
+      if (nameNode.type === 'object_pattern' || nameNode.type === 'array_pattern') return null
+
       const varName = nameNode.text
 
       let scope = node.parent
@@ -22,11 +35,28 @@ export const preferConstVisitor: CodeRuleVisitor = {
 
       let isReassigned = false
 
+      function patternContainsName(n: SyntaxNode, name: string): boolean {
+        if ((n.type === 'identifier' || n.type === 'shorthand_property_identifier_pattern')
+          && n.text === name) return true
+        for (let i = 0; i < n.childCount; i++) {
+          const c = n.child(i)
+          if (c && patternContainsName(c, name)) return true
+        }
+        return false
+      }
+
       function checkReassignment(n: SyntaxNode) {
         if (isReassigned) return
         if (n.type === 'assignment_expression' || n.type === 'augmented_assignment_expression') {
           const left = n.childForFieldName('left')
           if (left?.text === varName) {
+            isReassigned = true
+            return
+          }
+          // Destructured assignment (`[a, b] = …` or `({ a, b } = …)`)
+          // reassigns each binding inside the pattern.
+          if (left && (left.type === 'array_pattern' || left.type === 'object_pattern')
+            && patternContainsName(left, varName)) {
             isReassigned = true
             return
           }

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/floating-promise.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/floating-promise.ts
@@ -12,6 +12,15 @@ export const floatingPromiseVisitor: CodeRuleVisitor = {
     const expr = node.namedChildren[0]
     if (!expr) return null
 
+    // Honor an explicit `// eslint-disable-next-line …no-floating-promises`
+    // on the line above. The author has acknowledged the floating promise
+    // (e.g. application entrypoints that intentionally fire-and-forget).
+    const startRow = node.startPosition.row
+    if (startRow > 0) {
+      const prevLine = sourceCode.split('\n')[startRow - 1] ?? ''
+      if (/eslint-disable-next-line[^\n]*no-floating-promises/.test(prevLine)) return null
+    }
+
     // If the expression is already an await, it's fine
     if (expr.type === 'await_expression') return null
 

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -799,6 +799,12 @@
       "layer": "service"
     },
     {
+      "name": "duplicate-string-sql-fragment",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "EarlyThis",
       "service": "utils",
       "kind": "class",
@@ -811,7 +817,19 @@
       "layer": "service"
     },
     {
+      "name": "evaluateGate",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "fetchAllRecords",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "fireAndForget",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"
@@ -943,6 +961,12 @@
       "layer": "service"
     },
     {
+      "name": "pickStatusLabel",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "processAbandonedQueue",
       "service": "utils",
       "kind": "standalone",
@@ -962,6 +986,12 @@
     },
     {
       "name": "readGreeting",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "readOnce",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/duplicate-string-sql-fragment.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/duplicate-string-sql-fragment.ts
@@ -1,0 +1,20 @@
+/**
+ * A genuine duplicate-string bug: the same SQL fragment appears in
+ * three query builders. Extracting it to a constant deduplicates the
+ * SQL and keeps it consistent if the schema or filter changes.
+ */
+
+declare function db(): { query(sql: string): Promise<unknown> };
+
+// VIOLATION: code-quality/deterministic/duplicate-string
+export function listActiveUsers(): Promise<unknown> {
+  return db().query('SELECT id, email FROM users WHERE active = true');
+}
+
+export function countActiveUsers(): Promise<unknown> {
+  return db().query('SELECT id, email FROM users WHERE active = true');
+}
+
+export function exportActiveUsers(): Promise<unknown> {
+  return db().query('SELECT id, email FROM users WHERE active = true');
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/expression-complexity-boolean-chain.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/expression-complexity-boolean-chain.ts
@@ -1,0 +1,19 @@
+/**
+ * A genuine expression-complexity bug: a single return expression
+ * chains many arithmetic / comparison / logical operators. Breaking
+ * it into named intermediate variables would make the predicate
+ * easier to read and debug.
+ */
+
+declare const a: number;
+declare const b: number;
+declare const c: number;
+declare const d: number;
+declare const e: number;
+declare const f: number;
+declare const g: number;
+
+// VIOLATION: code-quality/deterministic/expression-complexity
+export function evaluateGate(): boolean {
+  return a > 0 && b < 10 && c === 0 && (d + e) * f > g && a + b + c + d > 100;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/magic-string-value-label.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/magic-string-value-label.ts
@@ -1,0 +1,14 @@
+/**
+ * A genuine magic-string / duplicate-string bug: the same multi-word
+ * user-facing status label appears in three return positions. The
+ * string is a domain phrase, not a property key or schema token, so
+ * extracting it to a named constant is the appropriate fix.
+ */
+
+// VIOLATION: code-quality/deterministic/magic-string
+// VIOLATION: code-quality/deterministic/duplicate-string
+export function pickStatusLabel(status: number): string {
+  if (status === 0) return 'Pending external verification step';
+  if (status === 1) return 'Pending external verification step';
+  return 'Pending external verification step';
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/prefer-const-simple-binding.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/prefer-const-simple-binding.ts
@@ -1,0 +1,13 @@
+/**
+ * A genuine prefer-const bug: a simple `let` binding initialized
+ * once, never reassigned (no augmented assignment, no destructured
+ * assignment, not a loop header). Changing `let` to `const` is safe.
+ */
+
+declare function compute(): number;
+
+export function readOnce(): number {
+  // VIOLATION: code-quality/deterministic/prefer-const
+  let value = compute();
+  return value * 2;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unhandled-promise-fire-and-forget.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unhandled-promise-fire-and-forget.ts
@@ -1,0 +1,12 @@
+/**
+ * A genuine unhandled-promise bug: a Promise-returning call sits as
+ * a statement with no `await`, `.catch()`, `void`, or eslint-disable
+ * suppression. Any rejection from `flushQueue` would be silently lost.
+ */
+
+declare function flushQueue(): Promise<void>;
+
+export function fireAndForget(): void {
+  // VIOLATION: bugs/deterministic/unhandled-promise
+  flushQueue();
+}

--- a/tests/fixtures/sample-js-project-positive/src/duplicate-string-kebab-tokens.ts
+++ b/tests/fixtures/sample-js-project-positive/src/duplicate-string-kebab-tokens.ts
@@ -1,0 +1,41 @@
+/**
+ * Short hyphenated single-token strings used as standard-library /
+ * API arguments — encoding names, region IDs, kind discriminants —
+ * are framework identifiers, not domain strings worth extracting.
+ * They are conceptually identical to the snake_case / camelCase
+ * tokens the rule already exempts; only the spelling differs.
+ */
+
+declare function readBlob(path: string, encoding: string): string;
+declare function writeBlob(path: string, data: string, encoding: string): void;
+declare function pingRegion(region: string): Promise<void>;
+
+export function loadAll(paths: readonly string[]): readonly string[] {
+  return [
+    readBlob(paths[0], 'utf-8'),
+    readBlob(paths[1], 'utf-8'),
+    readBlob(paths[2], 'utf-8'),
+  ];
+}
+
+export function saveAll(entries: ReadonlyArray<readonly [string, string]>): void {
+  for (const [path, data] of entries) {
+    writeBlob(path, data, 'utf-8');
+  }
+}
+
+type Outcome = { kind: 'in-flight' | 'long-poll' | 'short-poll' };
+
+declare function dispatch(kind: Outcome['kind']): void;
+
+export function reportAll(): void {
+  dispatch('in-flight');
+  dispatch('in-flight');
+  dispatch('in-flight');
+}
+
+export async function probeRegions(): Promise<void> {
+  await pingRegion('us-east-1');
+  await pingRegion('us-east-1');
+  await pingRegion('us-east-1');
+}

--- a/tests/fixtures/sample-js-project-positive/src/expression-complexity-function-rhs-and-jsx.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/expression-complexity-function-rhs-and-jsx.tsx
@@ -1,0 +1,42 @@
+/**
+ * Two shapes that the rule should not flag:
+ *
+ * 1. A variable declarator (or return) whose RHS is itself a
+ *    function — the function body's operators belong to nested
+ *    statements, which are visited separately. Counting them at the
+ *    outer declarator double-counts and inflates the score past the
+ *    threshold for reasons unrelated to the declarator itself.
+ * 2. A `return (<JSX/>)` expression — JSX naturally uses `&&` for
+ *    conditional composition; counting those as boolean-expression
+ *    operators reads declarative markup as tangled boolean logic.
+ */
+
+declare const flagA: boolean;
+declare const flagB: boolean;
+declare const flagC: boolean;
+declare const flagD: boolean;
+declare const flagE: boolean;
+declare const flagF: boolean;
+declare const flagG: boolean;
+
+export const collectGateErrors = (input: number): readonly string[] => {
+  const errors: string[] = [];
+  if (input < 0 || input > 1000) errors.push('range');
+  if (input === 0 && flagA && flagB) errors.push('zero');
+  if (flagC || flagD || flagE) errors.push('flagged');
+  return errors;
+};
+
+export function GateBanner(): JSX.Element {
+  return (
+    <div>
+      {flagA && <span>a</span>}
+      {flagB && <span>b</span>}
+      {flagC && <span>c</span>}
+      {flagD && <span>d</span>}
+      {flagE && <span>e</span>}
+      {flagF && <span>f</span>}
+      {flagG && <span>g</span>}
+    </div>
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/src/magic-string-keys-and-dotted.ts
+++ b/tests/fixtures/sample-js-project-positive/src/magic-string-keys-and-dotted.ts
@@ -1,0 +1,25 @@
+/**
+ * Strings used as object literal property keys (e.g. HTTP header
+ * names) and dotted-identifier strings (e.g. database column or
+ * namespaced API references) are framework / schema tokens, not
+ * domain strings worth extracting to a named constant.
+ */
+
+declare function post(
+  url: string,
+  opts: { headers: Record<string, string>; body: string },
+): Promise<unknown>;
+
+export async function sendBatch(): Promise<void> {
+  await post('/route-a', { headers: { 'Content-Type': 'mime-alpha' }, body: '{}' });
+  await post('/route-b', { headers: { 'Content-Type': 'mime-beta' }, body: '{}' });
+  await post('/route-c', { headers: { 'Content-Type': 'mime-gamma' }, body: '{}' });
+}
+
+declare function selectCols(cols: readonly string[]): Promise<unknown>;
+
+export async function readRows(): Promise<void> {
+  await selectCols(['Account.id', 'Account.label']);
+  await selectCols(['Account.id', 'Account.label']);
+  await selectCols(['Account.id', 'Account.label']);
+}

--- a/tests/fixtures/sample-js-project-positive/src/prefer-const-destructured-and-loop-header.ts
+++ b/tests/fixtures/sample-js-project-positive/src/prefer-const-destructured-and-loop-header.ts
@@ -1,0 +1,40 @@
+/**
+ * Three shapes that the rule should not flag:
+ *
+ * 1. Destructured `let` declarations (`let { width, height } = …`)
+ *    where individual bindings may be reassigned later via array /
+ *    object destructured assignment. The visitor's name-based check
+ *    can't reliably distinguish, and rewriting to `const` is broken
+ *    if any single binding is reassigned.
+ * 2. Simple `let` bindings reassigned via destructured assignment
+ *    (`[a, b] = await Promise.all([...])`) — the LHS is a pattern,
+ *    not the bare identifier, so a text-equality check misses it.
+ * 3. `let` declared inside a `for` statement header — even when
+ *    individual declarators aren't reassigned, the `let i, max`
+ *    loop-locals convention is idiomatic.
+ */
+
+declare function getPageSize(): { width: number; height: number };
+declare const isRotated: boolean;
+declare const corpusLength: number;
+
+export function swapDims(): readonly [number, number] {
+  let { width, height } = getPageSize();
+  if (isRotated) [width, height] = [height, width];
+  return [width, height];
+}
+
+export async function loadPair(): Promise<readonly [string | null, string | null]> {
+  let first: string | null = null;
+  let second: string | null = null;
+  [first, second] = await Promise.all([Promise.resolve('a'), Promise.resolve('b')]);
+  return [first, second];
+}
+
+export function lastIndex(): number {
+  let chosen = -1;
+  for (let i = 0, max = corpusLength - 1; i < max; i++) {
+    chosen = i;
+  }
+  return chosen;
+}

--- a/tests/fixtures/sample-js-project-positive/src/unhandled-promise-eslint-disabled.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unhandled-promise-eslint-disabled.ts
@@ -1,0 +1,12 @@
+/**
+ * Promise-returning expression statements with an explicit
+ * `// eslint-disable-next-line @typescript-eslint/no-floating-promises`
+ * directly above are intentionally fire-and-forget (typically
+ * application entrypoints). The author has already acknowledged
+ * the floating promise, so the rule should not flag it.
+ */
+
+declare function bootstrap(): Promise<void>;
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+bootstrap();


### PR DESCRIPTION
Closes #281
Closes #282
Closes #283
Closes #284
Closes #286

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/duplicate-string` | #281 | `tests/fixtures/sample-js-project-positive/src/duplicate-string-kebab-tokens.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/duplicate-string-sql-fragment.ts` |
| `code-quality/deterministic/magic-string` | #282 | `tests/fixtures/sample-js-project-positive/src/magic-string-keys-and-dotted.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/magic-string-value-label.ts` |
| `bugs/deterministic/unhandled-promise` | #283 | `tests/fixtures/sample-js-project-positive/src/unhandled-promise-eslint-disabled.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unhandled-promise-fire-and-forget.ts` |
| `code-quality/deterministic/expression-complexity` | #284 | `tests/fixtures/sample-js-project-positive/src/expression-complexity-function-rhs-and-jsx.tsx` | `tests/fixtures/sample-js-project-negative/shared/utils/src/expression-complexity-boolean-chain.ts` |
| `code-quality/deterministic/prefer-const` | #286 | `tests/fixtures/sample-js-project-positive/src/prefer-const-destructured-and-loop-header.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/prefer-const-simple-binding.ts` |

## code-quality/deterministic/duplicate-string

OSS source URLs from #281:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_internal+/[__htmltopdf]+/certificate.tsx#L300
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/signing/transports/google-cloud.ts#L11
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_unauthenticated+/organisation.sso.confirmation.$token.tsx#L32`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/app-tests/constants/field-alignment-pdf.ts#L84
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/api/v1/implementation.ts#L186

Positive fixture (`duplicate-string-kebab-tokens.ts`):

```ts
declare function readBlob(path: string, encoding: string): string;
declare function writeBlob(path: string, data: string, encoding: string): void;
declare function pingRegion(region: string): Promise<void>;

export function loadAll(paths: readonly string[]): readonly string[] {
  return [
    readBlob(paths[0], 'utf-8'),
    readBlob(paths[1], 'utf-8'),
    readBlob(paths[2], 'utf-8'),
  ];
}

export function saveAll(entries: ReadonlyArray<readonly [string, string]>): void {
  for (const [path, data] of entries) {
    writeBlob(path, data, 'utf-8');
  }
}

type Outcome = { kind: 'in-flight' | 'long-poll' | 'short-poll' };
declare function dispatch(kind: Outcome['kind']): void;

export function reportAll(): void {
  dispatch('in-flight');
  dispatch('in-flight');
  dispatch('in-flight');
}

export async function probeRegions(): Promise<void> {
  await pingRegion('us-east-1');
  await pingRegion('us-east-1');
  await pingRegion('us-east-1');
}
```

Negative fixture (`duplicate-string-sql-fragment.ts`):

```ts
declare function db(): { query(sql: string): Promise<unknown> };

// VIOLATION: code-quality/deterministic/duplicate-string
export function listActiveUsers(): Promise<unknown> {
  return db().query('SELECT id, email FROM users WHERE active = true');
}

export function countActiveUsers(): Promise<unknown> {
  return db().query('SELECT id, email FROM users WHERE active = true');
}

export function exportActiveUsers(): Promise<unknown> {
  return db().query('SELECT id, email FROM users WHERE active = true');
}
```

Visitor change: extended the exemption logic in three ways — (a) short kebab-case identifier tokens (`'utf-8'`, `'invalid-token'`, `'us-east-1'`) used as call/new arguments are exempted; (b) strings used as object literal property keys are exempted; (c) dotted-identifier strings (`'Envelope.id'`, `'User.email'`) — typically DB column or namespaced API references — are exempted. The visitor previously only exempted bare-identifier tokens.

## code-quality/deterministic/magic-string

OSS source URLs from #282:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/app-tests/e2e/fixtures/api-seeds.ts#L303
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/files/files.ts#L117
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/app-tests/constants/field-meta-pdf.ts#L259
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/document-flow/add-fields.tsx#L675
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/seal-document-sweep.handler.ts#L27`

Positive fixture (`magic-string-keys-and-dotted.ts`):

```ts
declare function post(
  url: string,
  opts: { headers: Record<string, string>; body: string },
): Promise<unknown>;

export async function sendBatch(): Promise<void> {
  await post('/route-a', { headers: { 'Content-Type': 'mime-alpha' }, body: '{}' });
  await post('/route-b', { headers: { 'Content-Type': 'mime-beta' }, body: '{}' });
  await post('/route-c', { headers: { 'Content-Type': 'mime-gamma' }, body: '{}' });
}

declare function selectCols(cols: readonly string[]): Promise<unknown>;

export async function readRows(): Promise<void> {
  await selectCols(['Account.id', 'Account.label']);
  await selectCols(['Account.id', 'Account.label']);
  await selectCols(['Account.id', 'Account.label']);
}
```

Negative fixture (`magic-string-value-label.ts`):

```ts
// VIOLATION: code-quality/deterministic/magic-string
// VIOLATION: code-quality/deterministic/duplicate-string
export function pickStatusLabel(status: number): string {
  if (status === 0) return 'Pending external verification step';
  if (status === 1) return 'Pending external verification step';
  return 'Pending external verification step';
}
```

Visitor change: applied the same three exemption rules as duplicate-string (kebab-case identifier tokens in call args, object property keys, dotted-identifier strings). Both rules share the same intent — flag extractable string literals — so the same FP shapes apply to both. Doing them together is necessary because positive fixtures for either rule trigger the other.

## bugs/deterministic/unhandled-promise

OSS source URL from #283 (the single FP; the other four samples are TPs per the issue's `why_fp`):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/entry.client.tsx#L49

Positive fixture (`unhandled-promise-eslint-disabled.ts`):

```ts
declare function bootstrap(): Promise<void>;

// eslint-disable-next-line @typescript-eslint/no-floating-promises
bootstrap();
```

Negative fixture (`unhandled-promise-fire-and-forget.ts`):

```ts
declare function flushQueue(): Promise<void>;

export function fireAndForget(): void {
  // VIOLATION: bugs/deterministic/unhandled-promise
  flushQueue();
}
```

Visitor change: honor an explicit `// eslint-disable-next-line @typescript-eslint/no-floating-promises` comment on the line above the statement. The author has acknowledged the floating promise (e.g. application entrypoints that intentionally fire-and-forget). The same fix was applied to `reliability/deterministic/floating-promise` and `bugs/deterministic/async-void-function`, which share the same suppression semantics — without that, the positive fixture would still fire those two rules and the test would fail.

## code-quality/deterministic/expression-complexity

OSS source URLs from #284:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/emails/send-signing-email.handler.ts#L30
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/ai-recipient-detection-dialog.tsx#L129
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/advanced-fields-validation/validate-text.ts#L3
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/forms/document-preferences-form.tsx#L96
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/components/document/document-share-button.tsx#L33

Positive fixture (`expression-complexity-function-rhs-and-jsx.tsx`):

```tsx
declare const flagA: boolean;
declare const flagB: boolean;
declare const flagC: boolean;
declare const flagD: boolean;
declare const flagE: boolean;
declare const flagF: boolean;
declare const flagG: boolean;

export const collectGateErrors = (input: number): readonly string[] => {
  const errors: string[] = [];
  if (input < 0 || input > 1000) errors.push('range');
  if (input === 0 && flagA && flagB) errors.push('zero');
  if (flagC || flagD || flagE) errors.push('flagged');
  return errors;
};

export function GateBanner(): JSX.Element {
  return (
    <div>
      {flagA && <span>a</span>}
      {flagB && <span>b</span>}
      {flagC && <span>c</span>}
      {flagD && <span>d</span>}
      {flagE && <span>e</span>}
      {flagF && <span>f</span>}
      {flagG && <span>g</span>}
    </div>
  );
}
```

Negative fixture (`expression-complexity-boolean-chain.ts`):

```ts
// VIOLATION: code-quality/deterministic/expression-complexity
export function evaluateGate(): boolean {
  return a > 0 && b < 10 && c === 0 && (d + e) * f > g && a + b + c + d > 100;
}
```

Visitor change: skip declarators / returns whose value is itself a function — the function body's operators are visited as their own statements, so counting them at the outer declarator double-counts and inflates the score past the threshold for reasons unrelated to the declarator itself. This is the dominant FP shape and the source of the -317 delta below. Also skip return statements whose value is a JSX element / fragment, since JSX naturally uses `&&` for conditional composition.

## code-quality/deterministic/prefer-const

OSS source URLs from #286:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/pdf/insert-field-in-pdf-v1.ts#L73
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/seal-document.handler.ts#L191
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/seal-document.handler.ts#L105
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/internal/seal-document.handler.ts#L192
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/signature-pad/helper.ts#L18

Positive fixture (`prefer-const-destructured-and-loop-header.ts`):

```ts
declare function getPageSize(): { width: number; height: number };
declare const isRotated: boolean;
declare const corpusLength: number;

export function swapDims(): readonly [number, number] {
  let { width, height } = getPageSize();
  if (isRotated) [width, height] = [height, width];
  return [width, height];
}

export async function loadPair(): Promise<readonly [string | null, string | null]> {
  let first: string | null = null;
  let second: string | null = null;
  [first, second] = await Promise.all([Promise.resolve('a'), Promise.resolve('b')]);
  return [first, second];
}

export function lastIndex(): number {
  let chosen = -1;
  for (let i = 0, max = corpusLength - 1; i < max; i++) {
    chosen = i;
  }
  return chosen;
}
```

Negative fixture (`prefer-const-simple-binding.ts`):

```ts
declare function compute(): number;

export function readOnce(): number {
  // VIOLATION: code-quality/deterministic/prefer-const
  let value = compute();
  return value * 2;
}
```

Visitor change: three fixes. (a) Skip `let` declared inside a `for` statement header — the `let i, max` loop-locals convention is idiomatic even when individual declarators (`max`) aren't reassigned. (b) Skip destructured `let` declarations (`let { a, b } = …`, `let [a, b] = …`) — the visitor's name-based reassignment check can't reliably distinguish individual destructured bindings. (c) Recognize destructured reassignment (`[a, b] = …`) as reassigning each binding within the pattern, so `let certificateDoc = null; [certificateDoc, auditLogDoc] = …` is no longer flagged.

## Skipped this batch

- #285 (`bugs/deterministic/async-void-function`) — FP no longer reproduces at `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f`. Resolved by the same fix made for #283 (single sample at `entry.client.tsx#L49` is the `main()` call, covered by the eslint-disable-next-line honor). Closed manually.

## FP-count delta (vs `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f` on `documenso/documenso`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/duplicate-string`       |   83 |   65 |  -18 |
| `code-quality/deterministic/magic-string`           |   69 |   51 |  -18 |
| `bugs/deterministic/unhandled-promise`              |    9 |    8 |   -1 |
| `code-quality/deterministic/expression-complexity`  |  362 |   45 | -317 |
| `code-quality/deterministic/prefer-const`           |    8 |    0 |   -8 |
| **Subtotal (these 5 rules)**                        |  531 |  169 | -362 |
| **All-rules total on target**                       | 50632 | 50268 | -364 |

(The remaining -2 in the all-rules total comes from `reliability/deterministic/floating-promise` (1 → 0) and `bugs/deterministic/async-void-function` (1 → 0), both side-effects of the eslint-disable honor added for #283.)

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcwAqHhZJD47rUueXnmQG2)_