### PR TITLE
fp-next-fix: all-blocked queue re-analyzes instead of dead-ending

### DIFF
--- a/.github/workflows/notify-routine-activity.yml
+++ b/.github/workflows/notify-routine-activity.yml
@@ -112,12 +112,15 @@ jobs:
             --data-urlencode "text=${MESSAGE}" \
             > /dev/null
 
-  # Campaign-close failure issues are filed individually and are rare —
-  # no rollup, fire per-issue.
-  notify-campaign-close-failure:
+  # Campaign-level alerts filed individually and rarely — no rollup,
+  # fire per-issue. Covers close-time failures ([fp-campaign-close])
+  # and the "all remaining issues blocked, can't self-progress"
+  # tracking issue ([fp-campaign-stuck]).
+  notify-campaign-alert:
     if: >
       github.event_name == 'issues' &&
-      startsWith(github.event.issue.title, '[fp-campaign-close]')
+      (startsWith(github.event.issue.title, '[fp-campaign-close]') ||
+       startsWith(github.event.issue.title, '[fp-campaign-stuck]'))
     runs-on: ubuntu-latest
     steps:
       - name: Send Telegram message
@@ -132,7 +135,7 @@ jobs:
             echo "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID secret not set — skipping notification."
             exit 0
           fi
-          MESSAGE=$(printf "⚠️ fp-campaign-close failure: #%s\n%s\n\n%s" \
+          MESSAGE=$(printf "⚠️ Campaign needs attention: #%s\n%s\n\n%s" \
             "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_URL")
           curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \

--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -390,7 +390,9 @@ the target — a row with `Delta: 0` is a smell.
   from the before/after measurements, label `fp-fix`. Comment + unlock
   each fixed issue. End.
 
-**Queue empty path** (no open `fp-fix` issues for the current campaign):
+**Queue empty path** (no *pickable* `fp-fix` issues — the queue is
+empty **or every remaining open issue is `fp-blocked`/`fp-skipped`**,
+and the session has 0 successes):
 
 1. `pnpm install && pnpm build:dist` to rebuild dist with all merged
    fixes on `main`.
@@ -408,9 +410,17 @@ the target — a row with `Delta: 0` is a smell.
    - body listing the campaign's rule fixes by PR number and the
      before/after TP-rate (noting the measurement was taken against
      `node dist/cli.mjs` from the freshly-built dist).
-4. **If < 90 %**: file new `fp-fix` issues for newly-discovered FPs
-   (same shape as discovery). Leave campaign `status: in_progress`.
-   **No campaign-close PR is opened** — no release is cut.
+4. **If < 90 %**: file new `fp-fix` issues for FP-rules that **don't
+   already have an open issue** (dedupe against existing, including
+   `fp-blocked`). Leave campaign `status: in_progress`. No
+   campaign-close PR.
+   - Filed ≥ 1 new issue → continue into the per-issue loop in the
+     same session and start fixing.
+   - Filed 0 (every FP-rule is already tracked and all are blocked) →
+     the campaign can't self-progress. File/update a single
+     `[fp-campaign-stuck] <owner>/<repo>` tracking issue (TP rate +
+     checklist of blocked issues, `cc @mushgev`) — this fires the TG
+     alert — then end. **Never dead-end silently.**
 5. End. The campaign-close PR merge fires `fp-campaign-close` and
    `fp-discover` in parallel.
 

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -79,7 +79,15 @@ iteration is one "attempt" (success or skip).
   **excluding** any with label `fp-in-progress`, `fp-blocked`, or
   `fp-skipped`.
 - Also exclude any issue already in `fixed_issues` for this session.
-- If none → break out of the loop and go to "Open the batched PR".
+- If none (the **pickable** queue is empty — note this is also true
+  when open issues remain but every one is `fp-blocked`/`fp-skipped`):
+  - If `successes >= 1` → break out of the loop and go to "Open the
+    batched PR" (ship the batch you've built).
+  - If `successes == 0` → go to the **Queue-empty path**. Do **not**
+    just end the session — an empty pickable queue is the cue to
+    re-measure the campaign (re-analyze, recompute TP, then close /
+    re-discover / flag-stuck). This holds even when the only remaining
+    issues are blocked.
 - Otherwise: pick the **oldest** by `created_at`.
 
 ### 2. Take the concurrency lock
@@ -257,9 +265,12 @@ error output so the reason is concrete, not "unknown".
 
 After the loop:
 
-- If `successes == 0`: end the session with no PR. (Comment on the
-  most recent `fp-fix` issue noting that the session ended with no
-  successful fixes after `attempts` attempts.)
+- If `successes == 0`: do **not** end here. You only reach this section
+  with zero successes if you attempted issues that all failed
+  (blocked / no-reproduce / refactor) — the pickable queue ran out
+  mid-session. Go to the **Queue-empty path** to re-measure the
+  campaign. (Step 1 already routes a start-empty queue straight there;
+  this catches the case where the queue drained during the loop.)
 - If `successes >= 1`:
   - **Verify your branch.** Run `git rev-parse --abbrev-ref HEAD` and
     confirm it starts with `claude/fp-fix/batch-`. If it doesn't —
@@ -323,9 +334,14 @@ After the loop:
 
 ## Queue-empty path
 
-If the per-issue loop's step 1 found zero open `fp-fix` issues (true
-queue empty, not just exhausted-the-batch), AND `successes == 0` so
-far in this session:
+Enter this path when the **pickable** queue is empty AND
+`successes == 0` this session. "Pickable empty" means step 1 found no
+open `fp-fix` issue that lacks `fp-in-progress`/`fp-blocked`/`fp-skipped`
+— **including the case where open issues remain but all are blocked.**
+Do not require "zero issues exist at all"; all-blocked counts.
+
+(If `successes >= 1`, you ship the batch PR instead — never run this
+path in a session that already produced fixes.)
 
 1. Find the campaign in `docs/fp-automation/campaigns.yaml` with
    `status: in_progress` or `status: discovering`. There should be
