### PR TITLE
feat(landing): dark-terminal redesign of marketing + request-access pages

### DIFF
--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -3,23 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TrueCourse · Validate the code your AI generates</title>
+    <title>TrueCourse · Keep your code on course</title>
     <meta
       name="description"
-      content="TrueCourse is the validation layer for AI-generated code. It cross-checks every change against your business logic and your codebase, catching hallucinated APIs, fabricated calls, and silent intent drift before they ship. Open source CLI for TS, JS, Python."
+      content="AI ships your code. We keep it on course. TrueCourse compiles your team's decisions into machine-readable contracts and checks every change against them — deterministically, with no LLM in the verification loop."
     />
-    <meta property="og:title" content="TrueCourse · Validate the code your AI generates" />
-    <meta property="og:description" content="The validation layer for AI-generated code. Catch hallucinated APIs, fabricated calls, and business-logic drift before they ship. Open source CLI + dashboard." />
+    <meta property="og:title" content="TrueCourse · Keep your code on course" />
+    <meta
+      property="og:description"
+      content="Every change, checked against what your team actually decided. TrueCourse compiles your decisions into contracts and verifies every change deterministically."
+    />
     <meta property="og:type" content="website" />
     <link rel="icon" href="/logo.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@400..700&family=Inter:wght@400..700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap"
       rel="stylesheet"
     />
   </head>
-  <body class="font-sans antialiased">
+  <body class="antialiased">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/landing/public/truecourse-mark.svg
+++ b/apps/landing/public/truecourse-mark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="40 0 320 295">
+  <polygon points="200,30 200,190 130,190" fill="currentColor" opacity="0.88"></polygon>
+  <line x1="200" y1="20" x2="200" y2="210" stroke="currentColor" stroke-width="4" stroke-linecap="round"></line>
+  <rect x="185" y="20" width="30" height="16" rx="3" fill="currentColor"></rect>
+  <line x1="200" y1="20" x2="200" y2="12" stroke="currentColor" stroke-width="3" stroke-linecap="round"></line>
+  <path d="M 100,210 L 300,210 L 280,250 L 120,250 Z" fill="currentColor"></path>
+  <path d="M 60,260 Q 90,248 120,260 Q 150,272 180,260 Q 210,248 240,260 Q 270,272 300,260 Q 330,248 360,260" fill="none" stroke="currentColor" stroke-width="3" opacity="0.55" stroke-linecap="round"></path>
+  <path d="M 50,275 Q 80,263 110,275 Q 140,287 170,275 Q 200,263 230,275 Q 260,287 290,275 Q 320,263 350,275" fill="none" stroke="currentColor" stroke-width="2.5" opacity="0.32" stroke-linecap="round"></path>
+</svg>

--- a/apps/landing/src/components/AccessForm.tsx
+++ b/apps/landing/src/components/AccessForm.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
-import { ArrowRight, Check, Loader2 } from 'lucide-react';
-import { Link } from 'react-router-dom';
 import { identifyUser, trackEvent } from '@/lib/posthog';
