### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/javascript/raw-error-in-response.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/javascript/raw-error-in-response.ts
@@ -35,6 +35,12 @@ export const rawErrorInResponseVisitor: CodeRuleVisitor = {
     //   - fed into a pattern matcher: `match(err.message)` / `.with(err.message)`
     //   - passed to a React state setter: `setSomething(err.message ...)`
     const usagePattern = new RegExp(`\\b${errName}\\.(?:message|stack)\\b`, 'g')
+    // An `errName instanceof X` gate anywhere earlier in the catch body
+    // blesses subsequent `errName.message`/`.stack` reads, even when the
+    // gate is far above (e.g. wrapping a logger call with a large
+    // structured-fields object). Scan once for any such gate; per-usage
+    // checks only need the immediate prefix below.
+    const instanceofGated = new RegExp(`\\b${errName}\\s+instanceof\\b`).test(bodyText)
     let hasUnsafeUsage = false
     for (const usage of bodyText.matchAll(usagePattern)) {
       const idx = usage.index ?? 0
@@ -46,9 +52,8 @@ export const rawErrorInResponseVisitor: CodeRuleVisitor = {
       if (/(?:\bmatch|\.with)\s*\(\s*$/.test(before)) continue
       // React state setter call
       if (/\bset[A-Z]\w*\s*\(\s*$/.test(before)) continue
-      // Inside an instanceof-gated branch — search the recent window for
-      // an `errName instanceof X` check.
-      if (new RegExp(`\\b${errName}\\s+instanceof\\b`).test(before)) continue
+      // Inside an instanceof-gated branch
+      if (instanceofGated) continue
 
       hasUnsafeUsage = true
       break

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/unreachable-loop.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/unreachable-loop.ts
@@ -3,6 +3,25 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { JS_LANGUAGES } from './_helpers.js'
 
+const LOOP_TYPES = new Set([
+  'for_statement',
+  'for_in_statement',
+  'while_statement',
+  'do_statement',
+])
+
+// True if `node` (or any descendant outside a nested loop) contains a
+// continue_statement that would target the enclosing loop. Nested loops are
+// skipped because their continues bind to the inner loop, not the outer one.
+function bodyHasContinue(node: SyntaxNode): boolean {
+  if (node.type === 'continue_statement') return true
+  for (const child of node.namedChildren) {
+    if (LOOP_TYPES.has(child.type)) continue
+    if (bodyHasContinue(child)) return true
+  }
+  return false
+}
+
 export const unreachableLoopVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/unreachable-loop',
   languages: JS_LANGUAGES,
@@ -27,9 +46,11 @@ export const unreachableLoopVisitor: CodeRuleVisitor = {
     const EXITS = new Set(['return_statement', 'throw_statement', 'break_statement'])
 
     if (EXITS.has(last.type)) {
-      // Check there's no continue or conditional before the exit
-      const hasContinue = statements.some((s) => s.type === 'continue_statement')
-      if (hasContinue) return null
+      // A continue anywhere in the loop body (e.g. inside an `if` guard) can
+      // keep the loop alive past the final unconditional exit, so the body
+      // isn't "always one iteration". Walk the body but don't descend into
+      // nested loops, whose continues target the inner loop.
+      if (bodyHasContinue(block)) return null
 
       // If the exit is inside an if, it's conditional — skip
       // We only flag when the unconditional last statement is an exit

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/negated-condition.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/negated-condition.ts
@@ -1,6 +1,7 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { isGeneratedFile } from '../../../_shared/javascript-helpers.js'
 
 // Count direct statements in a body. For a single-statement body (no braces),
 // the body node IS the statement. For a `statement_block`, count the
@@ -18,6 +19,11 @@ export const negatedConditionVisitor: CodeRuleVisitor = {
   languages: ['typescript', 'tsx', 'javascript'],
   nodeTypes: ['if_statement'],
   visit(node, filePath, sourceCode) {
+    // Codegen output (parser/lexer scaffolding) writes `if (!cond)` branches
+    // that mirror the grammar's structure; the generator picks the polarity,
+    // not the author, so inverting them isn't a meaningful suggestion.
+    if (isGeneratedFile(filePath, sourceCode)) return null
+
     const condition = node.childForFieldName('condition')
     const elsePart = node.children.find((c) => c.type === 'else_clause')
     if (!condition || !elsePart) return null

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/useless-escape.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/useless-escape.ts
@@ -1,11 +1,17 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { isGeneratedFile } from '../../../_shared/javascript-helpers.js'
 
 export const uselessEscapeVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/useless-escape',
   languages: ['typescript', 'tsx', 'javascript'],
   nodeTypes: ['string'],
   visit(node, filePath, sourceCode) {
+    // Codegen output (ANTLR parsers, protoc, generated lexers, etc.) often
+    // serializes binary blobs as string literals with `\'` etc. that are
+    // intentional inside the generator's encoding scheme. Don't flag.
+    if (isGeneratedFile(filePath, sourceCode)) return null
+
     const text = node.text
     const quoteChar = text[0]
     if (quoteChar !== '"' && quoteChar !== "'") return null

--- a/packages/analyzer/src/rules/database/visitors/javascript/connection-not-released.ts
+++ b/packages/analyzer/src/rules/database/visitors/javascript/connection-not-released.ts
@@ -1,6 +1,34 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { getMethodName, CONNECTION_ACQUIRE_METHODS, isInsideTryBody } from './_helpers.js'
+
+// Method names like `connect` / `acquire` / `getClient` collide with
+// non-database APIs (Docker networks, distributed locks, rate limiters,
+// MCP / WebSocket servers, etc.). Require the receiver name to carry a DB
+// hint so the rule only fires when there's a real connection-pool semantic.
+const DB_RECEIVER_TOKENS = new Set([
+  'db', 'database', 'pool', 'prisma', 'knex', 'sequelize', 'mongoose',
+  'mongo', 'postgres', 'pg', 'mysql', 'sqlite', 'mssql', 'oracle',
+  'drizzle', 'typeorm', 'datasource', 'conn', 'connection',
+])
+
+function receiverTokens(text: string): string[] {
+  return text
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[\s_$.]+/)
+    .filter(Boolean)
+    .map((t) => t.toLowerCase())
+}
+
+function receiverIsDbLike(fn: SyntaxNode): boolean {
+  const object = fn.childForFieldName('object')
+  if (!object) return false
+  for (const token of receiverTokens(object.text)) {
+    if (DB_RECEIVER_TOKENS.has(token)) return true
+  }
+  return false
+}
 
 export const connectionNotReleasedVisitor: CodeRuleVisitor = {
   ruleKey: 'database/deterministic/connection-not-released',
@@ -13,6 +41,8 @@ export const connectionNotReleasedVisitor: CodeRuleVisitor = {
     // Only flag method calls on objects (pool.connect()), not standalone functions (getClient())
     const fn = node.childForFieldName('function')
     if (!fn || fn.type !== 'member_expression') return null
+
+    if (!receiverIsDbLike(fn)) return null
 
     // If the call is inside a try block, that's fine — assume finally releases it
     if (isInsideTryBody(node)) return null

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -181,6 +181,12 @@
       "layer": "api"
     },
     {
+      "name": "reportFailureHandler",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "api"
+    },
+    {
       "name": "serveTemplate",
       "service": "api-gateway",
       "kind": "standalone",
@@ -847,6 +853,12 @@
       "layer": "service"
     },
     {
+      "name": "describeOwner",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "describePayload",
       "service": "utils",
       "kind": "standalone",
@@ -920,6 +932,12 @@
     },
     {
       "name": "fireAndForget",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "firstSquareUnder",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"
@@ -1213,6 +1231,12 @@
       "layer": "service"
     },
     {
+      "name": "runWithoutRelease",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "Salutation",
       "service": "utils",
       "kind": "class",
@@ -1286,6 +1310,12 @@
     },
     {
       "name": "summarize",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "summarizeAccount",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/raw-error-in-response-leak-handler.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/raw-error-in-response-leak-handler.ts
@@ -1,0 +1,13 @@
+interface Response {
+  status(code: number): Response;
+  json(payload: unknown): void;
+}
+
+export function reportFailureHandler(_req: unknown, res: Response): void {
+  try {
+    JSON.parse("not json");
+  } catch (err) {
+    // VIOLATION: architecture/deterministic/raw-error-in-response
+    res.status(500).json({ failure: err.message, trace: err.stack });
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/connection-not-released-pg-pool.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/connection-not-released-pg-pool.ts
@@ -1,0 +1,14 @@
+interface Conn {
+  query(sql: string): Promise<unknown>;
+  release(): void;
+}
+
+interface Pool {
+  connect(): Promise<Conn>;
+}
+
+export async function runWithoutRelease(pool: Pool): Promise<unknown> {
+  // VIOLATION: database/deterministic/connection-not-released
+  const conn = await pool.connect();
+  return conn.query("select 1");
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/negated-condition-guard-with-else.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/negated-condition-guard-with-else.ts
@@ -1,0 +1,11 @@
+export function summarizeAccount(account: { balance: number } | null): string {
+  // VIOLATION: code-quality/deterministic/negated-condition
+  if (!account) {
+    return "missing";
+  } else {
+    const total = account.balance * 2;
+    const half = account.balance / 2;
+    const sum = total + half;
+    return "balance=" + String(sum);
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unreachable-loop-counter-return.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unreachable-loop-counter-return.ts
@@ -1,0 +1,8 @@
+export function firstSquareUnder(limit: number): number {
+  // VIOLATION: bugs/deterministic/unreachable-loop
+  for (let i = 1; i < limit; i++) {
+    const square = i * i;
+    return square;
+  }
+  return 0;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/useless-escape-double-quoted-apostrophe.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/useless-escape-double-quoted-apostrophe.ts
@@ -1,0 +1,4 @@
+export function describeOwner(name: string): string {
+  // VIOLATION: code-quality/deterministic/useless-escape
+  return "the owner\'s name is " + name;
+}

--- a/tests/fixtures/sample-js-project-positive/services/api-gateway/src/raw-error-in-response-instanceof-far-server.ts
+++ b/tests/fixtures/sample-js-project-positive/services/api-gateway/src/raw-error-in-response-instanceof-far-server.ts
@@ -1,0 +1,42 @@
+interface Logger {
+  debug(msg: string, fields: Record<string, unknown>): void;
+}
+
+interface StreamSender {
+  send(payload: { event?: string; data: string }): void;
+}
+
+declare const logger: Logger;
+
+const ABORT_REASON = "abort-due-to-send-failure";
+
+interface Controller {
+  abort(reason: string): void;
+}
+
+export function streamWithLogging(
+  sender: StreamSender,
+  controller: Controller,
+  event: string | undefined,
+  data: string,
+): void {
+  try {
+    sender.send({ event, data });
+  } catch (error) {
+    if (error instanceof Error && error.name !== "TypeError") {
+      logger.debug("Error sending stream chunk", {
+        channel: "stream-presenter",
+        stage: "send",
+        eventName: event,
+        attemptedBytes: data.length,
+        guidance: "verify downstream throughput before retrying",
+        error: {
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        },
+      });
+    }
+    controller.abort(ABORT_REASON);
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/connection-not-released-non-db-receivers.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/connection-not-released-non-db-receivers.ts
@@ -1,0 +1,28 @@
+interface Limiter {
+  acquire(req: { readonly key: string }): Promise<{ token: string }>;
+}
+
+interface DistributedLock {
+  acquire(
+    resources: readonly string[],
+    ttl: number,
+  ): Promise<{ release(): Promise<void> }>;
+}
+
+const RATE_LIMIT_KEY = "tenant-1";
+const LOCK_TTL_MS = 5000;
+
+export async function reserveQuerySlot(
+  queryConcurrencyLimiter: Limiter,
+): Promise<string> {
+  const slot = await queryConcurrencyLimiter.acquire({ key: RATE_LIMIT_KEY });
+  return slot.token;
+}
+
+export async function takeRedlock(
+  redlock: DistributedLock,
+  resources: readonly string[],
+): Promise<void> {
+  const lock = await redlock.acquire(resources, LOCK_TTL_MS);
+  await lock.release();
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/negated-condition-generated.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/negated-condition-generated.ts
@@ -1,0 +1,24 @@
+// Generated from src/grammar/MiniGrammar.g4 by ANTLR 4.9.0-SNAPSHOT
+
+type Recoverable = { recoverInline: () => void; reportMatch: () => void };
+type State = { la: number; matchedEOF: boolean };
+
+const TOKEN_FN = 1;
+const TOKEN_FUN = 2;
+const TOKEN_EOF = -1;
+
+export function applyTransitions(
+  state: State,
+  handler: Recoverable,
+  consume: () => void,
+): void {
+  if (!(state.la === TOKEN_FN || state.la === TOKEN_FUN)) {
+    handler.recoverInline();
+  } else {
+    if (state.la === TOKEN_EOF) {
+      state.matchedEOF = true;
+    }
+    handler.reportMatch();
+    consume();
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/unreachable-loop-nested-continue.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/unreachable-loop-nested-continue.ts
@@ -1,0 +1,43 @@
+interface Snapshot {
+  version: number;
+  payload: unknown;
+}
+
+interface Store {
+  read(id: string): Promise<Snapshot | null>;
+  writeIfUnchanged(
+    id: string,
+    expectedVersion: number,
+    next: unknown,
+  ): Promise<{ updated: number }>;
+}
+
+export async function applyWithOptimisticRetry(
+  store: Store,
+  id: string,
+  mutate: (input: unknown) => unknown,
+): Promise<unknown> {
+  const MAX_RETRIES = 3;
+  let attempts = 0;
+
+  while (attempts <= MAX_RETRIES) {
+    const current = await store.read(id);
+    if (!current) {
+      throw new Error(`missing ${id}`);
+    }
+
+    const next = mutate(current.payload);
+    const result = await store.writeIfUnchanged(id, current.version, next);
+
+    if (result.updated === 0) {
+      if (attempts === MAX_RETRIES) {
+        return next;
+      }
+      attempts++;
+      continue;
+    }
+
+    return next;
+  }
+  return undefined;
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/useless-escape-generated-banner.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/useless-escape-generated-banner.ts
@@ -1,0 +1,8 @@
+// Generated from src/grammar/MiniParser.g4 by ANTLR 4.9.0-SNAPSHOT
+
+export const serializedAtn =
+  "\x03悋\xA72\x8B怜\xA0K\xCE˯䭲#\t#\x04$\t$\x04%\t%\x04&\t&\x04\'\t\'\x04(\t(\x04)\t)\x04*\t*\x04+\tX\tX\x04Y\tY";
+
+export function getAtn(): string {
+  return serializedAtn;
+}


### PR DESCRIPTION
Closes #354
Closes #355
Closes #356
Closes #357
Closes #358

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `bugs/deterministic/unreachable-loop` | #354 | `tests/fixtures/sample-js-project-positive/shared/utils/src/unreachable-loop-nested-continue.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unreachable-loop-counter-return.ts` |
| `code-quality/deterministic/useless-escape` | #355 | `tests/fixtures/sample-js-project-positive/shared/utils/src/useless-escape-generated-banner.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/useless-escape-double-quoted-apostrophe.ts` |
| `code-quality/deterministic/negated-condition` | #356 | `tests/fixtures/sample-js-project-positive/shared/utils/src/negated-condition-generated.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/negated-condition-guard-with-else.ts` |
| `architecture/deterministic/raw-error-in-response` | #357 | `tests/fixtures/sample-js-project-positive/services/api-gateway/src/raw-error-in-response-instanceof-far-server.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/raw-error-in-response-leak-handler.ts` |
| `database/deterministic/connection-not-released` | #358 | `tests/fixtures/sample-js-project-positive/shared/utils/src/connection-not-released-non-db-receivers.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/connection-not-released-pg-pool.ts` |

## `bugs/deterministic/unreachable-loop`

OSS source samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/services/metadata/updateMetadata.server.ts#L381
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/services/platformNotifications.server.ts#L499
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/run-engine/src/engine/locking.ts#L230

Positive fixture (`tests/fixtures/sample-js-project-positive/shared/utils/src/unreachable-loop-nested-continue.ts`):
```ts
interface Snapshot { version: number; payload: unknown }
interface Store {
  read(id: string): Promise<Snapshot | null>
  writeIfUnchanged(id: string, expectedVersion: number, next: unknown): Promise<{ updated: number }>
}

export async function applyWithOptimisticRetry(
  store: Store, id: string, mutate: (input: unknown) => unknown,
): Promise<unknown> {
  const MAX_RETRIES = 3
  let attempts = 0
  while (attempts <= MAX_RETRIES) {
    const current = await store.read(id)
    if (!current) throw new Error(`missing ${id}`)
    const next = mutate(current.payload)
    const result = await store.writeIfUnchanged(id, current.version, next)
    if (result.updated === 0) {
      if (attempts === MAX_RETRIES) return next
      attempts++
      continue       // nested-in-if — missed by direct-child scan
    }
    return next      // unconditional last statement
  }
  return undefined
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/unreachable-loop-counter-return.ts`):
```ts
export function firstSquareUnder(limit: number): number {
  // VIOLATION: bugs/deterministic/unreachable-loop
  for (let i = 1; i < limit; i++) {
    const square = i * i
    return square
  }
  return 0
}
```

Visitor summary: the visitor only scanned the loop body's direct children for `continue_statement`, so a `continue` nested inside an `if` guard was invisible — and any retry loop whose final unconditional `return` follows a guarded `continue` was wrongly flagged as one-shot. The fix replaces the direct-children check with `bodyHasContinue`, a recursive walk that skips nested loops (their continues bind to the inner loop). The "unconditional last exit" check is unchanged.

## `code-quality/deterministic/useless-escape`

OSS source samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/grammar/TSQLParser.ts#L6943
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/grammar/TSQLParser.ts#L6986

Positive fixture (`tests/fixtures/sample-js-project-positive/shared/utils/src/useless-escape-generated-banner.ts`):
```ts
// Generated from src/grammar/MiniParser.g4 by ANTLR 4.9.0-SNAPSHOT

export const serializedAtn =
  "\x03悋\xA72\x8B怜\xA0K\xCE˯䭲#\t#\x04$\t$\x04%\t%\x04&\t&\x04\'\t\'\x04(\t(\x04)\t)\x04*\t*\x04+\tX\tX\x04Y\tY"

export function getAtn(): string { return serializedAtn }
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/useless-escape-double-quoted-apostrophe.ts`):
```ts
export function describeOwner(name: string): string {
  // VIOLATION: code-quality/deterministic/useless-escape
  return "the owner\'s name is " + name
}
```

Visitor summary: ANTLR / protoc / similar codegen serialize binary blobs as string literals where `\'`, `\$`, etc. are intentional artifacts of the generator's encoding, not author intent. The visitor now early-returns when `isGeneratedFile(filePath, sourceCode)` matches the file's banner or path. Hand-written code is unaffected.

## `code-quality/deterministic/negated-condition`

OSS source samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/grammar/TSQLParser.ts#L1285
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/grammar/TSQLParser.ts#L1868

Positive fixture (`tests/fixtures/sample-js-project-positive/shared/utils/src/negated-condition-generated.ts`):
```ts
// Generated from src/grammar/MiniGrammar.g4 by ANTLR 4.9.0-SNAPSHOT
// ... full file in the diff ...
if (!(state.la === TOKEN_FN || state.la === TOKEN_FUN)) {
  handler.recoverInline()
} else {
  if (state.la === TOKEN_EOF) state.matchedEOF = true
  handler.reportMatch()
  consume()
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/negated-condition-guard-with-else.ts`):
```ts
export function summarizeAccount(account: { balance: number } | null): string {
  // VIOLATION: code-quality/deterministic/negated-condition
  if (!account) {
    return "missing"
  } else {
    const total = account.balance * 2
    const half = account.balance / 2
    const sum = total + half
    return "balance=" + String(sum)
  }
}
```

Visitor summary: parser/lexer scaffolding generated from a grammar reflects the grammar's structure — the `if (!cond)` polarity is the generator's choice, not the author's, so suggesting "invert the condition" is meaningless for these files. The visitor now bails early on `isGeneratedFile`, matching the approach taken by `useless-escape` in this same PR.

## `architecture/deterministic/raw-error-in-response`

OSS source samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/presenters/v3/RunStreamPresenter.server.ts#L90
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/presenters/v3/TasksStreamPresenter.server.ts#L73

Positive fixture (`tests/fixtures/sample-js-project-positive/services/api-gateway/src/raw-error-in-response-instanceof-far-server.ts`):
```ts
export function streamWithLogging(
  sender: StreamSender, controller: Controller,
  event: string | undefined, data: string,
): void {
  try {
    sender.send({ event, data })
  } catch (error) {
    if (error instanceof Error && error.name !== "TypeError") {
      logger.debug("Error sending stream chunk", {
        channel: "stream-presenter", stage: "send", eventName: event,
        attemptedBytes: data.length, guidance: "verify downstream throughput before retrying",
        error: { name: error.name, message: error.message, stack: error.stack },
      })
    }
    controller.abort(ABORT_REASON)
  }
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/api-gateway/src/raw-error-in-response-leak-handler.ts`):
```ts
export function reportFailureHandler(_req: unknown, res: Response): void {
  try {
    JSON.parse("not json")
  } catch (err) {
    // VIOLATION: architecture/deterministic/raw-error-in-response
    res.status(500).json({ failure: err.message, trace: err.stack })
  }
}
```

Visitor summary: the rule was checking only the 200 characters of text *immediately preceding* each `err.message`/`.stack` read for an `err instanceof X` gate. When the access lives inside a large structured-fields object (logger payload with many sibling fields), the gate sits more than 200 chars above the access and is missed. The fix hoists the `instanceof` check to a single regex run against the full catch body — when any gate exists, downstream reads inside the same catch are blessed. Real leaks (no gate; direct `res.json({ err.message })`) still fire.

## `database/deterministic/connection-not-released`

OSS source samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/supervisor/src/workloadManager/docker.ts#L277
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/services/queryService.server.ts#L155
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/run-engine/src/engine/locking.ts#L238
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/commands/mcp.ts#L125

Positive fixture (`tests/fixtures/sample-js-project-positive/shared/utils/src/connection-not-released-non-db-receivers.ts`, abridged):
```ts
export async function reserveQuerySlot(
  queryConcurrencyLimiter: Limiter,
): Promise<string> {
  const slot = await queryConcurrencyLimiter.acquire({ key: RATE_LIMIT_KEY })
  return slot.token
}
export async function takeRedlock(
  redlock: DistributedLock, resources: readonly string[],
): Promise<void> {
  const lock = await redlock.acquire(resources, LOCK_TTL_MS)
  await lock.release()
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/shared/utils/src/connection-not-released-pg-pool.ts`):
```ts
export async function runWithoutRelease(pool: Pool): Promise<unknown> {
  // VIOLATION: database/deterministic/connection-not-released
  const conn = await pool.connect()
  return conn.query("select 1")
}
```

Visitor summary: the rule was firing on any method named `connect`/`acquire`/`getClient`/etc. regardless of receiver, so Docker network attaches, distributed-lock acquires, rate-limiter token grants, and MCP/WebSocket server connects all looked like leaked DB connections. The visitor now tokenizes the receiver expression by camelCase and underscore and only fires when at least one token matches a DB hint (`db`, `pool`, `prisma`, `knex`, `mongo`, `postgres`, `mysql`, `drizzle`, `typeorm`, etc.). True positives like `pool.connect()` and `dbPool.getConnection()` still fire; `redlock.acquire`, `queryConcurrencyLimiter.acquire`, `server.connect`, `network.connect` no longer do.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `bugs/deterministic/unreachable-loop` | 11 | 3 | -8 |
| `code-quality/deterministic/useless-escape` | 6 | 0 | -6 |
| `code-quality/deterministic/negated-condition` | 29 | 4 | -25 |
| `architecture/deterministic/raw-error-in-response` | 26 | 11 | -15 |
| `database/deterministic/connection-not-released` | 15 | 2 | -13 |
| **Total (these 5 rules)** | 87 | 20 | -67 |
| **All-rules total on target** | 35965 | 35898 | -67 |

cc @mushgev


---
_Generated by [Claude Code](https://claude.ai/code/session_014Nv5bU8wm1A4FauGoEHoyE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced code quality and security rule accuracy to reduce false positives across error handling, loop detection, and database operations
  * Improved pattern recognition for database-related code to better distinguish genuine issues from similar APIs
  * Refined handling of generated code in analysis rules

* **Tests**
  * Expanded test coverage with comprehensive fixtures for code quality and security scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->