### PR TITLE
fix(fp): resolve 5 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/env-in-library-code.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/env-in-library-code.ts
@@ -40,6 +40,15 @@ export const envInLibraryCodeVisitor: CodeRuleVisitor = {
     // Allow in API route / entry point directories (Next.js, Express, etc.)
     if (lowerPath.includes('/app/api/') || lowerPath.includes('/pages/api/') || lowerPath.includes('/routes/')) return null
 
+    // Allow in infrastructure packages whose declared role IS to read env vars
+    // and hand back a configured client (DB client, rate limiter, telemetry
+    // sink). These are the env-bootstrap surface for the rest of the codebase
+    // — flagging them just relocates the access without removing it.
+    const bootstrapDirs = ['/prisma/', '/rate-limit/', '/telemetry/']
+    for (const dir of bootstrapDirs) {
+      if (lowerPath.includes(dir)) return null
+    }
+
     // Allow in logger config files
     const fileName = filePath.split('/').pop()?.toLowerCase() || ''
     if (fileName === 'logger.ts' || fileName === 'logger.js') return null

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/identical-functions.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/identical-functions.ts
@@ -12,8 +12,17 @@ export const identicalFunctionsVisitor: CodeRuleVisitor = {
 
     function walk(n: SyntaxNode) {
       if (JS_FUNCTION_TYPES.includes(n.type)) {
-        // Skip functions that are arguments to calls (e.g., Drizzle column defs)
-        if (n.parent?.type === 'arguments') { return }
+        // Skip functions used as inline call-site values — argument to a call
+        // (e.g. Drizzle column defs), value in an object-literal property bag
+        // (mutation/option-bag callbacks like `onSuccess: () => {...}`), or a
+        // JSX attribute expression. Identical bodies at distinct call sites
+        // are glue, not duplicated logic worth extracting.
+        const parentType = n.parent?.type
+        if (
+          parentType === 'arguments' ||
+          parentType === 'pair' ||
+          parentType === 'jsx_expression'
+        ) { return }
         const body = getFunctionBody(n)
         // Skip concise-body arrows (`(x) => expr`): these are by definition
         // single-expression lambdas — typically trivial event handlers or

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/indexed-loop-over-for-of.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/indexed-loop-over-for-of.ts
@@ -34,6 +34,28 @@ export const indexedLoopOverForOfVisitor: CodeRuleVisitor = {
     const lengthArithmeticRe = /\.length\s*[-+*/]/
     if (lengthArithmeticRe.test(condText)) return null
 
+    // Only flag when the upper bound is `<expr>.length`. A loop whose upper
+    // bound is a plain count or externally-tracked cursor (e.g.
+    // `i < currentRecipientIndex`) does a partial pass; replacing it with
+    // `for...of` would iterate the whole array and change the loop's range.
+    function isLengthBound(expr: SyntaxNode | null): boolean {
+      if (!expr) return false
+      if (expr.type === 'parenthesized_expression') {
+        return isLengthBound(expr.namedChild(0))
+      }
+      if (expr.type === 'member_expression') {
+        return expr.childForFieldName('property')?.text === 'length'
+      }
+      return false
+    }
+    const cmp = condition.type === 'binary_expression' ? condition : null
+    if (!cmp) return null
+    const left = cmp.childForFieldName('left')
+    const right = cmp.childForFieldName('right')
+    const indexIsLeft = left?.type === 'identifier' && left.text === indexName
+    const boundExpr = indexIsLeft ? right : left
+    if (!isLengthBound(boundExpr ?? null)) return null
+
     let usedOutsideIndex = false
     let usedAsArrayIndex = false
     function checkIndexUsage(n: SyntaxNode) {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/redundant-optional.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/redundant-optional.ts
@@ -13,24 +13,31 @@ export const redundantOptionalVisitor: CodeRuleVisitor = {
     const typeAnnotation = node.namedChildren.find((c) => c.type === 'type_annotation')
     if (!typeAnnotation) return null
 
-    function hasUndefinedMember(n: SyntaxNode): boolean {
+    const typeNode = typeAnnotation.namedChild(0)
+    if (!typeNode) return null
+
+    // `?` only makes the binding itself optional. `| undefined` is only
+    // redundant when it sits at the top of the declared type (or under a
+    // parenthesized wrapper / nested union at the top level). `undefined`
+    // appearing inside a generic argument, a function return type, a tuple
+    // element, etc. belongs to that nested position and is not redundant.
+    function topLevelHasUndefined(n: SyntaxNode): boolean {
+      if (n.type === 'parenthesized_type') {
+        const inner = n.namedChild(0)
+        return inner ? topLevelHasUndefined(inner) : false
+      }
       if (n.type === 'predefined_type' && n.text === 'undefined') return true
       if (n.type === 'literal_type' && n.text === 'undefined') return true
       if (n.type === 'union_type') {
         for (let i = 0; i < n.namedChildCount; i++) {
           const child = n.namedChild(i)
-          if (child && hasUndefinedMember(child)) return true
+          if (child && topLevelHasUndefined(child)) return true
         }
-        return false
-      }
-      for (let i = 0; i < n.namedChildCount; i++) {
-        const child = n.namedChild(i)
-        if (child && hasUndefinedMember(child)) return true
       }
       return false
     }
 
-    if (hasUndefinedMember(typeAnnotation)) {
+    if (topLevelHasUndefined(typeNode)) {
       const nameNode = node.childForFieldName('name') ?? node.childForFieldName('pattern')
       const name = nameNode?.text ?? 'property'
       return makeViolation(

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/selector-parameter.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/selector-parameter.ts
@@ -3,6 +3,22 @@ import { makeViolation } from '../../../types.js'
 import { JS_FUNCTION_TYPES, getFunctionBody } from './_helpers.js'
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 
+function typeContainsBoolean(n: SyntaxNode): boolean {
+  if (n.type === 'parenthesized_type') {
+    const inner = n.namedChild(0)
+    return inner ? typeContainsBoolean(inner) : false
+  }
+  if (n.type === 'predefined_type' && n.text === 'boolean') return true
+  if (n.type === 'literal_type' && (n.text === 'true' || n.text === 'false')) return true
+  if (n.type === 'union_type') {
+    for (let i = 0; i < n.namedChildCount; i++) {
+      const child = n.namedChild(i)
+      if (child && typeContainsBoolean(child)) return true
+    }
+  }
+  return false
+}
+
 export const selectorParameterVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/selector-parameter',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -19,15 +35,26 @@ export const selectorParameterVisitor: CodeRuleVisitor = {
 
     for (const param of paramList) {
       let paramName: string | null = null
+      let typeAnnotation: SyntaxNode | null = null
 
       if (param.type === 'identifier') {
         paramName = param.text
       } else if (param.type === 'required_parameter' || param.type === 'optional_parameter') {
         const p = param.childForFieldName('pattern') ?? param.namedChildren[0]
         if (p?.type === 'identifier') paramName = p.text
+        typeAnnotation = param.namedChildren.find((c) => c.type === 'type_annotation') ?? null
       }
 
       if (!paramName) continue
+
+      // Only flag boolean-typed parameters. A name like `allowed` or `included`
+      // matches the selector-word heuristic, but holding `string | string[]`
+      // (or any non-boolean type) means the parameter is data, not a behavior
+      // switch — splitting the function in two would not make sense.
+      if (typeAnnotation) {
+        const typeNode = typeAnnotation.namedChild(0)
+        if (typeNode && !typeContainsBoolean(typeNode)) continue
+      }
 
       function isUsedAsSelector(n: SyntaxNode): boolean {
         if (JS_FUNCTION_TYPES.includes(n.type) && n.id !== node.id) return false

--- a/tests/fixtures/sample-js-project-negative/packages/shared/lib/helpers.ts
+++ b/tests/fixtures/sample-js-project-negative/packages/shared/lib/helpers.ts
@@ -8,3 +8,8 @@ const apiKey = process.env.API_KEY || '';
 export function getApiKey(): string {
   return apiKey;
 }
+
+// VIOLATION: code-quality/deterministic/env-in-library-code
+export function buildAuthHeader(): string {
+  return `Bearer ${process.env.SESSION_TOKEN ?? ''}`;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-advanced.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-advanced.ts
@@ -152,6 +152,15 @@ export function indexLoop(arr: string[]) {
   return result;
 }
 
+// VIOLATION: code-quality/deterministic/indexed-loop-over-for-of
+export function bytesToString(buf: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < buf.length; i++) {
+    out += String.fromCharCode(buf[i]);
+  }
+  return out;
+}
+
 // VIOLATION: code-quality/deterministic/filter-first-over-find
 export function filterFirst(arr: number[]) {
   return arr.filter((x) => x > 10)[0];

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts
@@ -118,6 +118,16 @@ export function identicalB(x: number) {
   return result;
 }
 
+// VIOLATION: code-quality/deterministic/identical-functions
+export function computeShippingFee(weight: number) {
+  const total = weight * 1.5 + 4;
+  return total;
+}
+export function computeHandlingFee(weight: number) {
+  const total = weight * 1.5 + 4;
+  return total;
+}
+
 // VIOLATION: code-quality/deterministic/inconsistent-function-call
 class Widget {}
 export function inconsistentNew() {

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts
@@ -269,6 +269,14 @@ export function flagParam(isVerbose: boolean) {
   return 'short output';
 }
 
+// VIOLATION: code-quality/deterministic/selector-parameter
+export function renderHeading(text: string, isCondensed: boolean) {
+  if (isCondensed) {
+    return text.slice(0, 24);
+  }
+  return text;
+}
+
 // VIOLATION: code-quality/deterministic/require-unicode-regexp
 export const noUnicode = /hello/;
 

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-typescript.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-typescript.ts
@@ -22,6 +22,11 @@ export interface OptionalUndef {
   name?: string | undefined;
 }
 
+export interface PresignedAttachment {
+  // VIOLATION: code-quality/deterministic/redundant-optional
+  presignToken?: string | undefined;
+}
+
 // VIOLATION: code-quality/deterministic/duplicate-type-constituent
 export type DuplicateUnion = string | number | string;
 

--- a/tests/fixtures/sample-js-project-positive/identical-functions-inline-callbacks.ts
+++ b/tests/fixtures/sample-js-project-positive/identical-functions-inline-callbacks.ts
@@ -1,0 +1,29 @@
+// Inline arrow callbacks passed as object-literal property values are an
+// idiomatic call-site pattern (mutation hooks, framework option bags, etc.).
+// Two `onSuccess` handlers that happen to dispatch the same one-liner are not
+// duplicated logic worth extracting — they're glue at distinct call sites.
+
+interface MutationOptions<T> {
+  onSuccess?: (data: T) => void
+  onError?: (err: unknown) => void
+}
+
+declare function useMutation<T>(opts: MutationOptions<T>): void
+
+declare const cache: {
+  invalidate(opts: { key: string }): void
+}
+
+export function registerInvalidators(): void {
+  useMutation<number>({
+    onSuccess: () => {
+      cache.invalidate({ key: 'first' })
+    },
+  })
+
+  useMutation<string>({
+    onSuccess: () => {
+      cache.invalidate({ key: 'first' })
+    },
+  })
+}

--- a/tests/fixtures/sample-js-project-positive/indexed-loop-over-for-of-partial-range.ts
+++ b/tests/fixtures/sample-js-project-positive/indexed-loop-over-for-of-partial-range.ts
@@ -1,0 +1,30 @@
+// A counted loop whose upper bound is *not* `arr.length` (a count, an
+// externally-tracked cursor, etc.) does only a partial pass over the array.
+// `for...of` would iterate every element, changing the loop's range and its
+// behavior. Such loops aren't mechanical for-of conversions.
+
+interface Recipient {
+  signingStatus: string
+}
+
+export function isCurrentRecipientTurn(
+  recipients: readonly Recipient[],
+  currentRecipientIndex: number,
+): boolean {
+  for (let i = 0; i < currentRecipientIndex; i++) {
+    if (recipients[i].signingStatus !== 'SIGNED') {
+      return false
+    }
+  }
+  return true
+}
+
+export function firstNNonZero(values: readonly number[], n: number): number {
+  let found = 0
+  for (let i = 0; i < n; i++) {
+    if (values[i] !== 0) {
+      found += 1
+    }
+  }
+  return found
+}

--- a/tests/fixtures/sample-js-project-positive/packages/telemetry/client.ts
+++ b/tests/fixtures/sample-js-project-positive/packages/telemetry/client.ts
@@ -1,0 +1,16 @@
+// Infrastructure packages like `telemetry/`, `rate-limit/`, and `prisma/`
+// exist precisely to read env vars and hand back a configured client. That's
+// the env-bootstrap surface — the same role as `config.ts` or `env.ts` — so
+// direct `process.env` access here is the declared contract of the module,
+// not "env access deep in domain code."
+
+export interface TelemetryClientConfig {
+  endpoint: string
+  flushIntervalMs: number
+}
+
+export function loadTelemetryConfig(): TelemetryClientConfig {
+  const endpoint = process.env.TELEMETRY_ENDPOINT ?? 'http://localhost:4318'
+  const flushIntervalMs = Number(process.env.TELEMETRY_FLUSH_INTERVAL_MS ?? '5000')
+  return { endpoint, flushIntervalMs }
+}

--- a/tests/fixtures/sample-js-project-positive/redundant-optional-nested-undefined.ts
+++ b/tests/fixtures/sample-js-project-positive/redundant-optional-nested-undefined.ts
@@ -1,0 +1,22 @@
+// `?` only makes the property/parameter itself optional; `| undefined` that
+// appears inside a nested type (a generic argument, a function return type, a
+// tuple element) belongs to that nested position and is not made redundant by
+// the outer `?`. Stripping it would change the inner type signature.
+
+export interface ClientEnvShape {
+  publicEnv?: Record<string, string | undefined>;
+}
+
+export interface RateLimitConfig {
+  options?: { lookupKey?: (ctx: { ip: string }) => string | undefined };
+}
+
+export interface TupleHolder {
+  pair?: [string, string | undefined];
+}
+
+export function createLimiter(
+  config?: { resolveTenant?: () => string | undefined },
+): (input: string) => string {
+  return (input) => config?.resolveTenant?.() ?? input;
+}

--- a/tests/fixtures/sample-js-project-positive/selector-parameter-data-not-flag.ts
+++ b/tests/fixtures/sample-js-project-positive/selector-parameter-data-not-flag.ts
@@ -1,0 +1,17 @@
+// A parameter name that happens to match a selector word (`allow`, `include`,
+// `skip`, etc.) is only a behavior switch when the value itself is a boolean
+// flag. Holding a string or list of allowed values is data — splitting the
+// function in two would force callers to dispatch on the data they hold.
+
+export function getAllowedHeaders(
+  origin: string,
+  allowed?: string | string[],
+): string[] {
+  if (!allowed) return [origin]
+  return Array.isArray(allowed) ? allowed : [allowed]
+}
+
+export function joinIncluded(included: readonly string[]): string {
+  if (included.length === 0) return 'none'
+  return included.join(', ')
+}


### PR DESCRIPTION
Closes #302
Closes #303
Closes #304
Closes #305
Closes #306

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/redundant-optional` | #302 | `tests/fixtures/sample-js-project-positive/redundant-optional-nested-undefined.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-typescript.ts` |
| `code-quality/deterministic/identical-functions` | #303 | `tests/fixtures/sample-js-project-positive/identical-functions-inline-callbacks.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts` |
| `code-quality/deterministic/indexed-loop-over-for-of` | #304 | `tests/fixtures/sample-js-project-positive/indexed-loop-over-for-of-partial-range.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-advanced.ts` |
| `code-quality/deterministic/selector-parameter` | #305 | `tests/fixtures/sample-js-project-positive/selector-parameter-data-not-flag.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts` |
| `code-quality/deterministic/env-in-library-code` | #306 | `tests/fixtures/sample-js-project-positive/packages/telemetry/client.ts` | `tests/fixtures/sample-js-project-negative/packages/shared/lib/helpers.ts` |

## `code-quality/deterministic/redundant-optional`

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/embed/authoring/configure-fields-view.tsx#L44
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/rate-limit/rate-limit-middleware.ts#L25
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/utils/envelope-download.ts#L16
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/utils/envelope-download.ts#L48
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/client-only/providers/envelope-render-provider.tsx#L132

Positive fixture (new):
```ts
// `?` only makes the property/parameter itself optional; `| undefined` that
// appears inside a nested type (a generic argument, a function return type, a
// tuple element) belongs to that nested position and is not made redundant by
// the outer `?`. Stripping it would change the inner type signature.

export interface ClientEnvShape {
  publicEnv?: Record<string, string | undefined>;
}

export interface RateLimitConfig {
  options?: { lookupKey?: (ctx: { ip: string }) => string | undefined };
}

export interface TupleHolder {
  pair?: [string, string | undefined];
}

export function createLimiter(
  config?: { resolveTenant?: () => string | undefined },
): (input: string) => string {
  return (input) => config?.resolveTenant?.() ?? input;
}
```

Negative fixture (appended):
```ts
export interface PresignedAttachment {
  // VIOLATION: code-quality/deterministic/redundant-optional
  presignToken?: string | undefined;
}
```

Visitor change: the previous `hasUndefinedMember` walked all descendants of the type annotation and reported any `undefined` it found anywhere. That falsely fired on shapes like `x?: Record<string, string | undefined>` or `fn?: (c) => string | undefined`. Replaced it with `topLevelHasUndefined`, which only descends through parenthesized-type wrappers and nested `union_type` nodes — so only `| undefined` at the top of the declared type is treated as redundant with the outer `?`.

## `code-quality/deterministic/identical-functions`

OSS source:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/template/template-page-view-recent-activity.tsx#L78`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document/document-edit-form.tsx#L68
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/document/document-attachments-popover.tsx#L58`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/components/general/template/template-edit-form.tsx#L85
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/app/routes/_authenticated+/o.$orgUrl.support.tsx#L29

Positive fixture (new):
```ts
// Inline arrow callbacks passed as object-literal property values are an
// idiomatic call-site pattern (mutation hooks, framework option bags, etc.).
// Two `onSuccess` handlers that happen to dispatch the same one-liner are not
// duplicated logic worth extracting — they're glue at distinct call sites.

interface MutationOptions<T> {
  onSuccess?: (data: T) => void
  onError?: (err: unknown) => void
}

declare function useMutation<T>(opts: MutationOptions<T>): void

declare const cache: {
  invalidate(opts: { key: string }): void
}

export function registerInvalidators(): void {
  useMutation<number>({
    onSuccess: () => {
      cache.invalidate({ key: 'first' })
    },
  })

  useMutation<string>({
    onSuccess: () => {
      cache.invalidate({ key: 'first' })
    },
  })
}
```

Negative fixture (appended):
```ts
// VIOLATION: code-quality/deterministic/identical-functions
export function computeShippingFee(weight: number) {
  const total = weight * 1.5 + 4;
  return total;
}
export function computeHandlingFee(weight: number) {
  const total = weight * 1.5 + 4;
  return total;
}
```

Visitor change: the rule already skipped arrows passed directly as call arguments and concise-body arrows. Arrows that sit in object-literal property values (`useMutation({ onSuccess: () => { ... } })`) and arrows in JSX expression containers are the same shape: inline glue at distinct call sites, not duplicated logic worth extracting. Widened the parent-type skip-list from `arguments` to `arguments | pair | jsx_expression`.

## `code-quality/deterministic/indexed-loop-over-for-of`

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/recipient/get-is-recipient-turn.ts#L40
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/envelope/get-envelope-for-recipient-signing.ts#L267`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/security-headers.ts#L63

Positive fixture (new):
```ts
// A counted loop whose upper bound is *not* `arr.length` (a count, an
// externally-tracked cursor, etc.) does only a partial pass over the array.
// `for...of` would iterate every element, changing the loop's range and its
// behavior. Such loops aren't mechanical for-of conversions.

interface Recipient {
  signingStatus: string
}

export function isCurrentRecipientTurn(
  recipients: readonly Recipient[],
  currentRecipientIndex: number,
): boolean {
  for (let i = 0; i < currentRecipientIndex; i++) {
    if (recipients[i].signingStatus !== 'SIGNED') {
      return false
    }
  }
  return true
}

export function firstNNonZero(values: readonly number[], n: number): number {
  let found = 0
  for (let i = 0; i < n; i++) {
    if (values[i] !== 0) {
      found += 1
    }
  }
  return found
}
```

Negative fixture (appended):
```ts
// VIOLATION: code-quality/deterministic/indexed-loop-over-for-of
export function bytesToString(buf: Uint8Array): string {
  let out = '';
  for (let i = 0; i < buf.length; i++) {
    out += String.fromCharCode(buf[i]);
  }
  return out;
}
```

Visitor change: the previous check only skipped partial-range loops that used arithmetic on `.length` (e.g. `arr.length - 1`). A loop whose upper bound is a plain count or externally-tracked cursor (e.g. `i < currentRecipientIndex`) is also a partial pass — `for...of` would iterate the whole array and change the loop's range. The visitor now inspects the `binary_expression` condition directly and only flags when the upper bound is `<expr>.length` (optionally wrapped in parens).

## `code-quality/deterministic/selector-parameter`

OSS source:
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/openpage-api/lib/cors.ts#L69
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/pdf/insert-field-in-pdf-v1.ts#L553
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/app-tests/constants/field-overflow-pdf.ts#L76
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/advanced-fields-validation/validate-checkbox.ts#L9

Positive fixture (new):
```ts
// A parameter name that happens to match a selector word (`allow`, `include`,
// `skip`, etc.) is only a behavior switch when the value itself is a boolean
// flag. Holding a string or list of allowed values is data — splitting the
// function in two would force callers to dispatch on the data they hold.

export function getAllowedHeaders(
  origin: string,
  allowed?: string | string[],
): string[] {
  if (!allowed) return [origin]
  return Array.isArray(allowed) ? allowed : [allowed]
}

export function joinIncluded(included: readonly string[]): string {
  if (included.length === 0) return 'none'
  return included.join(', ')
}
```

Negative fixture (appended):
```ts
// VIOLATION: code-quality/deterministic/selector-parameter
export function renderHeading(text: string, isCondensed: boolean) {
  if (isCondensed) {
    return text.slice(0, 24);
  }
  return text;
}
```

Visitor change: the rule fired on any parameter whose name matched a selector-word regex (`^(is|has|should|with|enable|show|force|flag|toggle|include|exclude|allow|skip|only)`) and was used as an `if` condition, regardless of its type. That falsely fired on `allowed?: string | string[]` — data, not a boolean switch. Splitting such a function in two would force callers to dispatch on the data they hold. Added a `typeContainsBoolean` helper and now skip parameters whose explicit type annotation has no `boolean` member; untyped parameters still flag on name + selector-style usage.

## `code-quality/deterministic/env-in-library-code`

OSS source:
- `https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/user/service-accounts/legacy-service-account.ts#L8`
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/helper.ts#L14
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/helper.ts#L9
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/prisma/helper.ts#L27
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/rate-limit/rate-limit.ts#L70

Positive fixture (new):
```ts
// Infrastructure packages like `telemetry/`, `rate-limit/`, and `prisma/`
// exist precisely to read env vars and hand back a configured client. That's
// the env-bootstrap surface — the same role as `config.ts` or `env.ts` — so
// direct `process.env` access here is the declared contract of the module,
// not "env access deep in domain code."

export interface TelemetryClientConfig {
  endpoint: string
  flushIntervalMs: number
}

export function loadTelemetryConfig(): TelemetryClientConfig {
  const endpoint = process.env.TELEMETRY_ENDPOINT ?? 'http://localhost:4318'
  const flushIntervalMs = Number(process.env.TELEMETRY_FLUSH_INTERVAL_MS ?? '5000')
  return { endpoint, flushIntervalMs }
}
```

Negative fixture (appended):
```ts
// VIOLATION: code-quality/deterministic/env-in-library-code
export function buildAuthHeader(): string {
  return `Bearer ${process.env.SESSION_TOKEN ?? ''}`;
}
```

Visitor change: added three infrastructure-package directory patterns — `/prisma/`, `/rate-limit/`, `/telemetry/` — to the existing allowlist. Files under those paths exist precisely to read env vars and hand back a configured client; the same role as `config.ts` or `env.ts`. Flagging them just relocates the access without removing it. Filename-level allowlist is unchanged, so `lib/helpers.ts` etc. continue to be flagged.

## FP-count delta (vs `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f` on `documenso/documenso`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| code-quality/deterministic/redundant-optional | 8 | 5 | -3 |
| code-quality/deterministic/identical-functions | 10 | 4 | -6 |
| code-quality/deterministic/indexed-loop-over-for-of | 3 | 1 | -2 |
| code-quality/deterministic/selector-parameter | 4 | 3 | -1 |
| code-quality/deterministic/env-in-library-code | 51 | 19 | -32 |
| **Total (these 5 rules)** | 76 | 32 | -44 |
| **All-rules total on target** | 9590 | 9546 | -44 |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXLmh2BjZ2KEU7KSMoBest)_