### PR TITLE
ee: enterprise overlay (WorkOS SSO + Workspace)

### DIFF
--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,0 +1,17 @@
+TrueCourse Enterprise Edition License
+
+Copyright (c) 2026-present TrueCourse AI, Inc.
+
+All content in this directory (the "ee/" directory) and its
+subdirectories is licensed under this commercial license, NOT under the
+MIT License that governs the rest of the repository.
+
+You may read, copy, and modify the contents of this directory for the
+sole purposes of development and testing. Any use in production — or any
+use that provides the functionality herein to third parties, whether as
+a hosted service or otherwise — requires a valid TrueCourse Enterprise
+subscription and license key.
+
+This software is provided "as is", without warranty of any kind. See the
+root LICENSE file for the terms governing everything outside this
+directory.

--- a/ee/README.md
+++ b/ee/README.md
@@ -1,0 +1,28 @@
+# TrueCourse Enterprise Edition (`ee/`)
+
+Commercial-licensed enterprise features that layer onto the open-source
+core. **Everything in this directory is governed by [`ee/LICENSE`](./LICENSE),
+not the repository's root MIT license.**
+
+## Boundary rule
+
+Imports are one-way: **`ee/` may import from OSS packages; OSS code must
+never import from `ee/`.** OSS loads enterprise code only through the
+sanctioned runtime seams (a server plugin loader and a client route/slot
+registry), never via a static `import` of an `@truecourse/ee-*` package.
+This keeps the OSS build free of commercial code and lets the community
+edition run with `ee/` absent.
+
+## Packages
+
+- `packages/server` (`@truecourse/ee-server`) — enterprise server code
+  (WorkOS SSO/auth) that registers into the dashboard server's plugin seam.
+- `packages/client` (`@truecourse/ee-client`) — enterprise UI (the
+  Workspace page) contributed into the dashboard client's route + nav
+  registries.
+
+## Enablement
+
+Enterprise mode turns on when WorkOS is configured (or
+`TRUECOURSE_EDITION=enterprise`). When off, the dashboard runs exactly as
+the community edition with no authentication.

