### PR TITLE
Unblock 11 fp-blocked rules: refine void/regex/complexity/type-aware heuristics (−556 FPs on documenso)

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/non-number-arithmetic.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/non-number-arithmetic.ts
@@ -4,6 +4,39 @@ import { TS_LANGUAGES } from './_helpers.js'
 
 const ARITHMETIC_OPS = new Set(['-', '*', '/', '%', '**'])
 
+// Types that confidently produce NaN under arithmetic. Anything else — a
+// user-defined type name, an unresolved import, a complex union — is treated
+// as "uncertain, don't fire." This is intentionally fail-open: when the
+// target's node_modules isn't installed, `getTypeAtPosition` often returns
+// the parent type name (`PageRenderData`) instead of the resolved field type
+// (`number`), which slipped through the old "anything not in {number,
+// bigint, any}" gate and fired spuriously on every well-typed expression.
+const CONFIDENTLY_NON_NUMERIC = new Set([
+  'string',
+  'boolean',
+  'null',
+  'undefined',
+  'void',
+  'symbol',
+  'never',
+  'object',
+  // Common runtime types that don't auto-coerce to number in arithmetic.
+  'Date',
+])
+
+function isConfidentlyNonNumeric(t: string): boolean {
+  if (CONFIDENTLY_NON_NUMERIC.has(t)) return true
+  // String literal types: `"foo"`, `'bar'`.
+  if (/^["']/.test(t)) return true
+  // Boolean literal types.
+  if (t === 'true' || t === 'false') return true
+  // Array / readonly array of anything: `string[]`, `T[]`, `readonly string[]`.
+  if (/\[\]$/.test(t) || /^readonly\s/.test(t)) return true
+  // Function / object literal types: `(...) => ...`, `{ ... }`.
+  if (t.includes('=>') || t.startsWith('{')) return true
+  return false
+}
+
 /**
  * Detect: Arithmetic operator used with non-numeric operands.
  * Corresponds to sonarjs S3760 (non-number-in-arithmetic-expression).
@@ -27,24 +60,20 @@ export const nonNumberArithmeticVisitor: CodeRuleVisitor = {
     const rightType = typeQuery.getTypeAtPosition(filePath, right.startPosition.row, right.startPosition.column, right.endPosition.row, right.endPosition.column)
     if (!leftType || !rightType) return null
 
-    const numericTypes = new Set(['number', 'bigint', 'any'])
-    const leftOk = numericTypes.has(leftType) || /^\d+$/.test(leftType)
-    const rightOk = numericTypes.has(rightType) || /^\d+$/.test(rightType)
-
     // Skip if either operand is a numeric literal — it's definitely a number
     if (left.type === 'number' || right.type === 'number') return null
 
-    if (!leftOk || !rightOk) {
-      const badSide = !leftOk ? `left operand is \`${leftType}\`` : `right operand is \`${rightType}\``
-      return makeViolation(
-        this.ruleKey, node, filePath, 'high',
-        'Non-numeric value in arithmetic',
-        `Arithmetic operator \`${operator.text}\` used with non-numeric operand — ${badSide}. This will produce \`NaN\` at runtime.`,
-        sourceCode,
-        'Convert operands to numbers or fix the expression.',
-      )
-    }
+    const leftBad = isConfidentlyNonNumeric(leftType)
+    const rightBad = isConfidentlyNonNumeric(rightType)
+    if (!leftBad && !rightBad) return null
 
-    return null
+    const badSide = leftBad ? `left operand is \`${leftType}\`` : `right operand is \`${rightType}\``
+    return makeViolation(
+      this.ruleKey, node, filePath, 'high',
+      'Non-numeric value in arithmetic',
+      `Arithmetic operator \`${operator.text}\` used with non-numeric operand — ${badSide}. This will produce \`NaN\` at runtime.`,
+      sourceCode,
+      'Convert operands to numbers or fix the expression.',
+    )
   },
 }

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/shared-mutable-module-state.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/shared-mutable-module-state.ts
@@ -19,12 +19,47 @@ function isMutableInit(node: SyntaxNode): boolean {
   return node.type === 'object' || node.type === 'array' || node.type === 'new_expression'
 }
 
+// The "shared across requests" hazard only applies to server-side code.
+// Browser-only modules (React hooks, UI primitives, components, anything
+// marked `'use client'`) run per-tab — module-level mutable state there is
+// fine. Path tokens + the `'use client'` directive cover the typical
+// frameworks (Next.js app router, Remix, the shadcn convention).
+const CLIENT_PATH_TOKENS = [
+  '/client/',
+  '/client-only/',
+  '/hooks/',
+  '/primitives/',
+  '/components/',
+  '.client.ts',
+  '.client.tsx',
+]
+
+function isClientSideFile(filePath: string, program: SyntaxNode | null): boolean {
+  for (const tok of CLIENT_PATH_TOKENS) {
+    if (filePath.includes(tok)) return true
+  }
+  // First statement is a `'use client'` / `"use client"` directive.
+  const first = program?.namedChildren[0]
+  if (first?.type === 'expression_statement') {
+    const text = first.text.trim().replace(/;$/, '').replace(/['"`]/g, '')
+    if (text === 'use client') return true
+  }
+  return false
+}
+
 export const sharedMutableModuleStateVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/shared-mutable-module-state',
   languages: JS_LANGUAGES,
   nodeTypes: ['lexical_declaration', 'variable_declaration'],
   visit(node, filePath, sourceCode) {
     if (!isModuleLevel(node)) return null
+
+    // Skip client-side modules — module-level mutable state there isn't
+    // shared across requests, it's shared per-tab (the intended scope for
+    // React-style hook stores like shadcn's `use-toast`).
+    let program: SyntaxNode | null = node
+    while (program && program.type !== 'program') program = program.parent
+    if (isClientSideFile(filePath, program)) return null
 
     // Check if it's let or var (not const)
     const kindChild = node.children[0]

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/void-zero-argument.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/void-zero-argument.ts
@@ -1,6 +1,26 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { JS_LANGUAGES } from './_helpers.js'
+
+// `void <call()>` is the standard fire-and-forget idiom for an intentionally
+// unawaited promise (`void doAsyncThing()`), not a substitute for `undefined`.
+// Only `void <literal/identifier>` (canonically `void 0`) is the
+// replace-with-`undefined` pattern this rule targets. Walk through parens /
+// await / unary wrappers to find whether the operand bottoms out in a call.
+function operandIsCall(operand: SyntaxNode | null | undefined): boolean {
+  let cur: SyntaxNode | null | undefined = operand
+  while (cur) {
+    if (cur.type === 'call_expression' || cur.type === 'new_expression') return true
+    if (cur.type === 'parenthesized_expression' || cur.type === 'await_expression') {
+      // Descend into the wrapped expression (last named child).
+      cur = cur.namedChildren[cur.namedChildren.length - 1] ?? null
+      continue
+    }
+    return false
+  }
+  return false
+}
 
 export const voidZeroArgumentVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/void-zero-argument',
@@ -9,6 +29,10 @@ export const voidZeroArgumentVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     const op = node.children.find((c) => c.text === 'void')
     if (!op) return null
+
+    // Skip fire-and-forget `void promiseCall()` — replacing it with `undefined`
+    // would drop the call entirely. Only flag literal/identifier operands.
+    if (operandIsCall(node.children[node.children.length - 1])) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'medium',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/cognitive-complexity.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/cognitive-complexity.ts
@@ -3,6 +3,26 @@ import { makeViolation } from '../../../types.js'
 import { JS_FUNCTION_TYPES, getFunctionBody, getFunctionName } from './_helpers.js'
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 
+// JSX node types that wrap an embedded TS/JS expression. `cond && <X/>` and
+// `cond ? <A/> : <B/>` inside JSX are conditional-render idioms, not real
+// cognitive complexity — they're the React equivalent of writing two
+// templates. Skip increments when we're inside one of these (but still
+// inside the same outer function).
+const JSX_EXPRESSION_TYPES = new Set([
+  'jsx_expression',          // {expr} attribute / child
+  'jsx_attribute',           // attr={expr}
+])
+
+function isInsideJsxExpression(node: SyntaxNode, functionNodeId: number): boolean {
+  let cur: SyntaxNode | null = node.parent
+  while (cur && cur.id !== functionNodeId) {
+    if (JSX_EXPRESSION_TYPES.has(cur.type)) return true
+    if (JS_FUNCTION_TYPES.includes(cur.type)) return false
+    cur = cur.parent
+  }
+  return false
+}
+
 export const cognitiveComplexityVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/cognitive-complexity',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -19,14 +39,22 @@ export const cognitiveComplexityVisitor: CodeRuleVisitor = {
       if (JS_FUNCTION_TYPES.includes(n.type) && n.id !== node.id) return
 
       if (INCREMENT_TYPES.has(n.type)) {
-        complexity += 1 + nesting
+        // Ternaries inside JSX (`{cond ? <A/> : <B/>}`) are conditional-render
+        // structure, not control flow worth counting.
+        if (n.type === 'ternary_expression' && isInsideJsxExpression(n, node.id)) {
+          // intentionally don't count
+        } else {
+          complexity += 1 + nesting
+        }
       }
       if (n.type === 'else_clause') {
         complexity += 1
       }
       if (n.type === 'binary_expression') {
         const op = n.children.find((c) => c.type === '&&' || c.type === '||')
-        if (op) complexity += 1
+        // `cond && <X/>` / `cond || <X/>` inside JSX is the standard
+        // conditional-render idiom. Don't charge complexity for it.
+        if (op && !isInsideJsxExpression(n, node.id)) complexity += 1
       }
 
       const nextNesting = NESTING_TYPES.has(n.type) ? nesting + 1 : nesting

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/complex-type-alias.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/complex-type-alias.ts
@@ -1,5 +1,29 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+
+// `A | B | C | D` parses as a left-leaning chain of nested union_types in
+// tree-sitter-typescript, not a flat list. Flatten the chain so we can
+// classify each member directly.
+function flattenUnionMembers(node: SyntaxNode): SyntaxNode[] {
+  if (node.type !== 'union_type') return [node]
+  const out: SyntaxNode[] = []
+  for (const child of node.namedChildren) {
+    if (child.type === 'union_type') out.push(...flattenUnionMembers(child))
+    else out.push(child)
+  }
+  return out
+}
+
+const SIMPLE_UNION_MEMBER_TYPES = new Set([
+  'literal_type',
+  'string',
+  'number',
+  'type_identifier',
+  'predefined_type',
+  'null',
+  'undefined',
+])
 
 /**
  * Detects type aliases or inline types with very deep nesting (count depth of
@@ -48,15 +72,15 @@ export const complexTypeAliasVisitor: CodeRuleVisitor = {
     const depth = maxBracketDepth(typeText)
     const members = countUnionIntersectionMembers(typeText)
 
-    // Skip union types where ALL members are simple string or number literals
-    // (e.g., 'a' | 'b' | 'c' — these are enums/discriminated unions, not complex types)
+    // Skip union types whose members are all "simple": string/number/boolean
+    // literals (discriminated unions), single named type references
+    // (`TFoo | TBar | TBaz` enumerating subtypes), or predefined primitives.
+    // Long-but-flat unions of named subtypes are documentation, not
+    // complexity worth flagging.
     if (typeValue.type === 'union_type') {
-      const allLiterals = typeValue.namedChildren.every((child) => {
-        const t = child.type
-        return t === 'literal_type' || t === 'string' || t === 'number'
-          || (t === 'predefined_type' && (child.text === 'string' || child.text === 'number'))
-      })
-      if (allLiterals) return null
+      const members = flattenUnionMembers(typeValue)
+      const allSimple = members.every((m) => SIMPLE_UNION_MEMBER_TYPES.has(m.type))
+      if (allSimple) return null
     }
 
     if (depth >= DEPTH_THRESHOLD || members >= MEMBER_THRESHOLD) {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/negated-condition.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/negated-condition.ts
@@ -1,5 +1,17 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+
+// Count direct statements in a body. For a single-statement body (no braces),
+// the body node IS the statement. For a `statement_block`, count the
+// statement children. Other shapes (expressions, comments) count as one.
+function statementCount(body: SyntaxNode | null | undefined): number {
+  if (!body) return 0
+  if (body.type === 'statement_block') {
+    return body.namedChildren.filter((c) => c.type !== 'comment').length
+  }
+  return 1
+}
 
 export const negatedConditionVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/negated-condition',
@@ -17,6 +29,18 @@ export const negatedConditionVisitor: CodeRuleVisitor = {
 
     const elseBody = elsePart.namedChildren[0]
     if (elseBody?.type === 'if_statement') return null
+
+    // The rule's value is when inversion moves a short bail/guard branch out
+    // of the way of a substantial happy path: `if (!ready) return; else {…}`
+    // reads better as `if (ready) {…} else return;`. When both branches are
+    // substantive (and especially when the if-branch is bigger), the
+    // negation is a deliberate choice — naming the *negative* case the
+    // primary one — and inverting is no longer obviously better. Skip
+    // unless the else-body is meaningfully larger than the if-body.
+    const ifBody = node.childForFieldName('consequence')
+    const ifCount = statementCount(ifBody)
+    const elseCount = statementCount(elseBody)
+    if (elseCount < ifCount + 2) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/no-void.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/no-void.ts
@@ -1,5 +1,22 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+
+// `void <call()>` is the standard fire-and-forget idiom for an intentionally
+// unawaited promise — not a confusing stand-in for `undefined`. Only flag
+// `void <literal/identifier>`. Descend through parens / await wrappers.
+function operandIsCall(operand: SyntaxNode | null | undefined): boolean {
+  let cur: SyntaxNode | null | undefined = operand
+  while (cur) {
+    if (cur.type === 'call_expression' || cur.type === 'new_expression') return true
+    if (cur.type === 'parenthesized_expression' || cur.type === 'await_expression') {
+      cur = cur.namedChildren[cur.namedChildren.length - 1] ?? null
+      continue
+    }
+    return false
+  }
+  return false
+}
 
 export const noVoidVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/no-void',
@@ -10,6 +27,9 @@ export const noVoidVisitor: CodeRuleVisitor = {
     if (operator?.text !== 'void') return null
     const operand = node.children[1]
     if (operand?.text === '0') return null
+
+    // Skip the fire-and-forget `void promiseCall()` idiom.
+    if (operandIsCall(operand)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/require-unicode-regexp.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/require-unicode-regexp.ts
@@ -1,6 +1,21 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
+// The `u`/`v` flag only changes behavior when the pattern actually deals with
+// non-ASCII text: literal non-ASCII characters, unicode escapes (`\u…`,
+// `\p{…}`), or surrogate-relevant constructs. For a pure-ASCII pattern like
+// `/[a-z]+/` or `/^\d{4}$/`, adding `u` is a no-op — requiring it is noise.
+function unicodeFlagWouldMatter(pattern: string): boolean {
+  // Any non-ASCII codepoint in the source pattern.
+  // eslint-disable-next-line no-control-regex
+  if (/[^\x00-\x7F]/.test(pattern)) return true
+  // Unicode-specific escapes whose semantics differ under the u/v flag.
+  //   \u{...} codepoint escapes, \p{...}/\P{...} property escapes.
+  if (/\\u\{/.test(pattern)) return true
+  if (/\\[pP]\{/.test(pattern)) return true
+  return false
+}
+
 export const requireUnicodeRegexpVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/require-unicode-regexp',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -11,6 +26,12 @@ export const requireUnicodeRegexpVisitor: CodeRuleVisitor = {
     const flagText = flags?.text ?? ''
 
     if (flagText.includes('u') || flagText.includes('v')) return null
+
+    // Only flag when the unicode flag would actually change matching behavior.
+    // Pure-ASCII patterns are unaffected by `u`, so requiring it is a false
+    // positive.
+    const pattern = node.namedChildren.find((c) => c.type === 'regex_pattern')?.text ?? ''
+    if (!unicodeFlagWouldMatter(pattern)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/unnamed-regex-capture.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/unnamed-regex-capture.ts
@@ -9,7 +9,11 @@ export const unnamedRegexCaptureVisitor: CodeRuleVisitor = {
     const pattern = node.namedChildren.find((c) => c.type === 'regex_pattern')
     const src = pattern?.text ?? ''
 
-    let hasUnnamed = false
+    // Count "meaningful" unnamed capture groups. A single capture group is
+    // unambiguous — `m[1]` is self-evidently the one capture, so naming adds
+    // ceremony without value. Named groups disambiguate when there are
+    // *several* captures, so only flag when 2+ unnamed groups are present.
+    let unnamedCount = 0
     for (let i = 0; i < src.length; i++) {
       if (src[i] === '\\') { i++; continue }
       if (src[i] === '(') {
@@ -26,25 +30,37 @@ export const unnamedRegexCaptureVisitor: CodeRuleVisitor = {
           }
           const groupContent = src.slice(i + 1, j - 1)
 
+          // Skip groups immediately followed by a quantifier (`)+`, `)*`,
+          // `)?`, `){...}`). These are structural — used to apply the
+          // quantifier to a sub-pattern, not to extract data (you only ever
+          // get the last iteration's match), so naming adds nothing.
+          const after = src[j]
+          if (after === '+' || after === '*' || after === '?' || after === '{') {
+            continue
+          }
+
           // Skip groups that are purely alternation of short literals/tokens
-          // e.g., (a|b), (\?|$), (http|https), (s?)
+          // e.g., (a|b), (\?|$), (http|https), (s?) — these are
+          // matching/grouping constructs, not data captures worth naming.
           if (groupContent.includes('|')) {
             const alternatives = groupContent.split('|')
             const isSimpleAlternation = alternatives.every((alt) => /^[a-zA-Z0-9_\\?.^$*+\-]+$/.test(alt) && alt.length <= 10)
             if (isSimpleAlternation) continue
           }
 
-          hasUnnamed = true
-          break
+          unnamedCount++
         }
       }
     }
 
-    if (hasUnnamed) {
+    // A lone capture group reads fine as `match[1]`; named groups only earn
+    // their keep when multiple captures would otherwise be positional and
+    // easy to mix up.
+    if (unnamedCount >= 2) {
       return makeViolation(
         this.ruleKey, node, filePath, 'low',
-        'Unnamed capture group',
-        'Regex contains unnamed capture groups. Use named groups `(?<name>...)` for better readability.',
+        'Unnamed capture groups',
+        'Regex contains multiple unnamed capture groups. Use named groups `(?<name>...)` for better readability.',
         sourceCode,
         'Convert capture groups to named: `(?<name>...)` or non-capturing: `(?:...)`.',
       )

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/useless-empty-export.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/useless-empty-export.ts
@@ -1,5 +1,32 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+
+// `export {}` is the documented way to force a file to be parsed as an ES
+// module rather than a global script. That matters for:
+//   - bare barrel files with no actual exports
+//   - polyfills / `declare global { ... }` augmentations (need to be modules
+//     for the augmentation to apply)
+//   - any file lacking another import/export
+// Only flag when the file already contains other top-level imports or
+// exports — in those cases the empty `export {}` is genuinely redundant.
+function fileHasOtherTopLevelModuleStatement(emptyExport: SyntaxNode): boolean {
+  let program: SyntaxNode | null = emptyExport
+  while (program && program.type !== 'program') program = program.parent
+  if (!program) return false
+  for (const child of program.namedChildren) {
+    if (child.id === emptyExport.id) continue
+    if (child.type === 'import_statement') return true
+    if (child.type === 'export_statement') {
+      // Another export_statement counts — but ignore if it's another empty
+      // export (the file would still need at least one to be a module).
+      const inner = child.namedChildren.find((c) => c.type === 'named_exports' || c.type === 'export_clause')
+      if (!inner || inner.namedChildCount > 0) return true
+      // It's another empty export — keep scanning.
+    }
+  }
+  return false
+}
 
 export const uselessEmptyExportVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/useless-empty-export',
@@ -8,16 +35,17 @@ export const uselessEmptyExportVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     const namedExports = node.namedChildren.find((c) => c.type === 'named_exports' || c.type === 'export_clause')
     if (!namedExports) return null
+    if (namedExports.namedChildCount !== 0) return null
 
-    if (namedExports.namedChildCount === 0) {
-      return makeViolation(
-        this.ruleKey, node, filePath, 'low',
-        'Useless empty export',
-        '`export {}` does nothing useful. Remove it unless it is needed to mark the file as a module.',
-        sourceCode,
-        'Remove the empty `export {}` statement.',
-      )
-    }
-    return null
+    // Bare-barrel / global-augmentation / polyfill files need the marker.
+    if (!fileHasOtherTopLevelModuleStatement(node)) return null
+
+    return makeViolation(
+      this.ruleKey, node, filePath, 'low',
+      'Useless empty export',
+      '`export {}` does nothing useful. Remove it unless it is needed to mark the file as a module.',
+      sourceCode,
+      'Remove the empty `export {}` statement.',
+    )
   },
 }

--- a/tests/analyzer/bugs-rules.test.ts
+++ b/tests/analyzer/bugs-rules.test.ts
@@ -1684,10 +1684,24 @@ describe('bugs/deterministic/void-zero-argument', () => {
     expect(matches).toHaveLength(1);
   });
 
-  it('detects void expression', () => {
-    const violations = check(`void doSomething();`);
+  it('detects void with an identifier operand', () => {
+    const violations = check(`const x = void undefinedVar;`);
     const matches = violations.filter((v) => v.ruleKey === 'bugs/deterministic/void-zero-argument');
     expect(matches).toHaveLength(1);
+  });
+
+  it('does not flag fire-and-forget void call()', () => {
+    // `void doSomething()` is the standard idiom for an intentionally
+    // unawaited promise — replacing it with `undefined` would drop the call.
+    const violations = check(`void doSomething();`);
+    const matches = violations.filter((v) => v.ruleKey === 'bugs/deterministic/void-zero-argument');
+    expect(matches).toHaveLength(0);
+  });
+
+  it('does not flag fire-and-forget void await chain', () => {
+    const violations = check(`void getThing().then((r) => r);`);
+    const matches = violations.filter((v) => v.ruleKey === 'bugs/deterministic/void-zero-argument');
+    expect(matches).toHaveLength(0);
   });
 });
 

--- a/tests/analyzer/code-quality-rules.test.ts
+++ b/tests/analyzer/code-quality-rules.test.ts
@@ -1017,14 +1017,22 @@ describe('code-quality/deterministic/no-proto', () => {
 });
 
 describe('code-quality/deterministic/no-void', () => {
-  it('detects void expression', () => {
-    const violations = check(`void someFunction();`);
+  it('detects void with an identifier operand', () => {
+    const violations = check(`const x = void someValue;`);
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/no-void');
     expect(matches).toHaveLength(1);
   });
 
   it('does not flag void 0', () => {
     const violations = check(`const undef = void 0;`);
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/no-void');
+    expect(matches).toHaveLength(0);
+  });
+
+  it('does not flag fire-and-forget void call()', () => {
+    // `void someFunction()` is the standard fire-and-forget idiom for an
+    // intentionally unawaited promise — not a confusing `undefined` stand-in.
+    const violations = check(`void someFunction();`);
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/no-void');
     expect(matches).toHaveLength(0);
   });
@@ -3191,10 +3199,17 @@ describe('code-quality/deterministic/default-parameter-position', () => {
 });
 
 describe('code-quality/deterministic/unnamed-regex-capture', () => {
-  it('detects unnamed capture group in regex', () => {
-    const violations = check(`const re = /(\\d+)/;`);
+  it('detects multiple unnamed capture groups in regex', () => {
+    const violations = check(`const re = /(\\d{4})-(\\d{2})-(\\d{2})/;`);
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/unnamed-regex-capture');
     expect(matches).toHaveLength(1);
+  });
+
+  it('does not flag a single unnamed capture group', () => {
+    // One capture is unambiguous (`m[1]`); naming adds ceremony without value.
+    const violations = check(`const re = /(\\d+)/;`);
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/unnamed-regex-capture');
+    expect(matches).toHaveLength(0);
   });
 
   it('does not flag non-capturing group', () => {
@@ -5132,14 +5147,27 @@ describe('code-quality/deterministic/undef-init', () => {
 });
 
 describe('code-quality/deterministic/require-unicode-regexp', () => {
-  it('detects regex without u flag', () => {
-    const violations = check(`const r = /[a-z]+/;`);
+  it('detects unicode-relevant regex without u flag', () => {
+    // `\u{...}` codepoint escape only behaves correctly under the u flag.
+    const violations = check(`const r = /\\u{1F600}/;`);
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/require-unicode-regexp');
     expect(matches.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('detects property-escape regex without u flag', () => {
+    const violations = check(`const r = /\\p{Letter}+/;`);
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/require-unicode-regexp');
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not flag a pure-ASCII regex (u flag is a no-op)', () => {
+    const violations = check(`const r = /[a-z]+/;`);
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/require-unicode-regexp');
+    expect(matches).toHaveLength(0);
+  });
+
   it('does not flag regex with u flag', () => {
-    const violations = check(`const r = /[a-z]+/u;`);
+    const violations = check(`const r = /\\u{1F600}/u;`);
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/require-unicode-regexp');
     expect(matches).toHaveLength(0);
   });

--- a/tests/analyzer/code-quality-rules.test.ts
+++ b/tests/analyzer/code-quality-rules.test.ts
@@ -663,6 +663,40 @@ describe('code-quality/deterministic/cognitive-complexity', () => {
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/cognitive-complexity');
     expect(matches).toHaveLength(0);
   });
+
+  it('does not count short-circuits and ternaries inside JSX as cognitive complexity', () => {
+    // A React-style component whose only "complexity" is conditional render
+    // (`cond && <X/>`, `cond ? <A/> : <B/>`) — these are structural template
+    // patterns, not control-flow worth charging. The pre-fix heuristic
+    // counted each one and pushed many real components over the threshold.
+    const violations = check(`
+      function Panel({ a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q }: Record<string, boolean>) {
+        return (
+          <div>
+            {a && <span/>}
+            {b && <span/>}
+            {c && <span/>}
+            {d && <span/>}
+            {e && <span/>}
+            {f && <span/>}
+            {g && <span/>}
+            {h && <span/>}
+            {i ? <span/> : <em/>}
+            {j ? <span/> : <em/>}
+            {k ? <span/> : <em/>}
+            {l ? <span/> : <em/>}
+            {m ? <span/> : <em/>}
+            {n ? <span/> : <em/>}
+            {o ? <span/> : <em/>}
+            {p ? <span/> : <em/>}
+            {q ? <span/> : <em/>}
+          </div>
+        );
+      }
+    `);
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/cognitive-complexity');
+    expect(matches).toHaveLength(0);
+  });
 });
 
 describe('code-quality/deterministic/cyclomatic-complexity', () => {
@@ -3500,10 +3534,36 @@ describe('code-quality/deterministic/regex-unicode-awareness', () => {
 // ---------------------------------------------------------------------------
 
 describe('code-quality/deterministic/negated-condition', () => {
-  it('detects negated condition with else', () => {
-    const violations = check(`if (!isReady) { fallback(); } else { proceed(); }`);
+  it('detects small negated bail with substantial else body', () => {
+    // Classic case the rule is designed for: the inversion clearly moves a
+    // small early-bail out of the way of a larger happy path.
+    const violations = check(`
+      if (!ready) {
+        log('not ready');
+      } else {
+        step1();
+        step2();
+        step3();
+        step4();
+      }
+    `);
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/negated-condition');
     expect(matches).toHaveLength(1);
+  });
+
+  it('does not flag when both branches are substantive', () => {
+    // When both branches do real work, the negation is a deliberate semantic
+    // choice — inverting wouldn't obviously improve readability.
+    const violations = check(`
+      if (!isEmbedded) {
+        const response = await api.run();
+        result = response.data;
+      } else {
+        result = compute();
+      }
+    `);
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/negated-condition');
+    expect(matches).toHaveLength(0);
   });
 
   it('does not flag negated condition without else', () => {

--- a/tests/analyzer/code-quality-rules.test.ts
+++ b/tests/analyzer/code-quality-rules.test.ts
@@ -3422,10 +3422,22 @@ describe('code-quality/deterministic/triple-slash-reference', () => {
 });
 
 describe('code-quality/deterministic/useless-empty-export', () => {
-  it('detects empty export {}', () => {
-    const violations = check(`export {};`);
+  it('detects empty export {} alongside other exports (redundant module marker)', () => {
+    const violations = check(`
+      export const foo = 1;
+      export {};
+    `);
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/useless-empty-export');
     expect(matches).toHaveLength(1);
+  });
+
+  it('does not flag a lone export {} (file needs it to be a module)', () => {
+    // Bare barrels and `declare global` polyfill files need `export {}` to
+    // be parsed as ES modules — removing it changes the semantic
+    // module/script classification.
+    const violations = check(`export {};`);
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/useless-empty-export');
+    expect(matches).toHaveLength(0);
   });
 
   it('does not flag export with names', () => {
@@ -7741,10 +7753,22 @@ describe('code-quality/deterministic/complex-type-alias', () => {
     expect(matches).toHaveLength(1);
   });
 
-  it('detects type alias with many union members', () => {
-    const violations = check(`type Many = A | B | C | D | E | F | G;`);
+  it('detects type alias with many complex union members', () => {
+    // 7 members where each carries generics — genuine complexity, not just
+    // a flat enumeration of named subtypes.
+    const violations = check(
+      `type Many = Box<A> | Box<B> | Box<C> | Box<D> | Box<E> | Box<F> | Box<G>;`,
+    );
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/complex-type-alias');
     expect(matches).toHaveLength(1);
+  });
+
+  it('does not flag flat union of named subtypes (documentation, not complexity)', () => {
+    // `TFooMeta | TBarMeta | ...` is enumerating a discriminated-union family;
+    // each member is a single identifier, no generics.
+    const violations = check(`type Many = A | B | C | D | E | F | G;`);
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/complex-type-alias');
+    expect(matches).toHaveLength(0);
   });
 
   it('does not flag simple type alias', () => {

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-advanced.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-advanced.ts
@@ -52,11 +52,16 @@ export class EmptyStatic {
 }
 
 // VIOLATION: code-quality/deterministic/negated-condition
+// Small negated bail with a substantive else body — inverting moves the
+// happy path ahead of the early-bail and reads more naturally.
 export function negated(x: number) {
   if (!x) {
     return 'falsy';
   } else {
-    return 'truthy';
+    const doubled = x * 2;
+    const squared = x * x;
+    const cubed = x * x * x;
+    return `truthy: ${doubled} ${squared} ${cubed}`;
   }
 }
 

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-basics.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-basics.ts
@@ -48,9 +48,11 @@ export function getProto(obj: any) {
 
 // VIOLATION: code-quality/deterministic/no-void
 export function voidCall() {
-  return void someFunction();
+  // `void <identifier>` is the confusing stand-in for `undefined` the rule
+  // targets — NOT a fire-and-forget `void promiseCall()`, which is legitimate.
+  const value = 42;
+  return void value;
 }
-function someFunction() { return 42; }
 
 // VIOLATION: code-quality/deterministic/console-log
 export function logDebug() {

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/code-quality-misc.ts
@@ -278,9 +278,12 @@ export function renderHeading(text: string, isCondensed: boolean) {
 }
 
 // VIOLATION: code-quality/deterministic/require-unicode-regexp
-export const noUnicode = /hello/;
+// Unicode property escape — only matches correctly under the `u` flag, so
+// omitting it is a real bug (not a no-op on a pure-ASCII pattern).
+export const noUnicode = /\p{Emoji}/;
 
 // VIOLATION: code-quality/deterministic/regex-complexity
+// VIOLATION: code-quality/deterministic/unnamed-regex-capture
 export const complexRegex = /(?=abc)(?!def)(group1)(group2)(group3)(group4)(group5)/;
 
 // VIOLATION: code-quality/deterministic/regex-concise


### PR DESCRIPTION
Unblocks **9 of 11** `fp-blocked` rules on the documenso campaign — together **556 of the 608 blocked-rule FPs**. Each needed a unit-test edit outside `tests/fixtures/` (the routine's forbidden scope), which is why they were `fp-blocked` rather than auto-fixed.

## Rules fixed

### void-family (#117 `void-zero-argument`, #264 `no-void`)
Fired on every `void` expression. But `void promiseCall()` is the fire-and-forget idiom for an intentionally unawaited promise. Now both skip when the operand bottoms out in a call/new expression; only `void <literal/identifier>` flags.

### regex-family (#267 `require-unicode-regexp`, #269 `unnamed-regex-capture`)
- **#267**: The `u`/`v` flag is a no-op on pure-ASCII patterns. Now only flags when it would change behavior (non-ASCII char, `\u{…}` codepoint, `\p{…}`/`\P{…}` property escape).
- **#269**: A single unnamed group is unambiguous (`m[1]`). Now requires 2+ unnamed groups; also skips groups immediately followed by a quantifier (`)+`, `)?`, …) since those are structural.

### complexity-family (#257 `cognitive-complexity`, #263 `negated-condition`)
- **#257**: `cond && <X/>` and `cond ? <A/> : <B/>` inside JSX are conditional-render idioms, not control flow. Now skips short-circuits + ternaries inside `jsx_expression`/`jsx_attribute` (still inside the same outer function). Partial fix — 28% reduction; the residual 50 are genuine multi-branch validators.
- **#263**: Fired on every `if (!cond) {…} else {…}`. The rule's value is when inversion moves a *small* bail out of a *large* happy path. Now requires the else-body to be meaningfully larger than the if-body.

### type-aware (#112 `non-number-arithmetic`)
Fired whenever the operand type wasn't `{number, bigint, any}` — but with node_modules absent, destructured fields can report a parent type name like `"PageRenderData"`, slipping through. Switched to fail-open: only fire when the operand type is **confidently non-numeric** (string, boolean, null, undefined, void, symbol, Date, string/boolean literals, array types, function types, object literals).

### marker / module-state (#153 `useless-empty-export`, #197 `shared-mutable-module-state`)
- **#153**: A lone `export {}` is the documented way to force a file to be parsed as an ES module (bare barrels, `declare global` polyfills). Only flag when the file already has another top-level import/export.
- **#197**: The "shared across requests" hazard only applies server-side. Skip when the file path contains `/client/`, `/client-only/`, `/hooks/`, `/primitives/`, `/components/`, ends in `.client.ts(x)`, or starts with a `'use client'` directive.

### type-alias (#307 `complex-type-alias`)
Existing literal-only skip didn't fire because tree-sitter-typescript parses `A | B | C | D` as a *left-leaning chain* of nested `union_type` nodes, not a flat list. Now flattens the chain, and broadens "simple" to include `type_identifier` and `predefined_type` — so `TFooMeta | TBarMeta | …` and `string | number | boolean | null | undefined | Date` are recognised as documentation, not complexity.

## Impact (documenso@8f6be474, same `--no-llm` analyze, verified)

| Issue | Rule | Before | After |
|---|---|---:|---:|
| #117 | void-zero-argument | 205 | **0** |
| #264 | no-void | 205 | **0** |
| #267 | require-unicode-regexp | 73 | **0** |
| #269 | unnamed-regex-capture | 14 | **2** |
| #257 | cognitive-complexity | 70 | **50** |
| #263 | negated-condition | 9 | **0** |
| #112 | non-number-arithmetic | 21 | **0** |
| #153 | useless-empty-export | 7 | **0** |
| #307 | complex-type-alias | 3 | **0** |
| #197 | shared-mutable-module-state | 1 | **0** |
| #119 | data-layer-depends-on-api | 0 | **0** (already gone) |
| **Blocked-rule sum** | | **608** | **52** (−556, ~91%) |
| **All documenso violations** | | **5,970** | **5,414** (−556) |

## The 52 residuals

- **#257 cognitive-complexity (50)**: genuine multi-branch validators / handlers (e.g. `validateCheckboxField` with 7 sequential guards + a switch). The JSX-noise FP class is fixed; the residual is "strict-rule says this function is complex" territory where reasonable people disagree. Not over-tuning the heuristic further — that risks suppressing real TPs in non-React code.
- **#269 unnamed-regex-capture (2)**: borderline alternation groups used with `.test()` (e.g. `/^\/(signin|forgot-password|…)(\/|\.data|$)/`). Could be cleared by broadening the alternation heuristic but at risk of suppressing genuine multi-capture extraction.

#119 closes on merge (the underlying rule has already produced no hits on documenso for the current `target_ref`).

## Tests

Full suite green — **3,464 tests, 58 files**. Where the cleanup turned a previous TP unit test into a no-fire case, a new genuine-TP shape replaced it:
- `bugs-rules.test.ts`: void-zero-argument with identifier-operand + await-chain FP cases.
- `code-quality-rules.test.ts`: no-void/regex/negated-condition/complex-type-alias/useless-empty-export/cognitive-complexity all gained refined TP+FP pairs.
- Negative fixtures (`code-quality-basics.ts`, `code-quality-misc.ts`, `code-quality-advanced.ts`) updated to keep their VIOLATION markers representing real bugs under the new heuristics.

Closes #112
Closes #117
Closes #119
Closes #153
Closes #197
Closes #257
Closes #263
Closes #264
Closes #267
Closes #269
Closes #307

cc @mushgev