### PR TITLE
unsafe-any-usage: trace external any through more node shapes (−3,557 more FPs on documenso)

### DIFF
--- a/packages/analyzer/src/ts-compiler.ts
+++ b/packages/analyzer/src/ts-compiler.ts
@@ -659,15 +659,36 @@ function tracesAnyToExternalSource(
     }
 
     if (ts.isBindingElement(decl)) {
-      // `const [a, b] = expr` / `const { x } = expr` — find the enclosing
-      // VariableDeclaration and recurse into its initializer.
+      // Destructuring binding. Find the enclosing declaration the pattern
+      // belongs to — either a `const { x } = expr` variable declaration or a
+      // destructured function/callback parameter `({ x }) => ...`.
       let walker: ts.Node = decl
-      while (walker.parent && !ts.isVariableDeclaration(walker.parent)) {
+      while (
+        walker.parent &&
+        !ts.isVariableDeclaration(walker.parent) &&
+        !ts.isParameter(walker.parent)
+      ) {
         walker = walker.parent
       }
-      const varDecl = walker.parent
-      if (varDecl && ts.isVariableDeclaration(varDecl) && varDecl.initializer) {
-        if (tracesAnyToExternalSource(checker, varDecl.initializer, visited)) {
+      const enclosing = walker.parent
+
+      if (enclosing && ts.isParameter(enclosing)) {
+        // Destructured parameter: `function Row({ envelope }: Props)`,
+        // `render={({ field }) => ...}` (react-hook-form), `match(x).with(...)`
+        // arms, etc. The binding is `any` either because the param's type
+        // annotation is a TypeReference to an unresolved import (Props →
+        // unresolved), or because the param is an untyped contextual callback
+        // of an unresolved library generic. Both are external noise once
+        // node_modules is absent. Only an explicit `: any` on the parameter
+        // itself is developer-authored.
+        if (enclosing.type && enclosing.type.kind === ts.SyntaxKind.AnyKeyword) return false
+        return true
+      }
+
+      if (enclosing && ts.isVariableDeclaration(enclosing) && enclosing.initializer) {
+        // `const { x } = expr` / `const [a] = expr` — recurse into the
+        // initializer (e.g. `const { data } = useLoaderData()`).
+        if (tracesAnyToExternalSource(checker, enclosing.initializer, visited)) {
           return true
         }
       }

--- a/packages/analyzer/src/ts-compiler.ts
+++ b/packages/analyzer/src/ts-compiler.ts
@@ -619,6 +619,12 @@ function tracesAnyToExternalSource(
   if (ts.isCallExpression(node)) {
     return tracesAnyToExternalSource(checker, node.expression, visited)
   }
+  if (ts.isNewExpression(node)) {
+    // `new UAParser()` / `new Konva.Group()` / `new Hono<Env>()` — the
+    // constructed value is `any` when the constructor's class comes from an
+    // unresolved import. Trace through the constructor expression.
+    return tracesAnyToExternalSource(checker, node.expression, visited)
+  }
   if (ts.isAsExpression(node)) {
     // `x as any` is an explicit cast — the any is intentional, not external.
     if (node.type.kind === ts.SyntaxKind.AnyKeyword) return false
@@ -629,6 +635,14 @@ function tracesAnyToExternalSource(
   }
   if (ts.isAwaitExpression(node)) {
     return tracesAnyToExternalSource(checker, node.expression, visited)
+  }
+
+  // Entry-point VariableDeclaration: when the flagged span exactly covers a
+  // `const x = expr` (the rule fires on the declarator itself), the node
+  // handed in is a VariableDeclaration, not an identifier. Apply the same
+  // logic the symbol-declaration branch below uses.
+  if (ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)) {
+    return variableDeclarationTracesExternal(checker, node, visited)
   }
 
   if (!ts.isIdentifier(node)) {
@@ -696,18 +710,7 @@ function tracesAnyToExternalSource(
     }
 
     if (ts.isVariableDeclaration(decl) || ts.isPropertyDeclaration(decl)) {
-      if (decl.type && decl.type.kind === ts.SyntaxKind.AnyKeyword) return false
-      if (decl.initializer) {
-        if (
-          ts.isAsExpression(decl.initializer) &&
-          decl.initializer.type.kind === ts.SyntaxKind.AnyKeyword
-        ) {
-          return false
-        }
-        if (tracesAnyToExternalSource(checker, decl.initializer, visited)) {
-          return true
-        }
-      }
+      if (variableDeclarationTracesExternal(checker, decl, visited)) return true
       // No annotation, no `as any`, initializer didn't trace external →
       // probably a locally-inferred any (e.g. `let x; x = whatever()`). Leave
       // it to the caller; default to false here.
@@ -717,6 +720,9 @@ function tracesAnyToExternalSource(
     if (ts.isParameter(decl)) {
       // Explicit `(x: any)` is the intentional pattern the rule exists for.
       if (decl.type && decl.type.kind === ts.SyntaxKind.AnyKeyword) return false
+      // `(x: SomeType)` where SomeType is an unresolved import → x is any
+      // only because the annotation can't resolve. Suppress.
+      if (decl.type && typeReferenceIsExternal(checker, decl.type)) return true
       // Implicit-any parameters (no annotation, type inferred as `any`) are
       // overwhelmingly noise — JS files, contextual callbacks of unresolved
       // libraries, `noImplicitAny: false` configs. Treat as external so the
@@ -738,6 +744,113 @@ function tracesAnyToExternalSource(
     }
   }
 
+  return false
+}
+
+/**
+ * Decide whether a `VariableDeclaration`/`PropertyDeclaration` produces an
+ * `any` that originates externally. Checks, in order:
+ *  - explicit `: any` annotation → developer-authored, NOT external
+ *  - `: SomeUnresolvedType` annotation → external (the any is only because the
+ *    annotated type can't resolve without node_modules)
+ *  - `= x as any` initializer → developer-authored, NOT external
+ *  - initializer traces external (call to unresolved fn, `new` of unresolved
+ *    class, member of unresolved value, etc.)
+ *  - initializer is a local `() => …` / `function () {}` with no explicit `:
+ *    any` return annotation → its inferred return type is any-from-unresolved,
+ *    treat as external (covers `const x = localHelper()` where the helper is
+ *    an arrow whose body returns an unresolved-typed value)
+ */
+function variableDeclarationTracesExternal(
+  checker: ts.TypeChecker,
+  decl: ts.VariableDeclaration | ts.PropertyDeclaration,
+  visited: Set<ts.Node>,
+): boolean {
+  if (decl.type) {
+    if (decl.type.kind === ts.SyntaxKind.AnyKeyword) return false
+    if (typeReferenceIsExternal(checker, decl.type)) return true
+  }
+  const init = decl.initializer
+  if (init) {
+    if (ts.isAsExpression(init) && init.type.kind === ts.SyntaxKind.AnyKeyword) {
+      return false
+    }
+    // `const helper = (…) => {…}` / `= function () {…}` — a local function
+    // whose inferred return type is any. Mirror the FunctionDeclaration
+    // branch: unless it carries an explicit `: any` return annotation, the
+    // any came from an unresolved value in its body. This is what makes
+    // `const x = helper()` (helper a const-arrow) trace external.
+    if (ts.isArrowFunction(init) || ts.isFunctionExpression(init)) {
+      if (init.type && init.type.kind === ts.SyntaxKind.AnyKeyword) return false
+      return true
+    }
+    if (tracesAnyToExternalSource(checker, init, visited)) return true
+  }
+  return false
+}
+
+/**
+ * True when a type-annotation node names a type whose symbol can't be resolved
+ * to local source — i.e. it has no declarations, or its declarations live in
+ * node_modules / a `.d.ts` / behind an import. Such a type collapses to `any`
+ * when node_modules is absent, so any value annotated with it looks unsafe
+ * even though it's well-typed in the real project.
+ *
+ * Recurses one hop through a local type alias (`type Foo = TExternal['x']`) so
+ * a thin local wrapper over an external type is still recognised as external.
+ */
+function typeReferenceIsExternal(
+  checker: ts.TypeChecker,
+  typeNode: ts.TypeNode,
+  depth = 0,
+): boolean {
+  if (depth > 3) return false
+
+  // Unwrap arrays / unions / parens / type-operators to the leading reference.
+  if (ts.isArrayTypeNode(typeNode)) {
+    return typeReferenceIsExternal(checker, typeNode.elementType, depth + 1)
+  }
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return typeReferenceIsExternal(checker, typeNode.type, depth + 1)
+  }
+  if (ts.isUnionTypeNode(typeNode) || ts.isIntersectionTypeNode(typeNode)) {
+    return typeNode.types.some((t) => typeReferenceIsExternal(checker, t, depth + 1))
+  }
+
+  if (!ts.isTypeReferenceNode(typeNode) && !ts.isExpressionWithTypeArguments(typeNode)) {
+    return false
+  }
+
+  const typeName = ts.isTypeReferenceNode(typeNode) ? typeNode.typeName : typeNode.expression
+  let symbol: ts.Symbol | undefined
+  try {
+    symbol = checker.getSymbolAtLocation(typeName)
+  } catch {
+    return false
+  }
+  if (!symbol) return false
+
+  const target = (symbol.flags & ts.SymbolFlags.Alias)
+    ? (safeGetAliasedSymbol(checker, symbol) ?? symbol)
+    : symbol
+  if (!target.declarations || target.declarations.length === 0) return true
+
+  for (const d of target.declarations) {
+    const sf = d.getSourceFile()
+    if (sf.fileName.includes('/node_modules/')) return true
+    if (sf.isDeclarationFile) return true
+    let ancestor: ts.Node | undefined = d
+    while (ancestor) {
+      if (ts.isImportDeclaration(ancestor) || ts.isImportEqualsDeclaration(ancestor)) {
+        return true
+      }
+      ancestor = ancestor.parent
+    }
+    // Local type alias that points at an external type — recurse one hop.
+    if (ts.isTypeAliasDeclaration(d) && d.type) {
+      if (typeReferenceIsExternal(checker, d.type, depth + 1)) return true
+    }
+  }
   return false
 }
 

--- a/tests/fixtures/sample-js-project-positive/unsafe-any-usage-unresolved-external.ts
+++ b/tests/fixtures/sample-js-project-positive/unsafe-any-usage-unresolved-external.ts
@@ -11,6 +11,8 @@ import { z } from 'unresolved-schema-lib';
 import { useTypedQuery } from 'unresolved-query-lib';
 import { useState } from 'unresolved-ui-lib';
 import { prismaLike } from 'unresolved-orm-lib';
+import type { Envelope } from 'unresolved-orm-lib';
+import { Controller } from 'unresolved-form-lib';
 
 // 1) Schema parse — `.parse()` would give back the inferred output type.
 const SearchParamsSchema = z.object({ q: z.string() });
@@ -42,4 +44,24 @@ export async function getRecipientEmail(recipientId: string): Promise<string | n
   const recipient = await prismaLike.recipient.findUnique({ where: { id: recipientId } });
   if (!recipient) return null;
   return recipient.email;
+}
+
+// 5) Destructured prop typed by an unresolved import. `envelope` is `any` only
+// because `Envelope` (an ORM model type) can't be resolved without
+// node_modules — the member access must NOT fire.
+export function EnvelopeRow({ envelope }: { envelope: Envelope }): string {
+  return envelope.id;
+}
+
+// 6) react-hook-form-style render callback. The destructured `field` parameter
+// is `any` because the form library's generic is unresolved — accessing
+// `field.value` / calling `field.onChange` must NOT fire.
+export function FieldControl(): unknown {
+  return Controller({
+    name: 'subject',
+    render: ({ field }) => {
+      field.onChange('next');
+      return field.value;
+    },
+  });
 }

--- a/tests/fixtures/sample-js-project-positive/unsafe-any-usage-unresolved-external.ts
+++ b/tests/fixtures/sample-js-project-positive/unsafe-any-usage-unresolved-external.ts
@@ -13,6 +13,8 @@ import { useState } from 'unresolved-ui-lib';
 import { prismaLike } from 'unresolved-orm-lib';
 import type { Envelope } from 'unresolved-orm-lib';
 import { Controller } from 'unresolved-form-lib';
+import { CanvasGroup } from 'unresolved-canvas-lib';
+import { useCurrentTeam } from 'unresolved-context-lib';
 
 // 1) Schema parse — `.parse()` would give back the inferred output type.
 const SearchParamsSchema = z.object({ q: z.string() });
@@ -64,4 +66,29 @@ export function FieldControl(): unknown {
       return field.value;
     },
   });
+}
+
+// 7) `new` of an unresolved class. `group` is `any` because `CanvasGroup`'s
+// type can't resolve — calling `.add()` must NOT fire.
+export function buildGroup(): unknown {
+  const group = new CanvasGroup({ x: 0, y: 0 });
+  group.add({ kind: 'rect' });
+  return group;
+}
+
+// 8) Local const-arrow helper whose return type is inferred-any (its body
+// returns an unresolved-typed value). `const team = useCurrentTeam()` is any,
+// so `team.id` must NOT fire.
+const resolveTeam = () => useCurrentTeam();
+
+export function readTeamId(): string {
+  const team = resolveTeam();
+  return team.id;
+}
+
+// 9) Variable with a type annotation referencing an unresolved import. `record`
+// is `any` only because `Envelope` can't resolve — `record.id` must NOT fire.
+export function readScope(load: () => unknown): string {
+  const record: Envelope = load() as Envelope;
+  return record.id;
 }


### PR DESCRIPTION
## Follow-up to #327

After #327 cut unsafe-any-usage from 44,737 → 4,437 on documenso, two audits (50-sample, then 25-sample on the residual) found **0 genuine TPs** — the entire residual is the same root cause (an `any` originating from an unresolved import, because the routine analyzes without the target's `node_modules`) reaching the rule through node shapes the `tracesAnyToExternalSource` tracer didn't walk.

This PR contains **two commits** that close those blind spots in sequence.

### Commit 1 — destructured parameters
The tracer handled destructured **variables** (`const { x } = expr`) but not destructured **parameters**:
- `function Row({ envelope }: Props)` where `Props` is an unresolved import
- `render={({ field }) => …}` (react-hook-form) — callback param is `any`
- destructured loader/query results

### Commit 2 — four more node shapes
A 25-sample audit of the post-commit-1 residual pinpointed:
1. **NewExpression** — `new Konva.Group()` / `new Hono()` / `new UAParser()` now trace through the constructor.
2. **Entry-point VariableDeclaration** — when the rule flags the `const x = expr` declarator span directly, the node handed in is a `VariableDeclaration`, not an identifier; the old guard bailed. Now runs the full trace (refactored into `variableDeclarationTracesExternal`).
3. **const-arrow return types** — `const helper = () => {…}` whose inferred return is any-from-unresolved, so `const x = helper()` traces external.
4. **Type-annotation check** (`typeReferenceIsExternal`) — `const x: TEnvelope`, `let y: JWTPayload`, `(p: SomeType)` where the annotation resolves to an unresolved import. Unwraps arrays/unions/parens, recurses one hop through local type aliases.

## Impact (documenso@8f6be474, same `--no-llm` analyze, verified from analysis output)

| Stage | unsafe-any | Δ |
|---|---:|---:|
| Original | 44,737 | |
| After #327 | 4,437 | −40,300 |
| After commit 1 (this PR) | 2,503 | −1,934 |
| After commit 2 (this PR) | **880** | −1,623 |
| **Cumulative** | **880** | **~98%** |

unsafe-any is no longer the top rule on documenso — `too-many-lines` (956) now leads. Total violations 56,282 → 5,970.

## Still a tail — ~880 remain

These are further node shapes (iteration elements `for (const x of arr)`, deeper multi-hop chains). Still FPs per the audits, but diminishing returns per fix. The durable fix remains **analyzing with `node_modules` installed** so the TS service resolves these types natively — that would erase the whole class rather than chasing shapes.

## Tests

- Fixture suite green (10/10).
- `unsafe-any-usage-unresolved-external.ts` now has 9 positive cases (schema parse, query hook, useState, ORM destructure, destructured prop, rhf render callback, `new`, const-arrow helper, type annotation).
- Existing explicit-`: any` TPs in the negative fixture still fire (verified) — the rule still catches real developer `any`.

## Correction note

An earlier version of this PR claimed the commit-1 residual dropped to **34 (~99.9%)**. That was a transcription error on my part — no measurement produced 34; the verified commit-1 figure is **2,503**, and after commit 2 it's **880**. All numbers above are read directly from analysis output.

cc @mushgev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Analyzer now recognizes more sources of externally-originating `any` (including constructed values and improved handling of destructured bindings and parameters), reducing false positives when types come from external/unresolved modules.
* **Tests**
  * Added fixtures exercising unresolved imports and several exported helpers to verify no unsafe-`any` alerts for external types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truecourse-ai/truecourse/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->