### PR TITLE
fix(fp): resolve 2 FPs from documenso/documenso

### DIFF
--- a/packages/analyzer/src/rules/_shared/javascript-helpers.ts
+++ b/packages/analyzer/src/rules/_shared/javascript-helpers.ts
@@ -198,6 +198,21 @@ function findVariableInitializerValue(variable: Variable): SyntaxNode | null {
 }
 
 /**
+ * Unwrap `await`/parenthesized wrappers to reach the underlying expression
+ * (e.g. `await (req.json())` → the `req.json()` call_expression). Used to tell
+ * whether a variable's initializer is ultimately a function-call return.
+ */
+function unwrapToExpression(node: SyntaxNode): SyntaxNode {
+  let current = node
+  while (current.type === 'await_expression' || current.type === 'parenthesized_expression') {
+    const inner = current.namedChildren[0]
+    if (!inner) break
+    current = inner
+  }
+  return current
+}
+
+/**
  * Returns the first UserInputSource found anywhere in `node`'s subtree, or null.
  *
  * Detects three patterns:
@@ -214,10 +229,20 @@ function findVariableInitializerValue(variable: Variable): SyntaxNode | null {
  * Use this instead of `arg.text.includes('req.')`, which leaks across
  * substrings (`bodyParser`, `subQuery`, `everyBody`) and misses destructured
  * aliases entirely.
+ *
+ * `options.stopTaintAtCallReturns` (default off): when a tracked alias (pattern
+ * 3) is initialized from a function-call return value, follow only the
+ * callee/receiver, not the call's arguments. A function's return value is a
+ * fresh value determined by the function — `const x = build(req.body)` is not
+ * itself `req.body` — whereas a method on the request (`req.json()`,
+ * `req.body()`) still carries user input via its receiver. Callers that want
+ * raw-payload semantics (e.g. unvalidated-data-to-DB writes) opt in; the
+ * default preserves transitive taint for sink rules that need it.
  */
 export function findUserInputAccess(
   node: SyntaxNode,
   dataFlow?: DataFlowContext,
+  options?: { stopTaintAtCallReturns?: boolean },
 ): UserInputSource | null {
   const visited = new Set<number>()
 
@@ -253,7 +278,19 @@ export function findUserInputAccess(
         ) {
           const value = findVariableInitializerValue(variable)
           if (value) {
-            const source = walk(value)
+            // When the initializer is a function-call return value, the result
+            // is a fresh value, not the call's arguments. Following only the
+            // callee/receiver keeps request-method taint (`req.json()`) while
+            // dropping spurious taint from a helper's inputs
+            // (`const x = build(req.body)`).
+            let toWalk: SyntaxNode | null = value
+            if (options?.stopTaintAtCallReturns) {
+              const unwrapped = unwrapToExpression(value)
+              if (unwrapped?.type === 'call_expression') {
+                toWalk = unwrapped.childForFieldName('function')
+              }
+            }
+            const source = toWalk ? walk(toWalk) : null
             if (source) {
               return { kind: 'aliased-identifier', accessor: n.text }
             }

--- a/packages/analyzer/src/rules/architecture/visitors/javascript/route-without-auth-middleware.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/javascript/route-without-auth-middleware.ts
@@ -45,6 +45,20 @@ function isUrlCredentialAuthedPath(path: string): boolean {
 }
 
 /**
+ * OpenAPI / Swagger spec and documentation endpoints (`/openapi.json`,
+ * `/api/v2/openapi.json`, `/swagger.json`, `/api-docs`, `/swagger-ui`,
+ * `/redoc`) are public documentation surfaces by convention — doc viewers and
+ * client-SDK generators fetch the schema without credentials. Unlike the
+ * `PUBLIC_PATH_PATTERNS` prefixes these conventionally appear as a path
+ * *segment* (often under a versioned `/api/...` prefix), so match anywhere.
+ */
+const API_DOCS_PATH = /(?:^|\/)(?:openapi|swagger|api-docs|swagger-ui|redoc)(?:[-.][\w.-]*)?(?:\/|$)/i
+
+function isApiDocsPath(path: string): boolean {
+  return API_DOCS_PATH.test(path)
+}
+
+/**
  * Extract identifier names from the middleware arguments to a route definition.
  * Express/Koa/Hono pattern: `app.get('/path', mw1, mw2, handler)`
  * — middleware are args[1..n-2], handler is args[n-1].
@@ -173,6 +187,7 @@ export const routeWithoutAuthMiddlewareVisitor: CodeRuleVisitor = {
       const path = firstArg.text.replace(/^['"`]|['"`]$/g, '')
       if (isPublicPath(path)) return null
       if (isUrlCredentialAuthedPath(path)) return null
+      if (isApiDocsPath(path)) return null
     }
 
     // Check this specific route's middleware chain

--- a/packages/analyzer/src/rules/database/visitors/javascript/unvalidated-external-data.ts
+++ b/packages/analyzer/src/rules/database/visitors/javascript/unvalidated-external-data.ts
@@ -55,7 +55,14 @@ export const unvalidatedExternalDataVisitor: CodeRuleVisitor = {
     // codebases that use those names for non-request data (cache reads,
     // computed values, internal events).
     for (const arg of args.namedChildren) {
-      if (findUserInputAccess(arg, dataFlow)) {
+      // A value written to the DB is "unvalidated external data" only when it
+      // IS the raw request payload — not when it's a server-derived value
+      // returned from a helper that merely *received* request data (e.g. an
+      // authenticated entity from `resolveAccount({ token: req.headers... })`).
+      // `stopTaintAtCallReturns` keeps direct request reads and `req.json()`
+      // destructures flagged while dropping taint carried only through a
+      // helper's arguments.
+      if (findUserInputAccess(arg, dataFlow, { stopTaintAtCallReturns: true })) {
         return makeViolation(
           this.ruleKey, node, filePath, 'high',
           'Unvalidated external data used in database write',

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -169,6 +169,12 @@
       "layer": "data"
     },
     {
+      "name": "registerAdminRoutes",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "api"
+    },
+    {
       "name": "reliability",
       "service": "api-gateway",
       "kind": "standalone",
@@ -562,6 +568,12 @@
       "name": "Subject",
       "service": "user-service",
       "kind": "class",
+      "layer": "data"
+    },
+    {
+      "name": "subscribeWebhook",
+      "service": "user-service",
+      "kind": "standalone",
       "layer": "data"
     },
     {

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/routes/route-without-auth-middleware-admin.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/routes/route-without-auth-middleware-admin.ts
@@ -1,0 +1,25 @@
+/**
+ * Negative fixture for architecture/deterministic/route-without-auth-middleware.
+ *
+ * A privileged admin endpoint registered with no authentication middleware in
+ * its chain and no global auth hook applied to the app — anyone who knows the
+ * URL can trigger it. This is the real missing-auth bug the rule exists to
+ * catch.
+ */
+import 'hono';
+
+interface Ctx {
+  json: (body: unknown) => Response;
+}
+
+interface ApiRouter {
+  post: (path: string, handler: (c: Ctx) => Promise<Response>) => void;
+}
+
+declare const app: ApiRouter;
+declare const purgeAllAccounts: () => Promise<{ purged: number }>;
+
+export function registerAdminRoutes(): void {
+  // VIOLATION: architecture/deterministic/route-without-auth-middleware
+  app.post('/api/admin/accounts/purge', async (c) => c.json(await purgeAllAccounts()));
+}

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/db/unvalidated-external-data-raw-body.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/db/unvalidated-external-data-raw-body.ts
@@ -1,0 +1,28 @@
+/**
+ * Negative fixture for database/deterministic/unvalidated-external-data.
+ *
+ * The request body is destructured straight off `req.json()` and written to the
+ * database with no schema validation — the real bug the rule catches. The
+ * persisted values ARE the raw external payload, tainted through the request
+ * receiver itself.
+ */
+interface ApiRequest {
+  json: () => Promise<{ hookUrl: string; eventName: string }>;
+}
+
+interface Db {
+  subscription: {
+    create: (args: {
+      data: { url: string; event: string };
+    }) => Promise<{ id: string }>;
+  };
+}
+
+declare const db: Db;
+
+export async function subscribeWebhook(req: ApiRequest): Promise<{ id: string }> {
+  const { hookUrl, eventName } = await req.json();
+
+  // VIOLATION: database/deterministic/unvalidated-external-data
+  return db.subscription.create({ data: { url: hookUrl, event: eventName } });
+}

--- a/tests/fixtures/sample-js-project-positive/src/route-without-auth-middleware-openapi-spec.ts
+++ b/tests/fixtures/sample-js-project-positive/src/route-without-auth-middleware-openapi-spec.ts
@@ -1,0 +1,31 @@
+/**
+ * Positive fixture for architecture/deterministic/route-without-auth-middleware.
+ *
+ * OpenAPI / Swagger spec endpoints serve the generated API schema document.
+ * They are public documentation surfaces by convention — doc viewers and
+ * client-SDK generators fetch the schema without credentials — so registering
+ * them without an auth middleware is correct, not a missing-auth bug.
+ */
+import 'hono';
+
+interface Ctx {
+  json: (body: unknown) => Response;
+}
+
+interface ApiRouter {
+  use: (path: string, middleware: (c: Ctx) => Response) => void;
+  get: (path: string, handler: (c: Ctx) => Response) => void;
+}
+
+declare const app: ApiRouter;
+declare const apiRateLimitMiddleware: (c: Ctx) => Response;
+declare const apiSchemaDocument: unknown;
+
+export function registerSpecRoutes(): void {
+  // The API surface is rate-limited at the router level.
+  app.use('/api/v2/*', apiRateLimitMiddleware);
+
+  app.get('/api/v2/openapi.json', (c) => c.json(apiSchemaDocument));
+  app.get('/api/v2-beta/openapi.json', (c) => c.json(apiSchemaDocument));
+  app.get('/swagger.json', (c) => c.json(apiSchemaDocument));
+}

--- a/tests/fixtures/sample-js-project-positive/src/unvalidated-external-data-derived-entity.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unvalidated-external-data-derived-entity.ts
@@ -1,0 +1,43 @@
+/**
+ * Positive fixture for database/deterministic/unvalidated-external-data.
+ *
+ * The value written to the database is the RETURN of a helper that resolves an
+ * authenticated account from the request's authorization header. The persisted
+ * `account.id` / `account.organisationId` are server-derived identity fields,
+ * not raw request input — so this is not "unvalidated external data".
+ *
+ * A function's return value is a fresh value determined by the function, not by
+ * its arguments; taint must not propagate from `resolveAccount(...)`'s
+ * arguments onto its result.
+ */
+interface ApiRequest {
+  headers: { get: (name: string) => string | null };
+}
+
+interface Account {
+  id: string;
+  organisationId: string;
+}
+
+interface Db {
+  membership: {
+    create: (args: {
+      data: { accountId: string; organisationId: string };
+    }) => Promise<{ id: string }>;
+  };
+}
+
+declare const db: Db;
+declare function resolveAccount(args: { token: string | null }): Promise<Account>;
+
+export async function createMembership(req: ApiRequest): Promise<{ id: string }> {
+  const authHeader = req.headers.get('authorization');
+  const account = await resolveAccount({ token: authHeader });
+
+  return db.membership.create({
+    data: {
+      accountId: account.id,
+      organisationId: account.organisationId,
+    },
+  });
+}


### PR DESCRIPTION
Closes #314
Closes #315

Resolves 2 false positives surfaced in `documenso/documenso` at `8f6be47`. Each fix adds a paraphrased FP to the positive fixture project (which asserts zero violations) and a true-bug case to the negative fixture project, then narrows the rule's visitor. Full test suite is green.

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `architecture/deterministic/route-without-auth-middleware` | #314 | `…/sample-js-project-positive/src/route-without-auth-middleware-openapi-spec.ts` | `…/sample-js-project-negative/services/api-gateway/src/routes/route-without-auth-middleware-admin.ts` |
| `database/deterministic/unvalidated-external-data` | #315 | `…/sample-js-project-positive/src/unvalidated-external-data-derived-entity.ts` | `…/sample-js-project-negative/services/user-service/src/db/unvalidated-external-data-raw-body.ts` |

## architecture/deterministic/route-without-auth-middleware

OSS source (the FPs fixed here are the public OpenAPI spec endpoints):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/router.ts#L122
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/router.ts#L132
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/apps/remix/server/api/files/routes/get-envelope-item-pdf.ts#L31 (borderline query-param-token auth — left flagged, not part of this fix)

Positive fixture:
```diff
+import 'hono';
+
+interface Ctx { json: (body: unknown) => Response; }
+interface ApiRouter {
+  use: (path: string, middleware: (c: Ctx) => Response) => void;
+  get: (path: string, handler: (c: Ctx) => Response) => void;
+}
+declare const app: ApiRouter;
+declare const apiRateLimitMiddleware: (c: Ctx) => Response;
+declare const apiSchemaDocument: unknown;
+
+export function registerSpecRoutes(): void {
+  app.use('/api/v2/*', apiRateLimitMiddleware);
+  app.get('/api/v2/openapi.json', (c) => c.json(apiSchemaDocument));
+  app.get('/api/v2-beta/openapi.json', (c) => c.json(apiSchemaDocument));
+  app.get('/swagger.json', (c) => c.json(apiSchemaDocument));
+}
```

Negative fixture (true bug still flagged):
```diff
+import 'hono';
+
+interface Ctx { json: (body: unknown) => Response; }
+interface ApiRouter { post: (path: string, handler: (c: Ctx) => Promise<Response>) => void; }
+declare const app: ApiRouter;
+declare const purgeAllAccounts: () => Promise<{ purged: number }>;
+
+export function registerAdminRoutes(): void {
+  // VIOLATION: architecture/deterministic/route-without-auth-middleware
+  app.post('/api/admin/accounts/purge', async (c) => c.json(await purgeAllAccounts()));
+}
```

**Fix:** added an `isApiDocsPath` check to the visitor so OpenAPI/Swagger spec & documentation endpoints (`/openapi.json`, `/api/v2/openapi.json`, `/swagger.json`, `/api-docs`, `/swagger-ui`, `/redoc`) are treated as public — they are documentation surfaces fetched without credentials by convention. Unlike the existing public-path prefixes these conventionally appear as a path *segment* under a versioned `/api/...` prefix, so the match is applied anywhere in the path rather than only as a leading prefix. Privileged routes (e.g. `/api/admin/...`) are unaffected.

## database/deterministic/unvalidated-external-data

OSS source (FPs are the tRPC-procedure writes; the zapier writes are true positives and stay flagged):
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/embedding-router/create-embedding-template.ts#L56 (FP)
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/trpc/server/embedding-router/create-embedding-template.ts#L69 (FP)
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/webhooks/zapier/subscribe.ts#L21 (true positive — still flagged)
- https://github.com/documenso/documenso/blob/8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f/packages/lib/server-only/webhooks/zapier/unsubscribe.ts#L17 (true positive — still flagged)

Positive fixture:
```diff
+interface ApiRequest { headers: { get: (name: string) => string | null }; }
+interface Account { id: string; organisationId: string; }
+interface Db {
+  membership: {
+    create: (args: { data: { accountId: string; organisationId: string } }) => Promise<{ id: string }>;
+  };
+}
+declare const db: Db;
+declare function resolveAccount(args: { token: string | null }): Promise<Account>;
+
+export async function createMembership(req: ApiRequest): Promise<{ id: string }> {
+  const authHeader = req.headers.get('authorization');
+  const account = await resolveAccount({ token: authHeader });
+  return db.membership.create({
+    data: { accountId: account.id, organisationId: account.organisationId },
+  });
+}
```

Negative fixture (true bug still flagged):
```diff
+interface ApiRequest { json: () => Promise<{ hookUrl: string; eventName: string }>; }
+interface Db {
+  subscription: {
+    create: (args: { data: { url: string; event: string } }) => Promise<{ id: string }>;
+  };
+}
+declare const db: Db;
+
+export async function subscribeWebhook(req: ApiRequest): Promise<{ id: string }> {
+  const { hookUrl, eventName } = await req.json();
+  // VIOLATION: database/deterministic/unvalidated-external-data
+  return db.subscription.create({ data: { url: hookUrl, event: eventName } });
+}
```

**Fix:** the rule no longer taints a function's *return value* through that function's *arguments*. A new opt-in `stopTaintAtCallReturns` option on the shared `findUserInputAccess` helper (inert for all other callers — they get byte-for-byte unchanged behavior) is enabled only by this visitor: when a tracked alias is initialized from a function-call return (`const account = await resolveAccount({ token: req.headers... })`), only the callee/receiver is followed, not the call's arguments. This keeps request-method reads like `req.json()` flagged (taint flows through the receiver) while server-derived entities written to the DB (an authenticated `account.id`) no longer false-positive. The two zapier handlers that pass a raw `req.json()` payload straight to Prisma remain flagged.

## FP-count delta (vs `8f6be474a9ce44f88a5d175fb3130ca7fe3bbf5f` on `documenso/documenso`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `architecture/deterministic/route-without-auth-middleware` | 3 | 1 | -2 |
| `database/deterministic/unvalidated-external-data` | 4 | 2 | -2 |
| **Total (these 2 rules)** | 7 | 3 | -4 |
| **All-rules total on target** | 9531 | 9527 | -4 |

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` against a fresh `pnpm build:dist` — the exact artifact `publish.yml` ships to npm. The all-rules total dropped by exactly the subtotal (-4), confirming no collateral changes to other rules.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_013YzpHTFNWgHrrw5rPnNtnH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API documentation endpoints (OpenAPI/Swagger) are now recognized as public by convention and no longer trigger authentication requirement violations.

* **Bug Fixes**
  * Improved database security analysis to more accurately detect unvalidated external data in write operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truecourse-ai/truecourse/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->