### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/javascript/route-without-auth-middleware.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/javascript/route-without-auth-middleware.ts
@@ -12,11 +12,12 @@ import {
  * Match by exact path or as a prefix segment (`/login`, `/login/callback`).
  */
 const PUBLIC_PATH_PATTERNS = [
-  /^\/health(?:\b|\/)/,
-  /^\/healthz(?:\b|\/)/,
-  /^\/ready(?:\b|\/)/,
-  /^\/ping(?:\b|\/)/,
-  /^\/metrics(?:\b|\/)/,
+  /^\/health(?:check|z|y)?(?:\b|\/|$)/,
+  /^\/live(?:ness|z)?(?:\b|\/|$)/,
+  /^\/ready(?:ness|z)?(?:\b|\/|$)/,
+  /^\/ping(?:\b|\/|$)/,
+  /^\/status(?:\b|\/|$)/,
+  /^\/metrics(?:\b|\/|$)/,
   /^\/login(?:\b|\/)/,
   /^\/logout(?:\b|\/)/,
   /^\/signin(?:\b|\/)/,
@@ -56,6 +57,26 @@ const API_DOCS_PATH = /(?:^|\/)(?:openapi|swagger|api-docs|swagger-ui|redoc)(?:[
 
 function isApiDocsPath(path: string): boolean {
   return API_DOCS_PATH.test(path)
+}
+
+/**
+ * Meta-framework request-handler factories that own their own auth pipeline:
+ * Remix's `createRequestHandler`, React Router's, SvelteKit/Astro adapters,
+ * Next.js's pages handler, Nest's `handle`, etc. When one of these wraps the
+ * route handler, auth lives inside the framework's loaders/actions/middleware,
+ * not on the express-level mount.
+ */
+const FRAMEWORK_REQUEST_HANDLER_NAMES = /^(?:createRequestHandler|createPagesFunctionsHandler|getRequestHandler|handle|nextHandler|toNodeHandler|nodeHandler)$/
+
+function isFrameworkRequestHandler(arg: SyntaxNode | null | undefined): boolean {
+  if (!arg) return false
+  if (arg.type !== 'call_expression') return false
+  const fn = arg.childForFieldName('function')
+  if (!fn) return false
+  let name: string | undefined
+  if (fn.type === 'identifier') name = fn.text
+  else if (fn.type === 'member_expression') name = fn.childForFieldName('property')?.text
+  return !!name && FRAMEWORK_REQUEST_HANDLER_NAMES.test(name)
 }
 
 /**
@@ -188,6 +209,15 @@ export const routeWithoutAuthMiddlewareVisitor: CodeRuleVisitor = {
       if (isPublicPath(path)) return null
       if (isUrlCredentialAuthedPath(path)) return null
       if (isApiDocsPath(path)) return null
+      // Meta-framework catch-all: `app.all("*", createRequestHandler(...))`
+      // (Remix, React Router, etc.) hands every request off to the framework
+      // runtime, which runs auth inside its own loaders/actions. The
+      // express-level route is just the mount point.
+      if (path === '*' || path === '(.*)' || path === '/*') {
+        if (isFrameworkRequestHandler(args.namedChildren[args.namedChildren.length - 1])) {
+          return null
+        }
+      }
     }
 
     // Check this specific route's middleware chain

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/unsafe-unary-minus.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/unsafe-unary-minus.ts
@@ -21,16 +21,19 @@ export const unsafeUnaryMinusVisitor: CodeRuleVisitor = {
     const operand = node.namedChildren[0]
     if (!operand) return null
 
+    // Span-aware query: without the end position, smallest-node lookup can
+    // land on a sub-node (e.g. the `new` keyword inside `new Date()`) whose
+    // type isn't the expression's result type.
     const typeStr = typeQuery.getTypeAtPosition(
       filePath,
       operand.startPosition.row,
       operand.startPosition.column,
+      operand.endPosition.row,
+      operand.endPosition.column,
     )
     if (!typeStr) return null
 
-    // number, bigint, any, and literal number types are fine
-    if (typeStr === 'number' || typeStr === 'bigint' || typeStr === 'any') return null
-    if (/^\d+$/.test(typeStr)) return null // literal number type like '42'
+    if (isNumericOrBigintType(typeStr)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'high',
@@ -40,4 +43,20 @@ export const unsafeUnaryMinusVisitor: CodeRuleVisitor = {
       'Convert to a number first or remove the unary minus.',
     )
   },
+}
+
+// Numeric/bigint primitives, their literal types, and unions of those. The
+// compiler serializes literals as `1`, `-1`, `1.5`, `-9223372036854775808n`
+// etc. — accept any of those shapes (including unions like `1.5 | -1.5`).
+function isNumericOrBigintType(typeStr: string): boolean {
+  const parts = typeStr.split(/\s*\|\s*/)
+  return parts.every(isNumericOrBigintAtom)
+}
+
+function isNumericOrBigintAtom(part: string): boolean {
+  const t = part.trim()
+  if (t === 'number' || t === 'bigint' || t === 'any' || t === 'never') return true
+  if (/^-?\d+(\.\d+)?(e[+-]?\d+)?$/i.test(t)) return true // number literal
+  if (/^-?\d+n$/.test(t)) return true // bigint literal
+  return false
 }

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/values-not-convertible-to-number.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/values-not-convertible-to-number.ts
@@ -40,7 +40,11 @@ export const valuesNotConvertibleToNumberVisitor: CodeRuleVisitor = {
     if (!leftType || !rightType) return null
 
     // Relational operators coerce to number. Objects, arrays, booleans are problematic.
-    const nonComparableTypes = new Set(['boolean', 'object', 'void', 'undefined', 'null', 'never'])
+    // `never` is excluded: when the analyzer can't resolve an upstream type
+    // (Prisma payload generics, helpers behind missing node_modules,
+    // exhaustively-narrowed unions), TS serialises the operand as `never` —
+    // a type-information artifact, not a real coercion bug.
+    const nonComparableTypes = new Set(['boolean', 'object', 'void', 'undefined', 'null'])
 
     if (nonComparableTypes.has(leftType) || nonComparableTypes.has(rightType)) {
       const badType = nonComparableTypes.has(leftType) ? leftType : rightType

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/nested-template-literal.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/nested-template-literal.ts
@@ -19,6 +19,11 @@ export const nestedTemplateLiteralVisitor: CodeRuleVisitor = {
         return null
       }
     }
+    // Multi-line outer templates are typically banners, CSS-in-JS, SQL, or
+    // generated reports. The readability concern targets dense one-liners
+    // where the nested template visually disappears; a multi-line builder
+    // already reads vertically so an inline nested branch is fine.
+    if (node.startPosition.row !== node.endPosition.row) return null
     for (let i = 0; i < node.namedChildCount; i++) {
       const child = node.namedChild(i)
       if (child?.type === 'template_substitution') {

--- a/packages/analyzer/src/rules/database/visitors/javascript/missing-transaction.ts
+++ b/packages/analyzer/src/rules/database/visitors/javascript/missing-transaction.ts
@@ -1,6 +1,7 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import type { TypeQueryService } from '../../../../ts-compiler.js'
 import { getMethodName, ORM_WRITE_METHODS, getEnclosingFunctionBody, bodyHasTransactionCall, isInsideTransactionCallback } from './_helpers.js'
 
 // `destroy()` and `save()` are common method names on non-ORM objects
@@ -10,6 +11,27 @@ import { getMethodName, ORM_WRITE_METHODS, getEnclosingFunctionBody, bodyHasTran
 // shape is the dead giveaway of a UI/PDF library cleanup and a frequent
 // FP source for this rule.
 const ZERO_ARG_AMBIGUOUS_WRITE_METHODS = new Set(['destroy', 'save'])
+
+// In-memory containers share method names with ORMs (`.delete`, `.set`).
+// When the receiver's type is one of these, the call is not a DB write.
+const IN_MEMORY_CONTAINER_TYPES = /^(?:Readonly)?(?:Map|Set|WeakMap|WeakSet)\b/
+
+function isInMemoryContainerReceiver(call: SyntaxNode, typeQuery: TypeQueryService | undefined, filePath: string): boolean {
+  if (!typeQuery) return false
+  const fn = call.childForFieldName('function')
+  if (fn?.type !== 'member_expression') return false
+  const receiver = fn.childForFieldName('object')
+  if (!receiver) return false
+  const typeStr = typeQuery.getTypeAtPosition(
+    filePath,
+    receiver.startPosition.row,
+    receiver.startPosition.column,
+    receiver.endPosition.row,
+    receiver.endPosition.column,
+  )
+  if (!typeStr) return false
+  return IN_MEMORY_CONTAINER_TYPES.test(typeStr.trim())
+}
 
 function looksLikeOrmWriteCall(call: SyntaxNode, methodName: string): boolean {
   if (!ORM_WRITE_METHODS.has(methodName)) return false
@@ -24,9 +46,11 @@ export const missingTransactionVisitor: CodeRuleVisitor = {
   ruleKey: 'database/deterministic/missing-transaction',
   languages: ['typescript', 'tsx', 'javascript'],
   nodeTypes: ['call_expression'],
-  visit(node, filePath, sourceCode) {
+  needsTypeQuery: true,
+  visit(node, filePath, sourceCode, _dataFlow, typeQuery) {
     const methodName = getMethodName(node)
     if (!looksLikeOrmWriteCall(node, methodName)) return null
+    if (isInMemoryContainerReceiver(node, typeQuery, filePath)) return null
 
     const body = getEnclosingFunctionBody(node)
     if (!body) return null
@@ -56,7 +80,7 @@ export const missingTransactionVisitor: CodeRuleVisitor = {
         } else if (fn?.type === 'identifier') {
           mName = fn.text
         }
-        if (looksLikeOrmWriteCall(n, mName)) {
+        if (looksLikeOrmWriteCall(n, mName) && !isInMemoryContainerReceiver(n, typeQuery, filePath)) {
           writeCount++
           if (tableName) tableNames.add(tableName)
           if (n.id === node.id) {

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -949,6 +949,12 @@
       "layer": "service"
     },
     {
+      "name": "formatTaskRunId",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "formatters",
       "service": "utils",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -1105,6 +1105,12 @@
       "layer": "service"
     },
     {
+      "name": "negatedConfigValue",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "OffscreenRenderer",
       "service": "utils",
       "kind": "class",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -1021,6 +1021,12 @@
       "layer": "service"
     },
     {
+      "name": "isLeading",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "isSelectedBuggy",
       "service": "utils",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -541,6 +541,12 @@
       "layer": "data"
     },
     {
+      "name": "registerUser",
+      "service": "user-service",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "runLs",
       "service": "user-service",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/route-without-auth-unprotected-data.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/route-without-auth-unprotected-data.ts
@@ -1,0 +1,19 @@
+/**
+ * A data-fetching endpoint declared directly on the express app without any
+ * auth middleware in its chain and without a global auth registration in
+ * this file. The handler reads from a privileged store and should be gated.
+ */
+
+import express from 'express';
+
+const app = express();
+
+declare function loadInvoices(userId: string): Promise<Array<{ id: string }>>;
+
+// VIOLATION: architecture/deterministic/route-without-auth-middleware
+app.get('/api/invoices', async (req, res) => {
+  const invoices = await loadInvoices(String(req.query.userId));
+  res.json(invoices);
+});
+
+export { app };

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/missing-transaction-multi-table.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/missing-transaction-multi-table.ts
@@ -1,0 +1,19 @@
+/**
+ * Two database writes to two different tables inside the same function
+ * without a surrounding atomic boundary. If the second write fails, the
+ * first is not rolled back.
+ */
+
+interface PrismaClient {
+  readonly user: { create(args: { data: { email: string } }): Promise<{ id: string }> };
+  readonly profile: { create(args: { data: { userId: string; name: string } }): Promise<unknown> };
+}
+
+declare const prisma: PrismaClient;
+
+// VIOLATION: database/deterministic/missing-transaction
+export async function registerUser(email: string, name: string): Promise<string> {
+  const user = await prisma.user.create({ data: { email } });
+  await prisma.profile.create({ data: { userId: user.id, name } });
+  return user.id;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/nested-template-literal-inline.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/nested-template-literal-inline.ts
@@ -1,0 +1,10 @@
+/**
+ * Dense single-line template with a nested template inside a conditional
+ * substitution — extracting the inner expression to a variable would make
+ * the code easier to scan.
+ */
+
+export function formatTaskRunId(suffix: string, attempt?: number): string {
+  // VIOLATION: code-quality/deterministic/nested-template-literal
+  return `task-run-${suffix}${attempt && attempt > 1 ? `-att${attempt}` : ''}`;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unsafe-unary-minus-on-string.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unsafe-unary-minus-on-string.ts
@@ -1,0 +1,9 @@
+/**
+ * Unary minus on a string operand silently produces NaN at runtime — the
+ * developer probably meant to parse the string to a number first.
+ */
+
+export function negatedConfigValue(raw: string): number {
+  // VIOLATION: bugs/deterministic/unsafe-unary-minus
+  return -raw;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/values-not-convertible-boolean.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/values-not-convertible-boolean.ts
@@ -1,0 +1,10 @@
+/**
+ * Comparing a boolean to a number coerces `true` to 1 and `false` to 0 —
+ * almost certainly not what the caller meant. Probably a sign of a missing
+ * `.length`, a counter access, or a forgotten conversion.
+ */
+
+export function isLeading(flag: boolean, threshold: number): boolean {
+  // VIOLATION: bugs/deterministic/values-not-convertible-to-number
+  return flag > threshold;
+}

--- a/tests/fixtures/sample-js-project-positive/missing-transaction-map-set-deletes.ts
+++ b/tests/fixtures/sample-js-project-positive/missing-transaction-map-set-deletes.ts
@@ -1,0 +1,32 @@
+// In-memory Map/Set/WeakMap/WeakSet have a `.delete(key)` method that
+// matches the ORM write-method allow-list textually. They are not database
+// writes — calls into them should never be flagged as missing-transaction
+// candidates.
+
+interface CacheEntry {
+  readonly slotIndex: number;
+}
+
+export class TimerWheel {
+  private readonly entries = new Map<string, CacheEntry>();
+  private readonly bySlot = new Map<number, Set<string>>();
+
+  cancel(key: string): boolean {
+    const entry = this.entries.get(key);
+    if (!entry) return false;
+    const slot = this.bySlot.get(entry.slotIndex);
+    if (slot) slot.delete(key);
+    this.entries.delete(key);
+    return true;
+  }
+}
+
+interface Orchestration {
+  readonly activeTextPartIndexes: Map<string, number>;
+  readonly completedTextPartIds: Set<string>;
+}
+
+export function finalizeTextPart(orchestration: Orchestration, id: string): void {
+  orchestration.activeTextPartIndexes.delete(id);
+  orchestration.completedTextPartIds.delete(id);
+}

--- a/tests/fixtures/sample-js-project-positive/nested-template-literal-multiline-banner.ts
+++ b/tests/fixtures/sample-js-project-positive/nested-template-literal-multiline-banner.ts
@@ -1,0 +1,31 @@
+// Multi-line template literals are typically banners, CSS-in-JS, SQL, or
+// generated reports — the multi-line shape means the outer template already
+// reads vertically, so an inline nested template inside a substitution is
+// not the readability hazard the rule is meant to catch (which is dense
+// one-liner nests).
+
+export function buildBootstrapBanner(
+  groupName: string,
+  token: string,
+  tokenPath?: string,
+): string {
+  return `
+==========================
+Bootstrap - Worker Token
+
+WARNING: This will only be shown once.
+
+Worker group:
+${groupName}
+
+Token:
+${token}
+${
+  tokenPath
+    ? `Or, if using a file:
+TOKEN=file://${tokenPath}`
+    : ''
+}
+==========================
+  `;
+}

--- a/tests/fixtures/sample-js-project-positive/route-without-auth-public-paths.ts
+++ b/tests/fixtures/sample-js-project-positive/route-without-auth-public-paths.ts
@@ -1,0 +1,16 @@
+// `/healthcheck` is a load-balancer probe path that must be public. The
+// rule already exempted `/health` and `/healthz`; `/healthcheck` is the
+// same convention and was missing from the allow-list.
+
+import { Router } from 'express';
+import type { RequestHandler } from 'express';
+
+const router = Router();
+
+const healthHandler: RequestHandler = (_req, res): void => {
+  res.status(200).send('OK');
+};
+
+router.get('/healthcheck', healthHandler);
+
+export default router;

--- a/tests/fixtures/sample-js-project-positive/unsafe-unary-minus-numeric-operands.ts
+++ b/tests/fixtures/sample-js-project-positive/unsafe-unary-minus-numeric-operands.ts
@@ -1,0 +1,35 @@
+// Unary minus is safe on any operand whose type is `number` or `bigint`
+// (including literal-number/bigint types and method results that return one).
+// The rule should accept all of the shapes below.
+
+export function fractionalOffset(direction: 'forward' | 'backward'): number {
+  return direction === 'forward' ? 1.5 : -1.5;
+}
+
+export function localUtcOffsetMinutes(): number {
+  return -new Date().getTimezoneOffset();
+}
+
+export const LOWER_BIGINT_BOUND: bigint = -9223372036854775808n;
+export const UPPER_BIGINT_BOUND: bigint = 9223372036854775808n;
+
+interface RingState {
+  readonly capacity: number;
+  entries: ReadonlyArray<string>;
+}
+
+export function trimHistoryRing(state: RingState): ReadonlyArray<string> {
+  if (state.entries.length <= state.capacity) return state.entries;
+  return state.entries.slice(-state.capacity);
+}
+
+interface TailOptions {
+  readonly lines: number;
+}
+
+export function tailLogLines(
+  buffer: ReadonlyArray<string>,
+  options: TailOptions,
+): string {
+  return buffer.slice(-options.lines).join('\n');
+}

--- a/tests/fixtures/sample-js-project-positive/values-not-convertible-array-length.ts
+++ b/tests/fixtures/sample-js-project-positive/values-not-convertible-array-length.ts
@@ -1,0 +1,15 @@
+// When the analyzer's TS pass can't fully resolve an upstream type (Prisma
+// payload generics, helper-function return types behind missing
+// node_modules, exhaustively-narrowed unions, etc.), it sometimes serialises
+// the operand's type as `never`. The rule used to flag this as a
+// non-numeric comparison, but a `never` here is a "type-information
+// missing" artifact, not a real coercion bug — those code paths are
+// either unreachable or use numbers fine at runtime.
+
+export function unreachableCompare(x: never, threshold: number): boolean {
+  return x > threshold;
+}
+
+export function unreachableCompareReverse(threshold: number, x: never): boolean {
+  return threshold < x;
+}


### PR DESCRIPTION
Closes #359
Closes #360
Closes #361
Closes #362
Closes #363

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| bugs/deterministic/unsafe-unary-minus | #359 | `tests/fixtures/sample-js-project-positive/unsafe-unary-minus-numeric-operands.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unsafe-unary-minus-on-string.ts` |
| code-quality/deterministic/nested-template-literal | #360 | `tests/fixtures/sample-js-project-positive/nested-template-literal-multiline-banner.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/nested-template-literal-inline.ts` |
| architecture/deterministic/route-without-auth-middleware | #361 | `tests/fixtures/sample-js-project-positive/route-without-auth-public-paths.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/route-without-auth-unprotected-data.ts` |
| bugs/deterministic/values-not-convertible-to-number | #362 | `tests/fixtures/sample-js-project-positive/values-not-convertible-array-length.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/values-not-convertible-boolean.ts` |
| database/deterministic/missing-transaction | #363 | `tests/fixtures/sample-js-project-positive/missing-transaction-map-set-deletes.ts` | `tests/fixtures/sample-js-project-negative/services/user-service/src/missing-transaction-multi-table.ts` |

## bugs/deterministic/unsafe-unary-minus

OSS source samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/navigation/SideMenu.tsx#L1240
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/primitives/DateTime.tsx#L459
- `https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/eventRepository/sanitizeRowsOnParseError.server.ts#L31`
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/entryPoints/managed/snapshot.ts#L318
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/mcp/tools/devServer.ts#L218

Positive fixture (`unsafe-unary-minus-numeric-operands.ts`):
```ts
export function fractionalOffset(direction: 'forward' | 'backward'): number {
  return direction === 'forward' ? 1.5 : -1.5;
}

export function localUtcOffsetMinutes(): number {
  return -new Date().getTimezoneOffset();
}

export const LOWER_BIGINT_BOUND: bigint = -9223372036854775808n;
export const UPPER_BIGINT_BOUND: bigint = 9223372036854775808n;
// ...also tested: -this.property, slice(-options.lines)
```

Negative fixture (`unsafe-unary-minus-on-string.ts`):
```ts
export function negatedConfigValue(raw: string): number {
  // VIOLATION: bugs/deterministic/unsafe-unary-minus
  return -raw;
}
```

Visitor change: query the operand's type with the full start..end span (single-position lookup was landing on sub-nodes like the `new` keyword inside `new Date()`), and expand the allow-list past `/^\d+$/` so that fractional literals (`1.5`), signed literals (`-9223372036854775808n`), exponential notation, and unions of these (`1.5 | -1.5`) are recognised as numeric.

## code-quality/deterministic/nested-template-literal

OSS source samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/bootstrap.ts#L41

Positive fixture (`nested-template-literal-multiline-banner.ts`):
```ts
export function buildBootstrapBanner(
  groupName: string, token: string, tokenPath?: string,
): string {
  return `
==========================
Bootstrap - Worker Token
…
${tokenPath ? `Or, if using a file:
TOKEN=file://${tokenPath}` : ''}
==========================
  `;
}
```

Negative fixture (`nested-template-literal-inline.ts`):
```ts
export function formatTaskRunId(suffix: string, attempt?: number): string {
  // VIOLATION: code-quality/deterministic/nested-template-literal
  return `task-run-${suffix}${attempt && attempt > 1 ? `-att${attempt}` : ''}`;
}
```

Visitor change: skip the rule when the outer template literal spans multiple lines (`node.startPosition.row !== node.endPosition.row`). Multi-line builders — banners, CSS-in-JS, SQL, generated reports — already read vertically; the readability concern is the dense one-liner where a nested template visually disappears.

## architecture/deterministic/route-without-auth-middleware

OSS source samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/server.ts#L182
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/server.ts#L192

Positive fixture (`route-without-auth-public-paths.ts`):
```ts
const router = Router();
const healthHandler: RequestHandler = (_req, res): void => {
  res.status(200).send('OK');
};
router.get('/healthcheck', healthHandler);
```

Negative fixture (`route-without-auth-unprotected-data.ts`):
```ts
// VIOLATION: architecture/deterministic/route-without-auth-middleware
app.get('/api/invoices', async (req, res) => {
  const invoices = await loadInvoices(String(req.query.userId));
  res.json(invoices);
});
```

Visitor changes:
1. Expanded the public-path regex family from `/^\/health(?:\b|\/)/` to `/^\/health(?:check|z|y)?(?:\b|\/|$)/` (and parallel patterns for `/live(ness|z)`, `/ready(ness|z)`, `/status`). The old word-boundary check rejected `/healthcheck` because `\b` requires a non-word char after `health`, and `c` is a word char.
2. When the route path is a meta-framework catch-all (`"*"`, `"/*"`, `"(.*)"`) and the handler argument is a call to a known framework request-handler factory (Remix's `createRequestHandler`, SvelteKit/Astro adapters, Next.js's pages handler, etc.), skip — auth lives inside the framework's loaders/actions, not on the express-level mount. The catch-all path isn't covered by the positive fixture in this PR because `app.all("*", ...)` independently triggers `security/deterministic/mixed-http-methods` (a separate FP not in scope); the visitor change is verified by the target re-analysis dropping this rule from 2 → 0.

## bugs/deterministic/values-not-convertible-to-number

OSS source samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/api.v1.batches.$batchId.ts#L56
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/api.v2.batches.$batchId.ts#L50
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/references/hello-world/src/trigger/agentRelay.ts#L139

Positive fixture (`values-not-convertible-array-length.ts`):
```ts
export function unreachableCompare(x: never, threshold: number): boolean {
  return x > threshold;
}

export function unreachableCompareReverse(threshold: number, x: never): boolean {
  return threshold < x;
}
```

Negative fixture (`values-not-convertible-boolean.ts`):
```ts
export function isLeading(flag: boolean, threshold: number): boolean {
  // VIOLATION: bugs/deterministic/values-not-convertible-to-number
  return flag > threshold;
}
```

Visitor change: removed `'never'` from the non-comparable types set. When the analyzer can't resolve an upstream type (Prisma payload generics, helpers behind missing node_modules, exhaustively-narrowed unions), TypeScript serialises the operand as `never` — a type-information artifact, not a real coercion bug. The rule still flags genuine `boolean`/`object`/`void`/`undefined`/`null` mismatches.

## database/deterministic/missing-transaction

OSS source samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/supervisor/src/services/timerWheel.ts#L119
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/runs/v3/agent/AgentView.tsx#L644

Positive fixture (`missing-transaction-map-set-deletes.ts`):
```ts
export class TimerWheel {
  private readonly entries = new Map<string, CacheEntry>();
  private readonly bySlot = new Map<number, Set<string>>();
  cancel(key: string): boolean {
    const entry = this.entries.get(key);
    if (!entry) return false;
    const slot = this.bySlot.get(entry.slotIndex);
    if (slot) slot.delete(key);
    this.entries.delete(key);
    return true;
  }
}
```

Negative fixture (`missing-transaction-multi-table.ts`):
```ts
// VIOLATION: database/deterministic/missing-transaction
export async function registerUser(email: string, name: string): Promise<string> {
  const user = await prisma.user.create({ data: { email } });
  await prisma.profile.create({ data: { userId: user.id, name } });
  return user.id;
}
```

Visitor change: opted the rule into `needsTypeQuery`, and now skip ORM-write candidates whose receiver type matches `Map`/`Set`/`WeakMap`/`WeakSet` (or their `Readonly*` variants). `.delete` and `.set` are also the standard JS container methods; the textual allow-list can't distinguish in-memory containers from ORM tables without consulting the type checker.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| bugs/deterministic/unsafe-unary-minus | 8 | 0 | -8 |
| code-quality/deterministic/nested-template-literal | 100 | 40 | -60 |
| architecture/deterministic/route-without-auth-middleware | 2 | 0 | -2 |
| bugs/deterministic/values-not-convertible-to-number | 3 | 0 | -3 |
| database/deterministic/missing-transaction | 99 | 73 | -26 |
| **Total (these 5 rules)** | **212** | **113** | **-99** |
| **All-rules total on target** | **35898** | **35799** | **-99** |

The -99 cross-rule total exactly matches the all-rules total — no regressions in other rules.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMvdhbSx5NE6XVXYixUxUa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of public health/status endpoints to reduce false positives
  * Enhanced type checking for numeric operations with better literal and bigint recognition
  * Reduced false positives when analyzing in-memory data structures like Maps and Sets
  * Refined readability checks to exempt multi-line code structures

* **Tests**
  * Added test fixtures to validate improved detection logic across multiple rule types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->