--- a/ee/packages/client/package.json
+++ b/ee/packages/client/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@truecourse/ee-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.tsx",
+  "exports": {
+    ".": "./src/index.tsx"
+  },
+  "scripts": {
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@truecourse/shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/ee/packages/client/src/WorkspaceHome.tsx
+++ b/ee/packages/client/src/WorkspaceHome.tsx
@@ -1,0 +1,151 @@
+/**
+ * Enterprise home — the workspace dashboard. Replaces the OSS local-CLI
+ * onboarding screen with org stats and a list of repositories.
+ *
+ * Repo data is the locally-analyzed set today; once GitHub connection
+ * lands it becomes the GitHub-connected repos and "Connect repository"
+ * starts the install flow (stubbed for now).
+ */
+
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { WorkspaceOverviewResponse } from '@truecourse/shared';
+import { getJson } from './api';
+
+function timeAgo(iso: string | null): string {
+  if (!iso) return 'never';
+  const ms = Date.now() - Date.parse(iso);
+  if (Number.isNaN(ms)) return '—';
+  const mins = Math.floor(ms / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: number | string;
+  sub?: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-semibold text-foreground">{value}</div>
+      {sub && <div className="mt-1 text-[11px] text-muted-foreground">{sub}</div>}
+    </div>
+  );
+}
+
+export default function WorkspaceHome() {
+  const [data, setData] = useState<WorkspaceOverviewResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showSoon, setShowSoon] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getJson<WorkspaceOverviewResponse>('/api/ee/workspace/overview')
+      .then((d) => !cancelled && setData(d))
+      .catch((e) => !cancelled && setError(e instanceof Error ? e.message : String(e)));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const s = data?.stats;
+  const sev = s?.severity;
+
+  return (
+    <div className="mx-auto max-w-5xl p-8">
+      {/* Title row */}
+      <div className="flex items-end justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">
+            {data?.organizationName ?? 'Workspace'}
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {s ? `${s.repoCount} repositories` : 'Loading…'}
+          </p>
+        </div>
+        <div className="text-right">
+          <button
+            onClick={() => setShowSoon(true)}
+            className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:opacity-90"
+          >
+            + Connect repository
+          </button>
+          {showSoon && (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              GitHub connection is coming soon.
+            </p>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="mt-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
+          {error}
+        </div>
+      )}
+
+      {/* Stat cards — workspace code-health at a glance. Org/admin info
+          (members, SSO) lives on the Workspace page, not here. */}
+      <div className="mt-6 grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <StatCard label="Repositories" value={s?.repoCount ?? '—'} />
+        <StatCard
+          label="Open violations"
+          value={s?.violationCount ?? '—'}
+          sub={
+            sev
+              ? `${sev.critical} crit · ${sev.high} high · ${sev.medium} med`
+              : undefined
+          }
+        />
+        <StatCard label="BL drift" value={s?.driftCount ?? '—'} />
+        <StatCard
+          label="Needs analysis"
+          value={s?.staleCount ?? '—'}
+          sub={s ? `of ${s.repoCount} repos` : undefined}
+        />
+      </div>
+
+      {/* Repositories */}
+      <h2 className="mt-8 text-sm font-semibold text-foreground">Repositories</h2>
+      <div className="mt-2 overflow-hidden rounded-md border border-border">
+        {!data ? (
+          <div className="px-4 py-6 text-xs text-muted-foreground">Loading…</div>
+        ) : data.repos.length === 0 ? (
+          <div className="px-4 py-6 text-xs text-muted-foreground">
+            No repositories yet. Connect a GitHub repository to get started.
+          </div>
+        ) : (
+          <ul className="divide-y divide-border">
+            {data.repos.map((r) => (
+              <li key={r.id}>
+                <Link
+                  to={`/repos/${r.id}`}
+                  className="flex items-center justify-between px-4 py-2.5 text-sm hover:bg-muted/50 transition-colors"
+                >
+                  <span className="font-medium text-foreground">{r.name}</span>
+                  <span className="flex items-center gap-4 text-xs text-muted-foreground">
+                    <span>{r.violations} viol</span>
+                    <span>{r.drift ? `${r.drift} drift` : '—'}</span>
+                    <span>{timeAgo(r.lastAnalyzed)}</span>
+                    <span aria-hidden>→</span>
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ee/packages/client/src/WorkspacePage.tsx
+++ b/ee/packages/client/src/WorkspacePage.tsx
@@ -1,0 +1,121 @@
+/**
+ * Workspace — the enterprise-only page. Shows the org's SSO connection
+ * status and members, both sourced from WorkOS via the protected
+ * /api/ee/workspace endpoints.
+ */
+
+import { useEffect, useState } from 'react';
+import type {
+  SsoStatusResponse,
+  WorkspaceMembersResponse,
+} from '@truecourse/shared';
+import { getJson } from './api';
+
+export default function WorkspacePage() {
+  const [sso, setSso] = useState<SsoStatusResponse | null>(null);
+  const [members, setMembers] = useState<WorkspaceMembersResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      getJson<SsoStatusResponse>('/api/ee/workspace/sso-status'),
+      getJson<WorkspaceMembersResponse>('/api/ee/workspace/members'),
+    ])
+      .then(([s, m]) => {
+        if (cancelled) return;
+        setSso(s);
+        setMembers(m);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-3xl p-8">
+      <h1 className="text-xl font-semibold text-foreground">Workspace</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Enterprise SSO and members, synced from WorkOS.
+      </p>
+
+      {error && (
+        <div className="mt-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
+          {error}
+        </div>
+      )}
+
+      {/* SSO connection status */}
+      <section className="mt-6">
+        <h2 className="text-sm font-semibold text-foreground">
+          Single sign-on
+        </h2>
+        {sso === null ? (
+          <p className="mt-2 text-xs text-muted-foreground">Loading…</p>
+        ) : sso.configured ? (
+          <ul className="mt-2 space-y-2">
+            {sso.connections.map((c) => (
+              <li
+                key={c.id}
+                className="flex items-center justify-between rounded-md border border-border bg-card px-3 py-2"
+              >
+                <div>
+                  <div className="text-sm font-medium text-foreground">
+                    {c.name}
+                  </div>
+                  <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                    {c.type}
+                  </div>
+                </div>
+                <span
+                  className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                    c.state === 'active'
+                      ? 'bg-emerald-500/15 text-emerald-500'
+                      : 'bg-amber-500/15 text-amber-500'
+                  }`}
+                >
+                  {c.state}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-2 text-xs text-muted-foreground">
+            No SSO connection configured for this organization yet.
+          </p>
+        )}
+      </section>
+
+      {/* Members */}
+      <section className="mt-8">
+        <h2 className="text-sm font-semibold text-foreground">Members</h2>
+        {members === null ? (
+          <p className="mt-2 text-xs text-muted-foreground">Loading…</p>
+        ) : members.members.length === 0 ? (
+          <p className="mt-2 text-xs text-muted-foreground">No members found.</p>
+        ) : (
+          <ul className="mt-2 divide-y divide-border rounded-md border border-border">
+            {members.members.map((m) => {
+              const name =
+                [m.firstName, m.lastName].filter(Boolean).join(' ') || m.email;
+              return (
+                <li
+                  key={m.id}
+                  className="flex items-center justify-between px-3 py-2"
+                >
+                  <span className="text-sm text-foreground">{name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {m.email}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/ee/packages/client/src/api.ts
+++ b/ee/packages/client/src/api.ts
@@ -1,0 +1,20 @@
+/**
+ * Minimal authenticated fetch for the enterprise client pages. Resolves
+ * the API base the same way the OSS client does (dev: client :3000 →
+ * API :3001; prod: same origin) and sends the session cookie.
+ */
+
+function serverUrl(): string {
+  if (typeof window === 'undefined') return '';
+  const port = window.location.port;
+  if (port && port !== '3001') {
+    return `http://${window.location.hostname}:3001`;
+  }
+  return '';
+}
+
+export async function getJson<T>(path: string): Promise<T> {
+  const res = await fetch(`${serverUrl()}${path}`, { credentials: 'include' });
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  return res.json() as Promise<T>;
+}

--- a/ee/packages/client/src/index.tsx
+++ b/ee/packages/client/src/index.tsx
@@ -1,0 +1,38 @@
+/**
+ * Enterprise client entry point.
+ *
+ * The OSS dashboard client discovers this module through a gated
+ * dynamic import (never a static import) and merges its routes + nav
+ * items into the OSS route/nav registries. Each contribution is gated
+ * on a capability, so even when this module is loaded the entries only
+ * appear if the edition's license enables them.
+ *
+ * Route components are lazy (`load`) so they code-split into their own
+ * chunk.
+ */
+
+import type { EeClientModule } from '@truecourse/shared';
+
+const eeClientModule: EeClientModule = {
+  routes: [
+    {
+      path: '/workspace',
+      load: () => import('./WorkspacePage'),
+      requiredCapability: 'workspace',
+    },
+  ],
+  navItems: [
+    {
+      id: 'workspace',
+      label: 'Workspace',
+      to: '/workspace',
+      iconName: 'Building2',
+      requiredCapability: 'workspace',
+    },
+  ],
+  // Enterprise home: the workspace dashboard replaces the OSS onboarding
+  // page at "/".
+  homeComponent: () => import('./WorkspaceHome'),
+};
+
+export default eeClientModule;

--- a/ee/packages/client/tsconfig.json
+++ b/ee/packages/client/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "jsx": "react-jsx",
+    "types": ["node"],
+    "rootDir": "src",
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/ee/packages/server/package.json
+++ b/ee/packages/server/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@truecourse/ee-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@truecourse/core": "workspace:*",
+    "@truecourse/shared": "workspace:*",
+    "@workos-inc/node": "^7.0.0"
+  },
+  "peerDependencies": {
+    "express": "^4.21.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/ee/packages/server/src/auth.ts
+++ b/ee/packages/server/src/auth.ts
@@ -1,0 +1,175 @@
+/**
+ * WorkOS AuthKit auth: the session verifier the OSS gate calls, plus the
+ * public auth routes (login / callback / logout / me).
+ *
+ * Session model: AuthKit seals the session into an encrypted cookie
+ * (`tc_session`). The verifier unseals + validates it on each request;
+ * the callback sets it after exchanging the auth code.
+ */
+
+import { Router } from 'express';
+import { WorkOS } from '@workos-inc/node';
+import type { User } from '@workos-inc/node';
+import type { AuthResult, AuthUser, EeAuthVerifier } from '@truecourse/shared';
+import type { WorkosConfig } from './config.js';
+import { parseCookies, serializeCookie } from './cookies.js';
+
+export const SESSION_COOKIE = 'tc_session';
+const SESSION_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
+function isSecure(appUrl: string): boolean {
+  return appUrl.startsWith('https://');
+}
+
+function toAuthUser(u: User, organizationId?: string | null): AuthUser {
+  return {
+    id: u.id,
+    email: u.email,
+    firstName: u.firstName,
+    lastName: u.lastName,
+    profilePictureUrl: u.profilePictureUrl,
+    organizationId: organizationId ?? null,
+  };
+}
+
+/**
+ * Builds the verifier the OSS auth gate calls on every request.
+ *
+ * Validates the sealed session; if the access token has expired it
+ * transparently refreshes it (via the refresh token) and returns the
+ * rotated cookie so the gate can set it. Concurrent requests carrying
+ * the same expired cookie share ONE refresh (single-flight) — WorkOS
+ * rotates refresh tokens, so parallel refreshes would race and all but
+ * one would fail.
+ */
+export function createSessionVerifier(
+  workos: WorkOS,
+  cfg: WorkosConfig,
+): EeAuthVerifier {
+  const secure = isSecure(cfg.appUrl);
+  // Keyed by the (expired) sealed cookie so a burst of navigation
+  // requests dedupes to a single refresh.
+  const refreshInFlight = new Map<string, Promise<AuthResult | null>>();
+
+  async function refresh(
+    session: ReturnType<WorkOS['userManagement']['loadSealedSession']>,
+  ): Promise<AuthResult | null> {
+    const refreshed = await session.refresh();
+    if (!refreshed.authenticated || !refreshed.sealedSession) return null;
+    return {
+      user: toAuthUser(refreshed.user, refreshed.organizationId),
+      setCookie: serializeCookie(SESSION_COOKIE, refreshed.sealedSession, {
+        maxAgeSeconds: SESSION_MAX_AGE,
+        secure,
+      }),
+    };
+  }
+
+  return async (cookieHeader) => {
+    const sealed = parseCookies(cookieHeader)[SESSION_COOKIE];
+    if (!sealed) return null;
+    try {
+      const session = workos.userManagement.loadSealedSession({
+        sessionData: sealed,
+        cookiePassword: cfg.cookiePassword,
+      });
+      const result = await session.authenticate();
+      if (result.authenticated) {
+        return { user: toAuthUser(result.user, result.organizationId) };
+      }
+      // Access token expired/invalid → refresh (single-flight per cookie).
+      let pending = refreshInFlight.get(sealed);
+      if (!pending) {
+        pending = refresh(session).finally(() => refreshInFlight.delete(sealed));
+        refreshInFlight.set(sealed, pending);
+      }
+      return await pending;
+    } catch {
+      return null;
+    }
+  };
+}
+
+/** Public auth router mounted at /api/ee/auth (before the gate). */
+export function createAuthRouter(workos: WorkOS, cfg: WorkosConfig): Router {
+  const router = Router();
+  const verify = createSessionVerifier(workos, cfg);
+  const secure = isSecure(cfg.appUrl);
+
+  // Kick off login — redirect to the WorkOS AuthKit hosted UI.
+  router.get('/login', (_req, res) => {
+    const url = workos.userManagement.getAuthorizationUrl({
+      provider: 'authkit',
+      clientId: cfg.clientId,
+      redirectUri: cfg.redirectUri,
+    });
+    res.redirect(url);
+  });
+
+  // OAuth callback — exchange the code, seal the session into a cookie,
+  // then return the browser to the dashboard.
+  router.get('/callback', async (req, res) => {
+    const code = typeof req.query.code === 'string' ? req.query.code : '';
+    if (!code) {
+      res.redirect(`${cfg.appUrl}/?auth_error=missing_code`);
+      return;
+    }
+    try {
+      const auth = await workos.userManagement.authenticateWithCode({
+        clientId: cfg.clientId,
+        code,
+        session: { sealSession: true, cookiePassword: cfg.cookiePassword },
+      });
+      if (!auth.sealedSession) {
+        res.redirect(`${cfg.appUrl}/?auth_error=no_session`);
+        return;
+      }
+      res.setHeader(
+        'Set-Cookie',
+        serializeCookie(SESSION_COOKIE, auth.sealedSession, {
+          maxAgeSeconds: SESSION_MAX_AGE,
+          secure,
+        }),
+      );
+      res.redirect(cfg.appUrl);
+    } catch {
+      res.redirect(`${cfg.appUrl}/?auth_error=callback_failed`);
+    }
+  });
+
+  // Who am I — the client polls this to decide logged-in vs redirect.
+  router.get('/me', async (req, res) => {
+    const result = await verify(req.headers.cookie);
+    if (!result) {
+      res.status(401).json({ error: 'Not authenticated' });
+      return;
+    }
+    if (result.setCookie) res.append('Set-Cookie', result.setCookie);
+    res.json({ user: result.user });
+  });
+
+  // Logout — clear the cookie and hand back the WorkOS logout URL.
+  router.post('/logout', async (req, res) => {
+    const sealed = parseCookies(req.headers.cookie)[SESSION_COOKIE];
+    res.setHeader(
+      'Set-Cookie',
+      serializeCookie(SESSION_COOKIE, '', { maxAgeSeconds: 0, secure }),
+    );
+    if (sealed) {
+      try {
+        const session = workos.userManagement.loadSealedSession({
+          sessionData: sealed,
+          cookiePassword: cfg.cookiePassword,
+        });
+        const logoutUrl = await session.getLogoutUrl({ returnTo: cfg.appUrl });
+        res.json({ logoutUrl });
+        return;
+      } catch {
+        // fall through to the app url
+      }
+    }
+    res.json({ logoutUrl: cfg.appUrl });
+  });
+
+  return router;
+}

--- a/ee/packages/server/src/config.ts
+++ b/ee/packages/server/src/config.ts
@@ -1,0 +1,37 @@
+/**
+ * WorkOS configuration, read from the environment. `load()` throws if a
+ * required value is missing — the OSS plugin loader catches that and
+ * falls back to community, so a misconfigured enterprise deploy degrades
+ * loudly rather than booting half-authenticated.
+ */
+
+export interface WorkosConfig {
+  apiKey: string;
+  clientId: string;
+  redirectUri: string;
+  cookiePassword: string;
+  /** Where to send the browser after login/logout (the dashboard client). */
+  appUrl: string;
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`[EE] Missing required env var ${name}`);
+  return v;
+}
+
+export function loadWorkosConfig(): WorkosConfig {
+  const cookiePassword = required('WORKOS_COOKIE_PASSWORD');
+  if (cookiePassword.length < 32) {
+    throw new Error('[EE] WORKOS_COOKIE_PASSWORD must be at least 32 characters');
+  }
+  return {
+    apiKey: required('WORKOS_API_KEY'),
+    clientId: required('WORKOS_CLIENT_ID'),
+    redirectUri:
+      process.env.WORKOS_REDIRECT_URI ??
+      'http://localhost:3001/api/ee/auth/callback',
+    cookiePassword,
+    appUrl: process.env.WORKOS_APP_URL ?? 'http://localhost:3000',
+  };
+}

--- a/ee/packages/server/src/cookies.ts
+++ b/ee/packages/server/src/cookies.ts
@@ -1,0 +1,41 @@
+/**
+ * Tiny dependency-free Cookie header helpers. We only need to read one
+ * named cookie and serialize one Set-Cookie value, so a full cookie lib
+ * isn't warranted.
+ */
+
+export function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const k = part.slice(0, eq).trim();
+    const v = part.slice(eq + 1).trim();
+    if (k) out[k] = decodeURIComponent(v);
+  }
+  return out;
+}
+
+export interface CookieOptions {
+  maxAgeSeconds?: number;
+  secure?: boolean;
+}
+
+export function serializeCookie(
+  name: string,
+  value: string,
+  opts: CookieOptions = {},
+): string {
+  const parts = [
+    `${name}=${encodeURIComponent(value)}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+  ];
+  if (opts.secure) parts.push('Secure');
+  if (opts.maxAgeSeconds !== undefined) {
+    parts.push(`Max-Age=${opts.maxAgeSeconds}`);
+  }
+  return parts.join('; ');
+}

--- a/ee/packages/server/src/index.ts
+++ b/ee/packages/server/src/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Enterprise server entry point.
+ *
+ * The OSS dashboard server discovers this module at boot through its
+ * plugin loader (a guarded dynamic import — OSS never statically
+ * imports `@truecourse/ee-server`). When enterprise mode is on and this
+ * package resolves, the loader calls `register()`, which wires up
+ * WorkOS SSO: the public auth routes and the session verifier the OSS
+ * auth gate uses to protect the rest of the dashboard.
+ */
+
+import { WorkOS } from '@workos-inc/node';
+import type { EePlugin } from '@truecourse/shared';
+import { loadWorkosConfig } from './config.js';
+import { createAuthRouter, createSessionVerifier } from './auth.js';
+import { createWorkspaceRouter } from './workspace.js';
+
+const plugin: EePlugin = {
+  capabilities: ['sso', 'workspace'],
+  register(registry) {
+    // Throws if WorkOS env is incomplete; the OSS loader catches it and
+    // falls back to community rather than running half-authenticated.
+    const cfg = loadWorkosConfig();
+    const workos = new WorkOS(cfg.apiKey, { clientId: cfg.clientId });
+
+    // Auth endpoints must be reachable without a session.
+    registry.registerRouter('/api/ee/auth', createAuthRouter(workos, cfg), {
+      public: true,
+    });
+
+    // The gate uses this to protect every other route in enterprise mode.
+    registry.setAuthVerifier(createSessionVerifier(workos, cfg));
+
+    // Workspace data (SSO status + members) — protected, behind the gate.
+    registry.registerRouter('/api/ee/workspace', createWorkspaceRouter(workos));
+  },
+};
+
+export default plugin;

--- a/ee/packages/server/src/workspace.ts
+++ b/ee/packages/server/src/workspace.ts
@@ -1,0 +1,170 @@
+/**
+ * Workspace data endpoints (enterprise, protected by the OSS auth gate).
+ *
+ * Scoped to the signed-in user's WorkOS organization (read from the
+ * session the gate resolved). Surfaces the org's SSO connection status
+ * and member list for the Workspace page.
+ */
+
+import { Router } from 'express';
+import type { Request } from 'express';
+import { WorkOS } from '@workos-inc/node';
+import type {
+  AuthUser,
+  SeverityCounts,
+  SsoStatusResponse,
+  WorkspaceMembersResponse,
+  WorkspaceOverviewResponse,
+} from '@truecourse/shared';
+import { readRegistry } from '@truecourse/core/config/registry';
+import { listViolations } from '@truecourse/core/services/violation-query';
+import { readVerifyState } from '@truecourse/core/commands/spec-in-process';
+
+// A repo counts as stale if it was never analyzed or not within this window.
+const STALE_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+
+// Core readers the overview aggregates over, injectable so the route is
+// unit-testable without touching the real registry/filesystem.
+export interface WorkspaceDataReaders {
+  readRegistry: typeof readRegistry;
+  listViolations: typeof listViolations;
+  readVerifyState: typeof readVerifyState;
+}
+
+const defaultReaders: WorkspaceDataReaders = {
+  readRegistry,
+  listViolations,
+  readVerifyState,
+};
+
+// The OSS auth gate attaches the resolved user; read it without
+// depending on the OSS type augmentation.
+function orgIdOf(req: Request): string | null {
+  const user = (req as Request & { eeUser?: AuthUser }).eeUser;
+  return user?.organizationId ?? null;
+}
+
+export function createWorkspaceRouter(
+  workos: WorkOS,
+  readers: WorkspaceDataReaders = defaultReaders,
+): Router {
+  const router = Router();
+
+  router.get('/sso-status', async (req, res) => {
+    const organizationId = orgIdOf(req);
+    if (!organizationId) {
+      const empty: SsoStatusResponse = { configured: false, connections: [] };
+      res.json(empty);
+      return;
+    }
+    try {
+      const list = await workos.sso.listConnections({ organizationId });
+      const body: SsoStatusResponse = {
+        configured: list.data.length > 0,
+        connections: list.data.map((c) => ({
+          id: c.id,
+          name: c.name,
+          type: c.type,
+          state: c.state,
+        })),
+      };
+      res.json(body);
+    } catch {
+      res.status(502).json({ error: 'Failed to load SSO status from WorkOS' });
+    }
+  });
+
+  // Workspace home dashboard: aggregate repo/analysis stats (from the
+  // local registry via core) + member/org info (from WorkOS) in one
+  // call. Repo data is the locally-analyzed set today; the GitHub-
+  // connected source replaces it when that integration lands.
+  router.get('/overview', async (req, res) => {
+    const severity: SeverityCounts = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+    let violationCount = 0;
+    let driftCount = 0;
+    let staleCount = 0;
+    const now = Date.now();
+
+    const entries = readers.readRegistry();
+    const repos = entries.map((e) => {
+      let v = 0;
+      let d = 0;
+      try {
+        const { violations } = readers.listViolations(e.path, { status: 'active' });
+        v = violations.length;
+        for (const vi of violations) severity[vi.severity] += 1;
+      } catch {
+        // unanalyzed / unreadable repo — counts stay 0
+      }
+      try {
+        d = readers.readVerifyState(e.path)?.drifts.length ?? 0;
+      } catch {
+        // no verify run recorded
+      }
+      violationCount += v;
+      driftCount += d;
+      const stale =
+        !e.lastAnalyzed || now - Date.parse(e.lastAnalyzed) > STALE_WINDOW_MS;
+      if (stale) staleCount += 1;
+      return {
+        id: e.slug,
+        name: e.name,
+        lastAnalyzed: e.lastAnalyzed ?? null,
+        violations: v,
+        drift: d,
+      };
+    });
+
+    // Org name from WorkOS (best-effort — repo stats still render if
+    // WorkOS is briefly unavailable). Members live on the Workspace page.
+    let organizationName: string | null = null;
+    const organizationId = orgIdOf(req);
+    if (organizationId) {
+      try {
+        organizationName = (
+          await workos.organizations.getOrganization(organizationId)
+        ).name;
+      } catch {
+        /* ignore */
+      }
+    }
+
+    const body: WorkspaceOverviewResponse = {
+      organizationName,
+      stats: {
+        repoCount: entries.length,
+        violationCount,
+        driftCount,
+        staleCount,
+        severity,
+      },
+      repos,
+    };
+    res.json(body);
+  });
+
+  router.get('/members', async (req, res) => {
+    const organizationId = orgIdOf(req);
+    if (!organizationId) {
+      const empty: WorkspaceMembersResponse = { members: [] };
+      res.json(empty);
+      return;
+    }
+    try {
+      const list = await workos.userManagement.listUsers({ organizationId });
+      const body: WorkspaceMembersResponse = {
+        members: list.data.map((u) => ({
+          id: u.id,
+          email: u.email,
+          firstName: u.firstName,
+          lastName: u.lastName,
+        })),
+      };
+      res.json(body);
+    } catch {
+      res.status(502).json({ error: 'Failed to load members from WorkOS' });
+    }
+  });
+
+  return router;
+}

--- a/ee/packages/server/tsconfig.json
+++ b/ee/packages/server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "rootDir": "src",
+    "outDir": "./dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,53 @@ importers:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  ee/packages/client:
+    dependencies:
+      '@truecourse/shared':
+        specifier: workspace:*
+        version: link:../../../packages/shared
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      react-router-dom:
+        specifier: ^7.1.0
+        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  ee/packages/server:
+    dependencies:
+      '@truecourse/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@truecourse/shared':
+        specifier: workspace:*
+        version: link:../../../packages/shared
+      '@workos-inc/node':
+        specifier: ^7.0.0
+        version: 7.82.0(express@4.22.1)
+      express:
+        specifier: ^4.21.0
+        version: 4.22.1
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/analyzer:
     dependencies:
       '@truecourse/shared':
@@ -1547,6 +1594,20 @@ packages:
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
+  '@peculiar/asn1-schema@2.7.0':
+    resolution: {integrity: sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==}
+
+  '@peculiar/json-schema@1.1.12':
+    resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
+    engines: {node: '>=8.0.0'}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
+  '@peculiar/webcrypto@1.7.1':
+    resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
+    engines: {node: '>=14.18.0'}
+
   '@posthog/core@1.28.4':
     resolution: {integrity: sha512-wmtUYHYqA3zIAKDKvYWRNWAQsWOIBwxV08e+bWzVy0wQQzpaS/LzzRupXWRMRrLOk+1x3JKFxbqA3n0QGvpqsQ==}
 
@@ -1841,6 +1902,9 @@ packages:
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
+  '@types/accepts@1.3.7':
+    resolution: {integrity: sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -1865,8 +1929,17 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/content-disposition@0.5.9':
+    resolution: {integrity: sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==}
+
+  '@types/cookie@0.5.4':
+    resolution: {integrity: sha512-7z/eR6O859gyWIAjuvBWFzNURmf2oPBmJlfVWkwehU5nzIyjwBsTh7WMmEEV4JFnHuQ3ex4oyTvfKzcyJVDBNA==}
+
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
+  '@types/cookies@0.9.2':
+    resolution: {integrity: sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==}
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
@@ -1928,8 +2001,14 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@4.19.8':
+    resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
+
   '@types/express-serve-static-core@5.1.1':
     resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
@@ -1937,11 +2016,23 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/http-assert@1.5.6':
+    resolution: {integrity: sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw==}
+
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/keygrip@1.0.6':
+    resolution: {integrity: sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==}
+
+  '@types/koa-compose@3.2.9':
+    resolution: {integrity: sha512-BroAZ9FTvPiCy0Pi8tjD1OfJ7bgU1gQf0eR6e1Vm+JJATy9eKOG3hQMFtMciMawiSOVnLMdmUOC46s7HBhSTsA==}
+
+  '@types/koa@2.15.2':
+    resolution: {integrity: sha512-CB+iyjjh1uS5N6/CKwXvw0qA7USMS2WVc4Tjf660yCjhdvqzNr8gdFcIawB41zGGptOQ+d1fnpaQWIIUXYxR3w==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -1949,8 +2040,14 @@ packages:
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@17.0.45':
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
@@ -1969,8 +2066,14 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
@@ -2047,6 +2150,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@workos-inc/node@7.82.0':
+    resolution: {integrity: sha512-8h6XjIJf8nqNGYQMkWsjZ72WXMtzqrb4Azz39schXWoSRmwoK6tK+GpeAviJ9slddiJdOcp0Ht9/r+L6pGQMCg==}
+    engines: {node: '>=16'}
+
   '@xyflow/react@12.10.1':
     resolution: {integrity: sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==}
     peerDependencies:
@@ -2115,6 +2222,10 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2135,6 +2246,9 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   base64id@2.0.0:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
@@ -2165,6 +2279,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -2303,6 +2420,10 @@ packages:
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
+
+  cookie@0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -2913,6 +3034,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2946,6 +3070,24 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  iron-session@6.3.1:
+    resolution: {integrity: sha512-3UJ7y2vk/WomAtEySmPgM6qtYF1cZ3tXuWX5GsVX4PJXAcs5y/sV9HuSfpjKS6HkTL/OhZcTDWJNLZ7w+Erx3A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      express: '>=4'
+      koa: '>=2'
+      next: '>=10'
+    peerDependenciesMeta:
+      express:
+        optional: true
+      koa:
+        optional: true
+      next:
+        optional: true
+
+  iron-webcrypto@0.2.8:
+    resolution: {integrity: sha512-YPdCvjFMOBjXaYuDj5tiHst5CEk6Xw84Jo8Y2+jzhMceclAnb3+vNPP/CTtb5fO2ZEuXEaO4N+w62Vfko757KA==}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -3048,6 +3190,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@5.6.3:
+    resolution: {integrity: sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==}
+
   jose@6.2.1:
     resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
 
@@ -3099,6 +3244,9 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  leb@1.0.0:
+    resolution: {integrity: sha512-Y3c3QZfvKWHX60BVOQPhLCvVGmDYWyJEiINE3drOog6KCyN2AOwvuQQzlS3uJg1J85kzpILXIUwRXULWavir+w==}
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -3654,10 +3802,21 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
   pyright@1.1.408:
     resolution: {integrity: sha512-N61pxaLLCsPcUuPPHMNIrGoZgGBgrbjBX5UqkaT5UV8NVZdL7ExsO6N3ectv1DzAUsLOzdlyqoYtX76u8eF4YA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+    engines: {node: '>=0.6'}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -4416,6 +4575,9 @@ packages:
 
   web-vitals@5.2.0:
     resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
+
+  webcrypto-core@1.9.2:
+    resolution: {integrity: sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==}
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -5527,6 +5689,28 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@peculiar/asn1-schema@2.7.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/json-schema@1.1.12':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/webcrypto@1.7.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/json-schema': 1.1.12
+      '@peculiar/utils': 2.0.3
+      tslib: 2.8.1
+      webcrypto-core: 1.9.2
+
   '@posthog/core@1.28.4':
     dependencies:
       '@posthog/types': 1.372.10
@@ -5748,6 +5932,10 @@ snapshots:
       minimatch: 10.2.4
       path-browserify: 1.0.1
 
+  '@types/accepts@1.3.7':
+    dependencies:
+      '@types/node': 22.19.15
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -5785,7 +5973,18 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
 
+  '@types/content-disposition@0.5.9': {}
+
+  '@types/cookie@0.5.4': {}
+
   '@types/cookiejar@2.1.5': {}
+
+  '@types/cookies@0.9.2':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/express': 5.0.6
+      '@types/keygrip': 1.0.6
+      '@types/node': 22.19.15
 
   '@types/cors@2.8.19':
     dependencies:
@@ -5848,12 +6047,26 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@4.19.8':
+    dependencies:
+      '@types/node': 22.19.15
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
   '@types/express-serve-static-core@5.1.1':
     dependencies:
       '@types/node': 22.19.15
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
+
+  '@types/express@4.17.25':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.8
+      '@types/qs': 6.15.0
+      '@types/serve-static': 1.15.10
 
   '@types/express@5.0.6':
     dependencies:
@@ -5865,9 +6078,28 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/http-assert@1.5.6': {}
+
   '@types/http-errors@2.0.5': {}
 
   '@types/js-yaml@4.0.9': {}
+
+  '@types/keygrip@1.0.6': {}
+
+  '@types/koa-compose@3.2.9':
+    dependencies:
+      '@types/koa': 2.15.2
+
+  '@types/koa@2.15.2':
+    dependencies:
+      '@types/accepts': 1.3.7
+      '@types/content-disposition': 0.5.9
+      '@types/cookies': 0.9.2
+      '@types/http-assert': 1.5.6
+      '@types/http-errors': 2.0.5
+      '@types/keygrip': 1.0.6
+      '@types/koa-compose': 3.2.9
+      '@types/node': 22.19.15
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -5875,7 +6107,11 @@ snapshots:
 
   '@types/methods@1.1.4': {}
 
+  '@types/mime@1.3.5': {}
+
   '@types/ms@2.1.0': {}
+
+  '@types/node@17.0.45': {}
 
   '@types/node@22.19.15':
     dependencies:
@@ -5893,9 +6129,20 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 22.19.15
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 22.19.15
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.19.15
+      '@types/send': 0.17.6
 
   '@types/serve-static@2.2.0':
     dependencies:
@@ -6012,6 +6259,17 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@workos-inc/node@7.82.0(express@4.22.1)':
+    dependencies:
+      iron-session: 6.3.1(express@4.22.1)
+      jose: 5.6.3
+      leb: 1.0.0
+      qs: 6.14.1
+    transitivePeerDependencies:
+      - express
+      - koa
+      - next
+
   '@xyflow/react@12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@xyflow/system': 0.0.75
@@ -6082,6 +6340,12 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
+
   assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
@@ -6101,6 +6365,8 @@ snapshots:
   bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
 
   base64id@2.0.0: {}
 
@@ -6152,6 +6418,11 @@ snapshots:
       electron-to-chromium: 1.5.313
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-name@4.1.0:
     dependencies:
@@ -6258,6 +6529,8 @@ snapshots:
   cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
+
+  cookie@0.5.0: {}
 
   cookie@0.7.2: {}
 
@@ -6990,6 +7263,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -7010,6 +7285,22 @@ snapshots:
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  iron-session@6.3.1(express@4.22.1):
+    dependencies:
+      '@peculiar/webcrypto': 1.7.1
+      '@types/cookie': 0.5.4
+      '@types/express': 4.17.25
+      '@types/koa': 2.15.2
+      '@types/node': 17.0.45
+      cookie: 0.5.0
+      iron-webcrypto: 0.2.8
+    optionalDependencies:
+      express: 4.22.1
+
+  iron-webcrypto@0.2.8:
+    dependencies:
+      buffer: 6.0.3
 
   is-alphabetical@2.0.1: {}
 
@@ -7074,6 +7365,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@5.6.3: {}
+
   jose@6.2.1: {}
 
   js-tokens@4.0.0: {}
@@ -7130,6 +7423,8 @@ snapshots:
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  leb@1.0.0: {}
 
   lightningcss-android-arm64@1.31.1:
     optional: true
@@ -7866,9 +8161,19 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
+
   pyright@1.1.408:
     optionalDependencies:
       fsevents: 2.3.3
+
+  qs@6.14.1:
+    dependencies:
+      side-channel: 1.1.0
 
   qs@6.14.2:
     dependencies:
@@ -8751,6 +9056,14 @@ snapshots:
   web-tree-sitter@0.26.8: {}
 
   web-vitals@5.2.0: {}
+
+  webcrypto-core@1.9.2:
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/json-schema': 1.1.12
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
 
   webidl-conversions@7.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - "apps/landing"
   - "packages/*"
   - "tools/*"
+  - "ee/packages/*"


### PR DESCRIPTION
**Draft — enterprise overlay branch.** Heads up: this is *not* meant to merge into the public `main` as-is — doing so would ship `ee/` in the community / open-core line. It's a review + tracking surface for the enterprise work.

Branches off the released `0.6.0` `main` and restores the `ee/` overlay from `il-framework`. The open-core seams (`ee-loader`, `loadEeModule`, `edition`, `capabilities` route) already shipped to `main` in 0.6.0, so this just plugs the enterprise packages into them.

## What's here
- **`ee/packages/server`** — WorkOS AuthKit auth, cookies, workspace routes; registered via the server's `getPublicRouters` / `getProtectedRouters` seam.
- **`ee/packages/client`** — Workspace page, loaded through `loadEeModule`.
- `pnpm-workspace.yaml` gains `ee/packages/*`; lockfile adds `@workos-inc/node`.

## Verified
- `pnpm install` clean (13 workspace projects).
- `pnpm build` — 11/11 packages (ee-server + ee-client build; dashboard vite build picks up the overlay since `ee/` exists).
- `pnpm test` — 4183 passed, 0 failed/skipped (+10 vs main = enterprise-edition seam tests that activate once `ee/` is present).

`il-framework` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)