### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/await-in-loop.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/await-in-loop.ts
@@ -38,6 +38,117 @@ function containsOptionalChain(node: SyntaxNode): boolean {
   return false
 }
 
+// Walk up from `loopNode` looking for an enclosing arrow/function-expression
+// that is the callback argument of a `.$transaction(...)` / `.transaction(...)`
+// call. Prisma (and most ORMs) require all queries inside a transaction
+// callback to run sequentially against the same connection — parallelising
+// them via `Promise.all` is a bug, not a perf win.
+function isInsideTransactionCallback(loopNode: SyntaxNode): boolean {
+  let cur: SyntaxNode | null = loopNode.parent
+  while (cur) {
+    if (cur.type === 'arrow_function' || cur.type === 'function_expression') {
+      const parent = cur.parent
+      if (parent?.type === 'arguments') {
+        const callExpr = parent.parent
+        if (callExpr?.type === 'call_expression') {
+          const fn = callExpr.childForFieldName('function')
+          if (fn?.type === 'member_expression') {
+            const prop = fn.childForFieldName('property')
+            if (prop?.text === '$transaction' || prop?.text === 'transaction') return true
+          }
+        }
+      }
+    }
+    if (cur.type === 'function_declaration' || cur.type === 'method_definition') return false
+    cur = cur.parent
+  }
+  return false
+}
+
+// Iterator-protocol reads (`stream.read()`, `iter.next()`) are inherently
+// sequential — each call depends on the underlying iterator's position
+// after the previous call. There's no parallel form.
+function isIteratorProtocolAwait(awaitNode: SyntaxNode): boolean {
+  const call = awaitNode.namedChildren[0]
+  if (!call || call.type !== 'call_expression') return false
+  const fn = call.childForFieldName('function')
+  if (fn?.type !== 'member_expression') return false
+  const prop = fn.childForFieldName('property')
+  return prop?.text === 'read' || prop?.text === 'next'
+}
+
+// True if the awaited result is bound to a `const`/`let` declarator and an
+// `if (… <binding> …) { return | break | throw }` appears later in the same
+// loop body. This is a "search until found" loop where parallelisation
+// would speculatively waste work on iterations that early-exit would skip.
+function isAwaitUsedInEarlyExit(awaitNode: SyntaxNode, loopNode: SyntaxNode): boolean {
+  let parent: SyntaxNode | null = awaitNode.parent
+  let bindingName: string | null = null
+  while (parent && parent !== loopNode) {
+    if (parent.type === 'variable_declarator') {
+      const name = parent.childForFieldName('name')
+      if (name?.type === 'identifier') bindingName = name.text
+      break
+    }
+    parent = parent.parent
+  }
+  if (!bindingName) return false
+
+  let found = false
+  function walk(n: SyntaxNode): void {
+    if (found) return
+    if (n.type === 'if_statement') {
+      const cond = n.childForFieldName('condition')
+      const consequence = n.childForFieldName('consequence')
+      if (cond && consequence && referencesIdentifier(cond, bindingName!) && containsTerminator(consequence)) {
+        found = true
+        return
+      }
+    }
+    if (
+      n !== loopNode &&
+      (n.type === 'function_declaration' ||
+        n.type === 'function_expression' ||
+        n.type === 'arrow_function' ||
+        n.type === 'method_definition')
+    ) return
+    for (let i = 0; i < n.childCount; i++) {
+      const ch = n.child(i)
+      if (ch) walk(ch)
+    }
+  }
+  walk(loopNode)
+  return found
+}
+
+function referencesIdentifier(node: SyntaxNode, name: string): boolean {
+  if (node.type === 'identifier' && node.text === name) return true
+  for (let i = 0; i < node.childCount; i++) {
+    const ch = node.child(i)
+    if (ch && referencesIdentifier(ch, name)) return true
+  }
+  return false
+}
+
+function containsTerminator(node: SyntaxNode): boolean {
+  if (
+    node.type === 'return_statement' ||
+    node.type === 'break_statement' ||
+    node.type === 'throw_statement'
+  ) return true
+  if (
+    node.type === 'function_declaration' ||
+    node.type === 'function_expression' ||
+    node.type === 'arrow_function' ||
+    node.type === 'method_definition'
+  ) return false
+  for (let i = 0; i < node.childCount; i++) {
+    const ch = node.child(i)
+    if (ch && containsTerminator(ch)) return true
+  }
+  return false
+}
+
 export const awaitInLoopVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/await-in-loop',
   languages: JS_LANGUAGES,
