### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/architecture/checker.ts
+++ b/packages/analyzer/src/rules/architecture/checker.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+import { dirname, resolve as resolvePath } from 'node:path'
 import type { ServiceInfo, ServiceDependencyInfo, ModuleInfo, MethodInfo, ModuleDependency, ModuleLevelDependency, MethodLevelDependency, AnalysisRule, FileAnalysis } from '@truecourse/shared'
 import { getMaxParameters } from '../../language-config.js'
 import { findCycles, type EdgeMetadata } from './tarjan.js'
@@ -438,6 +439,7 @@ export function checkModuleRules(
         importedTargets.add(name)
       }
     }
+    const barrelReExportTargets = buildBarrelReExportTargets(fileAnalyses)
     // Also consider targets reached via method-level dependencies (constructor calls, etc.)
     if (methodLevelDeps) {
       for (const dep of methodLevelDeps) {
@@ -487,6 +489,12 @@ export function checkModuleRules(
       if (method.isExported && !importedTargets.has(method.name)) {
         // Skip exports from entry point files — they're consumed by the framework/runtime
         if (entryPointFiles?.has(method.filePath)) continue
+
+        // Skip exports from files re-exported by a barrel — the extractor
+        // only sees the first specifier per `export { … } from '…'` clause,
+        // so later specifiers look unimported. The barrel itself is the
+        // declared public-API surface; treat all of its targets as live.
+        if (barrelReExportTargets.has(method.filePath)) continue
 
         // Skip exports from seed/fixture directories — their consumers are
         // e2e specs and CLI seed scripts which are excluded from analysis.
@@ -545,6 +553,8 @@ export function checkModuleRules(
     for (const mod of modules) {
       if (mod.kind === 'class' && mod.exportCount > 0 && !importedTargets.has(mod.name)) {
         if (entryPointFiles?.has(mod.filePath)) continue
+
+        if (barrelReExportTargets.has(mod.filePath)) continue
 
         if (SEED_PATH_PATTERN.test(mod.filePath)) continue
         if (REMIX_ROUTE_PATH_PATTERN.test(mod.filePath)) continue
@@ -893,6 +903,45 @@ const SEED_PATH_PATTERN = /\/(?:seed|e2e\/fixtures|app-tests\/[^/]+\/fixtures)\/
 const REMIX_ROUTE_PATH_PATTERN = /\/app\/routes\//i
 
 /**
+ * A "barrel" file is one whose role is to re-export from sibling modules:
+ * it has at least one `export ... from '…'` statement and declares no
+ * own functions or classes. The tree-sitter export extractor only
+ * captures the first specifier per `export { a, b, c } from '…'` clause,
+ * so names after the first are invisible to the import-set used by
+ * unused-export / dead-method. The fix: treat every file targeted by
+ * any barrel's re-export edge as reachable. Tests, downstream packages,
+ * and other out-of-tree consumers reach those modules through the
+ * barrel; flagging their exports as unused is a false positive.
+ */
+function buildBarrelReExportTargets(fileAnalyses: FileAnalysis[] | undefined): Set<string> {
+  const result = new Set<string>()
+  if (!fileAnalyses) return result
+  const analyzedPaths = new Set(fileAnalyses.map((fa) => fa.filePath))
+  const EXTS = ['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs']
+  for (const fa of fileAnalyses) {
+    const hasReExport = fa.exports.some((e) => e.source !== undefined)
+    if (!hasReExport) continue
+    if (fa.functions.length > 0 || fa.classes.length > 0) continue
+    const barrelDir = dirname(fa.filePath)
+    for (const exp of fa.exports) {
+      if (!exp.source || !exp.source.startsWith('.')) continue
+      const base = resolvePath(barrelDir, exp.source)
+      let matched = false
+      for (const ext of EXTS) {
+        const candidate = base + ext
+        if (analyzedPaths.has(candidate)) { result.add(candidate); matched = true; break }
+      }
+      if (matched) continue
+      for (const ext of EXTS) {
+        const candidate = resolvePath(base, 'index' + ext)
+        if (analyzedPaths.has(candidate)) { result.add(candidate); break }
+      }
+    }
+  }
+  return result
+}
+
+/**
  * Check deterministic method-level rules and return violations.
  */
 export function checkMethodRules(
@@ -980,6 +1029,7 @@ export function checkMethodRules(
       connectedMethods.add(`${dep.callerService}::${dep.callerModule}::${dep.callerMethod}`)
       connectedMethods.add(`${dep.calleeService}::${dep.calleeModule}::${dep.calleeMethod}`)
     }
+    const barrelReExportTargets = buildBarrelReExportTargets(fileAnalyses)
 
     // Build set of method names referenced as event handler arguments
     // (e.g., .on('event', this.methodName), .once('close', this.handleClose))
@@ -1092,6 +1142,11 @@ export function checkMethodRules(
         // Skip methods in framework entry files — they're invoked by the framework
         // or called from JSX which isn't tracked in method-level dependencies
         if (entryPointFiles?.has(method.filePath)) continue
+
+        // Skip methods in files re-exported by a barrel — out-of-tree
+        // callers (tests, downstream packages) reach them through the
+        // public surface even when no analyzed file calls them directly.
+        if (method.isExported && barrelReExportTargets.has(method.filePath)) continue
 
         // Skip functions called directly within their own file
         if (calledInOwnFile.get(method.filePath)?.has(method.name)) continue

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/array-delete.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/array-delete.ts
@@ -1,6 +1,77 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { JS_LANGUAGES } from './_helpers.js'
+
+// `delete obj[key]` looks like the array-hole bug only when `obj` is
+// actually an array. When the receiver is a plain object map — the
+// canonical case is the spread-cloned record (`const next = { ...prev };
+// delete next[key]`) used to immutably remove a property — `delete` is
+// the correct operation. Look for an in-scope declaration of the
+// subscripted identifier and skip when its initializer is clearly an
+// object: an object literal, a spread / Object.assign / Object.fromEntries
+// expression, a destructuring rest pattern, or one of the common object-
+// constructing builtins.
+function isObjectLikeInit(init: SyntaxNode | null | undefined): boolean {
+  if (!init) return false
+  if (init.type === 'object' || init.type === 'object_pattern') return true
+  if (init.type === 'as_expression' || init.type === 'satisfies_expression' || init.type === 'type_assertion' || init.type === 'parenthesized_expression') {
+    return isObjectLikeInit(init.namedChild(0))
+  }
+  if (init.type === 'call_expression') {
+    const callee = init.childForFieldName('function')
+    if (!callee) return false
+    const text = callee.text
+    if (text === 'Object.assign' || text === 'Object.create' || text === 'Object.fromEntries' || text === 'structuredClone') return true
+  }
+  return false
+}
+
+function receiverIsObjectMap(receiver: SyntaxNode): boolean {
+  if (receiver.type !== 'identifier') return false
+  // Walk enclosing scopes looking for the declaration of this identifier.
+  let scope: SyntaxNode | null = receiver.parent
+  while (scope) {
+    if (
+      scope.type === 'statement_block' ||
+      scope.type === 'program' ||
+      scope.type === 'function_body' ||
+      scope.type === 'arrow_function' ||
+      scope.type === 'function_declaration' ||
+      scope.type === 'function_expression' ||
+      scope.type === 'method_definition'
+    ) {
+      for (let i = 0; i < scope.namedChildCount; i++) {
+        const stmt = scope.namedChild(i)
+        if (!stmt) continue
+        if (stmt.type === 'lexical_declaration' || stmt.type === 'variable_declaration') {
+          for (let j = 0; j < stmt.namedChildCount; j++) {
+            const decl = stmt.namedChild(j)
+            if (decl?.type !== 'variable_declarator') continue
+            const declName = decl.childForFieldName('name')
+            if (declName?.type === 'identifier' && declName.text === receiver.text) {
+              return isObjectLikeInit(decl.childForFieldName('value'))
+            }
+            if (declName?.type === 'object_pattern') {
+              for (let k = 0; k < declName.namedChildCount; k++) {
+                const part = declName.namedChild(k)
+                if (part?.type === 'rest_pattern') {
+                  const id = part.namedChild(0)
+                  if (id?.type === 'identifier' && id.text === receiver.text) {
+                    // Object-destructuring rest binding is an object map.
+                    return true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    scope = scope.parent
+  }
+  return false
+}
 
 export const arrayDeleteVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/array-delete',
@@ -13,6 +84,13 @@ export const arrayDeleteVisitor: CodeRuleVisitor = {
     const argument = node.childForFieldName('argument')
     if (!argument || argument.type !== 'subscript_expression') return null
 
+    // Skip the canonical immutable-record pattern: when the subscripted
+    // identifier was last assigned an object literal, spread expression,
+    // or destructuring-rest binding in scope, `delete` is the correct
+    // way to remove a property from a plain object — not an array hole.
+    const receiver = argument.childForFieldName('object')
+    if (receiver && receiverIsObjectMap(receiver)) return null
+
     return makeViolation(
       this.ruleKey, node, filePath, 'medium',
       'delete on array element',
@@ -22,3 +100,4 @@ export const arrayDeleteVisitor: CodeRuleVisitor = {
     )
   },
 }
+

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/alert-usage.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/alert-usage.ts
@@ -1,7 +1,76 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
 const BLOCKED_CALLS = new Set(['alert', 'confirm', 'prompt'])
+
+// See no-alert.ts for the rationale: when a local binding (imported
+// or declared) shadows `alert` / `confirm` / `prompt`, the call refers
+// to the local — not the browser dialog — and the rule must not fire.
+// CLI prompt libraries (`@clack/prompts`, `inquirer`, `prompts`) all
+// ship `confirm` / `prompt` named exports that hit this exact shape.
+// Keyed by program `id` so the cache invalidates on re-parse.
+const localBindingCache = new Map<number, Set<string>>()
+
+function collectLocalBindings(program: SyntaxNode): Set<string> {
+  const cached = localBindingCache.get(program.id)
+  if (cached) return cached
+  const names = new Set<string>()
+  for (let i = 0; i < program.namedChildCount; i++) {
+    const stmt = program.namedChild(i)
+    if (!stmt) continue
+    collectFromStatement(stmt, names)
+    if (stmt.type === 'export_statement') {
+      const decl = stmt.childForFieldName('declaration')
+      if (decl) collectFromStatement(decl, names)
+    }
+  }
+  localBindingCache.set(program.id, names)
+  return names
+}
+
+function collectFromStatement(stmt: SyntaxNode, names: Set<string>): void {
+  if (stmt.type === 'import_statement') {
+    for (let j = 0; j < stmt.namedChildCount; j++) {
+      const clause = stmt.namedChild(j)
+      if (!clause || clause.type !== 'import_clause') continue
+      for (let k = 0; k < clause.namedChildCount; k++) {
+        const part = clause.namedChild(k)
+        if (!part) continue
+        if (part.type === 'identifier') {
+          names.add(part.text)
+        } else if (part.type === 'namespace_import') {
+          const ns = part.namedChild(part.namedChildCount - 1)
+          if (ns?.type === 'identifier') names.add(ns.text)
+        } else if (part.type === 'named_imports') {
+          for (let m = 0; m < part.namedChildCount; m++) {
+            const spec = part.namedChild(m)
+            if (!spec || spec.type !== 'import_specifier') continue
+            const alias = spec.childForFieldName('alias')
+            const name = alias ?? spec.childForFieldName('name')
+            if (name?.type === 'identifier') names.add(name.text)
+          }
+        }
+      }
+    }
+  } else if (stmt.type === 'lexical_declaration' || stmt.type === 'variable_declaration') {
+    for (let j = 0; j < stmt.namedChildCount; j++) {
+      const decl = stmt.namedChild(j)
+      if (decl?.type !== 'variable_declarator') continue
+      const name = decl.childForFieldName('name')
+      if (name?.type === 'identifier') names.add(name.text)
+    }
+  } else if (stmt.type === 'function_declaration' || stmt.type === 'class_declaration') {
+    const name = stmt.childForFieldName('name')
+    if (name?.type === 'identifier') names.add(name.text)
+  }
+}
+
+function findProgram(node: SyntaxNode): SyntaxNode | null {
+  let cur: SyntaxNode | null = node
+  while (cur && cur.type !== 'program') cur = cur.parent
+  return cur
+}
 
 export const jsAlertUsageVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/alert-usage',
@@ -13,6 +82,12 @@ export const jsAlertUsageVisitor: CodeRuleVisitor = {
     if (fn.type !== 'identifier') return null
     const name = fn.text
     if (!BLOCKED_CALLS.has(name)) return null
+
+    const program = findProgram(node)
+    if (program) {
+      const localBindings = collectLocalBindings(program)
+      if (localBindings.has(name)) return null
+    }
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/empty-function.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/empty-function.ts
@@ -21,24 +21,17 @@ export const jsEmptyFunctionVisitor: CodeRuleVisitor = {
     }
 
     // Skip empty arrow functions used as intentional no-ops:
-    //  - inside .catch() — error suppression
-    //  - JSX attribute value — `onClick={() => {}}` placeholder for a required prop
-    //  - return value of another function — `return () => {}` no-op unsubscribe etc.
-    //  - default in `||` / `??` fallback — `cb || (() => {})` ensures a callable
+    //  - any arrow passed as a call argument (`.catch(() => {})`,
+    //    `useRef(() => {})`, `useEffect(noop, [])`) — the caller asked
+    //    for a callable and the empty body is the deliberate placeholder
+    //  - JSX attribute value — `onClick={() => {}}` placeholder
+    //  - return value of another function — `return () => {}` no-op
+    //  - default in `||` / `??` fallback — `cb || (() => {})`
     if (node.type === 'arrow_function') {
       let parent = node.parent
       // Look through parentheses, e.g. `(() => {})` in `x || (() => {})`
       while (parent?.type === 'parenthesized_expression') parent = parent.parent
-      if (parent?.type === 'arguments') {
-        const grandparent = parent.parent
-        if (grandparent?.type === 'call_expression') {
-          const gpFn = grandparent.childForFieldName('function')
-          if (gpFn?.type === 'member_expression') {
-            const gpProp = gpFn.childForFieldName('property')
-            if (gpProp?.text === 'catch') return null
-          }
-        }
-      }
+      if (parent?.type === 'arguments') return null
       if (parent?.type === 'jsx_expression' || parent?.type === 'jsx_attribute') return null
       if (parent?.type === 'return_statement') return null
       if (parent?.type === 'binary_expression') {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/no-alert.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/no-alert.ts
@@ -1,5 +1,79 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+
+const BLOCKING_NAMES = new Set(['alert', 'confirm', 'prompt'])
+
+// Cache of identifier names introduced into a file's top-level scope by
+// `import`, `const`, `let`, `var`, or `function` declarations. When one
+// of those bindings shadows `alert` / `confirm` / `prompt`, the call
+// site refers to the local binding (e.g. `import { confirm } from
+// "@clack/prompts"`) — not the browser dialog — and the rule must not
+// fire. Keyed by program `id` so the cache invalidates automatically
+// when a file is re-parsed.
+const localBindingCache = new Map<number, Set<string>>()
+
+function collectLocalBindings(program: SyntaxNode): Set<string> {
+  const cached = localBindingCache.get(program.id)
+  if (cached) return cached
+  const names = new Set<string>()
+  for (let i = 0; i < program.namedChildCount; i++) {
+    const stmt = program.namedChild(i)
+    if (!stmt) continue
+    collectFromStatement(stmt, names)
+    if (stmt.type === 'export_statement') {
+      const decl = stmt.childForFieldName('declaration')
+      if (decl) collectFromStatement(decl, names)
+    }
+  }
+  localBindingCache.set(program.id, names)
+  return names
+}
+
+function collectFromStatement(stmt: SyntaxNode, names: Set<string>): void {
+  if (stmt.type === 'import_statement') {
+    for (let j = 0; j < stmt.namedChildCount; j++) {
+      const clause = stmt.namedChild(j)
+      if (!clause) continue
+      if (clause.type === 'import_clause') {
+        for (let k = 0; k < clause.namedChildCount; k++) {
+          const part = clause.namedChild(k)
+          if (!part) continue
+          if (part.type === 'identifier') {
+            names.add(part.text)
+          } else if (part.type === 'namespace_import') {
+            const ns = part.namedChild(part.namedChildCount - 1)
+            if (ns?.type === 'identifier') names.add(ns.text)
+          } else if (part.type === 'named_imports') {
+            for (let m = 0; m < part.namedChildCount; m++) {
+              const spec = part.namedChild(m)
+              if (!spec || spec.type !== 'import_specifier') continue
+              const alias = spec.childForFieldName('alias')
+              const name = alias ?? spec.childForFieldName('name')
+              if (name?.type === 'identifier') names.add(name.text)
+            }
+          }
+        }
+      }
+    }
+  } else if (stmt.type === 'lexical_declaration' || stmt.type === 'variable_declaration') {
+    for (let j = 0; j < stmt.namedChildCount; j++) {
+      const decl = stmt.namedChild(j)
+      if (decl?.type !== 'variable_declarator') continue
+      const name = decl.childForFieldName('name')
+      if (name?.type === 'identifier') names.add(name.text)
+    }
+  } else if (stmt.type === 'function_declaration' || stmt.type === 'class_declaration') {
+    const name = stmt.childForFieldName('name')
+    if (name?.type === 'identifier') names.add(name.text)
+  }
+}
+
+function findProgram(node: SyntaxNode): SyntaxNode | null {
+  let cur: SyntaxNode | null = node
+  while (cur && cur.type !== 'program') cur = cur.parent
+  return cur
+}
 
 export const noAlertVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/no-alert',
@@ -8,15 +82,25 @@ export const noAlertVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     const fn = node.childForFieldName('function')
     if (!fn || fn.type !== 'identifier') return null
-    if (fn.text === 'alert' || fn.text === 'confirm' || fn.text === 'prompt') {
-      return makeViolation(
-        this.ruleKey, node, filePath, 'medium',
-        `${fn.text}() call`,
-        `\`${fn.text}()\` blocks the UI thread and should not be used in production. Use a modal dialog or custom UI instead.`,
-        sourceCode,
-        `Replace ${fn.text}() with a non-blocking modal or custom UI component.`,
-      )
+    if (!BLOCKING_NAMES.has(fn.text)) return null
+
+    // Skip when a local binding (imported or declared in this file)
+    // shadows the global — the call refers to that local, not the
+    // browser dialog. CLI prompt libraries (`@clack/prompts`,
+    // `inquirer`, `prompts`) ship a `confirm` / `prompt` named export
+    // that is the canonical trigger for this FP.
+    const program = findProgram(node)
+    if (program) {
+      const localBindings = collectLocalBindings(program)
+      if (localBindings.has(fn.text)) return null
     }
-    return null
+
+    return makeViolation(
+      this.ruleKey, node, filePath, 'medium',
+      `${fn.text}() call`,
+      `\`${fn.text}()\` blocks the UI thread and should not be used in production. Use a modal dialog or custom UI instead.`,
+      sourceCode,
+      `Replace ${fn.text}() with a non-blocking modal or custom UI component.`,
+    )
   },
 }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/no-empty-function.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/no-empty-function.ts
@@ -1,6 +1,26 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { getFunctionBody } from './_helpers.js'
+
+// TS parameter-property shorthand: any constructor parameter prefixed
+// with `private` / `public` / `protected` / `readonly` is implicitly
+// assigned to a same-named instance field. A constructor whose only
+// "logic" is parameter properties looks empty to the AST but is not.
+function hasParameterProperty(params: SyntaxNode): boolean {
+  for (let i = 0; i < params.namedChildCount; i++) {
+    const param = params.namedChild(i)
+    if (!param) continue
+    if (param.type !== 'required_parameter' && param.type !== 'optional_parameter') continue
+    for (let j = 0; j < param.childCount; j++) {
+      const child = param.child(j)
+      if (!child) continue
+      if (child.type === 'accessibility_modifier') return true
+      if (child.text === 'readonly') return true
+    }
+  }
+  return false
+}
 
 export const jsNoEmptyFunctionVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/no-empty-function',
@@ -18,22 +38,16 @@ export const jsNoEmptyFunctionVisitor: CodeRuleVisitor = {
     }
 
     // Skip empty functions used as intentional no-ops:
-    //  - inside .catch() — error suppression
-    //  - JSX attribute value — `onClick={() => {}}` placeholder for a required prop
-    //  - return value of another function — `return () => {}` no-op unsubscribe etc.
-    //  - default in `||` / `??` fallback — `cb || (() => {})` ensures a callable
+    //  - any function expression / arrow passed as a call argument
+    //    (`.catch(() => {})`, `useRef(() => {})`, `useEffect(noop, [])`,
+    //    `cb ?? (() => {})` after default-arg substitution) — the caller
+    //    asked for a callable and the empty body is the placeholder
+    //  - JSX attribute value — `onClick={() => {}}` placeholder
+    //  - return value of another function — `return () => {}` no-op
+    //  - default in `||` / `??` fallback — `cb || (() => {})`
     let parent = node.parent
     while (parent?.type === 'parenthesized_expression') parent = parent.parent
-    if (parent?.type === 'arguments') {
-      const grandparent = parent.parent
-      if (grandparent?.type === 'call_expression') {
-        const gpFn = grandparent.childForFieldName('function')
-        if (gpFn?.type === 'member_expression') {
-          const gpProp = gpFn.childForFieldName('property')
-          if (gpProp?.text === 'catch') return null
-        }
-      }
-    }
+    if (parent?.type === 'arguments') return null
     if (parent?.type === 'jsx_expression' || parent?.type === 'jsx_attribute') return null
     if (parent?.type === 'return_statement') return null
     if (parent?.type === 'binary_expression') {
@@ -41,10 +55,12 @@ export const jsNoEmptyFunctionVisitor: CodeRuleVisitor = {
       if (op?.text === '||' || op?.text === '??') return null
     }
 
-    // Skip private/protected empty constructors — the singleton and
-    // abstract-base patterns rely on `private constructor() {}` or
-    // `protected constructor() {}` to block instantiation. The empty
-    // body is the whole point.
+    // Skip TypeScript parameter-property constructors. `constructor(
+    // private opts: T) {}` and `constructor(readonly db: Db) {}` are
+    // not bodyless: the access modifier / `readonly` keyword on a
+    // parameter expands to `this.opts = opts` / `this.db = db` at
+    // class-init time. The empty body is the *whole point* of the
+    // shorthand.
     if (node.type === 'method_definition') {
       let isConstructor = false
       let hasRestrictedAccess = false
@@ -58,6 +74,10 @@ export const jsNoEmptyFunctionVisitor: CodeRuleVisitor = {
         }
       }
       if (isConstructor && hasRestrictedAccess) return null
+      if (isConstructor) {
+        const params = node.childForFieldName('parameters')
+        if (params && hasParameterProperty(params)) return null
+      }
     }
 
     const nameNode = node.childForFieldName('name')

--- a/packages/analyzer/src/rules/database/visitors/javascript/unvalidated-external-data.ts
+++ b/packages/analyzer/src/rules/database/visitors/javascript/unvalidated-external-data.ts
@@ -4,14 +4,15 @@ import { makeViolation } from '../../../types.js'
 import { getMethodName, ORM_WRITE_METHODS, SQL_WRITE_METHODS } from './_helpers.js'
 import { findUserInputAccess } from '../../../_shared/javascript-helpers.js'
 
-// Method names heavily overloaded by built-in JS collections - `Set.add`,
-// `Map.delete`, `Array.indexOf`-adjacent. ORM frameworks happen to use
-// the same words (`session.add(model)`), but firing on every `.add()` /
-// `.delete()` produces ~100% FPs on UI code. Require an ORM-shaped
-// receiver for these specific methods. `create` / `update` / `save` /
-// `upsert` / `destroy` stay unrestricted because they're rarely used as
-// JS collection method names.
-const AMBIGUOUS_ORM_METHODS = new Set(['add', 'delete'])
+// Method names heavily overloaded by built-in JS / Node APIs - `Set.add`,
+// `Map.delete`, `Hash.update` (crypto), `AsyncLocalStorage.run`, generic
+// task `.run()` helpers. ORM frameworks happen to use the same words,
+// but firing on every `.update()` / `.run()` produces ~100% FPs on
+// non-DB code. Require an ORM-shaped receiver for these specific
+// methods. `create` / `save` / `upsert` / `destroy` / `*Many` stay
+// unrestricted because they're rarely used as JS collection / crypto
+// / async-context method names.
+const AMBIGUOUS_ORM_METHODS = new Set(['add', 'delete', 'update', 'run'])
 const ORM_RECEIVER_NAMES = new Set([
   'session', 'db', 'conn', 'connection', 'cursor', 'engine', 'database',
   'manager', 'repo', 'repository', 'orm', 'em', 'tx', 'trx', 'knex',
@@ -21,14 +22,25 @@ const ORM_RECEIVER_NAMES = new Set([
 function hasOrmLikeReceiver(node: import('web-tree-sitter').Node): boolean {
   const fn = node.childForFieldName('function')
   if (fn?.type !== 'member_expression') return false
-  let receiver: import('web-tree-sitter').Node | null = fn.childForFieldName('object')
-  // Walk to the root identifier.
-  while (receiver?.type === 'member_expression') {
-    receiver = receiver.childForFieldName('object')
+  // Walk through the member chain (`this.prisma.user.update`,
+  // `db.users.update`, etc.) and accept if any segment — root identifier
+  // or intermediate property — names a known ORM receiver. This catches
+  // method-style receivers (`this.prisma.…`, `ctx.db.…`) where the root
+  // is `this`/`ctx`, not a bare ORM identifier.
+  let cur: import('web-tree-sitter').Node | null = fn.childForFieldName('object')
+  while (cur) {
+    if (cur.type === 'member_expression') {
+      const prop = cur.childForFieldName('property')
+      if (prop?.type === 'property_identifier' && ORM_RECEIVER_NAMES.has(prop.text.toLowerCase())) return true
+      cur = cur.childForFieldName('object')
+      continue
+    }
+    if (cur.type === 'identifier') {
+      return ORM_RECEIVER_NAMES.has(cur.text.toLowerCase())
+    }
+    return false
   }
-  if (receiver?.type !== 'identifier') return false
-  const name = receiver.text.toLowerCase()
-  return ORM_RECEIVER_NAMES.has(name)
+  return false
 }
 
 export const unvalidatedExternalDataVisitor: CodeRuleVisitor = {

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -1261,6 +1261,12 @@
       "layer": "service"
     },
     {
+      "name": "renameUser",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "required-type-annotations-bare-arrow",
       "service": "utils",
       "kind": "standalone",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -649,6 +649,12 @@
       "layer": "service"
     },
     {
+      "name": "array-delete-array-receiver",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "AsyncInit",
       "service": "utils",
       "kind": "class",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -1135,6 +1135,12 @@
       "layer": "service"
     },
     {
+      "name": "no-alert-browser-dialog",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "OffscreenRenderer",
       "service": "utils",
       "kind": "class",

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -1171,6 +1171,12 @@
       "layer": "service"
     },
     {
+      "name": "Plain",
+      "service": "utils",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "processAbandonedQueue",
       "service": "utils",
       "kind": "standalone",
@@ -1268,6 +1274,12 @@
     },
     {
       "name": "required-type-annotations-bare-arrow",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "reservedHook",
       "service": "utils",
       "kind": "standalone",
       "layer": "service"

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -589,6 +589,12 @@
       "layer": "data"
     },
     {
+      "name": "summarizeAuditLogEntries",
+      "service": "user-service",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "TaskHandlers",
       "service": "user-service",
       "kind": "class",

--- a/tests/fixtures/sample-js-project-negative/services/user-service/src/unused-export-no-barrel.ts
+++ b/tests/fixtures/sample-js-project-negative/services/user-service/src/unused-export-no-barrel.ts
@@ -1,0 +1,8 @@
+// A standalone exported helper that nothing imports and no barrel
+// re-exports. The export is genuinely dead and must be flagged.
+
+// VIOLATION: architecture/deterministic/unused-export
+// VIOLATION: architecture/deterministic/dead-method
+export function summarizeAuditLogEntries(entries: { weight: number }[]): number {
+  return entries.reduce((acc, e) => acc + e.weight, 0);
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/array-delete-array-receiver.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/array-delete-array-receiver.ts
@@ -1,0 +1,15 @@
+// `delete arr[i]` on an array leaves a hole at that index (the
+// `length` is unchanged, iteration yields `undefined`). Use `splice`.
+
+export function dropAtIndex(items: number[], index: number): number[] {
+  // VIOLATION: bugs/deterministic/array-delete
+  delete items[index];
+  return items;
+}
+
+export function clearFirst<T>(): (T | undefined)[] {
+  const arr: T[] = [];
+  // VIOLATION: bugs/deterministic/array-delete
+  delete arr[0];
+  return arr;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/no-alert-browser-dialog.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/no-alert-browser-dialog.ts
@@ -1,0 +1,21 @@
+// Bare `alert`, `confirm`, `prompt` calls with no imported / local
+// shadow refer to the browser dialog APIs — UI-thread-blocking calls
+// both `no-alert` and the parallel `alert-usage` rule must flag.
+
+export function notify(): void {
+  // VIOLATION: code-quality/deterministic/no-alert
+  // VIOLATION: code-quality/deterministic/alert-usage
+  alert("save failed");
+}
+
+export function askForName(): string | null {
+  // VIOLATION: code-quality/deterministic/no-alert
+  // VIOLATION: code-quality/deterministic/alert-usage
+  return prompt("enter your name");
+}
+
+export function dangerCheck(): boolean {
+  // VIOLATION: code-quality/deterministic/no-alert
+  // VIOLATION: code-quality/deterministic/alert-usage
+  return confirm("delete the workspace?");
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/no-empty-function-bare-empty.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/no-empty-function-bare-empty.ts
@@ -1,0 +1,12 @@
+// A standalone empty function with no parameter properties, no
+// `// intentionally empty` comment, and no enclosing-arg / JSX /
+// fallback context is the canonical "did you forget the body?" case
+// the rule must flag.
+
+// VIOLATION: code-quality/deterministic/no-empty-function
+export function reservedHook(): void {}
+
+export class Plain {
+  // VIOLATION: code-quality/deterministic/no-empty-function
+  noop(): void {}
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unvalidated-external-data-orm-update.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unvalidated-external-data-orm-update.ts
@@ -1,0 +1,22 @@
+// `db.users.update(req.body)` writes untrusted request data into the
+// database without schema validation — the canonical shape this rule
+// must catch.
+
+interface ExpressLikeRequest {
+  readonly body: { readonly id: string; readonly name: string };
+}
+
+interface OrmTable {
+  update(_data: { id: string; name: string }): Promise<void>;
+}
+
+interface DbHandle {
+  readonly users: OrmTable;
+}
+
+declare const db: DbHandle;
+
+export async function renameUser(req: ExpressLikeRequest): Promise<void> {
+  // VIOLATION: database/deterministic/unvalidated-external-data
+  await db.users.update(req.body);
+}

--- a/tests/fixtures/sample-js-project-positive/array-delete-spread-clone-object.ts
+++ b/tests/fixtures/sample-js-project-positive/array-delete-spread-clone-object.ts
@@ -1,0 +1,24 @@
+// The canonical immutable-record update is `const next = { ...prev };
+// delete next.key`. The receiver is a plain object map — there is
+// no array hole to leave behind — and `delete` is the correct way to
+// remove a property. The same holds for the `Object.create(null)` /
+// empty-object-literal shapes.
+
+interface FlagOverrides {
+  readonly enabled?: boolean;
+  readonly debug?: boolean;
+  readonly beta?: boolean;
+}
+
+export function unsetDebug(prev: FlagOverrides): FlagOverrides {
+  const next: { [key: string]: boolean | undefined } = { ...prev };
+  delete next["debug"];
+  return next as FlagOverrides;
+}
+
+export function clearByLiteralKey(): { [k: string]: number } {
+  const fresh: { [k: string]: number } = {};
+  fresh["alpha"] = 1;
+  delete fresh["alpha"];
+  return fresh;
+}

--- a/tests/fixtures/sample-js-project-positive/no-alert-cli-prompt-import.ts
+++ b/tests/fixtures/sample-js-project-positive/no-alert-cli-prompt-import.ts
@@ -1,0 +1,13 @@
+// CLI prompt libraries (e.g. `@clack/prompts`, `inquirer`, `prompts`)
+// ship `confirm` / `prompt` named exports. When a file imports one of
+// those, every bare `confirm(...)` or `prompt(...)` call refers to the
+// imported helper — not the browser dialog the rule is meant to flag.
+// Block the rule whenever a local binding shadows the global.
+
+import { confirm, default as prompt } from "./packages/no-alert-cli-stub";
+
+export async function runDeployFlow(): Promise<string> {
+  const ok = await confirm({ message: "Continue?" });
+  if (!ok) return "aborted";
+  return prompt({ message: "Enter project slug" });
+}

--- a/tests/fixtures/sample-js-project-positive/no-empty-function-parameter-property-and-noop-arg.ts
+++ b/tests/fixtures/sample-js-project-positive/no-empty-function-parameter-property-and-noop-arg.ts
@@ -1,0 +1,44 @@
+// Two idiomatic shapes that look empty to the AST but aren't:
+//
+//   1. TS parameter-property constructors. `constructor(private opts: T) {}`
+//      and `constructor(readonly db: Db) {}` are not bodyless — the access
+//      modifier / `readonly` keyword on the parameter expands to
+//      `this.opts = opts` / `this.db = db` at class-init time.
+//
+//   2. Empty arrow functions passed as call arguments — `useRef(() => {})`,
+//      `useEffect(() => {}, [])`, `cb ?? (() => {})`, `.catch(() => {})`.
+//      The caller asked for a callable and the empty body is the
+//      deliberate placeholder.
+
+interface ServiceOpts {
+  readonly forceSimulate: boolean;
+}
+
+interface Db {
+  readonly query: (_q: string) => Promise<unknown>;
+}
+
+export class TaskOperations {
+  constructor(private opts: ServiceOpts = { forceSimulate: false }) {}
+
+  describe(): boolean {
+    return this.opts.forceSimulate;
+  }
+}
+
+export class DataLayer {
+  constructor(readonly db: Db) {}
+
+  ping(): Promise<unknown> {
+    return this.db.query("select 1");
+  }
+}
+
+declare function useRef<T>(_initial: T): { current: T };
+declare function useEffect(_fn: () => void, _deps: ReadonlyArray<unknown>): void;
+
+export function flushScheduler(): { current: () => void } {
+  const scheduler = useRef<() => void>(() => {});
+  useEffect(() => {}, []);
+  return scheduler;
+}

--- a/tests/fixtures/sample-js-project-positive/packages/no-alert-cli-stub/index.ts
+++ b/tests/fixtures/sample-js-project-positive/packages/no-alert-cli-stub/index.ts
@@ -1,0 +1,14 @@
+// Stand-in for a CLI prompt library (e.g. `@clack/prompts`). The
+// positive fixture imports its `confirm` / `prompt` helpers; the rule
+// must treat the call sites as references to these locals, not the
+// browser dialogs.
+
+type PromptOpts = { message: string };
+
+export function confirm(_opts: PromptOpts): Promise<boolean> {
+  return Promise.resolve(true);
+}
+
+export default function prompt(_opts: PromptOpts): Promise<string> {
+  return Promise.resolve("");
+}

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/query-shape-helpers/public.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/query-shape-helpers/public.ts
@@ -1,0 +1,6 @@
+// Barrel that re-exports the directory's public surface for callers
+// outside the analyzed file set (tests, downstream packages). The presence
+// of these re-exports means the underlying file is intentionally reachable
+// even when no in-tree caller imports it directly.
+
+export { isValidQueryShape, getQueryShapeError } from "./queryLinter";

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/query-shape-helpers/queryLinter.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/query-shape-helpers/queryLinter.ts
@@ -1,0 +1,29 @@
+// An exported function that no analyzed file imports directly. Its only
+// consumer is a sibling `index.ts` barrel that re-exports it for external
+// callers (tests, downstream packages) which are outside the analyzed set.
+// The export is intentionally part of the directory's public API surface and
+// must not be flagged as unused.
+
+function parseQuery(input: string): { ok: boolean } {
+  if (!input.trim()) return { ok: true };
+  try {
+    JSON.parse(input);
+    return { ok: true };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export function isValidQueryShape(input: string): boolean {
+  return parseQuery(input).ok;
+}
+
+export function getQueryShapeError(input: string): string | null {
+  if (!input.trim()) return null;
+  try {
+    JSON.parse(input);
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : "unknown error";
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/unvalidated-external-data-crypto-async-context.ts
+++ b/tests/fixtures/sample-js-project-positive/unvalidated-external-data-crypto-async-context.ts
@@ -1,0 +1,33 @@
+// `update` and `run` are method names overloaded by Node's crypto Hash
+// objects (`hash.update(buf)`), `AsyncLocalStorage.run(store, fn)`, and
+// generic task-runner receivers. None of these write to a database, so
+// firing on every `.update()` / `.run()` produces ~100% FPs on
+// non-DB code. Require an ORM-shaped receiver to keep flagging real
+// writes.
+
+interface IncomingRequest {
+  readonly headers: Record<string, string>;
+  readonly body: { readonly token: string };
+}
+
+interface Hash {
+  update(_buf: Buffer): Hash;
+  digest(_encoding: string): string;
+}
+
+interface AsyncStorage<T> {
+  run<R>(_store: T, _fn: () => R): R;
+}
+
+declare function createHash(_algo: string): Hash;
+declare const tenantStorage: AsyncStorage<{ readonly tenantId: string }>;
+
+export function hashAuthToken(req: IncomingRequest): string {
+  const hash = createHash("sha256");
+  hash.update(Buffer.from(req.body.token, "utf8"));
+  return hash.digest("hex");
+}
+
+export function withTenantContext<R>(req: IncomingRequest, fn: () => R): R {
+  return tenantStorage.run({ tenantId: req.headers["x-tenant-id"] }, fn);
+}


### PR DESCRIPTION
Closes #364
Closes #366
Closes #367
Closes #369
Closes #370

## Fixes

| Rule | Issue | Positive fixture | Negative fixture |
|---|---|---|---|
| `architecture/deterministic/unused-export` | #364 | `tests/fixtures/sample-js-project-positive/shared/utils/src/query-shape-helpers/` (`queryLinter.ts` + `public.ts`) | `tests/fixtures/sample-js-project-negative/services/user-service/src/unused-export-no-barrel.ts` |
| `code-quality/deterministic/no-alert` | #366 | `tests/fixtures/sample-js-project-positive/no-alert-cli-prompt-import.ts` (+ stub under `packages/no-alert-cli-stub/`) | `tests/fixtures/sample-js-project-negative/shared/utils/src/no-alert-browser-dialog.ts` |
| `bugs/deterministic/array-delete` | #367 | `tests/fixtures/sample-js-project-positive/array-delete-spread-clone-object.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/array-delete-array-receiver.ts` |
| `database/deterministic/unvalidated-external-data` | #369 | `tests/fixtures/sample-js-project-positive/unvalidated-external-data-crypto-async-context.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unvalidated-external-data-orm-update.ts` |
| `code-quality/deterministic/no-empty-function` | #370 | `tests/fixtures/sample-js-project-positive/no-empty-function-parameter-property-and-noop-arg.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/no-empty-function-bare-empty.ts` |

## architecture/deterministic/unused-export

Upstream source:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/tsql/tsqlLinter.ts#L179
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/tsql/tsqlLinter.ts#L198

Added `tests/fixtures/sample-js-project-positive/shared/utils/src/query-shape-helpers/queryLinter.ts`:
```ts
function parseQuery(input: string): { ok: boolean } {
  if (!input.trim()) return { ok: true };
  try { JSON.parse(input); return { ok: true }; } catch { return { ok: false }; }
}

export function isValidQueryShape(input: string): boolean { return parseQuery(input).ok; }
export function getQueryShapeError(input: string): string | null {
  if (!input.trim()) return null;
  try { JSON.parse(input); return null; } catch (err) {
    return err instanceof Error ? err.message : "unknown error";
  }
}
```
and the barrel `public.ts` re-exporting both names.

Added negative `tests/fixtures/sample-js-project-negative/services/user-service/src/unused-export-no-barrel.ts`:
```ts
// VIOLATION: architecture/deterministic/unused-export
// VIOLATION: architecture/deterministic/dead-method
export function summarizeAuditLogEntries(entries: { weight: number }[]): number {
  return entries.reduce((acc, e) => acc + e.weight, 0);
}
```

Visitor: the tree-sitter export extractor only captures the first specifier per `export { a, b, c } from '…'` clause, so later specifiers are invisible to the import-set used by `unused-export` and `dead-method`. Added `buildBarrelReExportTargets` that flags any file targeted by a barrel re-export (a file with `export ... from '…'` and no own functions/classes) as reachable. The barrel itself is the declared public-API surface; tests and downstream packages reach those modules through it even when no analyzed file imports them directly.

## code-quality/deterministic/no-alert

Upstream sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/commands/dev.ts#L130
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/commands/env.ts#L395
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/commands/install-mcp.ts#L688
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/commands/install-rules.ts#L174
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/commands/install-rules.ts#L195

Added positive `tests/fixtures/sample-js-project-positive/no-alert-cli-prompt-import.ts`:
```ts
import { confirm, default as prompt } from "./packages/no-alert-cli-stub";

export async function runDeployFlow(): Promise<string> {
  const ok = await confirm({ message: "Continue?" });
  if (!ok) return "aborted";
  return prompt({ message: "Enter project slug" });
}
```
with the CLI stub at `packages/no-alert-cli-stub/index.ts`.

Added negative `tests/fixtures/sample-js-project-negative/shared/utils/src/no-alert-browser-dialog.ts`:
```ts
export function notify(): void {
  // VIOLATION: code-quality/deterministic/no-alert
  // VIOLATION: code-quality/deterministic/alert-usage
  alert("save failed");
}
// + askForName, dangerCheck
```

Visitor: walk the program's top-level statements to collect identifiers introduced by `import` / `const` / `let` / `var` / `function` / `class`; skip the rule whenever the call target name is in that set. Memoize the set per program node id. CLI prompt libraries (`@clack/prompts`, `inquirer`, `prompts`) ship `confirm` / `prompt` named exports — when one of those is imported, the call refers to the local, not the browser dialog. Applied the same fix to the sibling `alert-usage` rule (closes #368 as no-reproduce).

## bugs/deterministic/array-delete

Upstream sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/admin/FeatureFlagsDialog.tsx#L98
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/ChartConfigPanel.tsx#L340
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/ChartConfigPanel.tsx#L380
- `https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/integrations/VercelOnboardingModal.tsx#L433`

Added positive `tests/fixtures/sample-js-project-positive/array-delete-spread-clone-object.ts`:
```ts
export function unsetDebug(prev: FlagOverrides): FlagOverrides {
  const next: { [key: string]: boolean | undefined } = { ...prev };
  delete next["debug"];
  return next as FlagOverrides;
}
// + clearByLiteralKey
```

Added negative `tests/fixtures/sample-js-project-negative/shared/utils/src/array-delete-array-receiver.ts`:
```ts
export function dropAtIndex(items: number[], index: number): number[] {
  // VIOLATION: bugs/deterministic/array-delete
  delete items[index];
  return items;
}
// + clearFirst
```

Visitor: inspect the in-scope declaration of the subscripted identifier. When its initializer is an object literal, a spread / `Object.assign` / `Object.create` / `Object.fromEntries` / `structuredClone` call, or the binding is an object-destructuring rest, skip the rule — `delete obj[key]` on a plain-object map is the canonical immutable-record-update shape, not an array hole.

## database/deterministic/unvalidated-external-data

Upstream sources:
- `https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/services/authorizationRateLimitMiddleware.server.ts#L249`
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/services/tenantContext.server.ts#L27
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/services/tenantContextResolver.server.ts#L38

Added positive `tests/fixtures/sample-js-project-positive/unvalidated-external-data-crypto-async-context.ts`:
```ts
export function hashAuthToken(req: IncomingRequest): string {
  const hash = createHash("sha256");
  hash.update(Buffer.from(req.body.token, "utf8"));
  return hash.digest("hex");
}

export function withTenantContext<R>(req: IncomingRequest, fn: () => R): R {
  return tenantStorage.run({ tenantId: req.headers["x-tenant-id"] }, fn);
}
```

Added negative `tests/fixtures/sample-js-project-negative/shared/utils/src/unvalidated-external-data-orm-update.ts`:
```ts
export async function renameUser(req: ExpressLikeRequest): Promise<void> {
  // VIOLATION: database/deterministic/unvalidated-external-data
  await db.users.update(req.body);
}
```

Visitor: `update` and `run` are method names overloaded by Node's crypto Hash (`hash.update(buf)`), `AsyncLocalStorage.run(store, fn)`, and generic task-runner receivers. Add both to `AMBIGUOUS_ORM_METHODS` so they require an ORM-shaped receiver (`session`, `db`, `prisma`, `trx`, etc.) before firing. Also extend the receiver walk to inspect every segment of a member chain (not just the root), so `this.prisma.user.update(…)` and `ctx.db.users.update(…)` still register as ORM calls under the tightened rule.

## code-quality/deterministic/no-empty-function

Upstream sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/docker-provider/src/index.ts#L38
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/supervisor/src/services/otlpTraceService.ts#L22
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/runs/v3/agent/AgentView.tsx#L277
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/presenters/v3/AgentListPresenter.server.ts#L27
- `https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/presenters/v3/ApiRetrieveRunPresenter.server.ts#L105`

Added positive `tests/fixtures/sample-js-project-positive/no-empty-function-parameter-property-and-noop-arg.ts`:
```ts
export class TaskOperations {
  constructor(private opts: ServiceOpts = { forceSimulate: false }) {}
  describe(): boolean { return this.opts.forceSimulate; }
}

export function flushScheduler(): { current: () => void } {
  const scheduler = useRef<() => void>(() => {});
  useEffect(() => {}, []);
  return scheduler;
}
```

Added negative `tests/fixtures/sample-js-project-negative/shared/utils/src/no-empty-function-bare-empty.ts`:
```ts
// VIOLATION: code-quality/deterministic/no-empty-function
export function reservedHook(): void {}

export class Plain {
  // VIOLATION: code-quality/deterministic/no-empty-function
  noop(): void {}
}
```

Visitor: TS `constructor(private opts: T) {}` / `constructor(readonly db: Db) {}` aren't bodyless — the access modifier / `readonly` keyword on a parameter expands to `this.opts = opts` / `this.db = db` at class-init time. Detect parameter-property params and skip. Also widen the arrow-as-arg skip from the hard-coded `.catch` form to any `arguments` parent — `useRef(() => {})`, `useEffect(() => {}, [])`, `cb ?? (() => {})`, etc., all signal a deliberate noop. Applied the same arrow-widening to the sibling `empty-function` rule which fires on the identical shape.

## Skipped this batch

- #365 `bugs/deterministic/void-zero-argument` — refactor needed. The fix (restrict to `void <number-literal>`) conflicts with the rule's existing "detects void with an identifier operand" unit test in `tests/analyzer/bugs-rules.test.ts` (and the parallel test for the sibling `no-void` rule). Editing `tests/analyzer/**` is outside the routine's allowed scope, matching the precedent of PR #336. Marked `fp-blocked`.
- #368 `code-quality/deterministic/alert-usage` — no longer reproduces. The fix in this batch (commit b670fd5) applied the same "skip when a local binding shadows the global" logic to the sibling `alert-usage` rule. Closed.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `architecture/deterministic/unused-export`            | 154 | 152 | -2  |
| `code-quality/deterministic/no-alert`                 |  12 |   5 | -7  |
| `code-quality/deterministic/alert-usage`              |  12 |   5 | -7  |
| `bugs/deterministic/array-delete`                     |  18 |  11 | -7  |
| `database/deterministic/unvalidated-external-data`    |  16 |  12 | -4  |
| `code-quality/deterministic/no-empty-function`        | 145 |  62 | -83 |
| **Total (these 6 rules)**                             | 357 | 247 | **-110** |
| **All-rules total on target**                         | 35799 | 35673 | **-126** |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLeLWFRN3GDGZ31ioEmMCC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of code quality checks by respecting local bindings that shadow browser dialog functions.
  * Fixed false positives for array operations on plain objects.
  * Enhanced detection of intentional empty functions used as placeholders.
  * Added support for TypeScript parameter properties in constructor detection.
  * Refined ORM method detection for database analysis.

* **New Features**
  * Added barrel module reachability handling for more accurate dead-code detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->