-import { cn } from '@/lib/cn';
+
+const GITHUB_URL = 'https://github.com/truecourse-ai/truecourse';
 
 export function AccessForm() {
   const [email, setEmail] = useState('');
@@ -15,6 +14,7 @@ export function AccessForm() {
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    if (website) return; // honeypot
     if (!email.trim() || !email.includes('@')) {
       setError('Please enter a valid work email.');
       return;
@@ -41,30 +41,27 @@ export function AccessForm() {
 
   if (state === 'done') {
     return (
-      <div className="text-center">
-        <div className="mx-auto inline-flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-300">
-          <Check className="h-6 w-6" />
+      <div className="success">
+        <div className="check">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
         </div>
-        <h3 className="mt-4 text-xl font-semibold">Request received</h3>
-        <p className="mt-2 text-sm text-muted-foreground">
-          We&apos;ll reach out to{' '}
-          <span className="font-medium text-foreground">{email}</span> when the next batch
-          of teams gets access. In the meantime, the open source CLI is yours to use today.
+        <h3>Request received</h3>
+        <p>
+          We&apos;ll reach out to <span className="email">{email}</span> when the next batch
+          of teams gets access. In the meantime, the open-source CLI is yours to use today.
         </p>
-        <Link
-          to="/#open-source"
-          className="mt-6 inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm transition-colors hover:border-border-strong"
-        >
-          Try the open source CLI
-          <ArrowRight className="h-4 w-4" />
-        </Link>
+        <a className="btn btn-sm" style={{ marginTop: 22 }} href={GITHUB_URL}>
+          Try the open-source CLI <span className="arr">→</span>
+        </a>
       </div>
     );
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      {/* Honeypot */}
+    <form onSubmit={onSubmit} noValidate>
+      {/* honeypot */}
       <div
         aria-hidden
         style={{ position: 'absolute', left: '-10000px', width: '1px', height: '1px', overflow: 'hidden' }}
@@ -81,7 +78,10 @@ export function AccessForm() {
         />
       </div>
 
-      <Field label="Work email" htmlFor="email">
+      {error && <div className="form-error">{error}</div>}
+
+      <label className="field" htmlFor="email">
+        <span className="flabel">Work email</span>
         <input
           id="email"
           type="email"
@@ -90,10 +90,10 @@ export function AccessForm() {
           onChange={(e) => setEmail(e.target.value)}
           placeholder="you@company.com"
           autoComplete="email"
-          className="block w-full rounded-lg border border-border bg-background/60 px-4 py-3 text-base outline-none transition-colors placeholder:text-muted-foreground focus:border-accent focus:ring-2 focus:ring-accent/30"
         />
-      </Field>
-      <Field label="Company" htmlFor="company">
+      </label>
+      <label className="field" htmlFor="company">
+        <span className="flabel">Company</span>
         <input
           id="company"
           type="text"
@@ -101,64 +101,35 @@ export function AccessForm() {
           onChange={(e) => setCompany(e.target.value)}
           placeholder="Acme Inc."
           autoComplete="organization"
-          className="block w-full rounded-lg border border-border bg-background/60 px-4 py-3 text-base outline-none transition-colors placeholder:text-muted-foreground focus:border-accent focus:ring-2 focus:ring-accent/30"
         />
-      </Field>
-      <Field label="Team size" htmlFor="size">
-        <select
-          id="size"
-          value={size}
-          onChange={(e) => setSize(e.target.value)}
-          className="block w-full rounded-lg border border-border bg-background/60 px-4 py-3 text-base outline-none transition-colors focus:border-accent focus:ring-2 focus:ring-accent/30"
-        >
+      </label>
+      <label className="field" htmlFor="size">
+        <span className="flabel">Team size</span>
+        <select id="size" value={size} onChange={(e) => setSize(e.target.value)}>
           <option value="">Select…</option>
           <option value="1-10">1 – 10 engineers</option>
           <option value="11-50">11 – 50</option>
           <option value="51-200">51 – 200</option>
           <option value="200+">200+</option>
         </select>
-      </Field>
+      </label>
 
-      {error && (
-        <p className="rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
-          {error}
-        </p>
-      )}
-
-      <button
-        type="submit"
-        disabled={state === 'submitting'}
-        className={cn(
-          'inline-flex h-12 w-full items-center justify-center gap-2 rounded-lg border border-accent/40 bg-accent/15 px-4 text-sm font-medium text-foreground transition-all hover:border-accent/60 hover:bg-accent/25',
-          state === 'submitting' ? 'cursor-not-allowed opacity-70' : 'hover:-translate-y-0.5',
-        )}
-      >
+      <button type="submit" className="btn btn-primary btn-block" disabled={state === 'submitting'}>
         {state === 'submitting' ? (
           <>
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Submitting…
+            <span className="spinner" />
+            <span className="btn-label">Submitting…</span>
           </>
         ) : (
           <>
-            Request access
-            <ArrowRight className="h-4 w-4" />
+            <span className="btn-label">Request access</span>
+            <span className="arr">→</span>
           </>
         )}
       </button>
-      <p className="text-center text-[11px] text-muted-foreground">
+      <p className="form-note">
         We&apos;ll only use your email to talk about TrueCourse. No newsletters.
       </p>
     </form>
-  );
-}
-
-function Field({ label, htmlFor, children }: { label: string; htmlFor: string; children: React.ReactNode }) {
-  return (
-    <label htmlFor={htmlFor} className="block">
-      <span className="mb-1.5 block text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-        {label}
-      </span>
-      {children}
-    </label>
   );
 }

--- a/apps/landing/src/components/CTASection.tsx
+++ b/apps/landing/src/components/CTASection.tsx
@@ -1,30 +1,23 @@
-import { ArrowRight } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { Reveal } from './Reveal';
 
 export function CTASection() {
   return (
-    <section id="cta" className="relative overflow-hidden py-28 sm:py-36">
-      <div className="bg-radial-glow absolute inset-0 -z-10 opacity-70" />
-      <div className="mx-auto max-w-3xl px-4 text-center sm:px-6">
-        <h2 className="text-balance text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
-          <span className="text-gradient">Verify at</span>{' '}
-          <span className="text-gradient-accent">AI speed.</span>
-        </h2>
-
-        <p className="mx-auto mt-6 max-w-2xl text-pretty text-lg leading-relaxed text-muted-foreground sm:text-xl">
-          AI made writing code fast. Review is the bottleneck. We check every
-          change against what your team decided. Deterministically.
-        </p>
-
-        <div className="mt-10 flex justify-center">
-          <Link
-            to="/request-access"
-            className="glow-border group inline-flex h-12 items-center gap-2 rounded-xl border border-accent/40 bg-accent/15 px-6 text-base font-medium text-foreground backdrop-blur-md transition-all hover:-translate-y-0.5 hover:border-accent/60 hover:bg-accent/25"
-          >
-            Request access
-            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+    <section className="cta" id="cta">
+      <div className="hero-glow" />
+      <div className="wrap cta-inner">
+        <Reveal as="h2">
+          Verify at <span className="hl">AI speed.</span>
+        </Reveal>
+        <Reveal as="p" delay={80}>
+          AI made writing code fast. Review is the bottleneck. We check every change
+          against what your team decided — deterministically.
+        </Reveal>
+        <Reveal className="cta-row" delay={160}>
+          <Link className="btn btn-primary" to="/request-access">
+            Request access <span className="arr">→</span>
           </Link>
-        </div>
+        </Reveal>
       </div>
     </section>
   );

--- a/apps/landing/src/components/Enterprise.tsx
+++ b/apps/landing/src/components/Enterprise.tsx
@@ -6,20 +6,15 @@ import {
   Users,
   WifiOff,
 } from 'lucide-react';
-import { cn } from '@/lib/cn';
-import { useReveal } from '@/lib/useReveal';
+import { Reveal } from './Reveal';
 
-type Card = {
-  Icon: typeof Server;
-  title: string;
-  body: string;
-};
+type Card = { Icon: typeof Server; title: string; body: string };
 
 const CARDS: Card[] = [
   {
     Icon: Server,
     title: 'Self-hosted',
-    body: 'Deploy in your VPC or on-premises. Code and specs stay between your infrastructure and the LLM provider your team already uses. They never touch TrueCourse.',
+    body: 'Deploy in your VPC or on-prem. Code and specs stay between your infrastructure and your own LLM provider — they never touch TrueCourse.',
   },
   {
     Icon: KeyRound,
@@ -39,61 +34,39 @@ const CARDS: Card[] = [
   {
     Icon: WifiOff,
     title: 'Verify stays local',
-    body: 'The verifier is deterministic and runs entirely in your CI with no LLM calls. Optional anonymous telemetry helps us improve the engine, off with one flag.',
+    body: 'The verifier is deterministic and runs entirely in your CI with no LLM calls. Optional telemetry, off with one flag.',
   },
   {
     Icon: ClipboardCheck,
     title: 'Compliance-ready',
-    body: 'Designed for regulated industries: fintech, healthtech, defense. Documentation that satisfies auditors.',
+    body: 'Designed for regulated industries — fintech, healthtech, defense. Documentation that satisfies auditors.',
   },
 ];
 
 export function Enterprise() {
   return (
-    <section id="enterprise" className="relative border-b border-border py-24 sm:py-32">
-      <div className="mx-auto max-w-6xl px-4 sm:px-6">
-        <div className="max-w-3xl">
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-accent">
-            Enterprise &amp; data
-          </p>
-          <h2 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
-            <span className="text-gradient">Built for teams where</span>{' '}
-            <span className="text-gradient-accent">
-              data security is not optional.
-            </span>
-          </h2>
-        </div>
+    <section className="band" id="enterprise">
+      <div className="wrap">
+        <Reveal as="p" className="eyebrow">
+          Enterprise &amp; data
+        </Reveal>
+        <Reveal as="h2" className="section-title">
+          <span className="dim">Built for teams where</span> data security{' '}
+          <span className="hl">is not optional.</span>
+        </Reveal>
 
-        <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid cols-3" style={{ marginTop: 48 }}>
           {CARDS.map((c, i) => (
-            <EnterpriseCard key={c.title} card={c} delayMs={i * 60} />
+            <Reveal key={c.title} className="card hover" delay={i * 60}>
+              <span className="ico">
+                <c.Icon />
+              </span>
+              <h3>{c.title}</h3>
+              <p>{c.body}</p>
+            </Reveal>
           ))}
         </div>
       </div>
     </section>
-  );
-}
-
-function EnterpriseCard({ card, delayMs }: { card: Card; delayMs: number }) {
-  const { ref, visible } = useReveal<HTMLDivElement>();
-  const { Icon } = card;
-  return (
-    <div
-      ref={ref}
-      style={{ ['--delay' as string]: `${delayMs}ms` }}
-      className={cn(
-        'reveal surface-hover rounded-2xl border border-border bg-card/40 p-6 transition-colors hover:border-border-strong hover:bg-card',
-        visible && 'visible',
-      )}
-    >
-      <span
-        className="inline-flex h-11 w-11 items-center justify-center rounded-xl border border-accent/40 bg-accent/15 text-accent shadow-[0_0_20px_-6px] shadow-accent/30"
-        aria-hidden
-      >
-        <Icon className="h-5 w-5" />
-      </span>
-      <h3 className="mt-5 text-base font-semibold text-accent">{card.title}</h3>
-      <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{card.body}</p>
-    </div>
   );
 }

--- a/apps/landing/src/components/Footer.tsx
+++ b/apps/landing/src/components/Footer.tsx
@@ -1,146 +1,119 @@
-import { Github, Mail } from 'lucide-react';
+import { SiGithub } from 'react-icons/si';
 import { Link } from 'react-router-dom';
 import { DiscordIcon } from './DiscordIcon';
 
 const DISCORD_URL = 'https://discord.gg/TanxB63arz';
+const GITHUB_URL = 'https://github.com/truecourse-ai/truecourse';
+
+type LinkItem = { href: string; label: string };
+
+const PRODUCT: LinkItem[] = [
+  { href: '/#why-now', label: 'Why now' },
+  { href: '/#approach', label: 'Approach' },
+  { href: '/#integrations', label: 'Integrations' },
+  { href: '/#why-us', label: 'Why us' },
+  { href: '/#enterprise', label: 'Enterprise' },
+];
+
+const RESOURCES: LinkItem[] = [
+  { href: GITHUB_URL, label: 'GitHub' },
+  { href: DISCORD_URL, label: 'Discord' },
+  { href: 'https://www.npmjs.com/package/truecourse', label: 'npm' },
+  { href: 'https://github.com/truecourse-ai/truecourse#readme', label: 'Documentation' },
+  { href: 'mailto:mushegh@truecourse.dev', label: 'Contact' },
+];
+
+const LEGAL: LinkItem[] = [
+  {
+    href: 'https://github.com/truecourse-ai/truecourse/blob/main/LICENSE',
+    label: 'License (MIT)',
+  },
+  {
+    href: 'https://github.com/truecourse-ai/truecourse/blob/main/CODE_OF_CONDUCT.md',
+    label: 'Code of conduct',
+  },
+];
 
 export function Footer() {
   return (
-    <footer className="relative overflow-hidden">
-      <div className="bg-radial-glow absolute inset-x-0 -top-32 -z-10 h-64 opacity-50" />
-      <div className="mx-auto max-w-6xl px-4 py-16 sm:px-6">
-        <div className="grid gap-10 md:grid-cols-[1.4fr_1fr_1fr_1fr]">
-          <div>
-            <div className="flex items-center gap-2.5">
-              <img src="/logo.svg" alt="" className="h-7 w-7" />
-              <span className="text-base font-semibold tracking-tight">TrueCourse</span>
-            </div>
-            <p className="mt-4 max-w-sm text-sm leading-relaxed text-muted-foreground">
+    <footer className="site">
+      <div className="wrap">
+        <div className="foot-grid">
+          <div className="foot-about">
+            <Link to="/" className="brand">
+              <span className="mark" aria-hidden />
+              TrueCourse
+            </Link>
+            <p>
               The verified knowledge layer for engineering. Compile your team&apos;s
               decisions into contracts and check every commit against them.
             </p>
-            <div className="mt-5 flex items-center gap-2">
+            <div className="foot-social">
               <a
-                href="https://github.com/truecourse-ai/truecourse"
+                className="icon-btn"
+                href={GITHUB_URL}
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:border-border-strong hover:text-foreground"
                 aria-label="GitHub"
               >
-                <Github className="h-4 w-4" />
+                <SiGithub />
               </a>
               <a
+                className="icon-btn"
                 href={DISCORD_URL}
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:border-border-strong hover:text-[#5865F2]"
                 aria-label="Discord"
               >
-                <DiscordIcon className="h-4 w-4" />
+                <DiscordIcon />
               </a>
-              <a
-                href="mailto:mushegh@truecourse.dev"
-                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:border-border-strong hover:text-foreground"
-                aria-label="Email"
-              >
-                <Mail className="h-4 w-4" />
+              <a className="icon-btn" href="mailto:mushegh@truecourse.dev" aria-label="Email">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M2 5h20v14H2z" fill="none" stroke="currentColor" strokeWidth="1.6" />
+                  <path d="M3 6l9 7 9-7" fill="none" stroke="currentColor" strokeWidth="1.6" />
+                </svg>
               </a>
             </div>
           </div>
 
-          <Column
-            title="Product"
-            links={[
-              { href: '/#why-now', label: 'Why now' },
-              { href: '/#our-approach', label: 'Approach' },
-              { href: '/#integrations', label: 'Integrations' },
-              { href: '/#why-tests-cant-catch', label: 'Why us' },
-              { href: '/#enterprise', label: 'Enterprise' },
-              { href: '/request-access', label: 'Request access' },
-            ]}
-          />
-          <Column
-            title="Resources"
-            links={[
-              { href: 'https://github.com/truecourse-ai/truecourse', label: 'GitHub' },
-              { href: DISCORD_URL, label: 'Discord' },
-              { href: 'https://www.npmjs.com/package/truecourse', label: 'npm' },
-              {
-                href: 'https://github.com/truecourse-ai/truecourse#readme',
-                label: 'Documentation',
-              },
-              { href: 'mailto:mushegh@truecourse.dev', label: 'Contact' },
-            ]}
-          />
-          <Column
-            title="Legal"
-            links={[
-              {
-                href: 'https://github.com/truecourse-ai/truecourse/blob/main/LICENSE',
-                label: 'License (MIT)',
-              },
-              {
-                href: 'https://github.com/truecourse-ai/truecourse/blob/main/CODE_OF_CONDUCT.md',
-                label: 'Code of conduct',
-              },
-            ]}
-          />
+          <Column title="Product" links={PRODUCT} />
+          <Column title="Resources" links={RESOURCES} />
+          <Column title="Legal" links={LEGAL} />
         </div>
 
-        <div className="mt-12 flex flex-col items-start justify-between gap-4 border-t border-border pt-6 sm:flex-row sm:items-center">
-          <div className="text-xs text-muted-foreground">
-            <p>© {new Date().getFullYear()} TrueCourse AI, Inc.</p>
-            <p className="mt-1">
-              2261 Market Street STE 88087, San Francisco, CA 94114 US
-            </p>
-          </div>
-          <p className="text-xs text-muted-foreground sm:text-right">
-            Built with <span className="text-accent" aria-hidden>♥</span>
-            <span className="sr-only">love</span> for engineers shipping with AI.
-          </p>
+        <div className="foot-bottom">
+          <span>
+            © {new Date().getFullYear()} TrueCourse AI, Inc. · 2261 Market Street STE
+            88087, San Francisco, CA 94114
+          </span>
+          <span>
+            Built with <span className="heart">♥</span> for engineers shipping with AI.
+          </span>
         </div>
       </div>
     </footer>
   );
 }
 
-function Column({
-  title,
-  links,
-}: {
-  title: string;
-  links: { href: string; label: string }[];
-}) {
+function Column({ title, links }: { title: string; links: LinkItem[] }) {
   return (
-    <div>
-      <h4 className="text-[11px] font-medium uppercase tracking-wider text-foreground">
-        {title}
-      </h4>
-      <ul className="mt-4 space-y-2.5">
-        {links.map((l) => {
-          const className =
-            'text-sm text-muted-foreground transition-colors hover:text-foreground';
-          const isInternal = l.href.startsWith('/');
-          return (
-            <li key={l.href}>
-              {isInternal ? (
-                <Link to={l.href} className={className}>
-                  {l.label}
-                </Link>
-              ) : (
-                <a
-                  href={l.href}
-                  className={className}
-                  {...(l.href.startsWith('http')
-                    ? { target: '_blank', rel: 'noreferrer' }
-                    : {})}
-                >
-                  {l.label}
-                </a>
-              )}
-            </li>
-          );
-        })}
+    <div className="foot-col">
+      <h4>{title}</h4>
+      <ul>
+        {links.map((l) => (
+          <li key={l.href}>
+            {l.href.startsWith('/') ? (
+              <Link to={l.href}>{l.label}</Link>
+            ) : (
+              <a
+                href={l.href}
+                {...(l.href.startsWith('http') ? { target: '_blank', rel: 'noreferrer' } : {})}
+              >
+                {l.label}
+              </a>
+            )}
+          </li>
+        ))}
       </ul>
     </div>
   );

--- a/apps/landing/src/components/Header.tsx
+++ b/apps/landing/src/components/Header.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useState } from 'react';
-import { Github, Menu, X } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
+import { SiGithub } from 'react-icons/si';
 import { Link, useLocation } from 'react-router-dom';
 import { cn } from '@/lib/cn';
 import { DiscordIcon } from './DiscordIcon';
 
 const DISCORD_URL = 'https://discord.gg/TanxB63arz';
+const GITHUB_URL = 'https://github.com/truecourse-ai/truecourse';
 
-type NavItem = { href: string; label: string; external?: boolean };
-
-const NAV: NavItem[] = [
+const NAV = [
   { href: '/#why-now', label: 'Why now' },
-  { href: '/#our-approach', label: 'Approach' },
+  { href: '/#approach', label: 'Approach' },
   { href: '/#integrations', label: 'Integrations' },
   { href: '/#enterprise', label: 'Enterprise' },
 ];
@@ -19,6 +19,7 @@ export function Header() {
   const [scrolled, setScrolled] = useState(false);
   const [open, setOpen] = useState(false);
   const { pathname } = useLocation();
+  const onHome = pathname === '/';
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 8);
@@ -31,69 +32,69 @@ export function Header() {
     setOpen(false);
   }, [pathname]);
 
+  // Off the home page there's no hero behind the header, so keep the blurred
+  // surface always on (mirrors the request-access prototype).
+  const showSurface = scrolled || !onHome;
+
   return (
-    <header
-      className={cn(
-        'fixed inset-x-0 top-0 z-50 transition-all duration-300',
-        scrolled
-          ? 'border-b border-border bg-background/70 backdrop-blur-xl'
-          : 'border-b border-transparent',
-      )}
-    >
-      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6">
+    <header className={cn('site', showSurface && 'scrolled')} id="site-header">
+      <div className="wrap nav">
         <Link
           to="/"
           onClick={(e) => {
-            // Same-page click: react-router won't re-mount, so no Layout effect fires.
-            // Prevent default and scroll explicitly. On a different page, let the
-            // Link navigate normally; Layout's pathname effect handles the scroll.
-            if (pathname === '/') {
+            if (onHome) {
               e.preventDefault();
               window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
             }
           }}
-          className="flex items-center gap-2.5"
+          className="brand"
         >
-          <img src="/logo.svg" alt="" className="h-7 w-7" />
-          <span className="text-base font-semibold tracking-tight">TrueCourse</span>
+          <span className="mark" aria-hidden />
+          TrueCourse
         </Link>
 
-        <nav className="hidden items-center gap-1 md:flex">
+        <nav className="nav-links">
           {NAV.map((item) => (
-            <NavLink key={item.href} item={item} />
+            <Link key={item.href} to={item.href}>
+              {item.label}
+            </Link>
           ))}
         </nav>
 
-        <div className="flex items-center gap-2">
+        <div className="nav-actions">
           <a
+            className="icon-btn desktop-only"
             href={DISCORD_URL}
             target="_blank"
             rel="noreferrer"
-            className="hidden h-9 w-9 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:border-border-strong hover:text-[#5865F2] sm:inline-flex"
-            aria-label="Join the TrueCourse Discord"
+            aria-label="Discord"
           >
-            <DiscordIcon className="h-4 w-4" />
+            <DiscordIcon />
           </a>
           <a
-            href="https://github.com/truecourse-ai/truecourse"
+            className="icon-btn desktop-only"
+            href={GITHUB_URL}
             target="_blank"
             rel="noreferrer"
-            className="hidden h-9 items-center gap-2 rounded-md border border-border px-3 text-sm text-muted-foreground transition-colors hover:border-border-strong hover:text-foreground sm:inline-flex"
+            aria-label="GitHub"
           >
-            <Github className="h-4 w-4" />
-            GitHub
+            <SiGithub />
           </a>
-          <Link
-            to="/request-access"
-            className="hidden h-9 items-center rounded-md bg-foreground px-3.5 text-sm font-medium text-background transition-opacity hover:opacity-90 sm:inline-flex"
-          >
-            Request access
-          </Link>
+          {onHome ? (
+            <Link className="btn btn-primary btn-sm" to="/request-access">
+              Request access
+            </Link>
+          ) : (
+            <Link className="btn btn-sm" to="/">
+              <span className="arr">←</span> Back
+            </Link>
+          )}
           <button
             type="button"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border md:hidden"
+            className="icon-btn mobile-toggle"
             onClick={() => setOpen((v) => !v)}
             aria-label="Menu"
+            aria-expanded={open}
           >
             {open ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
           </button>
@@ -101,65 +102,22 @@ export function Header() {
       </div>
 
       {open && (
-        <div className="border-t border-border bg-background/95 backdrop-blur-xl md:hidden">
-          <nav className="mx-auto flex max-w-6xl flex-col px-4 py-3 sm:px-6">
+        <div className="mobile-menu">
+          <div className="wrap row">
             {NAV.map((item) => (
-              <NavLink key={item.href} item={item} mobile onNavigate={() => setOpen(false)} />
+              <Link key={item.href} to={item.href} onClick={() => setOpen(false)}>
+                {item.label}
+              </Link>
             ))}
-            <a
-              href="https://github.com/truecourse-ai/truecourse"
-              target="_blank"
-              rel="noreferrer"
-              className="mt-1 flex items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-            >
-              <Github className="h-4 w-4" />
-              GitHub
+            <a href={GITHUB_URL} target="_blank" rel="noreferrer">
+              <SiGithub /> GitHub
             </a>
-            <a
-              href={DISCORD_URL}
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-            >
-              <DiscordIcon className="h-4 w-4" />
-              Discord
+            <a href={DISCORD_URL} target="_blank" rel="noreferrer">
+              <DiscordIcon /> Discord
             </a>
-          </nav>
+          </div>
         </div>
       )}
     </header>
-  );
-}
-
-function NavLink({
-  item,
-  mobile,
-  onNavigate,
-}: {
-  item: NavItem;
-  mobile?: boolean;
-  onNavigate?: () => void;
-}) {
-  const cls = cn(
-    'rounded-md text-sm transition-colors',
-    mobile
-      ? 'px-3 py-2 text-muted-foreground hover:bg-muted/50 hover:text-foreground'
-      : 'px-3 py-1.5 text-muted-foreground hover:bg-muted/50 hover:text-foreground',
-  );
-
-  // Hash links to home page sections — let react-router handle them so the
-  // Layout's scroll-to-hash effect runs on navigation.
-  if (item.href.startsWith('/#')) {
-    return (
-      <Link to={item.href} onClick={onNavigate} className={cls}>
-        {item.label}
-      </Link>
-    );
-  }
-
-  return (
-    <Link to={item.href} onClick={onNavigate} className={cls}>
-      {item.label}
-    </Link>
   );
 }

--- a/apps/landing/src/components/Hero.tsx
+++ b/apps/landing/src/components/Hero.tsx
@@ -1,61 +1,67 @@
-import { ArrowRight, Sparkles } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { Reveal } from './Reveal';
+
+const GITHUB_URL = 'https://github.com/truecourse-ai/truecourse';
 
 export function Hero() {
   return (
-    <section
-      id="top"
-      className="relative isolate overflow-hidden border-b border-border pt-32 pb-32 sm:pt-40 sm:pb-40"
-    >
-      <div className="bg-radial-glow absolute inset-0 -z-10" />
-      <div className="bg-grid absolute inset-0 -z-10" />
+    <section className="hero" id="top">
+      <div className="hero-glow" />
+      <svg
+        className="hero-baseline"
+        viewBox="0 0 1440 220"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <line
+          className="bline"
+          x1="0"
+          y1="150"
+          x2="1440"
+          y2="150"
+          style={{ stroke: 'var(--accent)' }}
+          strokeWidth="1.5"
+          opacity="0.5"
+        />
+        <path
+          className="bdrift"
+          d="M0 150 C 760 150, 920 150, 1440 210"
+          fill="none"
+          style={{ stroke: 'var(--warn)' }}
+          strokeWidth="1.5"
+          strokeDasharray="2 9"
+          opacity="0.55"
+        />
+      </svg>
 
-      <div className="mx-auto max-w-6xl px-4 sm:px-6">
-        <div className="mx-auto max-w-3xl text-center">
-          <Link
-            to="/#why-now"
-            style={{ ['--delay' as string]: '0ms' }}
-            className="animate-fade-up animate-pulse-ring mx-auto inline-flex items-center gap-2 rounded-full border border-border bg-card/60 px-3 py-1 text-xs text-muted-foreground backdrop-blur-md transition-colors hover:border-border-strong hover:text-foreground"
-          >
-            <Sparkles className="h-3 w-3 text-accent" />
-            New &middot; Verified knowledge for AI-native engineering teams (preview)
-            <ArrowRight className="h-3 w-3" />
+      <div className="wrap hero-inner">
+        <Reveal as="span" className="badge pulse">
+          <span className="spark">✦</span> Verified knowledge for AI-native engineering
+          teams <span className="arr">· preview</span>
+        </Reveal>
+
+        <Reveal as="h1" delay={80}>
+          AI ships your code. We keep it <span className="hl">on course.</span>
+        </Reveal>
+
+        <Reveal as="p" className="sub" delay={160}>
+          Every change, checked against what your team actually decided.
+        </Reveal>
+
+        <Reveal as="p" className="micro" delay={220}>
+          We compile your team&apos;s decisions into{' '}
+          <b>machine-readable contracts</b> and check every change against them —{' '}
+          <b>deterministically</b>, with no LLM in the verification loop.
+        </Reveal>
+
+        <Reveal className="cta-row" delay={300}>
+          <Link className="btn btn-primary" to="/request-access">
+            Request access <span className="arr">→</span>
           </Link>
-
-          <h1
-            style={{ ['--delay' as string]: '80ms' }}
-            className="animate-fade-up mt-6 text-balance text-5xl font-semibold leading-[1.05] tracking-tight sm:text-6xl md:text-7xl"
-          >
-            <span className="text-gradient">AI ships your code.</span>
-            <br />
-            <span className="text-gradient-accent">
-              We make sure it ships what your team decided.
-            </span>
-          </h1>
-
-          <p
-            style={{ ['--delay' as string]: '200ms' }}
-            className="animate-fade-up mx-auto mt-6 max-w-2xl text-pretty text-lg leading-relaxed text-muted-foreground sm:text-xl"
-          >
-            The verified knowledge layer for AI-native engineering teams. We compile
-            your team&apos;s decisions into machine-readable contracts and check every
-            change against them. Deterministically, with no LLM in the verification
-            loop.
-          </p>
-
-          <div
-            style={{ ['--delay' as string]: '320ms' }}
-            className="animate-fade-up mt-10 flex justify-center"
-          >
-            <Link
-              to="/request-access"
-              className="group inline-flex h-12 items-center gap-2 rounded-xl border border-accent/40 bg-accent/15 px-6 text-base font-medium text-foreground backdrop-blur-md transition-all hover:-translate-y-0.5 hover:border-accent/60 hover:bg-accent/25"
-            >
-              Request access
-              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-            </Link>
-          </div>
-        </div>
+          <a className="btn" href={GITHUB_URL} target="_blank" rel="noreferrer">
+            View on GitHub
+          </a>
+        </Reveal>
       </div>
     </section>
   );

--- a/apps/landing/src/components/Hero.tsx
+++ b/apps/landing/src/components/Hero.tsx
@@ -36,8 +36,11 @@ export function Hero() {
 
       <div className="wrap hero-inner">
         <Reveal as="span" className="badge pulse">
-          <span className="spark">✦</span> Verified knowledge for AI-native engineering
-          teams <span className="arr">· preview</span>
+          <span className="spark">✦</span>
+          <span className="badge-text">
+            Verified knowledge for AI-native engineering teams{' '}
+            <span className="arr">· preview</span>
+          </span>
         </Reveal>
 
         <Reveal as="h1" delay={80}>
@@ -48,13 +51,7 @@ export function Hero() {
           Every change, checked against what your team actually decided.
         </Reveal>
 
-        <Reveal as="p" className="micro" delay={220}>
-          We compile your team&apos;s decisions into{' '}
-          <b>machine-readable contracts</b> and check every change against them —{' '}
-          <b>deterministically</b>, with no LLM in the verification loop.
-        </Reveal>
-
-        <Reveal className="cta-row" delay={300}>
+        <Reveal className="cta-row" delay={240}>
           <Link className="btn btn-primary" to="/request-access">
             Request access <span className="arr">→</span>
           </Link>

--- a/apps/landing/src/components/Integrations.tsx
+++ b/apps/landing/src/components/Integrations.tsx
@@ -2,7 +2,6 @@ import type { IconType } from 'react-icons';
 import {
   SiAsana,
   SiBitbucket,
-  SiClickup,
   SiConfluence,
   SiDiscord,
   SiDropbox,
@@ -16,14 +15,9 @@ import {
   SiSlack,
   SiTrello,
 } from 'react-icons/si';
-import { cn } from '@/lib/cn';
-import { useReveal } from '@/lib/useReveal';
+import { Reveal } from './Reveal';
 
-type Tool = {
-  Icon: IconType;
-  name: string;
-  hint?: string;
-};
+type Tool = { Icon: IconType; name: string; hint: string };
 
 const KB_TOOLS: Tool[] = [
   { Icon: SiNotion, name: 'Notion', hint: 'specs, OKRs' },
@@ -33,15 +27,9 @@ const KB_TOOLS: Tool[] = [
   { Icon: SiGoogledocs, name: 'Google Docs', hint: 'design reviews' },
   { Icon: SiLinear, name: 'Linear', hint: 'tickets' },
   { Icon: SiJira, name: 'Jira', hint: 'tickets' },
-  { Icon: SiAsana, name: 'Asana', hint: 'projects' },
 ];
 
-const KB_MORE: IconType[] = [
-  SiClickup,
-  SiTrello,
-  SiDropbox,
-  SiDiscord,
-];
+const KB_MORE: IconType[] = [SiAsana, SiTrello, SiDropbox, SiDiscord];
 
 const PR_GATES: Tool[] = [
   { Icon: SiGithub, name: 'GitHub', hint: 'cloud + Enterprise Server' },
@@ -52,144 +40,73 @@ const PR_GATES: Tool[] = [
 
 export function Integrations() {
   return (
-    <section
-      id="integrations"
-      className="relative border-b border-border py-24 sm:py-32"
-    >
-      <div className="mx-auto max-w-6xl px-4 sm:px-6">
-        <div className="max-w-3xl">
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-accent">
-            Integrations
-          </p>
-          <h2 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
-            <span className="text-gradient">We plug into the tools</span>{' '}
-            <span className="text-gradient-accent">your team already uses.</span>
-          </h2>
-          <p className="mt-5 max-w-2xl text-base leading-relaxed text-muted-foreground sm:text-lg">
-            No new workflow to adopt. We capture decisions from where your team
-            writes them and gate every PR on the platform you already host code
-            on.
-          </p>
-        </div>
+    <section className="band" id="integrations">
+      <div className="wrap">
+        <Reveal as="p" className="eyebrow">
+          Integrations
+        </Reveal>
+        <Reveal as="h2" className="section-title">
+          <span className="dim">We plug into the tools</span> your team{' '}
+          <span className="hl">already uses.</span>
+        </Reveal>
+        <Reveal as="p" className="section-lead">
+          No new workflow to adopt. We capture decisions from where your team writes them,
+          and gate every PR on the platform you already host code on.
+        </Reveal>
 
-        <SubsectionHeading
-          eyebrow="Knowledge sources"
-          title="Where decisions live"
-          subtitle="Capture from the sources your team already uses."
-        />
-        <div className="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        <Reveal className="subhead">
+          <p className="e">Knowledge sources</p>
+          <h3>Where decisions live</h3>
+          <p>Capture from the sources your team already uses.</p>
+        </Reveal>
+        <div className="grid cols-4" style={{ marginTop: 26 }}>
           {KB_TOOLS.map((t, i) => (
-            <ToolCard key={t.name} tool={t} delayMs={i * 50} />
+            <Reveal key={t.name} className="tool" delay={i * 50}>
+              <span className="glyph">
+                <t.Icon />
+              </span>
+              <div>
+                <div className="tname">{t.name}</div>
+                <div className="thint">{t.hint}</div>
+              </div>
+            </Reveal>
           ))}
-          <MoreCard icons={KB_MORE} delayMs={KB_TOOLS.length * 50} />
+          <Reveal className="tool dashed" delay={KB_TOOLS.length * 50}>
+            <span className="more-glyphs">
+              {KB_MORE.map((Icon, i) => (
+                <Icon key={i} />
+              ))}
+            </span>
+            <div>
+              <div className="tname">and more</div>
+              <div className="thint">on request</div>
+            </div>
+          </Reveal>
         </div>
 
-        <SubsectionHeading
-          eyebrow="PR gates"
-          title="Where we gate PRs"
-          subtitle="Verify every change on the platform you already host code on."
-          className="mt-20"
-        />
-        <div className="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Reveal className="subhead">
+          <p className="e">PR gates</p>
+          <h3>Where we gate PRs</h3>
+          <p>Verify every change on the platform you already host code on.</p>
+        </Reveal>
+        <div className="grid cols-4" style={{ marginTop: 26 }}>
           {PR_GATES.map((t, i) => (
-            <ToolCard key={t.name} tool={t} delayMs={i * 60} />
+            <Reveal key={t.name} className="tool" delay={i * 60}>
+              <span className="glyph">
+                <t.Icon />
+              </span>
+              <div>
+                <div className="tname">{t.name}</div>
+                <div className="thint">{t.hint}</div>
+              </div>
+            </Reveal>
           ))}
         </div>
 
-        <p className="mt-6 text-xs text-muted-foreground">
+        <Reveal as="p" className="fine">
           Azure DevOps and other platforms on request.
-        </p>
+        </Reveal>
       </div>
     </section>
-  );
-}
-
-function SubsectionHeading({
-  eyebrow,
-  title,
-  subtitle,
-  className,
-}: {
-  eyebrow: string;
-  title: string;
-  subtitle: string;
-  className?: string;
-}) {
-  return (
-    <div className={cn('mt-14', className)}>
-      <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
-        {eyebrow}
-      </p>
-      <h3 className="mt-2 text-balance text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
-        {title}
-      </h3>
-      <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-        {subtitle}
-      </p>
-    </div>
-  );
-}
-
-function ToolCard({ tool, delayMs }: { tool: Tool; delayMs: number }) {
-  const { ref, visible } = useReveal<HTMLDivElement>();
-  const { Icon } = tool;
-  return (
-    <div
-      ref={ref}
-      style={{ ['--delay' as string]: `${delayMs}ms` }}
-      className={cn(
-        'reveal surface-hover flex items-center gap-4 rounded-2xl border border-border bg-card/40 p-5 transition-colors hover:border-border-strong hover:bg-card',
-        visible && 'visible',
-      )}
-    >
-      <span
-        className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-border bg-background/60 text-foreground/90"
-        aria-hidden
-      >
-        <Icon className="h-5 w-5" />
-      </span>
-      <div className="min-w-0">
-        <div className="truncate text-sm font-semibold text-foreground">
-          {tool.name}
-        </div>
-        {tool.hint ? (
-          <div className="truncate text-xs text-muted-foreground">{tool.hint}</div>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-function MoreCard({ icons, delayMs }: { icons: IconType[]; delayMs: number }) {
-  const { ref, visible } = useReveal<HTMLDivElement>();
-  return (
-    <div
-      ref={ref}
-      style={{ ['--delay' as string]: `${delayMs}ms` }}
-      className={cn(
-        'reveal flex items-center gap-4 rounded-2xl border border-dashed border-border bg-card/20 p-5 transition-colors hover:border-accent/40',
-        visible && 'visible',
-      )}
-    >
-      <div
-        className="flex shrink-0 items-center gap-1.5 rounded-xl border border-border bg-background/60 px-2.5 py-2"
-        aria-hidden
-      >
-        {icons.slice(0, 4).map((Icon, i) => (
-          <Icon
-            key={i}
-            className="h-4 w-4 text-muted-foreground/80"
-          />
-        ))}
-      </div>
-      <div className="min-w-0">
-        <div className="truncate text-sm font-semibold text-foreground">
-          and more
-        </div>
-        <div className="truncate text-xs text-muted-foreground">
-          on request
-        </div>
-      </div>
-    </div>
   );
 }

--- a/apps/landing/src/components/Layout.tsx
+++ b/apps/landing/src/components/Layout.tsx
@@ -25,10 +25,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
   }, [pathname, hash]);
 
   return (
-    <div className="relative min-h-screen bg-background text-foreground">
+    <>
       <Header />
       <main>{children}</main>
       <Footer />
-    </div>
+    </>
   );
 }

--- a/apps/landing/src/components/OurApproach.tsx
+++ b/apps/landing/src/components/OurApproach.tsx
@@ -1,106 +1,74 @@
-import { Cog, FileText, ShieldCheck } from 'lucide-react';
-import { cn } from '@/lib/cn';
-import { useReveal } from '@/lib/useReveal';
+import { Reveal } from './Reveal';
 
 type Step = {
   num: string;
-  Icon: typeof FileText;
+  label: string;
   title: string;
   body: string;
+  accent?: boolean;
 };
 
 const STEPS: Step[] = [
   {
-    num: '1',
-    Icon: FileText,
-    title: 'Capture',
-    body: "Scan your docs, ADRs, READMEs, and Slack threads. Extract every decision your team made, with provenance back to the source.",
+    num: '01',
+    label: 'Capture',
+    title: 'From every source',
+    body: 'Scan docs, ADRs, READMEs, and Slack threads. Extract every decision your team made — with provenance back to the source.',
   },
   {
-    num: '2',
-    Icon: Cog,
-    title: 'Compile',
-    body: 'Decisions become machine-readable contracts. Versioned, reviewable, lives alongside your code.',
+    num: '02',
+    label: 'Compile',
+    title: 'Into contracts',
+    body: 'Decisions become machine-readable contracts. Versioned, reviewable, living alongside your code.',
   },
   {
-    num: '3',
-    Icon: ShieldCheck,
-    title: 'Verify',
-    body: 'A deterministic engine, no LLM in the loop, checks every change against the contracts. Same input, same result, every time.',
+    num: '03',
+    label: 'Verify',
+    title: 'Deterministically',
+    body: 'A deterministic engine — no LLM in the loop — checks every change against the contracts. Same input, same result, every time.',
+    accent: true,
   },
 ];
 
 export function OurApproach() {
   return (
-    <section
-      id="our-approach"
-      className="relative border-b border-border py-24 sm:py-32"
-    >
-      <div className="mx-auto max-w-6xl px-4 sm:px-6">
-        <div className="max-w-4xl">
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-accent">
-            Our approach
-          </p>
-          <h2 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
-            <span className="text-gradient">
-              We compile your team&apos;s decisions into contracts.
-            </span>{' '}
-            <span className="text-gradient-accent">
-              A deterministic engine checks every change against them.
-            </span>
-          </h2>
-        </div>
+    <section className="band" id="approach">
+      <div className="wrap">
+        <Reveal as="p" className="eyebrow">
+          Our approach
+        </Reveal>
+        <Reveal as="h2" className="section-title" style={{ maxWidth: '28ch' }}>
+          <span className="dim">We compile your team&apos;s decisions into contracts.</span>{' '}
+          A deterministic engine checks every change against them.
+        </Reveal>
 
-        <div className="mt-14 grid grid-cols-1 gap-6 md:grid-cols-3">
+        <div className="flow" style={{ marginTop: 52 }}>
           {STEPS.map((s, i) => (
-            <StepCard key={s.num} step={s} delayMs={i * 120} />
+            <Reveal key={s.num} className="fstep" delay={i * 120}>
+              <div className={s.accent ? 'card accent' : 'card'}>
+                <div className="fhead">
+                  <span className="kbig">{s.num}</span>
+                  <span
+                    className="knum"
+                    style={s.accent ? { color: 'var(--accent)' } : undefined}
+                  >
+                    {s.label}
+                  </span>
+                </div>
+                <h3>{s.title}</h3>
+                <p>{s.body}</p>
+              </div>
+            </Reveal>
           ))}
         </div>
 
-        <p className="mt-14 text-balance text-base leading-relaxed text-foreground/85 sm:text-lg">
-          <span className="text-foreground">
-            Every kind of drift surfaced.
-          </span>{' '}
-          <span className="text-muted-foreground">
-            Mechanical, behavioral, architectural.
-          </span>
-        </p>
+        <Reveal className="drift-line" delay={120}>
+          <b>Every kind of drift surfaced:</b>
+          <span className="dtag">mechanical</span>
+          <span className="dtag">behavioral</span>
+          <span className="dtag">architectural</span>
+        </Reveal>
       </div>
     </section>
-  );
-}
-
-function StepCard({ step, delayMs }: { step: Step; delayMs: number }) {
-  const { ref, visible } = useReveal<HTMLDivElement>();
-  const { Icon } = step;
-  return (
-    <div
-      ref={ref}
-      style={{ ['--delay' as string]: `${delayMs}ms` }}
-      className={cn(
-        'reveal surface-hover relative flex flex-col rounded-2xl border border-border bg-card/40 p-7 transition-colors hover:border-border-strong sm:p-8',
-        visible && 'visible',
-      )}
-    >
-      <div className="flex items-center gap-4">
-        <span
-          className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-accent/40 bg-accent/15 text-accent shadow-[0_0_24px_-6px] shadow-accent/30"
-          aria-hidden
-        >
-          <Icon className="h-6 w-6" />
-        </span>
-        <div>
-          <div className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
-            Step {step.num}
-          </div>
-          <h3 className="mt-0.5 text-balance text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
-            {step.title}
-          </h3>
-        </div>
-      </div>
-      <p className="mt-6 text-base leading-relaxed text-muted-foreground">
-        {step.body}
-      </p>
-    </div>
   );
 }

--- a/apps/landing/src/components/Reveal.tsx
+++ b/apps/landing/src/components/Reveal.tsx
@@ -1,0 +1,35 @@
+import {
+  createElement,
+  type CSSProperties,
+  type ElementType,
+  type ReactNode,
+} from 'react';
+import { cn } from '@/lib/cn';
+import { useReveal } from '@/lib/useReveal';
+
+type RevealProps = {
+  as?: ElementType;
+  className?: string;
+  /** Stagger delay in milliseconds, exposed to CSS as `--delay`. */
+  delay?: number;
+  style?: CSSProperties;
+  children?: ReactNode;
+};
+
+/**
+ * Fades + lifts its element into view on scroll. Pairs with the `.reveal` /
+ * `.reveal.visible` rules in globals.css. Polymorphic via `as` so it can wrap a
+ * heading, paragraph, card, or grid cell without extra markup.
+ */
+export function Reveal({ as = 'div', className, delay, style, children }: RevealProps) {
+  const { ref, visible } = useReveal<HTMLElement>();
+  return createElement(
+    as,
+    {
+      ref,
+      className: cn('reveal', visible && 'visible', className),
+      style: delay != null ? { ...style, ['--delay' as string]: `${delay}ms` } : style,
+    },
+    children,
+  );
+}

--- a/apps/landing/src/components/WhyNow.tsx
+++ b/apps/landing/src/components/WhyNow.tsx
@@ -1,103 +1,49 @@
 import { Bot, Clock, Rocket, TrendingUp, Zap } from 'lucide-react';
-import { cn } from '@/lib/cn';
-import { useReveal } from '@/lib/useReveal';
+import { Reveal } from './Reveal';
 
-type Bullet = {
-  Icon: typeof Bot;
-  text: string;
-};
-
-const BULLETS: Bullet[] = [
-  {
-    Icon: Bot,
-    text: 'AI coding agents now ship a growing share of production code',
-  },
-  {
-    Icon: TrendingUp,
-    text: 'PR volume is climbing faster than reviewers can keep up',
-  },
+const BULLETS = [
+  { Icon: Bot, text: 'AI coding agents now ship a growing share of production code.' },
+  { Icon: TrendingUp, text: 'PR volume is climbing faster than reviewers can keep up.' },
   {
     Icon: Clock,
-    text: 'Senior engineers spend their day reviewing AI output instead of building',
+    text: 'Senior engineers spend the day reviewing AI output instead of building.',
   },
-  {
-    Icon: Zap,
-    text: "Slowing AI down isn't the answer. Faster verification is.",
-  },
+  { Icon: Zap, text: "Slowing AI down isn't the answer. Faster verification is." },
 ];
 
 export function WhyNow() {
   return (
-    <section id="why-now" className="relative border-b border-border py-24 sm:py-32">
-      <div className="mx-auto max-w-6xl px-4 sm:px-6">
-        <div className="max-w-3xl">
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-accent">
-            Why now
-          </p>
-          <h2 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
-            <span className="text-gradient">AI made writing code fast.</span>{' '}
-            <span className="text-gradient-accent">Review is the new bottleneck.</span>
-          </h2>
-        </div>
+    <section className="band" id="why-now">
+      <div className="wrap">
+        <Reveal as="p" className="eyebrow">
+          Why now
+        </Reveal>
+        <Reveal as="h2" className="section-title">
+          <span className="dim">AI made writing code fast.</span> Review is the new{' '}
+          <span className="hl">bottleneck.</span>
+        </Reveal>
 
-        <ul className="mt-14 grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <div className="grid cols-2" style={{ marginTop: 52 }}>
           {BULLETS.map((b, i) => (
-            <BulletCard key={b.text} bullet={b} delayMs={i * 80} />
+            <Reveal key={b.text} className="bullet" delay={i * 80}>
+              <span className="ico">
+                <b.Icon />
+              </span>
+              <p>{b.text}</p>
+            </Reveal>
           ))}
-        </ul>
-
-        <div className="mt-14">
-          <Callout />
         </div>
+
+        <Reveal className="callout">
+          <span className="ico">
+            <Rocket />
+          </span>
+          <p>
+            The next <span className="hl">10×</span> in engineering comes from verifying
+            code at AI speed.
+          </p>
+        </Reveal>
       </div>
     </section>
-  );
-}
-
-function BulletCard({ bullet, delayMs }: { bullet: Bullet; delayMs: number }) {
-  const { ref, visible } = useReveal<HTMLLIElement>();
-  const { Icon } = bullet;
-  return (
-    <li
-      ref={ref}
-      style={{ ['--delay' as string]: `${delayMs}ms` }}
-      className={cn(
-        'reveal surface-hover flex items-start gap-5 rounded-2xl border border-border bg-card/40 p-6 transition-colors hover:border-border-strong hover:bg-card sm:p-7',
-        visible && 'visible',
-      )}
-    >
-      <span
-        className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-accent/40 bg-accent/15 text-accent shadow-[0_0_24px_-6px] shadow-accent/30"
-        aria-hidden
-      >
-        <Icon className="h-6 w-6" />
-      </span>
-      <p className="text-balance text-lg leading-relaxed text-foreground/90 sm:text-xl">
-        {bullet.text}
-      </p>
-    </li>
-  );
-}
-
-function Callout() {
-  const { ref, visible } = useReveal<HTMLDivElement>();
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        'reveal glow-border relative flex items-center gap-6 rounded-2xl border border-accent/40 bg-accent/10 p-7 sm:p-9',
-        visible && 'visible',
-      )}
-    >
-      <span
-        className="inline-flex h-14 w-14 shrink-0 items-center justify-center rounded-xl border border-accent/50 bg-accent/20 text-accent shadow-[0_0_32px_-6px] shadow-accent/50"
-        aria-hidden
-      >
-        <Rocket className="h-7 w-7" />
-      </span>
-      <p className="text-balance text-xl leading-relaxed text-foreground sm:text-2xl">
-        The next 10x in engineering comes from verifying code at AI speed.
-      </p>
-    </div>
   );
 }

--- a/apps/landing/src/components/WhyTestsCantCatch.tsx
+++ b/apps/landing/src/components/WhyTestsCantCatch.tsx
@@ -1,119 +1,63 @@
-import { cn } from '@/lib/cn';
-import { useReveal } from '@/lib/useReveal';
+import { Reveal } from './Reveal';
 
-type Tone = 'muted' | 'accent';
-
-const CARDS: Array<{
+type Card = {
   num: string;
   title: string;
   body: string;
-  tone: Tone;
-}> = [
+  accent?: boolean;
+};
+
+const CARDS: Card[] = [
   {
     num: '1',
-    title: 'Tests verify what was written, not whether it was right',
-    body: 'Whether the code is written by an engineer or an AI agent, the test inherits the same understanding of the spec. If that understanding is wrong, the test passes against the wrong implementation.',
-    tone: 'muted',
+    title: 'Tests verify what was written',
+    body: 'Engineer or AI agent, the test inherits the same understanding of the spec. If that’s wrong, it passes against the wrong implementation.',
   },
   {
     num: '2',
-    title: "AI reviewers share the writer's hallucinations",
-    body: "CodeRabbit, Gitar, Qodo all use LLMs to read the PR. The same kind of models that wrote the code. The same blind spots. They don't have access to your team's decisions either.",
-    tone: 'muted',
+    title: 'AI reviewers share the hallucinations',
+    body: 'CodeRabbit, Gitar, Qodo all use LLMs to read the PR — the same kind of model that wrote the code. Same blind spots, no access to your decisions.',
   },
   {
     num: '3',
-    title: 'TrueCourse is the only deterministic ground truth',
-    body: "We turn your team's decisions into machine-readable contracts. Then a deterministic engine, no LLM, checks every change against them. Same input, same result, every time.",
-    tone: 'accent',
+    title: 'Deterministic ground truth',
+    body: 'We turn your decisions into contracts, then a deterministic engine — no LLM — checks every change against them. Same input, same result, every time.',
+    accent: true,
   },
 ];
 
 export function WhyTestsCantCatch() {
   return (
-    <section
-      id="why-tests-cant-catch"
-      className="relative border-b border-border py-24 sm:py-32"
-    >
-      <div className="mx-auto max-w-6xl px-4 sm:px-6">
-        <div className="max-w-4xl">
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-accent">
-            Why the existing tools can't catch this
-          </p>
-          <h2 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
-            <span className="text-gradient">
-              Tests inherit the writer&apos;s understanding.
-            </span>{' '}
-            <span className="text-gradient-accent">
-              AI reviewers inherit the writer&apos;s blind spots.
-            </span>
-          </h2>
-        </div>
+    <section className="band" id="why-us">
+      <div className="wrap">
+        <Reveal as="p" className="eyebrow">
+          Why the existing tools can&apos;t catch this
+        </Reveal>
+        <Reveal as="h2" className="section-title" style={{ maxWidth: '30ch' }}>
+          <span className="dim">Tests inherit the writer&apos;s understanding.</span> AI
+          reviewers inherit the <span className="hl">blind spots.</span>
+        </Reveal>
 
-        <div className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-3">
+        <div className="grid cols-3" style={{ marginTop: 48 }}>
           {CARDS.map((c, i) => (
-            <Card key={c.num} {...c} delayMs={i * 100} />
+            <Reveal key={c.num} className={c.accent ? 'card accent' : 'card'} delay={i * 100}>
+              <div className="kbig" style={c.accent ? undefined : { color: 'var(--muted)' }}>
+                {c.num}
+              </div>
+              <h3 style={{ marginTop: 16, ...(c.accent ? { color: 'var(--accent)' } : {}) }}>
+                {c.title}
+              </h3>
+              <p>{c.body}</p>
+            </Reveal>
           ))}
         </div>
 
-        <p className="mt-12 text-balance text-base leading-relaxed text-foreground/85 sm:text-lg">
-          Tests check code against what you wrote. AI review checks AI&apos;s code
+        <Reveal as="p" className="closing">
+          Tests check code against what you <b>wrote</b>. AI review checks AI&apos;s code
           with more AI.{' '}
-          <span className="text-foreground">
-            We check code against what you actually decided.
-          </span>
-        </p>
+          <span className="hl">We check code against what you actually decided.</span>
+        </Reveal>
       </div>
     </section>
-  );
-}
-
-function Card({
-  num,
-  title,
-  body,
-  tone,
-  delayMs,
-}: {
-  num: string;
-  title: string;
-  body: string;
-  tone: Tone;
-  delayMs: number;
-}) {
-  const { ref, visible } = useReveal<HTMLDivElement>();
-  const accent = tone === 'accent';
-  return (
-    <div
-      ref={ref}
-      style={{ ['--delay' as string]: `${delayMs}ms` }}
-      className={cn(
-        'reveal relative rounded-2xl border bg-card/40 p-6 transition-colors sm:p-7',
-        accent
-          ? 'border-accent/50 bg-accent/[0.04] hover:border-accent/70'
-          : 'border-border hover:border-border-strong',
-        visible && 'visible',
-      )}
-    >
-      <div
-        className={cn(
-          'font-mono text-2xl font-semibold',
-          accent ? 'text-accent' : 'text-muted-foreground',
-        )}
-      >
-        {num}
-      </div>
-      <h3
-        className={cn(
-          'mt-4 text-balance text-lg font-semibold tracking-tight sm:text-xl',
-          accent ? 'text-accent' : 'text-foreground',
-        )}
-      >
-        {title}
-      </h3>
-      <p className="mt-3 text-sm leading-relaxed text-muted-foreground sm:text-base">
-        {body}
-      </p>
-    </div>
   );
 }

--- a/apps/landing/src/globals.css
+++ b/apps/landing/src/globals.css
@@ -2,236 +2,1099 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* ============================================================
+   TrueCourse — Landing
+   Dark / terminal design system, lifted from the product deck.
+   ============================================================ */
+
+@theme {
+  --font-sans: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 6px;
+}
+
+/* Tailwind colour utilities (used sparingly, e.g. the mobile menu) map onto
+   the design tokens below so anything we reach for stays on-palette. */
+@theme inline {
+  --color-background: var(--bg);
+  --color-foreground: var(--fg);
+  --color-muted: var(--bg-elev2);
+  --color-muted-foreground: var(--muted);
+  --color-border: var(--line);
+  --color-border-strong: var(--line-strong);
+  --color-card: var(--bg-elev);
+  --color-accent: var(--accent);
+}
+
 :root {
   color-scheme: dark;
 
-  --background: oklch(0.115 0.025 255);
-  --background-deep: oklch(0.085 0.025 258);
-  --background-soft: oklch(0.16 0.03 255);
-  --foreground: oklch(0.97 0.005 90);
-  --muted: oklch(0.20 0.025 255);
-  --muted-foreground: oklch(0.66 0.02 250);
-  --border: oklch(1 0 0 / 7%);
-  --border-strong: oklch(1 0 0 / 14%);
-  --card: oklch(0.145 0.028 255 / 75%);
-  --card-foreground: oklch(0.97 0.005 90);
-  --primary: oklch(0.78 0.10 245);
-  --primary-foreground: oklch(0.10 0.02 250);
-  --accent: oklch(0.80 0.09 245);
-  --ring: oklch(0.78 0.10 245);
+  --bg: #0d0f12;
+  --bg-elev: #15181d;
+  --bg-elev2: #1b1f26;
+  --line: rgba(232, 235, 239, 0.1);
+  --line-strong: rgba(232, 235, 239, 0.2);
+  --fg: #e8ebef;
+  --fg-dim: #b9c0ca;
+  --muted: #7d8794;
+  --muted-2: #5c6571;
+
+  --accent: oklch(0.83 0.16 152);
+  --accent-soft: oklch(0.83 0.16 152 / 0.13);
+  --accent-line: oklch(0.83 0.16 152 / 0.45);
+  --accent-2: oklch(0.74 0.13 248);
+  --warn: oklch(0.76 0.15 52);
+  --warn-soft: oklch(0.76 0.15 52 / 0.13);
+
+  --radius: 4px;
+  --radius-lg: 6px;
+  --maxw: 1180px;
+  --pad-x: clamp(20px, 5vw, 48px);
+
+  --font-body: var(--font-mono);
 }
 
-@theme inline {
-  --font-sans: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif;
-  --font-mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-border: var(--border);
-  --color-border-strong: var(--border-strong);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-accent: var(--accent);
-  --color-ring: var(--ring);
-
-  --radius-sm: 0.375rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 0.75rem;
-  --radius-xl: 1rem;
-  --radius-2xl: 1.25rem;
-  --radius-3xl: 1.75rem;
+* {
+  box-sizing: border-box;
 }
 
-@layer base {
-  * {
-    border-color: var(--border);
-  }
-  html,
-  body {
-    background: var(--background);
-    color: var(--foreground);
-    font-family: var(--font-sans);
-    -webkit-font-smoothing: antialiased;
-  }
-  ::selection {
-    background: oklch(0.78 0.10 245 / 35%);
-    color: var(--foreground);
-  }
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 90px;
 }
 
-/* ----- Background grid + glow (monochrome blue, matches palette) ----- */
-.bg-grid {
-  background-image:
-    linear-gradient(to right, oklch(1 0 0 / 4%) 1px, transparent 1px),
-    linear-gradient(to bottom, oklch(1 0 0 / 4%) 1px, transparent 1px);
-  background-size: 56px 56px;
-  background-position: -1px -1px;
-  mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 30%, transparent 80%);
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-body);
+  font-size: 17px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-.bg-radial-glow {
-  background:
-    radial-gradient(ellipse 80% 50% at 50% -10%, oklch(0.55 0.15 245 / 38%), transparent 70%),
-    radial-gradient(ellipse 60% 40% at 80% 30%, oklch(0.50 0.10 240 / 18%), transparent 70%),
-    radial-gradient(ellipse 50% 40% at 10% 40%, oklch(0.50 0.10 255 / 14%), transparent 70%);
+::selection {
+  background: var(--accent-soft);
+  color: var(--fg);
 }
 
-/* ----- Gradient text (monochrome blue family) ----- */
-.text-gradient {
-  background: linear-gradient(
-    180deg,
-    oklch(0.99 0 0) 0%,
-    oklch(0.99 0 0) 40%,
-    oklch(0.78 0.05 245) 100%
-  );
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
-.text-gradient-accent {
-  background: linear-gradient(
-    90deg,
-    oklch(0.86 0.10 235) 0%,
-    oklch(0.78 0.10 245) 50%,
-    oklch(0.70 0.12 255) 100%
-  );
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
+img,
+svg {
+  display: block;
 }
 
-/* ----- Glow border (shimmering accent ring) ----- */
-.glow-border {
-  position: relative;
-}
-.glow-border::before {
+/* page-wide faint grid */
+body::before {
   content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(var(--line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line) 1px, transparent 1px);
+  background-size: 80px 80px;
+  background-position: -1px -1px;
+  opacity: 0.4;
+  mask-image: radial-gradient(ellipse 90% 70% at 50% 0%, #000 35%, transparent 85%);
+}
+
+main,
+header,
+footer {
+  position: relative;
+  z-index: 1;
+}
+
+.wrap {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding-inline: var(--pad-x);
+}
+
+/* ---------- shared type ---------- */
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.7em;
+}
+.eyebrow::before {
+  content: '›';
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.section-title {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: clamp(30px, 4.2vw, 50px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 22px 0 0;
+  max-width: 20ch;
+  text-wrap: balance;
+}
+.section-title .dim {
+  color: var(--muted);
+}
+.section-title .hl {
+  color: var(--accent);
+}
+
+.section-lead {
+  font-size: clamp(16px, 1.6vw, 19px);
+  line-height: 1.55;
+  color: var(--fg-dim);
+  margin: 20px 0 0;
+  max-width: 60ch;
+}
+
+section.band {
+  padding-block: clamp(72px, 10vw, 128px);
+  border-bottom: 1px solid var(--line);
+}
+
+/* ---------- buttons ---------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  height: 48px;
+  padding-inline: 24px;
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border: 1px solid var(--line-strong);
+  color: var(--fg);
+  background: transparent;
+  cursor: pointer;
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    background 0.18s ease;
+}
+.btn:hover {
+  transform: translateY(-1px);
+  border-color: var(--accent-line);
+}
+.btn .arr {
+  transition: transform 0.18s ease;
+}
+.btn:hover .arr {
+  transform: translateX(3px);
+}
+.btn-primary {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+  color: var(--fg);
+}
+.btn-primary:hover {
+  background: oklch(0.83 0.16 152 / 0.22);
+}
+.btn-sm {
+  height: 38px;
+  padding-inline: 16px;
+  font-size: 13.5px;
+}
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  transform: none;
+}
+
+/* ---------- header ---------- */
+header.site {
+  position: fixed;
+  inset-inline: 0;
+  top: 0;
+  z-index: 50;
+  transition:
+    background 0.3s ease,
+    border-color 0.3s ease,
+    backdrop-filter 0.3s ease;
+  border-bottom: 1px solid transparent;
+}
+header.site.scrolled {
+  background: oklch(0.16 0.012 255 / 0.72);
+  backdrop-filter: blur(14px);
+  border-bottom-color: var(--line);
+}
+.nav {
+  height: 70px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 17px;
+  letter-spacing: 0.01em;
+}
+.brand .mark {
+  width: 26px;
+  height: 24px;
+  flex: 0 0 auto;
+  background: var(--fg);
+  -webkit-mask: url('/truecourse-mark.svg') center / contain no-repeat;
+  mask: url('/truecourse-mark.svg') center / contain no-repeat;
+}
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.nav-links a {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--muted);
+  padding: 8px 14px;
+  border-radius: var(--radius);
+  transition:
+    color 0.18s ease,
+    background 0.18s ease;
+}
+.nav-links a:hover {
+  color: var(--fg);
+  background: rgba(232, 235, 239, 0.05);
+}
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.icon-btn {
+  width: 38px;
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  color: var(--muted);
+  transition:
+    color 0.18s ease,
+    border-color 0.18s ease;
+}
+.icon-btn:hover {
+  color: var(--fg);
+  border-color: var(--accent-line);
+}
+.icon-btn svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+/* mobile nav (an enhancement over the static prototype, on-system) */
+.mobile-toggle {
+  display: none;
+}
+.mobile-menu {
+  border-top: 1px solid var(--line);
+  background: oklch(0.16 0.012 255 / 0.95);
+  backdrop-filter: blur(14px);
+}
+.mobile-menu a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 15px;
+  color: var(--fg-dim);
+  padding: 12px 0;
+}
+.mobile-menu a:hover {
+  color: var(--fg);
+}
+.mobile-menu a svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+.mobile-menu .row {
+  display: flex;
+  flex-direction: column;
+  padding: 8px 0 18px;
+}
+
+@media (max-width: 880px) {
+  .nav-links,
+  .nav-actions .desktop-only {
+    display: none;
+  }
+  .mobile-toggle {
+    display: inline-flex;
+  }
+}
+
+/* ---------- hero ---------- */
+.hero {
+  position: relative;
+  padding-top: clamp(140px, 18vh, 220px);
+  padding-bottom: clamp(90px, 12vw, 150px);
+  overflow: hidden;
+  border-bottom: 1px solid var(--line);
+}
+.hero-glow {
   position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  background: linear-gradient(
-    135deg,
-    oklch(0.78 0.10 245 / 45%),
-    oklch(0.78 0.10 245 / 18%) 35%,
-    transparent 65%
-  );
-  z-index: -1;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 70% 55% at 50% -8%, oklch(0.83 0.16 152 / 0.16), transparent 70%),
+    radial-gradient(ellipse 50% 40% at 82% 20%, oklch(0.74 0.13 248 / 0.1), transparent 70%);
+}
+.hero-baseline {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 220px;
+  z-index: 0;
+  width: 100%;
   pointer-events: none;
 }
-
-/* ----- Card surface ----- */
-.surface {
-  background:
-    linear-gradient(180deg, oklch(1 0 0 / 3%), oklch(1 0 0 / 0%)),
-    var(--card);
-  backdrop-filter: blur(8px);
+.hero-inner {
+  position: relative;
+  z-index: 1;
+  max-width: 900px;
+}
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  color: var(--fg-dim);
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  padding: 7px 16px;
+  background: var(--bg-elev);
+}
+.badge .spark {
+  color: var(--accent);
+}
+.badge .arr {
+  color: var(--muted);
+}
+.hero h1 {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: clamp(40px, 7vw, 86px);
+  line-height: 1.04;
+  letter-spacing: -0.03em;
+  margin: 28px 0 0;
+  text-wrap: balance;
+}
+.hero h1 .hl {
+  color: var(--accent);
+}
+.hero .sub {
+  font-size: clamp(18px, 2.1vw, 26px);
+  line-height: 1.4;
+  color: var(--fg-dim);
+  margin: 26px 0 0;
+  max-width: 30ch;
+}
+.hero .micro {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--muted);
+  margin: 22px 0 0;
+  max-width: 64ch;
+}
+.hero .micro b {
+  color: var(--fg-dim);
+  font-weight: 500;
+}
+.hero .cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 38px;
 }
 
-.surface-hover {
+/* ---------- cards / grids ---------- */
+.grid {
+  display: grid;
+  gap: 18px;
+}
+.cols-2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+.cols-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+.cols-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+@media (max-width: 920px) {
+  .cols-3,
+  .cols-4 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 620px) {
+  .cols-2,
+  .cols-3,
+  .cols-4 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elev);
+  padding: 28px;
   transition:
-    border-color 200ms ease,
-    transform 200ms ease,
-    background 200ms ease;
+    border-color 0.2s ease,
+    transform 0.2s ease,
+    background 0.2s ease;
 }
-.surface-hover:hover {
-  border-color: var(--border-strong);
+.card.hover:hover {
+  border-color: var(--line-strong);
+  transform: translateY(-3px);
+}
+.card.accent {
+  border-color: var(--accent-line);
+  background: linear-gradient(180deg, var(--accent-soft), transparent 60%), var(--bg-elev);
+}
+
+.ico {
+  width: 46px;
+  height: 46px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--accent-line);
+  border-radius: var(--radius);
+  color: var(--accent);
+  background: var(--accent-soft);
+  margin-bottom: 20px;
+}
+.ico svg {
+  width: 22px;
+  height: 22px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.card h3 {
+  font-family: var(--font-mono);
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--fg);
+}
+.card p {
+  font-size: 15.5px;
+  line-height: 1.55;
+  color: var(--fg-dim);
+  margin: 12px 0 0;
+}
+
+/* numbered mono label */
+.knum {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.kbig {
+  font-family: var(--font-mono);
+  font-size: 30px;
+  font-weight: 700;
+  color: var(--accent);
+  line-height: 1;
+}
+
+/* why-now bullets */
+.bullet {
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elev);
+  padding: 24px 26px;
+  transition: border-color 0.2s ease;
+}
+.bullet:hover {
+  border-color: var(--line-strong);
+}
+.bullet .ico {
+  margin-bottom: 0;
+}
+.bullet p {
+  margin: 0;
+  font-size: 17px;
+  line-height: 1.45;
+  color: var(--fg);
+  align-self: center;
+}
+
+.callout {
+  margin-top: 36px;
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  border: 1px solid var(--accent-line);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, var(--accent-soft), transparent 70%), var(--bg-elev);
+  padding: 30px 34px;
+}
+.callout .ico {
+  margin-bottom: 0;
+  width: 54px;
+  height: 54px;
+  flex: 0 0 auto;
+}
+.callout p {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: clamp(19px, 2.4vw, 26px);
+  font-weight: 500;
+  line-height: 1.3;
+  color: var(--fg);
+}
+.callout p .hl {
+  color: var(--accent);
+}
+
+/* approach flow */
+.flow {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+@media (max-width: 920px) {
+  .flow {
+    grid-template-columns: 1fr;
+  }
+}
+.fstep {
+  position: relative;
+}
+.fstep .card {
+  height: 100%;
+}
+.fhead {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+.drift-line {
+  display: inline-flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 26px;
+  font-family: var(--font-mono);
+  font-size: 15px;
+  color: var(--fg-dim);
+}
+.drift-line b {
+  color: var(--fg);
+  font-weight: 500;
+}
+.dtag {
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  color: var(--accent);
+  border: 1px solid var(--accent-line);
+  border-radius: var(--radius);
+  padding: 5px 12px;
+}
+
+/* sub heading inside integrations */
+.subhead {
+  margin-top: 56px;
+}
+.subhead .e {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted-2);
+}
+.subhead h3 {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 700;
+  margin: 8px 0 0;
+  color: var(--fg);
+}
+.subhead p {
+  font-size: 15px;
+  color: var(--muted);
+  margin: 6px 0 0;
+}
+
+/* tool chips */
+.tool {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elev);
+  padding: 18px 20px;
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease;
+}
+.tool:hover {
+  border-color: var(--line-strong);
   transform: translateY(-2px);
-  background:
-    linear-gradient(180deg, oklch(1 0 0 / 5%), oklch(1 0 0 / 0%)),
-    var(--card);
+}
+.tool .glyph {
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: var(--bg-elev2);
+}
+.tool .glyph svg {
+  width: 20px;
+  height: 20px;
+  fill: var(--fg-dim);
+}
+.tool .tname {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--fg);
+}
+.tool .thint {
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+.tool.dashed {
+  border-style: dashed;
+}
+.tool.dashed:hover {
+  border-color: var(--accent-line);
+}
+.more-glyphs {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  padding: 8px 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: var(--bg-elev2);
+}
+.more-glyphs svg {
+  width: 16px;
+  height: 16px;
+  fill: var(--muted);
 }
 
-/* ----- Entrance animations ----- */
-@keyframes fade-up {
-  from {
-    opacity: 0;
-    transform: translateY(16px);
+.fine {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--muted-2);
+  margin-top: 18px;
+}
+
+/* why-tests closing line */
+.closing {
+  font-size: clamp(17px, 2vw, 21px);
+  line-height: 1.5;
+  color: var(--muted);
+  margin: 40px 0 0;
+  max-width: 80ch;
+}
+.closing b {
+  color: var(--fg);
+  font-weight: 500;
+}
+.closing .hl {
+  color: var(--accent);
+  font-weight: 500;
+}
+
+/* CTA */
+.cta {
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+  padding-block: clamp(96px, 14vw, 170px);
+}
+.cta .hero-glow {
+  opacity: 0.7;
+}
+.cta-inner {
+  position: relative;
+  z-index: 1;
+}
+.cta h2 {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: clamp(40px, 6.5vw, 80px);
+  letter-spacing: -0.03em;
+  margin: 0;
+}
+.cta h2 .hl {
+  color: var(--accent);
+}
+.cta p {
+  font-size: clamp(17px, 2vw, 22px);
+  color: var(--fg-dim);
+  max-width: 56ch;
+  margin: 24px auto 0;
+  line-height: 1.45;
+}
+.cta .cta-row {
+  justify-content: center;
+  display: flex;
+  margin-top: 40px;
+}
+
+/* footer */
+footer.site {
+  padding-block: 64px 40px;
+}
+.foot-grid {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1fr 1fr;
+  gap: 40px;
+}
+@media (max-width: 820px) {
+  .foot-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 32px;
   }
+}
+.foot-about p {
+  font-size: 14.5px;
+  color: var(--muted);
+  line-height: 1.6;
+  margin: 18px 0 0;
+  max-width: 38ch;
+}
+.foot-social {
+  display: flex;
+  gap: 10px;
+  margin-top: 22px;
+}
+.foot-col h4 {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg);
+  margin: 0 0 16px;
+}
+.foot-col ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+.foot-col a {
+  font-size: 14.5px;
+  color: var(--muted);
+  transition: color 0.18s ease;
+}
+.foot-col a:hover {
+  color: var(--fg);
+}
+.foot-bottom {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--muted-2);
+}
+.foot-bottom .heart {
+  color: var(--accent);
+}
+
+/* ---------- request access page ---------- */
+.access-wrap {
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: clamp(120px, 16vh, 180px) var(--pad-x) 80px;
+  position: relative;
+  overflow: hidden;
+}
+.access-card-wrap {
+  width: 100%;
+  max-width: 460px;
+  position: relative;
+  z-index: 1;
+}
+.access-head {
+  text-align: center;
+  margin-bottom: 30px;
+}
+.beta-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border: 1px solid var(--accent-line);
+  background: var(--accent-soft);
+  border-radius: 999px;
+  padding: 6px 14px;
+}
+.access-head h1 {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: clamp(30px, 5vw, 42px);
+  letter-spacing: -0.02em;
+  margin: 22px 0 0;
+}
+.access-head p {
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--fg-dim);
+  margin: 14px 0 0;
+}
+.form-card {
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elev);
+  padding: 30px;
+  box-shadow: 0 24px 60px -20px rgba(0, 0, 0, 0.6);
+}
+.field {
+  display: block;
+  margin-bottom: 18px;
+}
+.field .flabel {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+.field input,
+.field select {
+  width: 100%;
+  height: 48px;
+  padding: 0 16px;
+  font-family: var(--font-body);
+  font-size: 16px;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  outline: none;
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.18s ease;
+}
+.field select {
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%237d8794' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
+  padding-right: 42px;
+}
+.field input::placeholder {
+  color: var(--muted-2);
+}
+.field input:focus,
+.field select:focus {
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.btn-block {
+  width: 100%;
+  justify-content: center;
+  height: 50px;
+}
+.form-note {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--muted-2);
+  text-align: center;
+  margin: 16px 0 0;
+}
+.form-error {
+  font-size: 13.5px;
+  color: var(--warn);
+  background: var(--warn-soft);
+  border: 1px solid oklch(0.76 0.15 52 / 0.4);
+  border-radius: var(--radius);
+  padding: 10px 14px;
+  margin-bottom: 16px;
+}
+.success {
+  text-align: center;
+  padding: 8px 0;
+}
+.success .check {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  color: var(--accent);
+}
+.success .check svg {
+  width: 28px;
+  height: 28px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.success h3 {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0;
+}
+.success p {
+  font-size: 15px;
+  color: var(--fg-dim);
+  line-height: 1.55;
+  margin: 12px 0 0;
+}
+.success .email {
+  color: var(--fg);
+  font-weight: 500;
+}
+.spinner {
+  width: 17px;
+  height: 17px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+@keyframes spin {
   to {
-    opacity: 1;
-    transform: translateY(0);
+    transform: rotate(360deg);
   }
-}
-.animate-fade-up {
-  opacity: 0;
-  animation: fade-up 720ms cubic-bezier(0.16, 0.84, 0.3, 1) forwards;
-  animation-delay: var(--delay, 0ms);
 }
 
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-.animate-fade-in {
-  opacity: 0;
-  animation: fade-in 900ms ease forwards;
-  animation-delay: var(--delay, 0ms);
-}
-
-/* Reveal-on-scroll: hidden by default, .visible class triggers transition */
+/* ---------- scroll reveal ---------- */
 .reveal {
   opacity: 0;
   transform: translateY(20px);
   transition:
-    opacity 700ms cubic-bezier(0.16, 0.84, 0.3, 1),
-    transform 700ms cubic-bezier(0.16, 0.84, 0.3, 1);
+    opacity 0.7s cubic-bezier(0.16, 0.84, 0.3, 1),
+    transform 0.7s cubic-bezier(0.16, 0.84, 0.3, 1);
   transition-delay: var(--delay, 0ms);
   will-change: opacity, transform;
 }
 .reveal.visible {
   opacity: 1;
-  transform: translateY(0);
+  transform: none;
 }
 
-/* Blinking caret for terminal mock */
-@keyframes blink {
-  0%,
-  49% {
-    opacity: 1;
-  }
-  50%,
-  100% {
-    opacity: 0;
-  }
-}
-.animate-blink {
-  animation: blink 1s steps(2, start) infinite;
-}
-
-/* Subtle pulsing ring for "new" pill */
+/* badge pulse ring */
 @keyframes pulse-ring {
   0%,
   100% {
-    box-shadow:
-      0 0 0 0 oklch(0.78 0.10 245 / 0%),
-      0 0 0 0 oklch(0.78 0.10 245 / 0%);
+    box-shadow: 0 0 0 0 oklch(0.83 0.16 152 / 0);
   }
   50% {
     box-shadow:
-      0 0 0 5px oklch(0.78 0.10 245 / 14%),
-      0 0 22px 0 oklch(0.78 0.10 245 / 22%);
+      0 0 0 5px oklch(0.83 0.16 152 / 0.14),
+      0 0 22px 0 oklch(0.83 0.16 152 / 0.22);
   }
 }
-.animate-pulse-ring {
-  animation: pulse-ring 3s ease-in-out infinite;
+.badge.pulse {
+  animation: pulse-ring 3.4s ease-in-out infinite;
 }
 
-/* Severity bar fill */
-.severity-fill {
-  width: 0;
-  transition: width 900ms cubic-bezier(0.16, 0.84, 0.3, 1);
-  transition-delay: var(--delay, 0ms);
+/* hero baseline draw-in */
+@keyframes draw-line {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+@keyframes drift-in {
+  to {
+    opacity: 0.55;
+  }
+}
+.hero-baseline .bline {
+  stroke-dasharray: 1440;
+  stroke-dashoffset: 1440;
+  animation: draw-line 1.7s 0.45s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+.hero-baseline .bdrift {
+  opacity: 0;
+  animation: drift-in 1.1s 1.5s ease forwards;
+}
+
+/* gentle float for callout icon */
+@keyframes float-y {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-5px);
+  }
+}
+.callout .ico {
+  animation: float-y 4.5s ease-in-out infinite;
 }
 
 /* ----- Scrollbar ----- */
@@ -250,23 +1113,25 @@
   background: oklch(1 0 0 / 18%);
 }
 
-/* ----- Reduced motion ----- */
 @media (prefers-reduced-motion: reduce) {
-  .animate-fade-up,
-  .animate-fade-in {
-    animation: none !important;
-    opacity: 1 !important;
-    transform: none !important;
+  html {
+    scroll-behavior: auto;
   }
   .reveal {
     opacity: 1 !important;
     transform: none !important;
     transition: none !important;
   }
-  .animate-blink,
-  .animate-pulse-ring,
-  .severity-fill {
+  .badge.pulse,
+  .callout .ico {
     animation: none !important;
-    transition: none !important;
+  }
+  .hero-baseline .bline {
+    stroke-dashoffset: 0 !important;
+    animation: none !important;
+  }
+  .hero-baseline .bdrift {
+    opacity: 0.55 !important;
+    animation: none !important;
   }
 }

--- a/apps/landing/src/globals.css
+++ b/apps/landing/src/globals.css
@@ -400,6 +400,7 @@ header.site.scrolled {
 }
 .badge .arr {
   color: var(--muted);
+  white-space: nowrap;
 }
 .hero h1 {
   font-family: var(--font-mono);
@@ -419,18 +420,6 @@ header.site.scrolled {
   color: var(--fg-dim);
   margin: 26px 0 0;
   max-width: 30ch;
-}
-.hero .micro {
-  font-family: var(--font-mono);
-  font-size: 15px;
-  line-height: 1.6;
-  color: var(--muted);
-  margin: 22px 0 0;
-  max-width: 64ch;
-}
-.hero .micro b {
-  color: var(--fg-dim);
-  font-weight: 500;
 }
 .hero .cta-row {
   display: flex;

--- a/apps/landing/src/pages/RequestAccessPage.tsx
+++ b/apps/landing/src/pages/RequestAccessPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
-import { Sparkles } from 'lucide-react';
 import { AccessForm } from '@/components/AccessForm';
+import { Reveal } from '@/components/Reveal';
 
 export default function RequestAccessPage() {
   useEffect(() => {
@@ -12,28 +12,50 @@ export default function RequestAccessPage() {
   }, []);
 
   return (
-    <section className="relative isolate flex min-h-screen items-start justify-center overflow-hidden px-4 pt-32 pb-16 sm:px-6">
-      <div className="bg-radial-glow absolute inset-0 -z-10" />
-      <div className="bg-grid absolute inset-0 -z-10" />
+    <section className="access-wrap">
+      <div className="hero-glow" />
+      <svg
+        className="hero-baseline"
+        viewBox="0 0 1440 220"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <line
+          className="bline"
+          x1="0"
+          y1="150"
+          x2="1440"
+          y2="150"
+          style={{ stroke: 'var(--accent)' }}
+          strokeWidth="1.5"
+          opacity="0.5"
+        />
+        <path
+          className="bdrift"
+          d="M0 150 C 760 150, 920 150, 1440 210"
+          fill="none"
+          style={{ stroke: 'var(--warn)' }}
+          strokeWidth="1.5"
+          strokeDasharray="2 9"
+          opacity="0.55"
+        />
+      </svg>
 
-      <div className="w-full max-w-md">
-        <div className="mb-8 text-center">
-          <div className="inline-flex items-center gap-2 rounded-full border border-accent/40 bg-accent/10 px-3 py-1 text-xs font-medium text-accent backdrop-blur-md">
-            <Sparkles className="h-3 w-3" />
-            Closed beta
-          </div>
-          <h1 className="mt-5 text-3xl font-semibold tracking-tight sm:text-4xl">
-            Request early access
-          </h1>
-          <p className="mt-3 text-base leading-relaxed text-muted-foreground">
-            We&apos;re onboarding teams in waves. Drop your details and we&apos;ll be in touch
-            when the next batch opens.
+      <div className="access-card-wrap">
+        <Reveal className="access-head">
+          <span className="beta-badge">
+            <span className="spark">✦</span> Closed beta
+          </span>
+          <h1>Request early access</h1>
+          <p>
+            We&apos;re onboarding teams in waves. Drop your details and we&apos;ll be in
+            touch when the next batch opens.
           </p>
-        </div>
+        </Reveal>
 
-        <div className="glow-border surface rounded-2xl border border-border p-6 shadow-2xl shadow-black/40">
+        <Reveal className="form-card" delay={100}>
           <AccessForm />
-        </div>
+        </Reveal>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

Ports the **Claude Design** handoff mockup (`TrueCourse Landing.html`) into the React/Tailwind landing app, replacing the blue/Geist look with the **dark-terminal** design system lifted from the product deck: near-black canvas, **JetBrains Mono**, **verified-green** accent (amber for drift), faint page grid, sailboat brand mark, thin rules, the hero baseline motif, and monochrome brand glyphs.

Recreated the design's *visual output* in the target stack (per the bundle README) rather than copying the prototype's structure — `landing.css` was adopted as the design system so it's faithful to the source.

## Changes
- **`globals.css`** — new design tokens (green accent, amber drift, mono fonts, 4–6px radii), page-wide grid, hero glow + baseline draw-in, reveal/pulse/float keyframes, request-form styles. Tailwind theme remapped onto the new palette.
- **`Reveal`** — new reusable scroll-reveal helper (IntersectionObserver via `useReveal`).
- **Every section rewritten** — Hero (two CTAs + baseline motif), WhyNow (bullets + 10× callout), OurApproach (01·02·03 flow + drift tags), Integrations (knowledge sources + PR gates with monochrome glyphs), WhyTestsCantCatch (`#why-us`), Enterprise, CTA, Footer. Section ids aligned to the design (`approach`, `why-us`).
- **Header** — masked brand mark, context-aware action (Request access on home / ← Back on request page), restyled mobile menu.
- **Request access** — restyled to the new system; **AccessForm keeps the real `/api/waitlist` submission** (not the prototype's static mock).
- **Assets/meta** — `public/truecourse-mark.svg` (recolorable monochrome mark); `index.html` loads JetBrains Mono + updated title/meta.

## Verification
- `pnpm --filter @truecourse/landing build` ✓
- `tsc --noEmit` ✓
- Rendered in headless Chrome — all sections render correctly, **no console errors**. Verified home (hero + all sections) and `/request-access`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)