@@ -366,23 +382,44 @@ far in this session:
      with `cc @mushgev`.
    - End. The merge fires fp-campaign-close (tags + ships) and
      fp-discover (next campaign).
-6. **If `tp_rate < 0.90`** — campaign continues. File one new fp-fix
-   issue per rule with FPs (same shape as discovery). Leave the
-   campaign's `status` as `in_progress`. **Do not** open a
-   campaign-close PR; no release is cut.
+6. **If `tp_rate < 0.90`** — campaign continues. Leave the campaign's
+   `status` as `in_progress`. **Do not** open a campaign-close PR; no
+   release is cut.
 
-   **Then continue into the per-issue loop in this same session** —
-   the target clone, dist build, `before_counts`, and counters are
-   all still valid; only the issue list needs re-fetching. Process
-   the freshly-filed issues with the remaining `successes`/`attempts`
-   budget. If the budget allows at least one success, the session
-   will end with a normal batched PR (which carries the FP-count
-   delta and fires Trigger B on merge).
+   **File new issues, but dedupe first.** For each rule that still
+   shows FPs, check whether an **open** `fp-fix` issue for that
+   `rule_key` already exists (any label — `fp-blocked` counts).
+   - Rule has no open issue → file a new fp-fix issue (same shape as
+     discovery).
+   - Rule already has an open issue → **skip it**. Re-filing a rule
+     that's already tracked (especially one that's `fp-blocked`) just
+     creates duplicates.
 
