### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/cyclomatic-complexity.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/cyclomatic-complexity.ts
@@ -14,21 +14,29 @@ export const cyclomaticComplexityVisitor: CodeRuleVisitor = {
     let complexity = 1
     const DECISION_TYPES = new Set(['if_statement', 'for_statement', 'for_in_statement', 'while_statement', 'do_statement', 'catch_clause', 'ternary_expression'])
 
-    function walk(n: SyntaxNode) {
+    function walk(n: SyntaxNode, inJsxExpr: boolean) {
       if (JS_FUNCTION_TYPES.includes(n.type) && n.id !== node.id) return
-      if (DECISION_TYPES.has(n.type)) complexity++
+      const childInJsxExpr = inJsxExpr || n.type === 'jsx_expression'
+      if (DECISION_TYPES.has(n.type)) {
+        // Conditional-rendering ternaries inside JSX expressions (`{x ? <A/> : <B/>}`)
+        // are presentation, not imperative branching — don't inflate complexity.
+        if (!(n.type === 'ternary_expression' && childInJsxExpr)) complexity++
+      }
       if (n.type === 'switch_case') complexity++
       if (n.type === 'binary_expression') {
         const op = n.children.find((c) => c.type === '&&' || c.type === '||')
-        if (op) complexity++
+        // Short-circuit operators inside a JSX expression (`{cond && <Foo/>}`,
+        // `{a ?? b}`) are the canonical conditional-render idiom; skip them
+        // the same way as the ternary above.
+        if (op && !childInJsxExpr) complexity++
       }
       for (let i = 0; i < n.childCount; i++) {
         const child = n.child(i)
-        if (child) walk(child)
+        if (child) walk(child, childInJsxExpr)
       }
     }
 
-    walk(bodyNode)
+    walk(bodyNode, false)
 
     if (complexity > 10) {
       const name = getFunctionName(node)

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/hardcoded-url.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/hardcoded-url.ts
@@ -39,6 +39,10 @@ export const hardcodedUrlVisitor: CodeRuleVisitor = {
     // Skip well-known stable third-party API domains — these are fixed endpoints, not environment-specific
     if (/googleapis\.com|maps\.google|api\.stripe\.com|api\.twilio\.com|api\.sendgrid\.com|api\.github\.com|cdn\.|fonts\.googleapis|cloudflare|unpkg\.com|cdnjs\.cloudflare|jsdelivr\.net/.test(text)) return null
 
+    // Skip OAuth/OIDC provider discovery endpoints — these `.well-known/*`
+    // paths are owned by the identity provider and have no env-specific form.
+    if (/\.well-known\/(openid-configuration|oauth-authorization-server|jwks(?:\.json)?)/.test(text)) return null
+
     // Skip URLs assigned to variables whose names suggest placeholder/example/default values
     if (parent?.type === 'variable_declarator' || parent?.type === 'assignment_expression' || parent?.type === 'pair') {
       const nameNode2 = parent.type === 'pair'

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/nested-template-literal.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/nested-template-literal.ts
@@ -7,6 +7,18 @@ export const nestedTemplateLiteralVisitor: CodeRuleVisitor = {
   languages: ['typescript', 'tsx', 'javascript'],
   nodeTypes: ['template_string'],
   visit(node, filePath, sourceCode) {
+    // Skip tagged templates whose tag is a known i18n / DSL identifier.
+    // For `msg`...``, `t`...``, `gql`...``, etc. the nested literal inside
+    // a substitution is a convention (formatting a value before it joins
+    // the translated/queried message), not a readability hazard.
+    const parent = node.parent
+    if (parent?.type === 'call_expression') {
+      const fn = parent.childForFieldName('function')
+      const tagName = fn?.type === 'identifier' ? fn.text : null
+      if (tagName && /^(msg|t|jt|defineMessage|plural|select|selectOrdinal|gql|css|html|sql|graphql)$/.test(tagName)) {
+        return null
+      }
+    }
     for (let i = 0; i < node.namedChildCount; i++) {
       const child = node.namedChild(i)
       if (child?.type === 'template_substitution') {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unnecessary-type-parameter.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unnecessary-type-parameter.ts
@@ -69,6 +69,17 @@ export const unnecessaryTypeParameterVisitor: CodeRuleVisitor = {
       const count = matches ? matches.length : 0
 
       if (count <= 1) {
+        // Skip when the type parameter is also referenced inside the function
+        // body (e.g. `useRef<T | null>`, callback params `(data: T) => ...`,
+        // type assertions `as T`, intermediate `const x: T = ...`). These body
+        // references make the parameter meaningful even when it appears only
+        // once in the surface signature.
+        const fnBody = node.childForFieldName('body')
+        if (fnBody) {
+          const bodyRegex = new RegExp(`\\b${paramName}\\b`)
+          if (bodyRegex.test(fnBody.text)) continue
+        }
+
         // Skip when the type parameter appears in both the return type AND
         // a type assertion (`as T`) in the function body — common pattern for
         // typed HTTP request methods like `request<T>(): Promise<T>`

--- a/packages/analyzer/src/rules/performance/visitors/javascript/missing-cleanup-useeffect.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/missing-cleanup-useeffect.ts
@@ -6,9 +6,16 @@ import { containsMethodCall } from './_helpers.js'
 const NEEDS_CLEANUP_METHODS = new Set(['addEventListener', 'setInterval', 'setTimeout'])
 
 function hasReturnStatement(body: SyntaxNode): boolean {
-  // Direct children of the statement_block that are return_statement
+  // Walk the callback body for any return_statement that belongs to it —
+  // skip into nested function/arrow bodies so their returns don't count
+  // as the useEffect cleanup. Returns inside `if` / `switch` / `try` are
+  // still legitimate cleanup paths and DO count.
   for (const child of body.namedChildren) {
     if (child.type === 'return_statement') return true
+    if (child.type === 'function' || child.type === 'arrow_function' || child.type === 'function_declaration' || child.type === 'method_definition' || child.type === 'generator_function' || child.type === 'generator_function_declaration') {
+      continue
+    }
+    if (hasReturnStatement(child)) return true
   }
   return false
 }

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -793,6 +793,18 @@
       "layer": "service"
     },
     {
+      "name": "describeUserRow",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "dispatchRoute",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "api"
+    },
+    {
       "name": "duplicate-string-error-message",
       "service": "utils",
       "kind": "standalone",
@@ -827,6 +839,12 @@
       "service": "utils",
       "kind": "standalone",
       "layer": "service"
+    },
+    {
+      "name": "fetchInvoiceReport",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "api"
     },
     {
       "name": "fireAndForget",
@@ -914,6 +932,12 @@
     },
     {
       "name": "loadRelated",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "logFirstField",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"
@@ -1334,6 +1358,12 @@
     },
     {
       "name": "UserForm",
+      "service": "web",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "WindowSizeWatcher",
       "service": "web",
       "kind": "standalone",
       "layer": "service"

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/MissingCleanupListener.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/MissingCleanupListener.tsx
@@ -1,0 +1,19 @@
+// True bug pattern: useEffect attaches a window event listener but
+// never returns a cleanup function. On each re-render or unmount, a
+// new listener is added and the old one leaks.
+
+import { useEffect, useState } from 'react';
+
+export function WindowSizeWatcher(): JSX.Element {
+  const [width, setWidth] = useState<number>(0);
+
+  // VIOLATION: performance/deterministic/missing-cleanup-useeffect
+  useEffect(() => {
+    const handleResize = (): void => {
+      setWidth(window.innerWidth);
+    };
+    window.addEventListener('resize', handleResize);
+  }, []);
+
+  return <span>{width}</span>;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/cyclomatic-complexity-deep-router.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/cyclomatic-complexity-deep-router.ts
@@ -1,0 +1,28 @@
+// True bug pattern: a single function makes many imperative branching
+// decisions on disjoint conditions. The decision graph is wide and
+// every path needs separate test coverage — the classic case for
+// extracting a lookup table or smaller helpers.
+
+type RouteRequest = {
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  path: string;
+  body?: unknown;
+  user?: { role?: string; id?: number };
+};
+
+// VIOLATION: code-quality/deterministic/cyclomatic-complexity
+export function dispatchRoute(req: RouteRequest): string {
+  if (req.method === 'GET' && req.path === '/health') return 'ok';
+  if (req.method === 'GET' && req.path === '/version') return 'v1';
+  if (req.method === 'GET' && req.path === '/metrics') return 'metrics';
+  if (req.method === 'POST' && req.path === '/login') return 'login';
+  if (req.method === 'POST' && req.path === '/logout') return 'logout';
+  if (req.method === 'POST' && req.path === '/register') return 'register';
+  if (req.method === 'PUT' && req.path === '/profile') return 'profile';
+  if (req.method === 'PUT' && req.path === '/password') return 'password';
+  if (req.method === 'DELETE' && req.path === '/account') return 'account';
+  if (req.method === 'GET' && req.path === '/orders') return 'orders';
+  if (req.method === 'POST' && req.path === '/orders') return 'create-order';
+  if (req.method === 'GET' && req.path === '/admin' && req.user?.role === 'admin') return 'admin';
+  return 'not-found';
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/hardcoded-url-service-endpoint.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/hardcoded-url-service-endpoint.ts
@@ -1,0 +1,10 @@
+// True bug pattern: an application service hardcodes its production
+// API base URL into source. This should be hoisted to an environment
+// variable so the same code can target staging, prod, or a local
+// instance without a redeploy.
+
+export async function fetchInvoiceReport(invoiceId: string): Promise<unknown> {
+  // VIOLATION: code-quality/deterministic/hardcoded-url
+  const response = await fetch(`https://reports.acme-internal.prod/v2/invoices/${invoiceId}`);
+  return response.json();
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/nested-template-literal-untagged-composition.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/nested-template-literal-untagged-composition.ts
@@ -1,0 +1,8 @@
+// True bug pattern: an untagged template literal embeds another
+// untagged template literal directly, hiding what's being composed.
+// The inner literal should be hoisted to a variable for readability.
+
+export function describeUserRow(name: string, id: number, role: string): string {
+  // VIOLATION: code-quality/deterministic/nested-template-literal
+  return `user=${`${name}#${id}`} role=${role}`;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-parameter-single-use.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-parameter-single-use.ts
@@ -1,0 +1,9 @@
+// True bug pattern: a generic type parameter appears exactly once in
+// the function signature, never in the body, and the return type
+// doesn't carry it. The parameter relates nothing — `unknown` or the
+// constraint type works just as well.
+
+// VIOLATION: code-quality/deterministic/unnecessary-type-parameter
+export function logFirstField<T>(record: { id: T }): void {
+  console.log('first field', String(record.id));
+}

--- a/tests/fixtures/sample-js-project-positive/src/cyclomatic-complexity-jsx-heavy.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/cyclomatic-complexity-jsx-heavy.tsx
@@ -1,0 +1,57 @@
+/**
+ * JSX-heavy form component. The function body itself has trivial
+ * control flow (a couple of state hooks and a single return), but the
+ * returned JSX uses many `&&` / `?:` operators for conditional
+ * rendering. Counting those as cyclomatic decision points inflates
+ * complexity to >10 even though the imperative branching is small.
+ */
+
+import { useState } from 'react';
+
+type LoginPanelProps = {
+  initialEmail?: string;
+  googleEnabled?: boolean;
+  microsoftEnabled?: boolean;
+  oidcEnabled?: boolean;
+  oidcLabel?: string;
+  showPasskey?: boolean;
+  showCaptcha?: boolean;
+  showTwoFactor?: boolean;
+  twoFactorMode?: 'totp' | 'backup';
+  bannerText?: string;
+};
+
+export function LoginPanel({
+  initialEmail,
+  googleEnabled,
+  microsoftEnabled,
+  oidcEnabled,
+  oidcLabel,
+  showPasskey,
+  showCaptcha,
+  showTwoFactor,
+  twoFactorMode,
+  bannerText,
+}: LoginPanelProps): JSX.Element {
+  const [email, setEmail] = useState<string>(initialEmail ?? '');
+  const [submitting, setSubmitting] = useState<boolean>(false);
+
+  return (
+    <form>
+      {bannerText && <div className="banner">{bannerText}</div>}
+      <input value={email} onChange={(e) => setEmail(e.target.value)} />
+      {googleEnabled && <button type="button">Google</button>}
+      {microsoftEnabled && <button type="button">Microsoft</button>}
+      {oidcEnabled && <button type="button">{oidcLabel ?? 'OIDC'}</button>}
+      {showPasskey && <button type="button">Passkey</button>}
+      {showCaptcha && <div className="captcha">captcha here</div>}
+      {showTwoFactor && twoFactorMode === 'totp' && <input placeholder="One-time code" />}
+      {showTwoFactor && twoFactorMode === 'backup' && <input placeholder="Backup code" />}
+      {!showTwoFactor && (
+        <button type="submit" disabled={submitting}>
+          {submitting ? 'Signing in' : 'Sign in'}
+        </button>
+      )}
+    </form>
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/src/hardcoded-url-oauth-well-known.ts
+++ b/tests/fixtures/sample-js-project-positive/src/hardcoded-url-oauth-well-known.ts
@@ -1,0 +1,33 @@
+/**
+ * OAuth/OIDC provider `.well-known/openid-configuration` URLs are
+ * standardized discovery endpoints published by the identity provider
+ * itself — there is no environment-specific form of these URLs.
+ * Flagging them as "should move to config/env" is a false positive
+ * because the provider, not the caller, owns the URL.
+ */
+
+type OAuthProviderConfig = {
+  id: string;
+  scope: string[];
+  clientId: string;
+  clientSecret: string;
+  wellKnownUrl: string;
+};
+
+declare function readSecret(key: string): string;
+
+export const googleProvider: OAuthProviderConfig = {
+  id: 'google',
+  scope: ['openid', 'email', 'profile'],
+  clientId: readSecret('GOOGLE_CLIENT_ID'),
+  clientSecret: readSecret('GOOGLE_CLIENT_SECRET'),
+  wellKnownUrl: 'https://accounts.google.com/.well-known/openid-configuration',
+};
+
+export const microsoftProvider: OAuthProviderConfig = {
+  id: 'microsoft',
+  scope: ['openid', 'email', 'profile'],
+  clientId: readSecret('MICROSOFT_CLIENT_ID'),
+  clientSecret: readSecret('MICROSOFT_CLIENT_SECRET'),
+  wellKnownUrl: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
+};

--- a/tests/fixtures/sample-js-project-positive/src/missing-cleanup-useeffect-conditional-return.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/missing-cleanup-useeffect-conditional-return.tsx
@@ -1,0 +1,30 @@
+/**
+ * useEffect that conditionally attaches an event listener and returns
+ * the matching cleanup from inside the same `if` block. The listener
+ * is correctly removed when the effect tears down — the cleanup just
+ * doesn't sit at the top of the callback body.
+ */
+
+import { useEffect } from 'react';
+
+declare function getFormContainer(): HTMLElement | null;
+declare function recordBlur(): void;
+
+export function AutoSaveOnBlur({ enabled }: { enabled: boolean }): null {
+  useEffect(() => {
+    const container = getFormContainer();
+
+    const handleBlur = (): void => {
+      recordBlur();
+    };
+
+    if (container && enabled) {
+      container.addEventListener('blur', handleBlur, true);
+      return () => {
+        container.removeEventListener('blur', handleBlur, true);
+      };
+    }
+  }, [enabled]);
+
+  return null;
+}

--- a/tests/fixtures/sample-js-project-positive/src/nested-template-literal-tagged-i18n.ts
+++ b/tests/fixtures/sample-js-project-positive/src/nested-template-literal-tagged-i18n.ts
@@ -1,0 +1,19 @@
+/**
+ * Nested template literals inside a tagged-template i18n message are
+ * library convention: the i18n tag (`t`, `msg`, `jt`, `plural`, ...)
+ * collects the static parts and substitutions into a translatable
+ * message ID, so callers commonly wrap an interpolated value in quotes
+ * or punctuation by nesting a plain template literal inside.
+ * The nested literal here is for formatting, not deep composition.
+ */
+
+declare function t(strings: TemplateStringsArray, ...values: unknown[]): string;
+declare function msg(strings: TemplateStringsArray, ...values: unknown[]): string;
+
+export function buildSigningSubject(title: string, actorVerb: string): string {
+  return t`You have initiated the document ${`"${title}"`} that requires you to ${actorVerb} it.`;
+}
+
+export function buildSigningHeader(title: string): string {
+  return msg`The document ${`"${title}"`} is ready for review.`;
+}

--- a/tests/fixtures/sample-js-project-positive/src/unnecessary-type-parameter-body-references.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unnecessary-type-parameter-body-references.ts
@@ -1,0 +1,39 @@
+/**
+ * Generic type parameter that appears only once in the signature
+ * (`saveFn: (data: T) => Promise<void>`) but is referenced multiple
+ * times *inside the function body* — as ref element types, callback
+ * parameters, and intermediate variables. Removing the parameter
+ * would force every body use back to `unknown`, so it is not
+ * unnecessary.
+ */
+
+declare function useRef<T>(initial: T): { current: T };
+declare function useState<S>(initial: S): [S, (next: S) => void];
+
+type BatcherHandle<T> = {
+  enqueue: (data: T) => void;
+  flush: () => Promise<void>;
+  pending: boolean;
+  delay: number;
+};
+
+export function buildBatcher<T>(saveFn: (data: T) => Promise<void>, delay = 1000): BatcherHandle<T> {
+  const lastArgsRef = useRef<T | null>(null);
+  const [pending, setPending] = useState<boolean>(false);
+
+  const enqueue = (data: T): void => {
+    lastArgsRef.current = data;
+    setPending(true);
+  };
+
+  const flush = async (): Promise<void> => {
+    const args: T | null = lastArgsRef.current;
+    if (args === null) {
+      return;
+    }
+    await saveFn(args);
+    setPending(false);
+  };
+
+  return { enqueue, flush, pending, delay };
+}


### PR DESCRIPTION
Closes #292
Closes #293
Closes #294
Closes #295
Closes #296

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/hardcoded-url` | #292 | `tests/fixtures/sample-js-project-positive/src/hardcoded-url-oauth-well-known.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/hardcoded-url-service-endpoint.ts` |
| `performance/deterministic/missing-cleanup-useeffect` | #293 | `tests/fixtures/sample-js-project-positive/src/missing-cleanup-useeffect-conditional-return.tsx` | `tests/fixtures/sample-js-project-negative/services/web/src/components/MissingCleanupListener.tsx` |
| `code-quality/deterministic/unnecessary-type-parameter` | #294 | `tests/fixtures/sample-js-project-positive/src/unnecessary-type-parameter-body-references.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-parameter-single-use.ts` |
| `code-quality/deterministic/nested-template-literal` | #295 | `tests/fixtures/sample-js-project-positive/src/nested-template-literal-tagged-i18n.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/nested-template-literal-untagged-composition.ts` |
| `code-quality/deterministic/cyclomatic-complexity` | #296 | `tests/fixtures/sample-js-project-positive/src/cyclomatic-complexity-jsx-heavy.tsx` | `tests/fixtures/sample-js-project-negative/shared/utils/src/cyclomatic-complexity-deep-router.ts` |

## code-quality/deterministic/hardcoded-url

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/api/hono.ts#L18
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/docs/src/app/docs/%5B%5B...slug%5D%5D/page.tsx#L35
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/templates/document-invite.tsx#L29
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/email/templates/confirm-team-email.tsx#L21
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/api/v1/openapi.ts#L14

Positive fixture (`tests/fixtures/sample-js-project-positive/src/hardcoded-url-oauth-well-known.ts`):

```ts
/**
 * OAuth/OIDC provider `.well-known/openid-configuration` URLs are
 * standardized discovery endpoints published by the identity provider
 * itself — there is no environment-specific form of these URLs.
 * Flagging them as "should move to config/env" is a false positive
 * because the provider, not the caller, owns the URL.
 */

type OAuthProviderConfig = {
  id: string;
  scope: string[];
  clientId: string;
  clientSecret: string;
  wellKnownUrl: string;
};

declare function readSecret(key: string): string;

export const googleProvider: OAuthProviderConfig = {
  id: 'google',
  scope: ['openid', 'email', 'profile'],
  clientId: readSecret('GOOGLE_CLIENT_ID'),
  clientSecret: readSecret('GOOGLE_CLIENT_SECRET'),
  wellKnownUrl: 'https://accounts.google.com/.well-known/openid-configuration',
};

export const microsoftProvider: OAuthProviderConfig = {
  id: 'microsoft',
  scope: ['openid', 'email', 'profile'],
  clientId: readSecret('MICROSOFT_CLIENT_ID'),
  clientSecret: readSecret('MICROSOFT_CLIENT_SECRET'),
  wellKnownUrl: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
};
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/hardcoded-url-service-endpoint.ts`):

```ts
// True bug pattern: an application service hardcodes its production
// API base URL into source. This should be hoisted to an environment
// variable so the same code can target staging, prod, or a local
// instance without a redeploy.

export async function fetchInvoiceReport(invoiceId: string): Promise<unknown> {
  // VIOLATION: code-quality/deterministic/hardcoded-url
  const response = await fetch(`https://reports.acme-internal.prod/v2/invoices/${invoiceId}`);
  return response.json();
}
```

Visitor change: add a skip for URLs whose path is a standardized OAuth/OIDC discovery endpoint (`.well-known/openid-configuration`, `oauth-authorization-server`, `jwks` / `jwks.json`). These endpoints are owned by the identity provider, not the caller, so there is no env-specific form of the URL to extract.

## performance/deterministic/missing-cleanup-useeffect

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/document-flow/add-subject.tsx#L134

Positive fixture (`tests/fixtures/sample-js-project-positive/src/missing-cleanup-useeffect-conditional-return.tsx`):

```tsx
/**
 * useEffect that conditionally attaches an event listener and returns
 * the matching cleanup from inside the same `if` block. The listener
 * is correctly removed when the effect tears down — the cleanup just
 * doesn't sit at the top of the callback body.
 */

import { useEffect } from 'react';

declare function getFormContainer(): HTMLElement | null;
declare function recordBlur(): void;

export function AutoSaveOnBlur({ enabled }: { enabled: boolean }): null {
  useEffect(() => {
    const container = getFormContainer();

    const handleBlur = (): void => {
      recordBlur();
    };

    if (container && enabled) {
      container.addEventListener('blur', handleBlur, true);
      return () => {
        container.removeEventListener('blur', handleBlur, true);
      };
    }
  }, [enabled]);

  return null;
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/web/src/components/MissingCleanupListener.tsx`):

```tsx
// True bug pattern: useEffect attaches a window event listener but
// never returns a cleanup function. On each re-render or unmount, a
// new listener is added and the old one leaks.

import { useEffect, useState } from 'react';

export function WindowSizeWatcher(): JSX.Element {
  const [width, setWidth] = useState<number>(0);

  // VIOLATION: performance/deterministic/missing-cleanup-useeffect
  useEffect(() => {
    const handleResize = (): void => {
      setWidth(window.innerWidth);
    };
    window.addEventListener('resize', handleResize);
  }, []);

  return <span>{width}</span>;
}
```

Visitor change: `hasReturnStatement` only inspected direct children of the effect callback's `statement_block`, so a cleanup `return () => ...` placed inside `if (container) { ... }` was missed. Recurse into nested blocks (`if`, `switch`, `try`), but explicitly skip nested function / arrow / method bodies so a `return` from an inner function isn't mistaken for the cleanup.

## code-quality/deterministic/unnecessary-type-parameter

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/utils/render-custom-email-template.ts#L1
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/utils/zod-form-data.ts#L32
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/hooks/use-envelope-autosave.ts#L3
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/utils/recipients.ts#L101
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/hooks/use-autosave.ts#L8

Positive fixture (`tests/fixtures/sample-js-project-positive/src/unnecessary-type-parameter-body-references.ts`):

```ts
/**
 * Generic type parameter that appears only once in the signature
 * (`saveFn: (data: T) => Promise<void>`) but is referenced multiple
 * times *inside the function body* — as ref element types, callback
 * parameters, and intermediate variables. Removing the parameter
 * would force every body use back to `unknown`, so it is not
 * unnecessary.
 */

declare function useRef<T>(initial: T): { current: T };
declare function useState<S>(initial: S): [S, (next: S) => void];

type BatcherHandle<T> = {
  enqueue: (data: T) => void;
  flush: () => Promise<void>;
  pending: boolean;
  delay: number;
};

export function buildBatcher<T>(saveFn: (data: T) => Promise<void>, delay = 1000): BatcherHandle<T> {
  const lastArgsRef = useRef<T | null>(null);
  const [pending, setPending] = useState<boolean>(false);

  const enqueue = (data: T): void => {
    lastArgsRef.current = data;
    setPending(true);
  };

  const flush = async (): Promise<void> => {
    const args: T | null = lastArgsRef.current;
    if (args === null) {
      return;
    }
    await saveFn(args);
    setPending(false);
  };

  return { enqueue, flush, pending, delay };
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/unnecessary-type-parameter-single-use.ts`):

```ts
// True bug pattern: a generic type parameter appears exactly once in
// the function signature, never in the body, and the return type
// doesn't carry it. The parameter relates nothing — `unknown` or the
// constraint type works just as well.

// VIOLATION: code-quality/deterministic/unnecessary-type-parameter
export function logFirstField<T>(record: { id: T }): void {
  console.log('first field', String(record.id));
}
```

Visitor change: the single-occurrence count only considered the function signature (`params + returnType`), so generics that were threaded through the body — `useRef<T | null>`, `(data: T) => ...` callback params, intermediate `const x: T = ...`, type assertions `as T` — were treated as unused. Add a body-text check: if the type parameter name also appears anywhere in the function body, continue the loop instead of flagging.

## code-quality/deterministic/nested-template-literal

OSS sources:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/emails/send-signing-email.handler.ts#L112
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/pdf/render-audit-logs.ts#L622
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/document-flow/field-items-advanced-settings/dropdown-field.tsx#L109`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/pdf/render-certificate.ts#L806
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/recipient-branding.tsx#L58

Positive fixture (`tests/fixtures/sample-js-project-positive/src/nested-template-literal-tagged-i18n.ts`):

```ts
/**
 * Nested template literals inside a tagged-template i18n message are
 * library convention: the i18n tag (`t`, `msg`, `jt`, `plural`, ...)
 * collects the static parts and substitutions into a translatable
 * message ID, so callers commonly wrap an interpolated value in quotes
 * or punctuation by nesting a plain template literal inside.
 * The nested literal here is for formatting, not deep composition.
 */

declare function t(strings: TemplateStringsArray, ...values: unknown[]): string;
declare function msg(strings: TemplateStringsArray, ...values: unknown[]): string;

export function buildSigningSubject(title: string, actorVerb: string): string {
  return t`You have initiated the document ${`"${title}"`} that requires you to ${actorVerb} it.`;
}

export function buildSigningHeader(title: string): string {
  return msg`The document ${`"${title}"`} is ready for review.`;
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/nested-template-literal-untagged-composition.ts`):

```ts
// True bug pattern: an untagged template literal embeds another
// untagged template literal directly, hiding what's being composed.
// The inner literal should be hoisted to a variable for readability.

export function describeUserRow(name: string, id: number, role: string): string {
  // VIOLATION: code-quality/deterministic/nested-template-literal
  return `user=${`${name}#${id}`} role=${role}`;
}
```

Visitor change: skip the rule when the outer `template_string` is the argument to a tagged-template call whose tag is a recognized i18n or embedded-DSL identifier (`msg`, `t`, `jt`, `defineMessage`, `plural`, `select`, `selectOrdinal`, `gql` / `graphql`, `css`, `html`, `sql`). Wrapping a substituted value in formatting characters via a nested template literal is the canonical idiom for these tags — they collect their static parts into a message/query ID and let callers format values inline.

## code-quality/deterministic/cyclomatic-complexity

OSS sources:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/enterprise-router/update-organisation-authentication-portal.ts#L18`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/jobs/definitions/emails/send-signing-email.handler.ts#L30
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_recipient+/sign.%24token+/_index.tsx#L45
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/forms/signin.tsx#L68
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/field/sign-field-with-token.ts#L50

Positive fixture (`tests/fixtures/sample-js-project-positive/src/cyclomatic-complexity-jsx-heavy.tsx`):

```tsx
/**
 * JSX-heavy form component. The function body itself has trivial
 * control flow (a couple of state hooks and a single return), but the
 * returned JSX uses many `&&` / `?:` operators for conditional
 * rendering. Counting those as cyclomatic decision points inflates
 * complexity to >10 even though the imperative branching is small.
 */

import { useState } from 'react';

type LoginPanelProps = {
  initialEmail?: string;
  googleEnabled?: boolean;
  microsoftEnabled?: boolean;
  oidcEnabled?: boolean;
  oidcLabel?: string;
  showPasskey?: boolean;
  showCaptcha?: boolean;
  showTwoFactor?: boolean;
  twoFactorMode?: 'totp' | 'backup';
  bannerText?: string;
};

export function LoginPanel({ /* ...props... */ }: LoginPanelProps): JSX.Element {
  // ... two useState hooks ...
  return (
    <form>
      {bannerText && <div className="banner">{bannerText}</div>}
      {googleEnabled && <button type="button">Google</button>}
      {microsoftEnabled && <button type="button">Microsoft</button>}
      {oidcEnabled && <button type="button">{oidcLabel ?? 'OIDC'}</button>}
      {showPasskey && <button type="button">Passkey</button>}
      {showCaptcha && <div className="captcha">captcha here</div>}
      {showTwoFactor && twoFactorMode === 'totp' && <input placeholder="One-time code" />}
      {showTwoFactor && twoFactorMode === 'backup' && <input placeholder="Backup code" />}
      {!showTwoFactor && (
        <button type="submit" disabled={submitting}>
          {submitting ? 'Signing in' : 'Sign in'}
        </button>
      )}
    </form>
  );
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/cyclomatic-complexity-deep-router.ts`):

```ts
// True bug pattern: a single function makes many imperative branching
// decisions on disjoint conditions. The decision graph is wide and
// every path needs separate test coverage — the classic case for
// extracting a lookup table or smaller helpers.

// VIOLATION: code-quality/deterministic/cyclomatic-complexity
export function dispatchRoute(req: RouteRequest): string {
  if (req.method === 'GET' && req.path === '/health') return 'ok';
  if (req.method === 'GET' && req.path === '/version') return 'v1';
  if (req.method === 'GET' && req.path === '/metrics') return 'metrics';
  if (req.method === 'POST' && req.path === '/login') return 'login';
  // ... 9 more disjoint method+path branches ...
  return 'not-found';
}
```

Visitor change: thread an `inJsxExpr` flag through the AST walk. When a `binary_expression` whose operator is `&&` / `||` — or a `ternary_expression` — sits inside a `jsx_expression`, don't increment complexity. These are the canonical conditional-render idioms (`{cond && <Foo/>}`, `{cond ? <A/> : <B/>}`) and they're presentation, not imperative branching. Statements (`if` / `for` / `while` / `catch`) are still counted everywhere, including inside JSX expressions, since they remain real control flow.

## FP-count delta (vs `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f` on `documenso/documenso`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/hardcoded-url` | 43 | 40 | -3 |
| `performance/deterministic/missing-cleanup-useeffect` | 1 | 0 | -1 |
| `code-quality/deterministic/unnecessary-type-parameter` | 8 | 5 | -3 |
| `code-quality/deterministic/nested-template-literal` | 16 | 13 | -3 |
| `code-quality/deterministic/cyclomatic-complexity` | 137 | 94 | -43 |
| **Total (these 5 rules)** | 205 | 152 | -53 |
| **All-rules total on target** | 9784 | 9731 | -53 |

Measured by running `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a fresh `pnpm build:dist` (the exact artifact `publish.yml` ships to npm) against `documenso/documenso` at the ref above.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2Ujhw6MfvAgcGzVq2tqEM)_