### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/architecture/checker.ts
+++ b/packages/analyzer/src/rules/architecture/checker.ts
@@ -212,6 +212,29 @@ function isTestSupportModulePath(filePath: string): boolean {
 }
 
 /**
+ * React component files (`.tsx`/`.jsx`) commonly collect many small
+ * sub-components, format variants, and helpers in a single file — a
+ * "primitive" like `<Select>`, `<DateTime>`, `<BlankStatePanels>` ships
+ * 10–40 PascalCase exports that share state, styling, or Radix slots. The
+ * god-module count threshold treats those exports like business methods
+ * and fires. Skip when the module is in a JSX file and most of its
+ * methods are PascalCase-named (i.e. component/sub-component definitions
+ * rather than business logic).
+ */
+function isJsxComponentCollection(
+  mod: ModuleInfo,
+  methods: MethodInfo[],
+): boolean {
+  if (!/\.(?:tsx|jsx)$/i.test(mod.filePath)) return false
+  const ownMethods = methods.filter(
+    (m) => m.filePath === mod.filePath && m.moduleName === mod.name,
+  )
+  if (ownMethods.length === 0) return false
+  const pascalCase = ownMethods.filter((m) => /^[A-Z]/.test(m.name)).length
+  return pascalCase / ownMethods.length >= 0.6
+}
+
+/**
  * Check deterministic module-level rules and return violations.
  */
 export function checkModuleRules(
@@ -356,6 +379,7 @@ export function checkModuleRules(
   if (ruleKeys.has('architecture/deterministic/god-module')) {
     for (const mod of modules) {
       if (isTestSupportModulePath(mod.filePath)) continue
+      if (isJsxComponentCollection(mod, methods)) continue
       if (mod.methodCount > GOD_MODULE_THRESHOLD) {
         violations.push({
           ruleKey: 'architecture/deterministic/god-module',

--- a/packages/analyzer/src/rules/architecture/visitors/javascript/duplicate-import.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/javascript/duplicate-import.ts
@@ -31,6 +31,22 @@ export const duplicateImportVisitor: CodeRuleVisitor = {
         const currentIsSideEffectOnly = isSideEffectOnly(imp)
         if (prevIsSideEffectOnly !== currentIsSideEffectOnly) continue
 
+        // Skip when one import is a namespace import (`import * as X from 'm'`)
+        // and the other is a named import (`import { a } from 'm'`). The
+        // only legal combined forms are `default + named` and
+        // `default + namespace`; `namespace + named` is not valid ES module
+        // syntax, so the suggested merge isn't actionable.
+        const prevHasNamespace = hasNamespaceImport(prevImp)
+        const currentHasNamespace = hasNamespaceImport(imp)
+        const prevHasNamed = hasNamedImports(prevImp)
+        const currentHasNamed = hasNamedImports(imp)
+        if (
+          (prevHasNamespace && currentHasNamed && !currentHasNamespace) ||
+          (currentHasNamespace && prevHasNamed && !prevHasNamespace)
+        ) {
+          continue
+        }
+
         return makeViolation(
           this.ruleKey, imp, filePath, 'low',
           'Duplicate import',
@@ -54,5 +70,17 @@ function isSideEffectOnly(imp: SyntaxNode): boolean {
     if (child.type === 'import_clause') return false
   }
   return true
+}
+
+function hasNamespaceImport(imp: SyntaxNode): boolean {
+  const clause = imp.namedChildren.find((c) => c.type === 'import_clause')
+  if (!clause) return false
+  return clause.namedChildren.some((c) => c.type === 'namespace_import')
+}
+
+function hasNamedImports(imp: SyntaxNode): boolean {
+  const clause = imp.namedChildren.find((c) => c.type === 'import_clause')
+  if (!clause) return false
+  return clause.namedChildren.some((c) => c.type === 'named_imports')
 }
 

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/duplicate-import.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/duplicate-import.ts
@@ -28,6 +28,21 @@ export const duplicateImportVisitor: CodeRuleVisitor = {
             // loaded for its top-level effects. Merging them erases intent.
             if (isSideEffectOnly(prev) !== isSideEffectOnly(child)) continue
 
+            // A namespace binding (`import * as X from 'm'`) cannot be
+            // syntactically merged with a sibling named import — the only
+            // legal combined forms are `default + named` and
+            // `default + namespace`. Skip the pair.
+            const prevHasNs = hasNamespaceImport(prev)
+            const currHasNs = hasNamespaceImport(child)
+            const prevHasNamed = hasNamedImports(prev)
+            const currHasNamed = hasNamedImports(child)
+            if (
+              (prevHasNs && currHasNamed && !currHasNs) ||
+              (currHasNs && prevHasNamed && !prevHasNs)
+            ) {
+              continue
+            }
+
             return makeViolation(
               this.ruleKey, child, filePath, 'medium',
               'Duplicate import',
@@ -50,4 +65,16 @@ function isSideEffectOnly(imp: SyntaxNode): boolean {
     if (child.type === 'import_clause') return false
   }
   return true
+}
+
+function hasNamespaceImport(imp: SyntaxNode): boolean {
+  const clause = imp.namedChildren.find((c) => c.type === 'import_clause')
+  if (!clause) return false
+  return clause.namedChildren.some((c) => c.type === 'namespace_import')
+}
+
+function hasNamedImports(imp: SyntaxNode): boolean {
+  const clause = imp.namedChildren.find((c) => c.type === 'import_clause')
+  if (!clause) return false
+  return clause.namedChildren.some((c) => c.type === 'named_imports')
 }

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/unmodified-loop-condition.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/unmodified-loop-condition.ts
@@ -24,6 +24,14 @@ export const unmodifiedLoopConditionVisitor: CodeRuleVisitor = {
     const right = inner.childForFieldName('right')
     if (!left || !right) return null
 
+    // Bail out when the condition contains a call_expression (e.g.
+    // `while (Date.now() - start < delayMs)`, `while (queue.length() > 0)`).
+    // Function calls in the condition are implicitly time-varying — by
+    // symmetry with the body's `call_expression` short-circuit below, we
+    // treat them as legitimate "moving" state. Without this, busy-wait
+    // helpers and queue-drain loops trip the rule.
+    if (containsCallExpression(left) || containsCallExpression(right)) return null
+
     // Collect identifiers from the condition
     const condVars: string[] = []
     if (left.type === 'identifier') condVars.push(left.text)
@@ -54,6 +62,15 @@ export const unmodifiedLoopConditionVisitor: CodeRuleVisitor = {
       for (let i = 0; i < n.childCount; i++) {
         const child = n.child(i)
         if (child && isModified(child)) return true
+      }
+      return false
+    }
+
+    function containsCallExpression(n: SyntaxNode): boolean {
+      if (n.type === 'call_expression') return true
+      for (let i = 0; i < n.childCount; i++) {
+        const child = n.child(i)
+        if (child && containsCallExpression(child)) return true
       }
       return false
     }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/missing-env-validation.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/missing-env-validation.ts
@@ -1,6 +1,19 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
+// Zod / valibot / yup / class-validator chain methods that take an env-var
+// argument as the fallback or transform input. Reading `process.env.X` here
+// is the validation entry point, not an unguarded access.
+const SCHEMA_DEFAULTING_METHODS = new Set([
+  'default',
+  'catch',
+  'fallback',
+  'transform',
+  'preprocess',
+  'parse',
+  'pipe',
+])
+
 export const missingEnvValidationVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/missing-env-validation',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -38,6 +51,18 @@ export const missingEnvValidationVisitor: CodeRuleVisitor = {
         const op = ancestor.childForFieldName('operator')?.text
           ?? ancestor.child(0)?.text
         if (op === '!') return null
+      }
+      // Schema-builder method calls like `z.string().default(process.env.X)`,
+      // `.catch(process.env.X)`, `.optional()`-then-`.default(process.env.X)`
+      // are the validation — zod (and similar) consume the env var via the
+      // schema and surface a typed, validated value. The default arg is the
+      // fallback when the env var is undefined, not an unguarded read.
+      if (t === 'call_expression') {
+        const fn = ancestor.childForFieldName('function')
+        const callee = fn?.type === 'member_expression'
+          ? fn.childForFieldName('property')?.text
+          : undefined
+        if (callee && SCHEMA_DEFAULTING_METHODS.has(callee)) return null
       }
       ancestor = ancestor.parent
       depth++

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/useless-constructor.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/useless-constructor.ts
@@ -1,5 +1,6 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { isGeneratedFile } from '../../../_shared/javascript-helpers.js'
 
 export const uselessConstructorVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/useless-constructor',
@@ -8,6 +9,14 @@ export const uselessConstructorVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     const nameNode = node.childForFieldName('name')
     if (nameNode?.text !== 'constructor') return null
+
+    // Generator-produced files (ANTLR parsers/lexers, Protobuf stubs,
+    // GraphQL Code Generator output) emit a constructor on every grammar
+    // rule context that just forwards `(parent, invokingState)` to
+    // `super(parent, invokingState)`. The visitor sees that as "useless",
+    // but the user can't remove it without modifying generated output —
+    // re-running the generator would put it back. Skip generated files.
+    if (isGeneratedFile(filePath, sourceCode)) return null
 
     // `private`/`protected` constructors aren't useless — they restrict
     // instantiation (e.g. singleton pattern). Removing them would expose

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -655,6 +655,12 @@
       "layer": "service"
     },
     {
+      "name": "buildApiUrl",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "Builder",
       "service": "utils",
       "kind": "class",
@@ -676,6 +682,12 @@
       "name": "CaseHelpers",
       "service": "utils",
       "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "checkContact",
+      "service": "utils",
+      "kind": "standalone",
       "layer": "service"
     },
     {
@@ -925,6 +937,12 @@
       "layer": "service"
     },
     {
+      "name": "FriendlyGreeter",
+      "service": "utils",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "function-in-loop-var-binding",
       "service": "utils",
       "kind": "standalone",
@@ -943,7 +961,19 @@
       "layer": "service"
     },
     {
+      "name": "god-module-business-helpers",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "Greeter",
+      "service": "utils",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "GreeterBase",
       "service": "utils",
       "kind": "class",
       "layer": "service"
@@ -1339,6 +1369,12 @@
       "layer": "service"
     },
     {
+      "name": "waitForFlag",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "web-security",
       "service": "utils",
       "kind": "standalone",
@@ -1605,6 +1641,15 @@
       "targetService": "user-service",
       "importedNames": [
         "UserRepository"
+      ]
+    },
+    {
+      "source": "checkContact",
+      "sourceService": "utils",
+      "target": "validators",
+      "targetService": "utils",
+      "importedNames": [
+        "validateEmail"
       ]
     },
     {

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/duplicate-import-named.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/duplicate-import-named.ts
@@ -1,0 +1,15 @@
+/**
+ * Paraphrased true-bug for architecture/deterministic/duplicate-import.
+ *
+ * Two named imports from the same module on adjacent lines — the canonical
+ * case the rule is meant to catch. These ARE merge-able into a single
+ * `import { a, b } from 'm'` statement.
+ */
+
+// VIOLATION: architecture/deterministic/duplicate-import
+import { validateEmail } from '@sample/shared-utils';
+import { validateName } from '@sample/shared-utils';
+
+export function checkContact(email: string, name: string): boolean {
+  return validateEmail(email) && validateName(name);
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/god-module-business-helpers.tsx
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/god-module-business-helpers.tsx
@@ -1,0 +1,27 @@
+// VIOLATION: architecture/deterministic/god-module
+/**
+ * Paraphrased true-bug for architecture/deterministic/god-module.
+ *
+ * A `.tsx` file but whose top-level methods are predominantly camelCase
+ * business helpers — not PascalCase React components. The exempt-on-JSX
+ * heuristic correctly identifies this as a real god module: too many
+ * unrelated responsibilities collected in one file.
+ */
+
+export function loadAccount(id: string): string { return id; }
+export function loadProfile(id: string): string { return id; }
+export function loadSettings(id: string): string { return id; }
+export function loadBilling(id: string): string { return id; }
+export function loadInvoices(id: string): string { return id; }
+export function loadOrders(id: string): string { return id; }
+export function loadShipments(id: string): string { return id; }
+export function loadCart(id: string): string { return id; }
+export function loadWishlist(id: string): string { return id; }
+export function loadHistory(id: string): string { return id; }
+export function loadPreferences(id: string): string { return id; }
+export function loadNotifications(id: string): string { return id; }
+export function loadMessages(id: string): string { return id; }
+export function loadFriends(id: string): string { return id; }
+export function loadGroups(id: string): string { return id; }
+export function loadActivity(id: string): string { return id; }
+export function loadInsights(id: string): string { return id; }

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/missing-env-validation-bare-read.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/missing-env-validation-bare-read.ts
@@ -1,0 +1,13 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/missing-env-validation.
+ *
+ * A plain unguarded `process.env.X` read in business code: no `if (!x) throw`,
+ * no schema chain, no negation. At runtime `X` may be `undefined` and the
+ * concatenation silently produces "<https://undefined>" instead of crashing
+ * loudly — the exact bug the rule is meant to catch.
+ */
+
+export function buildApiUrl(): string {
+  // VIOLATION: code-quality/deterministic/missing-env-validation
+  return `https://${process.env.API_HOST}`;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unmodified-loop-condition-stuck.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unmodified-loop-condition-stuck.ts
@@ -1,0 +1,16 @@
+/**
+ * Paraphrased true-bug for bugs/deterministic/unmodified-loop-condition.
+ *
+ * `done` is never reassigned inside the loop body and the condition is a
+ * pure identifier comparison — the loop spins forever. The canonical
+ * "forgot to flip the flag" mistake.
+ */
+
+export function waitForFlag(): void {
+  let done = false;
+  // VIOLATION: bugs/deterministic/unmodified-loop-condition
+  while (done === false) {
+    const sentinel = 1 + 1;
+    void sentinel;
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/useless-constructor-pass-through.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/useless-constructor-pass-through.ts
@@ -1,0 +1,19 @@
+/**
+ * Paraphrased true-bug for code-quality/deterministic/useless-constructor.
+ *
+ * Hand-written subclass whose constructor only forwards the parent's
+ * argument list to `super()`. Removing it doesn't change observable
+ * behavior — the default constructor inherited from the parent would
+ * do exactly the same thing.
+ */
+
+class GreeterBase {
+  constructor(protected readonly name: string) {}
+}
+
+export class FriendlyGreeter extends GreeterBase {
+  // VIOLATION: code-quality/deterministic/useless-constructor
+  constructor(name: string) {
+    super(name);
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/src/duplicate-import-namespace-and-named.ts
+++ b/tests/fixtures/sample-js-project-positive/src/duplicate-import-namespace-and-named.ts
@@ -1,0 +1,20 @@
+/**
+ * Positive fixture for architecture/deterministic/duplicate-import.
+ *
+ * A namespace import (`import * as X from 'm'`) cannot be syntactically
+ * merged with a sibling named import (`import { a } from 'm'`). The two
+ * legal "combined" forms are `default + named` and `default + namespace`;
+ * `namespace + named` is not valid ES module syntax. Flagging this pair
+ * as "duplicate, merge them" sends the author down a dead end.
+ */
+
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+
+export function useToggle(): [boolean, () => void] {
+  const [on, setOn] = useState<boolean>(false);
+  useEffect(() => {
+    React.useRef({ on });
+  }, [on]);
+  return [on, () => setOn(!on)];
+}

--- a/tests/fixtures/sample-js-project-positive/src/god-module-jsx-component-collection.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/god-module-jsx-component-collection.tsx
@@ -1,0 +1,61 @@
+/**
+ * Positive fixture for architecture/deterministic/god-module.
+ *
+ * A primitive component file (DateTime, Select, Badge, Panel-collection)
+ * naturally ships many small PascalCase sub-components — format variants,
+ * Radix-shaped slot wrappers, layout shells. They share state, styling
+ * tokens, or composition context, so splitting them across files would
+ * shred the single conceptual unit. The god-module heuristic
+ * (>15 methods) treats every export as a business method and fires.
+ */
+
+interface PanelProps {
+  readonly title: string;
+  readonly body?: string;
+}
+
+interface HeaderProps {
+  readonly title: string;
+}
+
+interface BodyProps {
+  readonly body?: string;
+}
+
+interface FooterProps {
+  readonly tag?: string;
+}
+
+export function PanelHeader(p: HeaderProps): JSX.Element {
+  return <h2>{p.title}</h2>;
+}
+export function PanelBody(p: BodyProps): JSX.Element {
+  return <div>{p.body ?? ''}</div>;
+}
+export function PanelFooter(p: FooterProps): JSX.Element {
+  return <footer>{p.tag ?? ''}</footer>;
+}
+export function PanelShell(p: PanelProps): JSX.Element {
+  return (
+    <section>
+      <PanelHeader title={p.title} />
+      <PanelBody body={p.body} />
+      <PanelFooter />
+    </section>
+  );
+}
+export function PanelEmpty(): JSX.Element { return <PanelShell title="empty" />; }
+export function PanelLoading(): JSX.Element { return <PanelShell title="loading" />; }
+export function PanelError(): JSX.Element { return <PanelShell title="error" />; }
+export function PanelInfo(): JSX.Element { return <PanelShell title="info" />; }
+export function PanelSuccess(): JSX.Element { return <PanelShell title="success" />; }
+export function PanelWarning(): JSX.Element { return <PanelShell title="warning" />; }
+export function PanelDestructive(): JSX.Element { return <PanelShell title="destructive" />; }
+export function PanelMuted(): JSX.Element { return <PanelShell title="muted" />; }
+export function PanelHighlight(): JSX.Element { return <PanelShell title="highlight" />; }
+export function PanelOutline(): JSX.Element { return <PanelShell title="outline" />; }
+export function PanelGhost(): JSX.Element { return <PanelShell title="ghost" />; }
+export function PanelLink(): JSX.Element { return <PanelShell title="link" />; }
+export function PanelInline(): JSX.Element { return <PanelShell title="inline" />; }
+export function PanelBlock(): JSX.Element { return <PanelShell title="block" />; }
+export function PanelCompact(): JSX.Element { return <PanelShell title="compact" />; }

--- a/tests/fixtures/sample-js-project-positive/src/missing-env-validation-zod-default.ts
+++ b/tests/fixtures/sample-js-project-positive/src/missing-env-validation-zod-default.ts
@@ -1,0 +1,25 @@
+/**
+ * Positive fixture for code-quality/deterministic/missing-env-validation.
+ *
+ * Inside a zod (or valibot/yup/class-validator) env schema, passing
+ * `process.env.X` as the `.default(...)` / `.catch(...)` argument IS the
+ * validation — the schema consumes the env var and surfaces a typed,
+ * validated value (with the env var as the fallback when undefined).
+ * Flagging the read as "unvalidated" misses that the surrounding
+ * `z.object({...}).parse(process.env)` IS the guard.
+ */
+
+interface ZodLike {
+  default(value: string | undefined): ZodLike;
+  catch(value: string): ZodLike;
+  optional(): ZodLike;
+}
+
+declare const z: {
+  string(): ZodLike;
+};
+
+export const envSchema = {
+  APP_ENV: z.string().default(process.env.NODE_ENV),
+  REGION: z.string().catch(process.env.AWS_REGION ?? 'us-east-1'),
+};

--- a/tests/fixtures/sample-js-project-positive/src/unmodified-loop-condition-busy-wait.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unmodified-loop-condition-busy-wait.ts
@@ -1,0 +1,18 @@
+/**
+ * Positive fixture for bugs/deterministic/unmodified-loop-condition.
+ *
+ * `Date.now()` in the condition advances on every iteration — the loop
+ * terminates as soon as the clock crosses the deadline. The local `start`
+ * and `delayMs` bindings are intentionally never assigned inside the
+ * loop body; the moving state is the side-effect-free call.
+ *
+ * Same shape applies to `performance.now()` deadline loops and
+ * `queue.length`-style helpers that return ever-changing values.
+ */
+
+export function spin(delayMs: number): void {
+  const start = Date.now();
+  while (Date.now() - start < delayMs) {
+    // Intentional busy-wait — used by tests that measure event-loop lag.
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/src/useless-constructor-generated.ts
+++ b/tests/fixtures/sample-js-project-positive/src/useless-constructor-generated.ts
@@ -1,0 +1,28 @@
+// Generated from src/grammar/Bar.g4 by ANTLR 4.9.0-SNAPSHOT
+// Do not edit — re-run the generator.
+
+/**
+ * Positive fixture for code-quality/deterministic/useless-constructor.
+ *
+ * Generator-produced parser-rule classes emit a constructor on every
+ * subclass that just forwards `(parent, invokingState)` to
+ * `super(parent, invokingState)`. Flagging this as "useless" floods the
+ * report with noise the author can't act on — removing the constructor
+ * means modifying generated output, and re-running the generator would
+ * just put it back.
+ */
+
+export class GeneratedRuleContextBase {
+  protected readonly parent: unknown;
+  protected readonly invokingState: number;
+  constructor(parent: unknown, invokingState: number) {
+    this.parent = parent;
+    this.invokingState = invokingState;
+  }
+}
+
+export class GeneratedDeclarationContext extends GeneratedRuleContextBase {
+  constructor(parent: unknown, invokingState: number) {
+    super(parent, invokingState);
+  }
+}


### PR DESCRIPTION
Closes #349
Closes #350
Closes #351
Closes #352
Closes #353

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `architecture/deterministic/duplicate-import` | #349 | `tests/fixtures/sample-js-project-positive/src/duplicate-import-namespace-and-named.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/duplicate-import-named.ts` |
| `bugs/deterministic/unmodified-loop-condition` | #350 | `tests/fixtures/sample-js-project-positive/src/unmodified-loop-condition-busy-wait.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unmodified-loop-condition-stuck.ts` |
| `code-quality/deterministic/useless-constructor` | #351 | `tests/fixtures/sample-js-project-positive/src/useless-constructor-generated.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/useless-constructor-pass-through.ts` |
| `code-quality/deterministic/missing-env-validation` | #352 | `tests/fixtures/sample-js-project-positive/src/missing-env-validation-zod-default.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/missing-env-validation-bare-read.ts` |
| `architecture/deterministic/god-module` | #353 | `tests/fixtures/sample-js-project-positive/src/god-module-jsx-component-collection.tsx` | `tests/fixtures/sample-js-project-negative/shared/utils/src/god-module-business-helpers.tsx` |

## `architecture/deterministic/duplicate-import`

Upstream sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/primitives/Checkbox.tsx#L2
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/primitives/Select.tsx#L2

```diff
+ /**
+  * Positive fixture for architecture/deterministic/duplicate-import.
+  *
+  * A namespace import (`import * as X from 'm'`) cannot be syntactically
+  * merged with a sibling named import (`import { a } from 'm'`). The two
+  * legal "combined" forms are `default + named` and `default + namespace`;
+  * `namespace + named` is not valid ES module syntax. Flagging this pair
+  * as "duplicate, merge them" sends the author down a dead end.
+  */
+
+ import * as React from 'react';
+ import { useEffect, useState } from 'react';
+
+ export function useToggle(): [boolean, () => void] {
+   const [on, setOn] = useState<boolean>(false);
+   useEffect(() => {
+     React.useRef({ on });
+   }, [on]);
+   return [on, () => setOn(!on)];
+ }
```

```diff
+ /**
+  * Paraphrased true-bug for architecture/deterministic/duplicate-import.
+  *
+  * Two named imports from the same module on adjacent lines — the canonical
+  * case the rule is meant to catch. These ARE merge-able into a single
+  * `import { a, b } from 'm'` statement.
+  */
+
+ // VIOLATION: architecture/deterministic/duplicate-import
+ import { validateEmail } from '@sample/shared-utils';
+ import { validateName } from '@sample/shared-utils';
+
+ export function checkContact(email: string, name: string): boolean {
+   return validateEmail(email) && validateName(name);
+ }
```

The visitor previously flagged any pair of imports from the same module unless one was type-only or side-effect-only. But `import * as X from 'm'` (namespace binding) and `import { a } from 'm'` (named bindings) cannot be syntactically merged: the only legal combined forms are `default + named` and `default + namespace`; `namespace + named` is not valid ES module syntax. The fix checks for that pairing and skips. Applied symmetrically to the `bugs/deterministic/duplicate-import` clone visitor since the two implement identical logic and the positive fixture would otherwise trip the sibling rule. (This also resolves #385 by side effect — the bugs/duplicate-import FP at the same target is a strict subset.)

## `bugs/deterministic/unmodified-loop-condition`

Upstream source: https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/references/test-tasks/src/trigger/helpers.ts#L201

```diff
+ /**
+  * Positive fixture for bugs/deterministic/unmodified-loop-condition.
+  *
+  * `Date.now()` in the condition advances on every iteration — the loop
+  * terminates as soon as the clock crosses the deadline. The local `start`
+  * and `delayMs` bindings are intentionally never assigned inside the
+  * loop body; the moving state is the side-effect-free call.
+  */
+
+ export function spin(delayMs: number): void {
+   const start = Date.now();
+   while (Date.now() - start < delayMs) {
+     // Intentional busy-wait — used by tests that measure event-loop lag.
+   }
+ }
```

```diff
+ /**
+  * Paraphrased true-bug for bugs/deterministic/unmodified-loop-condition.
+  *
+  * `done` is never reassigned inside the loop body and the condition is a
+  * pure identifier comparison — the loop spins forever. The canonical
+  * "forgot to flip the flag" mistake.
+  */
+
+ export function waitForFlag(): void {
+   let done = false;
+   // VIOLATION: bugs/deterministic/unmodified-loop-condition
+   while (done === false) {
+     const sentinel = 1 + 1;
+     void sentinel;
+   }
+ }
```

Busy-wait helpers like `while (Date.now() - start < delayMs)` and queue-drain loops like `while (queue.length() > 0)` were tripping the rule — the only identifier in the condition is `delayMs` (or similar) and it never changes, but the moving state lives in the `Date.now()` / `queue.length()` call. By symmetry with the body's existing `call_expression` short-circuit (a call inside the body is treated as state-changing), a call in the condition is treated as time-varying. The visitor now bails out early when either side of the binary condition contains a `call_expression`.

## `code-quality/deterministic/useless-constructor`

Upstream sources (ANTLR-generated grammar):
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/grammar/TSQLParser.ts#L7672
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/grammar/TSQLParser.ts#L7695
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/grammar/TSQLParser.ts#L7715

```diff
+ // Generated from src/grammar/Bar.g4 by ANTLR 4.9.0-SNAPSHOT
+ // Do not edit — re-run the generator.
+
+ /**
+  * Positive fixture for code-quality/deterministic/useless-constructor.
+  *
+  * Generator-produced parser-rule classes emit a constructor on every
+  * subclass that just forwards `(parent, invokingState)` to
+  * `super(parent, invokingState)`. Flagging this as "useless" floods the
+  * report with noise the author can't act on — removing the constructor
+  * means modifying generated output, and re-running the generator would
+  * just put it back.
+  */
+
+ export class GeneratedRuleContextBase {
+   protected readonly parent: unknown;
+   protected readonly invokingState: number;
+   constructor(parent: unknown, invokingState: number) {
+     this.parent = parent;
+     this.invokingState = invokingState;
+   }
+ }
+
+ export class GeneratedDeclarationContext extends GeneratedRuleContextBase {
+   constructor(parent: unknown, invokingState: number) {
+     super(parent, invokingState);
+   }
+ }
```

```diff
+ /**
+  * Paraphrased true-bug for code-quality/deterministic/useless-constructor.
+  *
+  * Hand-written subclass whose constructor only forwards the parent's
+  * argument list to `super()`. Removing it doesn't change observable
+  * behavior — the default constructor inherited from the parent would
+  * do exactly the same thing.
+  */
+
+ class GreeterBase {
+   constructor(protected readonly name: string) {}
+ }
+
+ export class FriendlyGreeter extends GreeterBase {
+   // VIOLATION: code-quality/deterministic/useless-constructor
+   constructor(name: string) {
+     super(name);
+   }
+ }
```

Generator-produced classes (ANTLR parsers/lexers, Protobuf stubs, GraphQL Code Generator output) emit a pass-through `constructor(parent, invokingState) { super(parent, invokingState); }` on every rule context. The author can't remove it — re-running the generator would put it back — so the violation is unactionable noise. The visitor now short-circuits on generated files via the existing `isGeneratedFile` helper (added for `unused-private-member` in #461).

## `code-quality/deterministic/missing-env-validation`

Upstream source: https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/env.server.ts#L135

```diff
+ /**
+  * Positive fixture for code-quality/deterministic/missing-env-validation.
+  *
+  * Inside a zod (or valibot/yup/class-validator) env schema, passing
+  * `process.env.X` as the `.default(...)` / `.catch(...)` argument IS the
+  * validation — the schema consumes the env var and surfaces a typed,
+  * validated value (with the env var as the fallback when undefined).
+  * Flagging the read as "unvalidated" misses that the surrounding
+  * `z.object({...}).parse(process.env)` IS the guard.
+  */
+
+ export const envSchema = {
+   APP_ENV: z.string().default(process.env.NODE_ENV),
+   REGION: z.string().catch(process.env.AWS_REGION ?? 'us-east-1'),
+ };
```

```diff
+ /**
+  * Paraphrased true-bug for code-quality/deterministic/missing-env-validation.
+  *
+  * A plain unguarded `process.env.X` read in business code: no
+  * `if (!x) throw`, no schema chain, no negation. At runtime `X` may be
+  * `undefined` and the concatenation silently produces
+  * "<https://undefined>" instead of crashing loudly — the exact bug the
+  * rule is meant to catch.
+  */
+
+ export function buildApiUrl(): string {
+   // VIOLATION: code-quality/deterministic/missing-env-validation
+   return `https://${process.env.API_HOST}`;
+ }
```

`process.env.X` passed to a schema-builder method (`z.string().default(process.env.X)`, `.catch(...)`, `.transform(...)`, etc.) IS the validation — zod consumes the env var and surfaces a typed value with the env var as the fallback. The visitor's 5-level ancestor walk now also short-circuits when it encounters a `call_expression` whose callee is one of the known schema-defaulting methods (`default`, `catch`, `fallback`, `transform`, `preprocess`, `parse`, `pipe`).

## `architecture/deterministic/god-module`

Upstream sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/primitives/Select.tsx#L1
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/primitives/DateTime.tsx#L1
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/BlankStatePanels.tsx#L1
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/TSQLResultsTable.tsx#L1

```diff
+ /**
+  * Positive fixture for architecture/deterministic/god-module.
+  *
+  * A primitive component file (DateTime, Select, Badge, Panel-collection)
+  * naturally ships many small PascalCase sub-components — format variants,
+  * Radix-shaped slot wrappers, layout shells. They share state, styling
+  * tokens, or composition context, so splitting them across files would
+  * shred the single conceptual unit. The god-module heuristic
+  * (>15 methods) treats every export as a business method and fires.
+  */
+
+ export function PanelHeader(p: HeaderProps): JSX.Element { ... }
+ export function PanelBody(p: BodyProps): JSX.Element { ... }
+ ...
+ export function PanelCompact(): JSX.Element { return <PanelShell title="compact" />; }
```

```diff
+ // VIOLATION: architecture/deterministic/god-module
+ /**
+  * Paraphrased true-bug for architecture/deterministic/god-module.
+  *
+  * A `.tsx` file but whose top-level methods are predominantly camelCase
+  * business helpers — not PascalCase React components. The exempt-on-JSX
+  * heuristic correctly identifies this as a real god module: too many
+  * unrelated responsibilities collected in one file.
+  */
+
+ export function loadAccount(id: string): string { return id; }
+ export function loadProfile(id: string): string { return id; }
+ ... (17 camelCase helpers)
```

Primitive React component files (`Select.tsx`, `DateTime.tsx`, `BlankStatePanels.tsx`, `TSQLResultsTable.tsx`) ship many small sub-components, format variants, and Radix slot wrappers in a single file — splitting them would shred the shared state/styling/composition context. The new `isJsxComponentCollection` heuristic exempts a module when it's in a `.tsx`/`.jsx` file AND at least 60% of its methods are PascalCase-named (signaling component/sub-component definitions rather than business helpers). The negative fixture is a `.tsx` file whose methods are predominantly camelCase business helpers — still flagged.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `architecture/deterministic/duplicate-import` | 40 | 34 | -6 |
| `bugs/deterministic/unmodified-loop-condition` | 1 | 0 | -1 |
| `code-quality/deterministic/useless-constructor` | 94 | 4 | -90 |
| `code-quality/deterministic/missing-env-validation` | 110 | 108 | -2 |
| `architecture/deterministic/god-module` | 87 | 79 | -8 |
| **Total (these 5 rules)** | 332 | 225 | -107 |
| **All-rules total on target** | 36078 | 35965 | -113 |

The all-rules total drops by 113 (vs the sum of 107 for the five listed rules) because the same namespace+named fix was applied to the sibling `bugs/deterministic/duplicate-import` visitor (also -6), which implicitly resolves the queued issue #385 for that rule.

cc @mushgev


---
_Generated by [Claude Code](https://claude.ai/code/session_0136dYMZ5TJuEJBimLdtnir9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved god-module detection to reduce false positives in React component collections.
  * Enhanced duplicate-import rule to properly handle namespace import scenarios.
  * Improved unmodified-loop-condition detection to recognize time-varying function calls.
  * Added support for schema-based environment variable validation patterns.
  * Fixed useless-constructor rule to skip generated code files.

* **Tests**
  * Added comprehensive test fixtures to validate rule improvements and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->