### PR TITLE
chore(fp): start discovery for triggerdotdev/trigger.dev

### DIFF
--- a/docs/fp-automation/campaigns.yaml
+++ b/docs/fp-automation/campaigns.yaml
@@ -31,7 +31,7 @@ campaigns:
   - target_repo: triggerdotdev/trigger.dev
     tech_stack: [typescript, monorepo, state-machines]
     priority: 2
-    status: pending
+    status: discovering
     baseline: { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     final:    { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     notes: []

--- a/docs/fp-automation/campaigns.yaml
+++ b/docs/fp-automation/campaigns.yaml
@@ -32,7 +32,7 @@ campaigns:
     tech_stack: [typescript, monorepo, state-machines]
     priority: 2
     status: discovering
-    baseline: { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
+    baseline: { analyzed_at: "2026-06-02", target_ref: "2dd9f37b4045d2a414c0a300995d068f28926d50", total_violations: 36177, tp: 850, fp: 421, tp_rate: 0.67 }
     final:    { analyzed_at: null, target_ref: null, total_violations: null, tp: null, fp: null, tp_rate: null }
     notes: []
 


### PR DESCRIPTION
Starting an fp-discover run for `triggerdotdev/trigger.dev` (priority 2 in `docs/fp-automation/campaigns.yaml`).

## What this PR does

- Flips the campaign's `status` from `pending` to `discovering`.
- Acts as the durable surface for this discovery session: the analyze run, baseline numbers, and any blockers will be pushed as follow-up commits/comments here.

## What happens next

While this PR is open, the session is:
1. Building truecourse from local source (`pnpm build:dist`).
2. Cloning `triggerdotdev/trigger.dev` to `/tmp/target` and running `analyze --no-llm --no-stash --no-skills` against it.
3. Triaging violations rule-by-rule, sampling up to 10 per rule.
4. Filing one GitHub issue per rule with an FP rate ≥ 10 %, labelled `fp-fix` + `fp-target:triggerdotdev-trigger.dev`.
5. Pushing the baseline numbers (`total_violations`, `tp`, `fp`, `tp_rate`, `target_ref`) back into this PR.

Merging this PR (with the `fp-discover` label applied) is what fires `fp-next-fix` to start the inner repair loop. The user merges it when they're ready to start; this routine does not auto-merge.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvxFE2Y8DgCBYyPA3mEyrD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated campaign entry status to "discovering" and added baseline analysis metrics (analysis timestamp, target reference, violation and true/false positive counts, and computed rate).
* **Chores**
  * Left final results unset and preserved existing notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->