@@ -51,6 +162,9 @@ export const awaitInLoopVisitor: CodeRuleVisitor = {
       const t = current.type
       if (t === 'for_statement' || t === 'for_in_statement' || t === 'while_statement' || t === 'do_statement') {
         if (isSerialChainWalk(current)) return null
+        if (isInsideTransactionCallback(current)) return null
+        if (isIteratorProtocolAwait(node)) return null
+        if (isAwaitUsedInEarlyExit(node, current)) return null
         // Make sure we're in the loop body (not the initializer/condition of a for loop)
         // and not inside a nested async function
         return makeViolation(

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/function-return-type-varies.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/function-return-type-varies.ts
@@ -20,6 +20,25 @@ function normalizeType(typeStr: string): string {
   return typeStr
 }
 
+/**
+ * Peel `expr as const`, `expr satisfies T`, `<T>expr`, and `(expr)` wrappers
+ * so callers can inspect the underlying expression (e.g. an object literal).
+ */
+function unwrapTypeAssertions(node: SyntaxNode): SyntaxNode {
+  let cur: SyntaxNode = node
+  while (
+    cur.type === 'as_expression' ||
+    cur.type === 'satisfies_expression' ||
+    cur.type === 'type_assertion' ||
+    cur.type === 'parenthesized_expression'
+  ) {
+    const inner = cur.namedChildren[0]
+    if (!inner) break
+    cur = inner
+  }
+  return cur
+}
+
 function collectReturnStatements(node: SyntaxNode): SyntaxNode[] {
   const returns: SyntaxNode[] = []
   function walk(n: SyntaxNode) {
@@ -106,15 +125,20 @@ export const functionReturnTypeVariesVisitor: CodeRuleVisitor = {
     }
     if (allReturnsAreCallsToSameFunction && returnCallNames.size === 1) return null
 
-    // Skip when all return expressions are object literals with the same set of keys
-    // (discriminated unions like {isNew: true} vs {isNew: false} are consistent shapes)
-    const allObjectLiterals = returnStmts.every(ret => {
-      const value = ret.namedChildren[0]
-      return value && value.type === 'object'
+    // Skip when all return expressions are object literals (possibly wrapped in
+    // `as const` / `satisfies T` / a type assertion / parens) with either:
+    //   - the same set of keys (e.g. `{isNew: true}` vs `{isNew: false}`)
+    //   - a shared discriminator key whose value is a literal in every return
+    //     (e.g. `{state: 'A', x}` vs `{state: 'B', y}` — TypeScript-style
+    //     discriminated union, by design has different payload keys per arm)
+    const objectLiterals = returnStmts.map(ret => {
+      const raw = ret.namedChildren[0]
+      return raw ? unwrapTypeAssertions(raw) : null
     })
+    const allObjectLiterals = objectLiterals.every(v => v !== null && v.type === 'object')
     if (allObjectLiterals && returnStmts.length >= 2) {
-      const keySets = returnStmts.map(ret => {
-        const value = ret.namedChildren[0]!
+      const objects = objectLiterals as SyntaxNode[]
+      const keySets = objects.map(value => {
         const keys: string[] = []
         for (let i = 0; i < value.namedChildCount; i++) {
           const prop = value.namedChild(i)
@@ -131,6 +155,32 @@ export const functionReturnTypeVariesVisitor: CodeRuleVisitor = {
       })
       const allSameKeys = keySets.every(k => k === keySets[0])
       if (allSameKeys) return null
+
+      // Discriminated-union check: collect property keys whose value is a primitive
+      // literal (string/number/boolean) in each return. If at least one such key
+      // is present in every return, that's the discriminator and the union is
+      // narrowable at call sites.
+      const literalKeysPerReturn = objects.map(value => {
+        const keys = new Set<string>()
+        for (let i = 0; i < value.namedChildCount; i++) {
+          const prop = value.namedChild(i)
+          if (prop?.type !== 'pair') continue
+          const key = prop.childForFieldName('key')
+          const val = prop.childForFieldName('value')
+          if (!key || !val) continue
+          if (val.type === 'string' || val.type === 'number' ||
+              val.type === 'true' || val.type === 'false') {
+            keys.add(key.text)
+          }
+        }
+        return keys
+      })
+      if (literalKeysPerReturn.every(s => s.size > 0)) {
+        const common = [...literalKeysPerReturn[0]].filter(k =>
+          literalKeysPerReturn.every(s => s.has(k)),
+        )
+        if (common.length > 0) return null
+      }
     }
 
     // Normalize void-like return types: void, Promise<void>, and undefined are semantically equivalent

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/prototype-pollution.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/prototype-pollution.ts
@@ -28,9 +28,23 @@ export const prototypePollutionVisitor: CodeRuleVisitor = {
       if (objProp?.text === 'current') return null
     }
 
+    // Resolve `const typedKey = key (as T)?` chains so checks downstream see
+    // the underlying iteration / counter / param name. Example:
+    //   for (const key in obj) {
+    //     const typedKey = key as keyof Foo
+    //     out[typedKey] = ...        // ← `typedKey` resolves to `key`
+    //   }
+    const originalKeyName = index.text
+    const keyName = resolveKeyAliasChain(node, originalKeyName)
+
+    // Skip when the key is a module-level (or any scope) const declared with a
+    // primitive string-literal initializer — those values can never be
+    // `"__proto__"` etc. unless the developer literally wrote that string.
+    if (isKeyStringLiteralConst(node, keyName)) return null
+    if (originalKeyName !== keyName && isKeyStringLiteralConst(node, originalKeyName)) return null
+
     // Skip when the key comes from Object.entries(), Object.keys(), or for...in over a local object.
     // These iterate controlled mapping objects, not user input.
-    const keyName = index.text
     if (isKeyFromControlledIteration(node, keyName)) return null
 
     // Skip when the key was computed from a local helper call in the same
@@ -82,6 +96,109 @@ export const prototypePollutionVisitor: CodeRuleVisitor = {
       `Validate that \`${index.text}\` is not "__proto__", "constructor", or "prototype" before assignment, or use Map instead.`,
     )
   },
+}
+
+/**
+ * Walk `const newName = oldName (as T)?` chains and return the deepest
+ * underlying identifier. So `const typedKey = key as keyof Foo` resolves
+ * `typedKey` back to `key`, letting the rest of the visitor's heuristics
+ * recognise that the alias is bound to a controlled iteration variable.
+ */
+function resolveKeyAliasChain(assignmentNode: SyntaxNode, keyName: string): string {
+  let scope: SyntaxNode | null = assignmentNode.parent
+  while (scope) {
+    if (
+      scope.type === 'function_declaration' ||
+      scope.type === 'function_expression' ||
+      scope.type === 'arrow_function' ||
+      scope.type === 'method_definition' ||
+      scope.type === 'program'
+    ) break
+    scope = scope.parent
+  }
+  if (!scope) return keyName
+
+  const visited = new Set<string>()
+  let current = keyName
+  while (!visited.has(current)) {
+    visited.add(current)
+    const next = findAliasTarget(scope, current)
+    if (!next || next === current) break
+    current = next
+  }
+  return current
+}
+
+function findAliasTarget(scope: SyntaxNode, keyName: string): string | null {
+  let target: string | null = null
+  function walk(n: SyntaxNode): void {
+    if (target !== null) return
+    if (n.type === 'variable_declarator') {
+      const name = n.childForFieldName('name')
+      const value = n.childForFieldName('value')
+      if (name?.type === 'identifier' && name.text === keyName && value) {
+        let inner: SyntaxNode | null = value
+        while (
+          inner &&
+          (inner.type === 'as_expression' ||
+            inner.type === 'type_assertion' ||
+            inner.type === 'parenthesized_expression' ||
+            inner.type === 'satisfies_expression' ||
+            inner.type === 'non_null_expression')
+        ) {
+          inner = inner.namedChildren[0] ?? null
+        }
+        if (inner?.type === 'identifier') {
+          target = inner.text
+          return
+        }
+      }
+    }
+    if (
+      n !== scope &&
+      (n.type === 'function_declaration' ||
+        n.type === 'function_expression' ||
+        n.type === 'arrow_function' ||
+        n.type === 'method_definition')
+    ) return
+    for (let i = 0; i < n.childCount; i++) {
+      const ch = n.child(i)
+      if (ch) walk(ch)
+    }
+  }
+  walk(scope)
+  return target
+}
+
+/**
+ * True if `keyName` is declared anywhere in the file as a `const` (or
+ * `let`/`var`) initialised directly from a primitive string literal. The
+ * value cannot become `"__proto__"`/`"constructor"`/`"prototype"` unless the
+ * developer literally wrote that string in the declarator, which is not the
+ * shape this rule is intended to catch.
+ */
+function isKeyStringLiteralConst(assignmentNode: SyntaxNode, keyName: string): boolean {
+  let root: SyntaxNode = assignmentNode
+  while (root.parent) root = root.parent
+
+  let found = false
+  function walk(n: SyntaxNode): void {
+    if (found) return
+    if (n.type === 'variable_declarator') {
+      const name = n.childForFieldName('name')
+      const value = n.childForFieldName('value')
+      if (name?.type === 'identifier' && name.text === keyName && value?.type === 'string') {
+        found = true
+        return
+      }
+    }
+    for (let i = 0; i < n.childCount; i++) {
+      const ch = n.child(i)
+      if (ch) walk(ch)
+    }
+  }
+  walk(root)
+  return found
 }
 
 /**

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/for-in-without-filter.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/for-in-without-filter.ts
@@ -13,6 +13,16 @@ export const forInWithoutFilterVisitor: CodeRuleVisitor = {
     const body = node.childForFieldName('body')
     if (!body) return null
 
+    // Skip when the iterable is a binding with an explicit TypeScript type
+    // annotation (a function parameter typed `Partial<X>` / `Record<K, V>` /
+    // mapped type / interface, or a `const … : T = …` declarator). The author
+    // has constrained the shape via the type system, so the `for…in` is
+    // iterating a known-keys object rather than untrusted data.
+    const right = node.childForFieldName('right')
+    if (right?.type === 'identifier' && isIdentifierTypedAnnotation(node, right.text)) {
+      return null
+    }
+
     function hasOwnPropertyCheck(n: SyntaxNode): boolean {
       if (n.type === 'call_expression') {
         const fn = n.childForFieldName('function')
@@ -40,4 +50,91 @@ export const forInWithoutFilterVisitor: CodeRuleVisitor = {
     }
     return null
   },
+}
+
+/**
+ * True when `name` is declared in any enclosing scope as either a function
+ * parameter or a `const`/`let`/`var` declarator with a TS type annotation
+ * that constrains the key set — i.e. NOT `Record<string, …>`, `Map<string,
+ * …>`, `{[k: string]: …}`, `any`, `unknown`, or `object`. A constrained
+ * type means the keys are drawn from a finite set known at compile time, so
+ * iterating with `for…in` cannot pick up inherited keys the author didn't
+ * anticipate.
+ */
+function isIdentifierTypedAnnotation(node: SyntaxNode, name: string): boolean {
+  let scope: SyntaxNode | null = node.parent
+  while (scope) {
+    if (
+      scope.type === 'function_declaration' ||
+      scope.type === 'function_expression' ||
+      scope.type === 'arrow_function' ||
+      scope.type === 'method_definition'
+    ) {
+      const params = scope.childForFieldName('parameters') ?? scope.childForFieldName('parameter')
+      if (params && paramHasConstrainingType(params, name)) return true
+    }
+    if (scopeHasConstrainingLocal(scope, name)) return true
+    if (scope.type === 'program') break
+    scope = scope.parent
+  }
+  return false
+}
+
+function paramHasConstrainingType(params: SyntaxNode, name: string): boolean {
+  for (let i = 0; i < params.namedChildCount; i++) {
+    const param = params.namedChild(i)
+    if (!param) continue
+    if (param.type === 'required_parameter' || param.type === 'optional_parameter') {
+      const pattern = param.childForFieldName('pattern') ?? param.namedChildren[0]
+      const typeAnn = param.childForFieldName('type')
+      if (pattern?.type === 'identifier' && pattern.text === name && typeAnn) {
+        if (isConstrainingTypeText(typeAnn.text)) return true
+      }
+    }
+  }
+  return false
+}
+
+function scopeHasConstrainingLocal(scope: SyntaxNode, name: string): boolean {
+  let found = false
+  function walk(n: SyntaxNode): void {
+    if (found) return
+    if (n.type === 'variable_declarator') {
+      const declName = n.childForFieldName('name')
+      const typeAnn = n.childForFieldName('type')
+      if (declName?.type === 'identifier' && declName.text === name && typeAnn) {
+        if (isConstrainingTypeText(typeAnn.text)) {
+          found = true
+          return
+        }
+      }
+    }
+    if (
+      n !== scope &&
+      (n.type === 'function_declaration' ||
+        n.type === 'function_expression' ||
+        n.type === 'arrow_function' ||
+        n.type === 'method_definition')
+    ) return
+    for (let i = 0; i < n.childCount; i++) {
+      const ch = n.child(i)
+      if (ch) walk(ch)
+    }
+  }
+  walk(scope)
+  return found
+}
+
+function isConstrainingTypeText(text: string): boolean {
+  // `text` includes the leading colon from the field — strip it.
+  const t = text.replace(/^\s*:\s*/, '').trim()
+  // Untyped escape hatches.
+  if (/\b(any|unknown)\b/.test(t)) return false
+  if (t === 'object' || t === 'Object' || t === '{}') return false
+  // Unbounded string-keyed records / maps.
+  if (/\bRecord\s*<\s*string\b/.test(t)) return false
+  if (/\b(Map|WeakMap)\s*<\s*string\b/.test(t)) return false
+  // `{[k: string]: …}` index signature.
+  if (/\[\s*\w+\s*:\s*string\s*\]\s*:/.test(t)) return false
+  return true
 }

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/catch-without-error-type.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/catch-without-error-type.ts
@@ -1,4 +1,5 @@
 import type { CodeRuleVisitor } from '../../../types.js'
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import { makeViolation } from '../../../types.js'
 
 export const catchWithoutErrorTypeVisitor: CodeRuleVisitor = {
@@ -34,6 +35,14 @@ export const catchWithoutErrorTypeVisitor: CodeRuleVisitor = {
     )
     if (stmts.length <= 1) return null
 
+    // Skip uniform handlers: multi-statement bodies that contain no `if`
+    // / `switch` / ternary branching. UI error handlers in particular
+    // (`console.error(err); toast(...); throw err;`) handle every error
+    // the same way — log, surface a generic user message, optionally
+    // rethrow. No type discrimination would change behaviour, so flagging
+    // them is noise.
+    if (!hasBranchingConstruct(body)) return null
+
     return makeViolation(
       this.ruleKey, node, filePath, 'medium',
       'Catch without error type discrimination',
@@ -42,4 +51,23 @@ export const catchWithoutErrorTypeVisitor: CodeRuleVisitor = {
       'Use instanceof checks or type guards in the catch block to handle specific error types.',
     )
   },
+}
+
+function hasBranchingConstruct(node: SyntaxNode): boolean {
+  if (
+    node.type === 'if_statement' ||
+    node.type === 'switch_statement' ||
+    node.type === 'ternary_expression'
+  ) return true
+  if (
+    node.type === 'function_declaration' ||
+    node.type === 'function_expression' ||
+    node.type === 'arrow_function' ||
+    node.type === 'method_definition'
+  ) return false
+  for (let i = 0; i < node.childCount; i++) {
+    const ch = node.child(i)
+    if (ch && hasBranchingConstruct(ch)) return true
+  }
+  return false
 }

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -685,6 +685,12 @@
       "layer": "service"
     },
     {
+      "name": "classify",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "classifyRequest",
       "service": "utils",
       "kind": "standalone",
@@ -803,6 +809,12 @@
       "service": "utils",
       "kind": "standalone",
       "layer": "api"
+    },
+    {
+      "name": "dumpKeys",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
     },
     {
       "name": "duplicate-string-error-message",
@@ -1045,6 +1057,12 @@
       "layer": "service"
     },
     {
+      "name": "readWithFallback",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "ReassignableClass",
       "service": "utils",
       "kind": "class",
@@ -1129,6 +1147,12 @@
       "layer": "service"
     },
     {
+      "name": "setEntry",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "SetterNoReturn",
       "service": "utils",
       "kind": "class",
@@ -1166,6 +1190,12 @@
     },
     {
       "name": "todoHandler",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "totalSummaryBytes",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/await-in-loop-parallel-safe-fanout.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/await-in-loop-parallel-safe-fanout.ts
@@ -1,0 +1,22 @@
+/**
+ * Paraphrased true-bug for bugs/deterministic/await-in-loop.
+ *
+ * The loop awaits an independent network fetch per id and collects the
+ * sizes into an array. Iterations have no shared state, no early exit, no
+ * iterator-protocol dependency, and no transaction context — the canonical
+ * "use Promise.all" case.
+ */
+
+async function fetchUserSummary(id: string): Promise<{ id: string; bytes: number }> {
+  return { id, bytes: id.length * 2 };
+}
+
+export async function totalSummaryBytes(ids: readonly string[]): Promise<number> {
+  const sizes: number[] = [];
+  for (const id of ids) {
+    // VIOLATION: bugs/deterministic/await-in-loop
+    const summary = await fetchUserSummary(id);
+    sizes.push(summary.bytes);
+  }
+  return sizes.reduce((a, b) => a + b, 0);
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/catch-without-error-type-branches-on-err.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/catch-without-error-type-branches-on-err.ts
@@ -1,0 +1,26 @@
+/**
+ * Paraphrased true-bug for reliability/deterministic/catch-without-error-type.
+ *
+ * The catch body branches on `err.code` — different error shapes lead to
+ * different recovery behaviour. Without narrowing the error type (no
+ * `instanceof` / `typeof` / no type annotation on the catch parameter),
+ * the `err.code` access is unchecked and the branches may run against
+ * unintended error shapes.
+ */
+
+import * as fs from 'fs';
+
+export function readWithFallback(path: string): string {
+  try {
+    return fs.readFileSync(path, 'utf-8');
+    // VIOLATION: reliability/deterministic/catch-without-error-type
+  } catch (err) {
+    if ((err as { code?: string }).code === 'ENOENT') {
+      return '';
+    }
+    if ((err as { code?: string }).code === 'EACCES') {
+      return 'denied';
+    }
+    throw err;
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/for-in-without-filter-untyped-json.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/for-in-without-filter-untyped-json.ts
@@ -1,0 +1,18 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/for-in-without-filter.
+ *
+ * `parsed` is the result of `JSON.parse(...)` with no type annotation — its
+ * runtime shape is whatever the caller wrote into the input string,
+ * including arbitrary inherited keys. Iterating with `for…in` and writing
+ * the values without a `hasOwnProperty` check leaks inherited properties.
+ */
+
+export function dumpKeys(input: string): string[] {
+  const parsed = JSON.parse(input);
+  const keys: string[] = [];
+  // VIOLATION: code-quality/deterministic/for-in-without-filter
+  for (const key in parsed) {
+    keys.push(key);
+  }
+  return keys;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/function-return-type-varies-mixed-primitives.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/function-return-type-varies-mixed-primitives.ts
@@ -1,0 +1,19 @@
+/**
+ * Paraphrased true-bug for bugs/deterministic/function-return-type-varies.
+ *
+ * `classify` returns a string on one path, a number on another, and an
+ * unrelated object on a third — there is no shared discriminator key and
+ * the return types are genuinely heterogeneous. Callers cannot rely on a
+ * stable shape without runtime type checks.
+ */
+
+// VIOLATION: bugs/deterministic/function-return-type-varies
+export function classify(input: number) {
+  if (Number.isNaN(input)) {
+    return 'not-a-number';
+  }
+  if (input < 0) {
+    return -1;
+  }
+  return { value: input, doubled: input * 2 };
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/prototype-pollution-untrusted-param.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/prototype-pollution-untrusted-param.ts
@@ -1,0 +1,17 @@
+/**
+ * Paraphrased true-bug for bugs/deterministic/prototype-pollution.
+ *
+ * The setter takes an arbitrary string `key` from its caller and writes
+ * directly into `target[key]` without checking for `__proto__` /
+ * `constructor` / `prototype`. A caller passing `"__proto__"` mutates the
+ * prototype chain instead of the target object.
+ */
+
+export function setEntry(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  // VIOLATION: bugs/deterministic/prototype-pollution
+  target[key] = value;
+}

--- a/tests/fixtures/sample-js-project-positive/src/await-in-loop-transaction-and-search.ts
+++ b/tests/fixtures/sample-js-project-positive/src/await-in-loop-transaction-and-search.ts
@@ -1,0 +1,70 @@
+/**
+ * Positive fixture for bugs/deterministic/await-in-loop.
+ *
+ * Three FP shapes covered:
+ *
+ *   1. Awaits inside an ORM transaction callback (`db.$transaction(async
+ *      (tx) => { for (...) { await tx.X(...) } })`). All queries against
+ *      the same transaction must run sequentially against one connection —
+ *      `Promise.all` against the tx is a bug, not a perf win.
+ *
+ *   2. "Search until found" loop where the awaited result is checked by an
+ *      `if (...) return / break / throw`. Parallelising would
+ *      speculatively waste work on iterations that early-exit would skip.
+ *
+ *   3. Iterator-protocol reads (`reader.read()`, `iter.next()`) — the
+ *      iterator's position advances after each call; the calls are not
+ *      independent and there is no parallel form.
+ */
+
+declare const db: {
+  $transaction: <T>(cb: (tx: {
+    record: { create: (args: { data: unknown }) => Promise<void> };
+  }) => Promise<T>) => Promise<T>;
+};
+declare function makeOtp(seed: string, counter: number): Promise<string>;
+
+interface ChunkReader {
+  read(): Promise<{ done: boolean; value?: string }>;
+}
+
+declare function getChunkReader(): ChunkReader;
+
+export async function persistAll(items: ReadonlyArray<{ id: string }>): Promise<void> {
+  await db.$transaction(async (tx) => {
+    for (const item of items) {
+      await tx.record.create({ data: item });
+    }
+  });
+}
+
+export async function findValidOtp(
+  seed: string,
+  code: string,
+  windowSize: number,
+  period: number,
+): Promise<boolean> {
+  let now = Date.now();
+  for (let i = 0; i < windowSize; i++) {
+    const counter = Math.floor(now / period);
+    const otp = await makeOtp(seed, counter);
+    if (otp === code) {
+      return true;
+    }
+    now -= period;
+  }
+  return false;
+}
+
+export async function countChunks(): Promise<number> {
+  const reader = getChunkReader();
+  let n = 0;
+  let done = false;
+  while (!done) {
+    const result = await reader.read();
+    done = result.done;
+    if (done) break;
+    if (result.value) n += 1;
+  }
+  return n;
+}

--- a/tests/fixtures/sample-js-project-positive/src/catch-without-error-type-uniform-handler.ts
+++ b/tests/fixtures/sample-js-project-positive/src/catch-without-error-type-uniform-handler.ts
@@ -1,0 +1,37 @@
+/**
+ * Positive fixture for reliability/deterministic/catch-without-error-type.
+ *
+ * Both handlers below are uniform — they log + surface a generic user-facing
+ * message + optionally rethrow. No branch in the body depends on the error
+ * type, so demanding `instanceof` / `typeof` discrimination would not
+ * change behaviour. Flagging these is noise.
+ */
+
+declare function toast(args: { title: string; description: string; variant: string }): void;
+
+interface AppErrorShape {
+  message: string;
+}
+declare const AppError: {
+  parseError(err: unknown): AppErrorShape;
+};
+
+export async function removeAttachment(deleteAttachment: (a: { id: string }) => Promise<void>, id: string): Promise<void> {
+  try {
+    await deleteAttachment({ id });
+    toast({ title: 'OK', description: 'Attachment removed.', variant: 'default' });
+  } catch (err) {
+    const parsed = AppError.parseError(err);
+    toast({ title: 'Error', description: parsed.message, variant: 'destructive' });
+  }
+}
+
+export async function submitSignature(payload: { id: string }, sign: (p: { id: string }) => Promise<void>): Promise<void> {
+  try {
+    await sign(payload);
+  } catch (err) {
+    console.error('Signature submission failed', err);
+    toast({ title: 'Error', description: 'Signing failed.', variant: 'destructive' });
+    throw err;
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/src/for-in-without-filter-typed-param.ts
+++ b/tests/fixtures/sample-js-project-positive/src/for-in-without-filter-typed-param.ts
@@ -1,0 +1,20 @@
+/**
+ * Positive fixture for code-quality/deterministic/for-in-without-filter.
+ *
+ * `input` is a function parameter with an explicit TypeScript type
+ * annotation (`Partial<Foo>`). The author has constrained the shape via the
+ * type system, so the `for…in` iterates a known-keys object. Demanding a
+ * `hasOwnProperty` / `Object.hasOwn` check here is a false positive.
+ */
+
+type Foo = { a: string; b: number; c: boolean };
+
+export function countTruthy(input: Partial<Foo>): number {
+  let n = 0;
+  for (const key in input) {
+    if (input[key as keyof Foo] != null) {
+      n += 1;
+    }
+  }
+  return n;
+}

--- a/tests/fixtures/sample-js-project-positive/src/function-return-type-varies-discriminated-union.ts
+++ b/tests/fixtures/sample-js-project-positive/src/function-return-type-varies-discriminated-union.ts
@@ -1,0 +1,38 @@
+/**
+ * Positive fixture for bugs/deterministic/function-return-type-varies.
+ *
+ * Discriminated-union return shape using `as const`. Each path returns an
+ * object literal with a shared `state` discriminator and a different set of
+ * payload fields. The compiler infers a literal-typed union here, and the
+ * shape is consistent at every call site via narrowing on the discriminator
+ * — treating this as "inconsistent return types" is a false positive.
+ */
+
+type LoaderArgs = { params: { token?: string }; viewerId: string | null };
+type Record = { id: string; ownerId: string };
+
+declare function findRecord(token: string): Promise<Record | null>;
+
+export async function loader({ params, viewerId }: LoaderArgs) {
+  if (!params.token) {
+    return { state: 'InvalidLink' } as const;
+  }
+
+  const record = await findRecord(params.token);
+  if (!record) {
+    return { state: 'InvalidLink' } as const;
+  }
+
+  if (record.ownerId !== viewerId) {
+    return {
+      state: 'LoginRequired',
+      recordId: record.id,
+    } as const;
+  }
+
+  return {
+    state: 'Success',
+    recordId: record.id,
+    ownerId: record.ownerId,
+  } as const;
+}

--- a/tests/fixtures/sample-js-project-positive/src/prototype-pollution-typed-key-alias.ts
+++ b/tests/fixtures/sample-js-project-positive/src/prototype-pollution-typed-key-alias.ts
@@ -1,0 +1,37 @@
+/**
+ * Positive fixture for bugs/deterministic/prototype-pollution.
+ *
+ * Two FP shapes covered:
+ *
+ *   1. `const typedKey = key as keyof Foo` — the assignment uses an
+ *      `as`-asserted alias of a for…in loop variable. The underlying
+ *      iteration is over a typed object's own keys, not user input.
+ *   2. `out[MIME_TYPE] = …` — the index is a module-level `const`
+ *      initialised from a primitive string literal. Its value cannot become
+ *      `"__proto__"` etc. unless the developer literally wrote that string.
+ */
+
+type FeatureFlags = { fast: boolean; safe: boolean; rich: boolean };
+
+const ARCHIVE_MIME_TYPE = 'application/zip';
+
+export function pickEnabledFlags(
+  candidate: Partial<FeatureFlags>,
+  baseline: Partial<FeatureFlags>,
+): Record<keyof FeatureFlags, true> {
+  const result: { [k in keyof FeatureFlags]?: true } = {};
+  for (const key in candidate) {
+    if (!Object.hasOwn(candidate, key)) continue;
+    const typedKey = key as keyof FeatureFlags;
+    if (candidate[typedKey] === true && baseline[typedKey] !== true) {
+      result[typedKey] = true;
+    }
+  }
+  return result as Record<keyof FeatureFlags, true>;
+}
+
+export function getArchiveAcceptDescriptor(): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  out[ARCHIVE_MIME_TYPE] = ['.zip'];
+  return out;
+}


### PR DESCRIPTION
## Summary
Resolves 5 false positives surfaced by the documenso/documenso analysis at `8f6be47`. Each rule now skips a clearly identifiable by-design pattern while continuing to flag the underlying bug.

Closes #297
Closes #298
Closes #299
Closes #300
Closes #301

## Fixes

| Rule | Issue | Positive fixture | Negative fixture |
|---|---|---|---|
| `bugs/deterministic/function-return-type-varies` | [#297](https://github.com/truecourse-ai/truecourse/issues/297) | `tests/fixtures/sample-js-project-positive/src/function-return-type-varies-discriminated-union.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/function-return-type-varies-mixed-primitives.ts` |
| `bugs/deterministic/prototype-pollution` | [#298](https://github.com/truecourse-ai/truecourse/issues/298) | `tests/fixtures/sample-js-project-positive/src/prototype-pollution-typed-key-alias.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/prototype-pollution-untrusted-param.ts` |
| `code-quality/deterministic/for-in-without-filter` | [#299](https://github.com/truecourse-ai/truecourse/issues/299) | `tests/fixtures/sample-js-project-positive/src/for-in-without-filter-typed-param.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/for-in-without-filter-untyped-json.ts` |
| `bugs/deterministic/await-in-loop` | [#300](https://github.com/truecourse-ai/truecourse/issues/300) | `tests/fixtures/sample-js-project-positive/src/await-in-loop-transaction-and-search.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/await-in-loop-parallel-safe-fanout.ts` |
| `reliability/deterministic/catch-without-error-type` | [#301](https://github.com/truecourse-ai/truecourse/issues/301) | `tests/fixtures/sample-js-project-positive/src/catch-without-error-type-uniform-handler.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/catch-without-error-type-branches-on-err.ts` |

## bugs/deterministic/function-return-type-varies

Documenso source samples:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_unauthenticated+/organisation.invite.%24token.tsx#L10`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_recipient+/sign.%24token+/complete.tsx#L34
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_recipient+/sign.%24token+/expired.tsx#L20
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_share+/share.%24slug.tsx#L9
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/multiselect.tsx#L89

Positive fixture (added):
```ts
// tests/fixtures/sample-js-project-positive/src/function-return-type-varies-discriminated-union.ts
type LoaderArgs = { params: { token?: string }; viewerId: string | null };
type Record = { id: string; ownerId: string };
declare function findRecord(token: string): Promise<Record | null>;

export async function loader({ params, viewerId }: LoaderArgs) {
  if (!params.token) return { state: 'InvalidLink' } as const;
  const record = await findRecord(params.token);
  if (!record) return { state: 'InvalidLink' } as const;
  if (record.ownerId !== viewerId) {
    return { state: 'LoginRequired', recordId: record.id } as const;
  }
  return { state: 'Success', recordId: record.id, ownerId: record.ownerId } as const;
}
```

Negative fixture (added):
```ts
// VIOLATION: bugs/deterministic/function-return-type-varies
export function classify(input: number) {
  if (Number.isNaN(input)) return 'not-a-number';
  if (input < 0) return -1;
  return { value: input, doubled: input * 2 };
}
```

Visitor summary: The existing object-literal "same keys" skip now unwraps `as const` / `satisfies T` / parens around the returned object before comparing. A new "discriminated union" skip fires when every return is an object literal whose properties include at least one shared key whose value is a primitive literal (string / number / boolean) in every return — the canonical TypeScript discriminator pattern.

## bugs/deterministic/prototype-pollution

Documenso source samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/admin-router/update-subscription-claim.ts#L58
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/constants/document-conversion.ts#L86
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/ui/primitives/multiselect.tsx#L103

Positive fixture (added):
```ts
// tests/fixtures/sample-js-project-positive/src/prototype-pollution-typed-key-alias.ts
type FeatureFlags = { fast: boolean; safe: boolean; rich: boolean };
const ARCHIVE_MIME_TYPE = 'application/zip';

export function pickEnabledFlags(
  candidate: Partial<FeatureFlags>,
  baseline: Partial<FeatureFlags>,
): Record<keyof FeatureFlags, true> {
  const result: { [k in keyof FeatureFlags]?: true } = {};
  for (const key in candidate) {
    if (!Object.hasOwn(candidate, key)) continue;
    const typedKey = key as keyof FeatureFlags;
    if (candidate[typedKey] === true && baseline[typedKey] !== true) {
      result[typedKey] = true;
    }
  }
  return result as Record<keyof FeatureFlags, true>;
}

export function getArchiveAcceptDescriptor(): Record<string, string[]> {
  const out: Record<string, string[]> = {};
  out[ARCHIVE_MIME_TYPE] = ['.zip'];
  return out;
}
```

Negative fixture (added):
```ts
export function setEntry(
  target: Record<string, unknown>,
  key: string,
  value: unknown,
): void {
  // VIOLATION: bugs/deterministic/prototype-pollution
  target[key] = value;
}
```

Visitor summary: Added an alias-resolution pass that follows `const x = y (as T)?` / `(y)` / `y satisfies T` declarators back to the underlying identifier before applying the existing controlled-iteration / counter / destructured-param checks, so `const typedKey = key as keyof Foo` inherits the safety of its for-in source. Also added a new skip for keys whose value is bound to a `const` initialised from a primitive string literal — module-level mime-type constants and similar can never become `__proto__` etc.

## code-quality/deterministic/for-in-without-filter

Documenso source sample:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/admin-router/update-subscription-claim.ts#L53

Positive fixture (added):
```ts
// tests/fixtures/sample-js-project-positive/src/for-in-without-filter-typed-param.ts
type Foo = { a: string; b: number; c: boolean };

export function countTruthy(input: Partial<Foo>): number {
  let n = 0;
  for (const key in input) {
    if (input[key as keyof Foo] != null) {
      n += 1;
    }
  }
  return n;
}
```

Negative fixture (added):
```ts
export function dumpKeys(input: string): string[] {
  const parsed = JSON.parse(input);
  const keys: string[] = [];
  // VIOLATION: code-quality/deterministic/for-in-without-filter
  for (const key in parsed) {
    keys.push(key);
  }
  return keys;
}
```

Visitor summary: The rule now resolves the for-in's iterable identifier back to its declaration (function parameter or `const`/`let`/`var`) and skips when the declaration carries an explicit TS type annotation that constrains the key set — that is, anything except `any` / `unknown` / `object` / `{}` / `Record<string, …>` / `Map<string, …>` / `{[k: string]: …}` index signatures. `Partial<T>` and named types remain narrowable via `keyof T`; unbounded string-keyed records keep firing.

## bugs/deterministic/await-in-loop

Documenso source samples:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/ai/detect-fields.client.ts#L112
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/2fa/email/validate-2fa-token-from-email.ts#L27
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/envelope/create-envelope.ts#L520

Positive fixture (added) — transaction callback + search-with-early-exit + iterator-protocol read:
```ts
// tests/fixtures/sample-js-project-positive/src/await-in-loop-transaction-and-search.ts (excerpt)
export async function persistAll(items: ReadonlyArray<{ id: string }>): Promise<void> {
  await db.$transaction(async (tx) => {
    for (const item of items) {
      await tx.record.create({ data: item });
    }
  });
}

export async function findValidOtp(seed: string, code: string, windowSize: number, period: number): Promise<boolean> {
  let now = Date.now();
  for (let i = 0; i < windowSize; i++) {
    const counter = Math.floor(now / period);
    const otp = await makeOtp(seed, counter);
    if (otp === code) return true;
    now -= period;
  }
  return false;
}

export async function countChunks(): Promise<number> {
  const reader = getChunkReader();
  let n = 0, done = false;
  while (!done) {
    const result = await reader.read();
    done = result.done;
    if (done) break;
    if (result.value) n += 1;
  }
  return n;
}
```

Negative fixture (added):
```ts
async function fetchUserSummary(id: string): Promise<{ id: string; bytes: number }> {
  return { id, bytes: id.length * 2 };
}

export async function totalSummaryBytes(ids: readonly string[]): Promise<number> {
  const sizes: number[] = [];
  for (const id of ids) {
    // VIOLATION: bugs/deterministic/await-in-loop
    const summary = await fetchUserSummary(id);
    sizes.push(summary.bytes);
  }
  return sizes.reduce((a, b) => a + b, 0);
}
```

Visitor summary: Three new skip clauses run when the rule finds a loop wrapping the `await`. (1) The loop sits inside an arrow/function-expression passed to `.$transaction(...)` / `.transaction(...)` — ORM transaction callbacks must run sequentially against one connection. (2) The awaited expression is an iterator-protocol call (`x.read()` / `x.next()`) where parallel form does not exist. (3) The awaited value is bound to a `const`/`let` declarator that's later inspected by an `if (…) return | break | throw` in the same loop body — a "search until found" loop whose parallel form would speculatively waste work.

## reliability/deterministic/catch-without-error-type

Documenso source samples:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document/document-attachments-popover.tsx#L114`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document-signing/document-signing-radio-field.tsx#L120`
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/dialogs/organisation-member-invite-dialog.tsx#L221`

Positive fixture (added):
```ts
// tests/fixtures/sample-js-project-positive/src/catch-without-error-type-uniform-handler.ts
export async function removeAttachment(deleteAttachment: (a: { id: string }) => Promise<void>, id: string): Promise<void> {
  try {
    await deleteAttachment({ id });
    toast({ title: 'OK', description: 'Attachment removed.', variant: 'default' });
  } catch (err) {
    const parsed = AppError.parseError(err);
    toast({ title: 'Error', description: parsed.message, variant: 'destructive' });
  }
}

export async function submitSignature(payload: { id: string }, sign: (p: { id: string }) => Promise<void>): Promise<void> {
  try {
    await sign(payload);
  } catch (err) {
    console.error('Signature submission failed', err);
    toast({ title: 'Error', description: 'Signing failed.', variant: 'destructive' });
    throw err;
  }
}
```

Negative fixture (added):
```ts
export function readWithFallback(path: string): string {
  try {
    return fs.readFileSync(path, 'utf-8');
    // VIOLATION: reliability/deterministic/catch-without-error-type
  } catch (err) {
    if ((err as { code?: string }).code === 'ENOENT') return '';
    if ((err as { code?: string }).code === 'EACCES') return 'denied';
    throw err;
  }
}
```

Visitor summary: Added a "uniform handler" skip. After the existing single-statement / `instanceof` / `typeof` / type-annotation skips, the rule now walks the catch body and silently skips when there is no `if_statement`, `switch_statement`, or `ternary_expression` anywhere in the body. UI handlers that just `console.error(err); toast(...); throw err;` are the dominant catch shape in app code and never branch on error type; demanding type discrimination there is noise. Handlers that genuinely branch on error properties keep firing.

## FP-count delta (vs `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f` on `documenso/documenso`)

Measured against a freshly-built `dist/cli.mjs` (`pnpm build:dist` → `node dist/cli.mjs analyze --no-llm --no-stash --no-skills`):

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `bugs/deterministic/function-return-type-varies` | 9 | 3 | -6 |
| `bugs/deterministic/prototype-pollution` | 5 | 3 | -2 |
| `code-quality/deterministic/for-in-without-filter` | 1 | 0 | -1 |
| `bugs/deterministic/await-in-loop` | 46 | 38 | -8 |
| `reliability/deterministic/catch-without-error-type` | 159 | 35 | -124 |
| **Total (these 5 rules)** | **220** | **79** | **-141** |
| **All-rules total on target** | **9731** | **9590** | **-141** |

cc @mushgev


---
_Generated by [Claude Code](https://claude.ai/code/session_01C3VopiRxrofkxKMT7FhXrw)_