-   The rationale: this path used to end here and require a manual
-   "Run now" click to kick the loop. Continuing in-session removes
-   that hand-off — the session that filed the new issues immediately
-   starts processing them.
+   **Then branch on what you filed:**
+   - **Filed ≥ 1 new issue** → continue into the per-issue loop in
+     this same session. The target clone, dist build, `before_counts`,
+     and counters are all still valid; only the issue list needs
+     re-fetching. If the budget allows at least one success, the
+     session ends with a normal batched PR (carrying the FP-count
+     delta, firing Trigger B on merge). This removes the old manual
+     "Run now" hand-off.
+   - **Filed 0 new issues** (every FP-rule already has an open issue,
+     and all pickable ones are blocked) → the campaign **cannot
+     self-progress**: the only thing standing between it and 0.90 is
+     human-gated work. Do not end silently. Instead **file or update a
+     single tracking issue**:
+     - First search for an open issue titled
+       `[fp-campaign-stuck] <owner>/<repo>`.
+     - If none exists → open one. Title:
+       `[fp-campaign-stuck] <owner>/<repo>`. Body: current `tp_rate`,
+       the close threshold (0.90), and a checklist of every open
+       `fp-blocked` issue (number + rule_key) that must be resolved by
+       a human before automation can proceed. End the body with
+       `cc @mushgev`.
+     - If one already exists → add a comment refreshing the `tp_rate`
+       and the current blocked list (don't open a duplicate).
+     - Then end the session. Opening/commenting the tracking issue is
+       the human signal — never dead-end without it.
 
 If the queue empties during the per-issue loop **after** at least one
 success, go to "Open the batched PR" with what you have — don't run


### PR DESCRIPTION
## What broke

The last fp-next-fix run hit an all-`fp-blocked` queue, ended with no PR, and **never re-analyzed** — freezing documenso on its stale 0.62 TP baseline even after the −40k unsafe-any drop and ~30 batched fixes.

**Root cause: contradictory routing.** Step 1 sent "no pickable issues" → "Open the batched PR" (which ends when `successes == 0`), while the Queue-empty path *also* claimed that case but its trigger read *"true queue empty, not just exhausted-the-batch."* The all-blocked case fell in the crack, so nobody recomputed TP or decided close-vs-continue.

## Fixes

**Routing (`fp-next-fix.md`)**
- Step 1: an empty *pickable* queue (including all-blocked) with `successes == 0` now routes into the Queue-empty path, not "end no PR." `successes >= 1` still ships the batch.
- "Open the batched PR" `successes == 0` branch redirects to the Queue-empty path instead of dead-ending.
- Queue-empty trigger reworded to fire on an empty *pickable* queue, explicitly including all-blocked.

**Behavior (Queue-empty path, `tp_rate < 0.90`)**
- **Dedupe**: only file new issues for FP-rules that don't already have an open `fp-fix` issue (`fp-blocked` counts). Kills the duplicate storm the last session correctly feared.
- **New terminal case**: if 0 new issues were filed (every FP-rule already tracked, all pickable ones blocked), file/update a single `[fp-campaign-stuck] <owner>/<repo>` tracking issue (current TP + checklist of blocked issues, `cc @mushgev`) and end. Never dead-end silently.

**Notification (`notify-routine-activity.yml`)**
- Broaden the per-issue campaign-alert job to also fire on `[fp-campaign-stuck]` titles → the stuck signal reaches Telegram.

## Net effect

The routine always re-measures when the pickable queue empties:
- TP ≥ 0.90 → campaign-close PR (ships).
- TP < 0.90 with new FP-rules → file (deduped) + keep fixing.
- TP < 0.90 but only human-gated work left → one loud, deduped stuck issue + TG ping.

## To unstick documenso right now

This is prompt-only — it takes effect on the next fp-next-fix run, but nothing will trigger that run (no fp-fix PR left to merge). After this merges, **click Run now on fp-next-fix once**; it'll re-analyze documenso under the new routing and either open a campaign-close PR (if TP ≥ 0.90) or raise the `[fp-campaign-stuck]` issue.

## Test plan

- [ ] Merge, then Run now on fp-next-fix.
- [ ] Confirm it re-analyzes documenso (doesn't end with "no PR, 0 successes").
- [ ] Confirm outcome is either a campaign-close PR or a single `[fp-campaign-stuck] documenso/documenso` issue with a TG ping — not silence.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated campaign alerts now cover both closed and stuck campaigns with clearer, generic notification messaging.
  * Stuck campaigns are now tracked with dedicated issues instead of silently ending, improving visibility into blocked false positive fixes.

* **Improvements**
  * Enhanced deduplication logic to avoid filing duplicate false positive issues already tracked and blocked in the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truecourse-ai/truecourse/pull/333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->