### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/array-sort-without-compare.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/array-sort-without-compare.ts
@@ -6,7 +6,8 @@ export const arraySortWithoutCompareVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/array-sort-without-compare',
   languages: JS_LANGUAGES,
   nodeTypes: ['call_expression'],
-  visit(node, filePath, sourceCode) {
+  needsTypeQuery: true,
+  visit(node, filePath, sourceCode, _dataFlow, typeQuery) {
     const fn = node.childForFieldName('function')
     if (!fn || fn.type !== 'member_expression') return null
 
@@ -19,6 +20,21 @@ export const arraySortWithoutCompareVisitor: CodeRuleVisitor = {
     const argNodes = args.namedChildren
     // sort() or sort(undefined) with no compare function
     if (argNodes.length === 0 || (argNodes.length === 1 && argNodes[0].type === 'undefined')) {
+      // Sorting strings without a comparator is lexicographic, which is
+      // exactly what users want for string arrays — the rule's concern is
+      // numeric arrays sorted as strings. When type info is available and
+      // the receiver is a string-array type, skip.
+      const obj = fn.childForFieldName('object')
+      if (obj && typeQuery) {
+        const typeStr = typeQuery.getTypeAtPosition(
+          filePath,
+          obj.startPosition.row,
+          obj.startPosition.column,
+          obj.endPosition.row,
+          obj.endPosition.column,
+        )
+        if (typeStr && isStringArrayType(typeStr)) return null
+      }
       return makeViolation(
         this.ruleKey, node, filePath, 'medium',
         'Array sorted without comparator',
@@ -29,4 +45,30 @@ export const arraySortWithoutCompareVisitor: CodeRuleVisitor = {
     }
     return null
   },
+}
+
+function isStringArrayType(typeStr: string): boolean {
+  let s = typeStr.trim()
+  // Strip leading 'readonly '
+  s = s.replace(/^readonly\s+/, '')
+
+  // Shape: <element>[] or (<union>)[]
+  const bracketParen = /^\((.+)\)\[\]$/.exec(s)
+  const bracketBare = /^(.+)\[\]$/.exec(s)
+  const inner = bracketParen ? bracketParen[1] : bracketBare ? bracketBare[1] : null
+  if (inner !== null) return isStringOrStringLiteralUnion(inner)
+
+  // Shape: Array<X> or ReadonlyArray<X>
+  const generic = /^(?:Readonly)?Array<(.+)>$/.exec(s)
+  if (generic) return isStringOrStringLiteralUnion(generic[1])
+
+  return false
+}
+
+function isStringOrStringLiteralUnion(elementType: string): boolean {
+  const parts = elementType.split('|').map((p) => p.trim()).filter((p) => p.length > 0)
+  if (parts.length === 0) return false
+  return parts.every(
+    (p) => p === 'string' || /^"[^"]*"$/.test(p) || /^'[^']*'$/.test(p),
+  )
 }

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/fallthrough-case.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/fallthrough-case.ts
@@ -1,6 +1,7 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
-import { CASE_TERMINATORS, JS_LANGUAGES } from './_helpers.js'
+import { JS_LANGUAGES } from './_helpers.js'
 
 export const fallthroughCaseVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/fallthrough-case',
@@ -22,16 +23,8 @@ export const fallthroughCaseVisitor: CodeRuleVisitor = {
       // Empty case body (intentional grouping) — skip
       if (statements.length === 0) continue
 
-      // Check if the last statement is a terminator
       const last = statements[statements.length - 1]
-      if (!last || CASE_TERMINATORS.has(last.type)) continue
-
-      // Check if last statement is a block containing a terminator
-      if (last.type === 'statement_block') {
-        const blockChildren = last.namedChildren.filter((c) => c.type !== 'comment')
-        const blockLast = blockChildren[blockChildren.length - 1]
-        if (blockLast && CASE_TERMINATORS.has(blockLast.type)) continue
-      }
+      if (last && isTerminating(last)) continue
 
       return makeViolation(
         this.ruleKey, caseNode, filePath, 'medium',
@@ -43,4 +36,53 @@ export const fallthroughCaseVisitor: CodeRuleVisitor = {
     }
     return null
   },
+}
+
+// A statement terminates control flow if every path through it ends in a
+// break / return / throw / continue. Recurses into blocks, try/catch/finally,
+// and if/else so wrapped patterns are recognized.
+function isTerminating(node: SyntaxNode): boolean {
+  if (
+    node.type === 'break_statement' ||
+    node.type === 'return_statement' ||
+    node.type === 'throw_statement' ||
+    node.type === 'continue_statement'
+  ) {
+    return true
+  }
+
+  if (node.type === 'statement_block') {
+    const stmts = node.namedChildren.filter((c) => c.type !== 'comment')
+    if (stmts.length === 0) return false
+    return isTerminating(stmts[stmts.length - 1])
+  }
+
+  if (node.type === 'try_statement') {
+    const body = node.childForFieldName('body')
+    if (!body || !isTerminating(body)) return false
+    let sawCatch = false
+    for (const child of node.namedChildren) {
+      if (child.type === 'catch_clause') {
+        sawCatch = true
+        const cbody = child.childForFieldName('body')
+        if (!cbody || !isTerminating(cbody)) return false
+      } else if (child.type === 'finally_clause') {
+        const fbody = child.childForFieldName('body')
+        if (fbody && isTerminating(fbody)) return true
+      }
+    }
+    return sawCatch || true
+  }
+
+  if (node.type === 'if_statement') {
+    const consequence = node.childForFieldName('consequence')
+    const alternative = node.childForFieldName('alternative')
+    if (!consequence || !alternative) return false
+    if (!isTerminating(consequence)) return false
+    const altInner = alternative.type === 'else_clause' ? alternative.namedChildren[0] : alternative
+    if (!altInner) return false
+    return isTerminating(altInner)
+  }
+
+  return false
 }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/async-promise-function.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/async-promise-function.ts
@@ -1,3 +1,4 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
@@ -13,39 +14,112 @@ export const asyncPromiseFunctionVisitor: CodeRuleVisitor = {
     const body = node.childForFieldName('body')
     if (!body) return null
 
-    // Check if the function body contains a `return new Promise(...)` pattern
-    function hasReturnNewPromise(n: import('web-tree-sitter').Node): boolean {
+    // Find `return new Promise(executor)` in the body and return the executor
+    function findReturnedPromiseExecutor(n: SyntaxNode): SyntaxNode | null {
       if (n.type === 'return_statement') {
         const ret = n.namedChildren[0]
         if (ret?.type === 'new_expression') {
           const ctor = ret.childForFieldName('constructor')
-          if (ctor?.text === 'Promise') return true
+          if (ctor?.text === 'Promise') {
+            const args = ret.childForFieldName('arguments')
+            const exec = args?.namedChildren[0]
+            if (exec && (exec.type === 'arrow_function' || exec.type === 'function_expression')) {
+              return exec
+            }
+            return exec ?? null
+          }
         }
       }
       // Don't descend into nested functions
       if (n.id !== body?.id && (n.type === 'function_declaration' || n.type === 'function_expression'
-        || n.type === 'arrow_function' || n.type === 'method_definition')) return false
+        || n.type === 'arrow_function' || n.type === 'method_definition')) return null
       for (let i = 0; i < n.childCount; i++) {
         const child = n.child(i)
-        if (child && hasReturnNewPromise(child)) return true
+        if (child) {
+          const r = findReturnedPromiseExecutor(child)
+          if (r) return r
+        }
       }
-      return false
+      return null
     }
 
-    if (hasReturnNewPromise(body)) {
-      // Skip when the Promise wraps callback-based APIs — these can't use async/await
-      const bodyText = body.text
-      if (/\b(setTimeout|setInterval|addEventListener)\b/.test(bodyText) ||
-          /\.on\s*\(/.test(bodyText) || /\.once\s*\(/.test(bodyText)) return null
-      const nameNode = node.childForFieldName('name')
-      return makeViolation(
-        this.ruleKey, node, filePath, 'low',
-        'Non-async function returns new Promise',
-        `Function \`${nameNode?.text ?? 'anonymous'}\` explicitly constructs a \`new Promise\` — mark it \`async\` and use \`await\` instead.`,
-        sourceCode,
-        'Mark the function `async` and replace `new Promise(...)` with `await`.',
-      )
+    const executor = findReturnedPromiseExecutor(body)
+    if (!executor) return null
+
+    // The executor must be a function with a body we can inspect — otherwise
+    // we can't tell whether `resolve` is deferred and shouldn't flag.
+    if (executor.type !== 'arrow_function' && executor.type !== 'function_expression') return null
+    const execBody = executor.childForFieldName('body')
+    if (!execBody) return null
+
+    // Read the executor's param names so we can recognize when resolve/reject
+    // is passed as a callback identifier (the deferred-resolver pattern, e.g.
+    // `this.resolvers.set(id, resolve)`).
+    const params = executor.childForFieldName('parameters')
+    const paramNames: string[] = []
+    if (params) {
+      for (const p of params.namedChildren) {
+        // required_parameter / optional_parameter wraps an identifier; plain
+        // identifier appears for `x => ...` arrow functions
+        if (p.type === 'identifier') paramNames.push(p.text)
+        else {
+          const id = p.childForFieldName('pattern') ?? p.namedChildren.find((c) => c.type === 'identifier')
+          if (id) paramNames.push(id.text)
+        }
+      }
     }
-    return null
+    const resolveName = paramNames[0] ?? null
+    const rejectName = paramNames[1] ?? null
+
+    // If resolve is never called synchronously — i.e. every reference to it
+    // sits inside a nested callback OR it's passed as an identifier
+    // argument to be invoked later — the function can't be rewritten as a
+    // simple async returning a value. Detect either pattern by walking the
+    // executor body for call_expression args that are callbacks or that
+    // pass resolve/reject by name.
+    if (executorDefersResolution(execBody, resolveName, rejectName)) return null
+
+    const nameNode = node.childForFieldName('name')
+    return makeViolation(
+      this.ruleKey, node, filePath, 'low',
+      'Non-async function returns new Promise',
+      `Function \`${nameNode?.text ?? 'anonymous'}\` explicitly constructs a \`new Promise\` — mark it \`async\` and use \`await\` instead.`,
+      sourceCode,
+      'Mark the function `async` and replace `new Promise(...)` with `await`.',
+    )
   },
+}
+
+function executorDefersResolution(
+  execBody: SyntaxNode,
+  resolveName: string | null,
+  rejectName: string | null,
+): boolean {
+  let found = false
+  function walk(n: SyntaxNode): void {
+    if (found) return
+    if (n.type === 'call_expression') {
+      const args = n.childForFieldName('arguments')
+      if (args) {
+        for (const arg of args.namedChildren) {
+          // Callback passed inline → resolve will be invoked later by the callee.
+          if (arg.type === 'arrow_function' || arg.type === 'function_expression') {
+            found = true
+            return
+          }
+          // resolve/reject passed by identifier → stored or used as callback.
+          if (arg.type === 'identifier') {
+            if (resolveName && arg.text === resolveName) { found = true; return }
+            if (rejectName && arg.text === rejectName) { found = true; return }
+          }
+        }
+      }
+    }
+    for (let i = 0; i < n.childCount; i++) {
+      const c = n.child(i)
+      if (c) walk(c)
+    }
+  }
+  walk(execBody)
+  return found
 }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/case-without-break.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/case-without-break.ts
@@ -1,3 +1,4 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
@@ -11,16 +12,8 @@ export const caseWithoutBreakVisitor: CodeRuleVisitor = {
 
     if (stmts.length === 0) return null
 
-    let last = stmts[stmts.length - 1]
-    // If the last statement is a block, check the last statement inside the block
-    if (last.type === 'statement_block') {
-      const blockStmts = last.namedChildren
-      if (blockStmts.length > 0) last = blockStmts[blockStmts.length - 1]
-    }
-    if (last.type === 'break_statement' || last.type === 'return_statement'
-      || last.type === 'throw_statement' || last.type === 'continue_statement') {
-      return null
-    }
+    const last = stmts[stmts.length - 1]
+    if (isTerminating(last)) return null
 
     const nodeText = node.text
     if (/fallthrough|falls?\s*through|fall-through/i.test(nodeText)) return null
@@ -33,4 +26,57 @@ export const caseWithoutBreakVisitor: CodeRuleVisitor = {
       'Add `break;` at the end of the case, or add a `// fallthrough` comment if intentional.',
     )
   },
+}
+
+// A statement terminates control flow if every path through it ends in a
+// break / return / throw / continue. Recurses into blocks, try/catch/finally,
+// and if/else so wrapped patterns (`case X: { try { return … } catch { return
+// … } }`) are recognized.
+function isTerminating(node: SyntaxNode): boolean {
+  if (
+    node.type === 'break_statement' ||
+    node.type === 'return_statement' ||
+    node.type === 'throw_statement' ||
+    node.type === 'continue_statement'
+  ) {
+    return true
+  }
+
+  if (node.type === 'statement_block') {
+    const stmts = node.namedChildren
+    if (stmts.length === 0) return false
+    return isTerminating(stmts[stmts.length - 1])
+  }
+
+  if (node.type === 'try_statement') {
+    const body = node.childForFieldName('body')
+    if (!body || !isTerminating(body)) return false
+    let sawCatch = false
+    for (const child of node.namedChildren) {
+      if (child.type === 'catch_clause') {
+        sawCatch = true
+        const cbody = child.childForFieldName('body')
+        if (!cbody || !isTerminating(cbody)) return false
+      } else if (child.type === 'finally_clause') {
+        const fbody = child.childForFieldName('body')
+        if (fbody && isTerminating(fbody)) return true
+      }
+    }
+    // If there's no catch, an uncaught throw could escape — but it still
+    // exits the case via throwing, so the case doesn't fall through.
+    return sawCatch || true
+  }
+
+  if (node.type === 'if_statement') {
+    const consequence = node.childForFieldName('consequence')
+    const alternative = node.childForFieldName('alternative')
+    if (!consequence || !alternative) return false
+    if (!isTerminating(consequence)) return false
+    // alternative is an 'else_clause' wrapping the next statement, or directly the statement
+    const altInner = alternative.type === 'else_clause' ? alternative.namedChildren[0] : alternative
+    if (!altInner) return false
+    return isTerminating(altInner)
+  }
+
+  return false
 }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/no-return-await.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/no-return-await.ts
@@ -1,6 +1,11 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { JS_FUNCTION_TYPES } from './_helpers.js'
+
+const PROMISE_FACTORY_METHODS = new Set([
+  'resolve', 'reject', 'all', 'allSettled', 'race', 'any',
+])
 
 export const noReturnAwaitVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/no-return-await',
@@ -9,6 +14,26 @@ export const noReturnAwaitVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     const expr = node.namedChildren[0]
     if (!expr || expr.type !== 'await_expression') return null
+
+    const awaited = expr.namedChildren[0]
+    if (!awaited) return null
+
+    // Per updated @typescript-eslint/return-await guidance, `return await foo()`
+    // on a real call/method chain is preferred — the explicit await produces
+    // cleaner stack traces and reliable in-frame error propagation. Only flag
+    // the truly redundant shapes:
+    //   - return await <bare identifier>
+    //   - return await Promise.resolve(...) / Promise.reject(...) / Promise.all(...) / …
+    //   - return await new Promise(...)
+    if (awaited.type === 'call_expression') {
+      const callee = awaited.childForFieldName('function')
+      if (!isPromiseFactoryCall(callee)) return null
+    } else if (awaited.type === 'new_expression') {
+      const ctor = awaited.childForFieldName('constructor')
+      if (ctor?.text !== 'Promise') return null
+    } else if (awaited.type === 'subscript_expression') {
+      return null
+    }
 
     let parent = node.parent
     while (parent) {
@@ -35,4 +60,12 @@ export const noReturnAwaitVisitor: CodeRuleVisitor = {
     }
     return null
   },
+}
+
+function isPromiseFactoryCall(callee: SyntaxNode | null): boolean {
+  if (!callee || callee.type !== 'member_expression') return false
+  const obj = callee.childForFieldName('object')
+  const prop = callee.childForFieldName('property')
+  if (obj?.text !== 'Promise' || !prop) return false
+  return PROMISE_FACTORY_METHODS.has(prop.text)
 }

--- a/packages/analyzer/src/rules/performance/visitors/javascript/event-listener-no-remove.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/event-listener-no-remove.ts
@@ -3,6 +3,22 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { containsMethodCall } from './_helpers.js'
 
+// Events whose target owns the listener's lifecycle — the listener becomes
+// irrelevant when the event fires or when the host object is disposed of,
+// so requiring a paired removeEventListener call would be wrong.
+const LIFECYCLE_EVENT_TYPES = new Set([
+  'abort',          // AbortSignal — auto-detaches when aborted
+  'close',          // WebSocket / EventSource — released by host.close()
+  'error',          // WebSocket / EventSource — released by host.close()
+  'beforeunload',   // window — page unload tears down all listeners
+  'unload',         // window — same
+  'visibilitychange', // document — bound to page lifecycle
+])
+
+// Receiver text patterns suggesting an object whose listeners are managed by
+// its own lifecycle (AbortSignal/EventSource/WebSocket).
+const LIFECYCLE_RECEIVER_RE = /(^|\.)(signal|abortSignal|eventSource|ws|socket)\??$/
+
 export const eventListenerNoRemoveVisitor: CodeRuleVisitor = {
   ruleKey: 'performance/deterministic/event-listener-no-remove',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -13,6 +29,25 @@ export const eventListenerNoRemoveVisitor: CodeRuleVisitor = {
 
     const prop = fn.childForFieldName('property')
     if (prop?.text !== 'addEventListener') return null
+
+    // Skip patterns where the listener's lifetime is bounded by something
+    // other than an explicit removeEventListener — AbortSignal abort
+    // handlers, `{ once: true }` listeners, WebSocket/EventSource close/error
+    // handlers, and window/document terminal-lifecycle events.
+    const args = node.childForFieldName('arguments')
+    const argNodes = args?.namedChildren ?? []
+
+    const eventTypeArg = argNodes[0]
+    if (eventTypeArg && eventTypeArg.type === 'string') {
+      const eventType = eventTypeArg.text.replace(/^['"`]|['"`]$/g, '')
+      if (LIFECYCLE_EVENT_TYPES.has(eventType)) return null
+    }
+
+    const optionsArg = argNodes[2]
+    if (optionsArg && optionsArg.type === 'object' && objectHasOnceTrue(optionsArg)) return null
+
+    const obj = fn.childForFieldName('object')
+    if (obj && LIFECYCLE_RECEIVER_RE.test(obj.text)) return null
 
     // Find the enclosing function body
     let enclosingBody: SyntaxNode | null = null
@@ -49,4 +84,16 @@ export const eventListenerNoRemoveVisitor: CodeRuleVisitor = {
       'Add a corresponding removeEventListener call, e.g., in a cleanup function or componentWillUnmount.',
     )
   },
+}
+
+function objectHasOnceTrue(obj: SyntaxNode): boolean {
+  for (const child of obj.namedChildren) {
+    if (child.type !== 'pair') continue
+    const key = child.childForFieldName('key')
+    const value = child.childForFieldName('value')
+    if (!key || !value) continue
+    const keyText = key.text.replace(/^['"`]|['"`]$/g, '')
+    if (keyText === 'once' && value.text === 'true') return true
+  }
+  return false
 }

--- a/tests/analyzer/code-quality-rules.test.ts
+++ b/tests/analyzer/code-quality-rules.test.ts
@@ -1216,14 +1216,34 @@ async def compute_total(items):
 });
 
 describe('code-quality/deterministic/no-return-await', () => {
-  it('detects return await in async function', () => {
+  it('detects return await on a bare promise variable', () => {
+    const violations = check(`
+      async function passThrough(p: Promise<number>) {
+        return await p;
+      }
+    `);
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/no-return-await');
+    expect(matches).toHaveLength(1);
+  });
+
+  it('detects return await on Promise.resolve', () => {
+    const violations = check(`
+      async function wrap() {
+        return await Promise.resolve(42);
+      }
+    `);
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/no-return-await');
+    expect(matches).toHaveLength(1);
+  });
+
+  it('does not flag return await on a call/method invocation (preferred for stack traces)', () => {
     const violations = check(`
       async function fetchData() {
         return await fetch("/api");
       }
     `);
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/no-return-await');
-    expect(matches).toHaveLength(1);
+    expect(matches).toHaveLength(0);
   });
 
   it('does not flag return without await', () => {
@@ -1239,9 +1259,9 @@ describe('code-quality/deterministic/no-return-await', () => {
 
   it('does not flag return await inside try block', () => {
     const violations = check(`
-      async function fetchData() {
+      async function passThrough(p: Promise<number>) {
         try {
-          return await fetch("/api");
+          return await p;
         } catch (e) {
           return null;
         }

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -871,6 +871,12 @@
       "layer": "service"
     },
     {
+      "name": "describeFlag",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "describeOwner",
       "service": "utils",
       "kind": "standalone",
@@ -1165,6 +1171,12 @@
       "layer": "service"
     },
     {
+      "name": "passThroughPromise",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "pickStatusLabel",
       "service": "utils",
       "kind": "standalone",
@@ -1387,6 +1399,12 @@
       "layer": "service"
     },
     {
+      "name": "toSortedNumeric",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "totalSummaryBytes",
       "service": "utils",
       "kind": "standalone",
@@ -1474,6 +1492,18 @@
       "name": "Widget",
       "service": "utils",
       "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "wireResize",
+      "service": "utils",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "wrapSync",
+      "service": "utils",
+      "kind": "standalone",
       "layer": "service"
     },
     {

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/array-sort-without-compare-tosorted.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/array-sort-without-compare-tosorted.ts
@@ -1,0 +1,8 @@
+// Numeric arrays sorted without a comparator are the actual bug the rule
+// targets — lexicographic order produces [1, 10, 2, 20, 3] instead of the
+// expected numeric order. .toSorted() has the same pitfall as .sort().
+
+// VIOLATION: bugs/deterministic/array-sort-without-compare
+export function toSortedNumeric(items: readonly number[]): number[] {
+  return items.toSorted();
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/async-promise-function-sync-resolve.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/async-promise-function-sync-resolve.ts
@@ -1,0 +1,10 @@
+// A non-async function that builds and returns `new Promise` only to
+// immediately resolve a synchronously-available value is the actual bug —
+// the function should just be marked `async` and return the value directly.
+
+// VIOLATION: code-quality/deterministic/async-promise-function
+export function wrapSync(value: number): Promise<number> {
+  return new Promise((resolve) => {
+    resolve(value * 2);
+  });
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/case-without-break-falls-through.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/case-without-break-falls-through.ts
@@ -1,0 +1,18 @@
+// The real bug: a case body that simply executes a statement and then falls
+// through to the next case without a break/return/throw.
+
+export function describeFlag(flag: number): string {
+  let label = '';
+  switch (flag) {
+    // VIOLATION: code-quality/deterministic/case-without-break
+    case 0:
+      label = 'zero';
+    case 1:
+      label = 'one';
+      break;
+    default:
+      label = 'other';
+      break;
+  }
+  return label;
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/event-listener-no-remove-window-resize.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/event-listener-no-remove-window-resize.ts
@@ -1,0 +1,12 @@
+// Adding a non-lifecycle listener (e.g. window 'resize') without a paired
+// removeEventListener is the actual bug — the listener outlives the caller
+// and accumulates on every invocation, leaking memory.
+
+interface DocumentLike {
+  addEventListener(type: 'resize', listener: () => void): void;
+}
+
+// VIOLATION: performance/deterministic/event-listener-no-remove
+export function wireResize(doc: DocumentLike, onResize: () => void): void {
+  doc.addEventListener('resize', onResize);
+}

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/no-return-await-bare-identifier.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/no-return-await-bare-identifier.ts
@@ -1,0 +1,8 @@
+// `return await promise` where the awaited expression is a bare identifier
+// (a variable already holding a Promise) is the truly redundant shape — the
+// async function would return the same Promise without the extra await.
+
+// VIOLATION: code-quality/deterministic/no-return-await
+export async function passThroughPromise(promise: Promise<number>) {
+  return await promise;
+}

--- a/tests/fixtures/sample-js-project-positive/array-sort-without-compare-string-array.ts
+++ b/tests/fixtures/sample-js-project-positive/array-sort-without-compare-string-array.ts
@@ -1,0 +1,39 @@
+// Sorting a string array without a comparator is lexicographic by design.
+// The rule's concern is numeric arrays sorted as strings; pure string arrays
+// (Object.keys results, Set/Map keys, mapped slug/name lists) are safe.
+
+interface Catalog {
+  controlTypes: Record<string, boolean>;
+}
+
+export function sortedFlagKeys(data: Catalog): string[] {
+  return Object.keys(data.controlTypes).sort();
+}
+
+export function sortedTimezones(): string[] {
+  return Intl.supportedValuesOf('timeZone').sort();
+}
+
+export function sortFeatureNames(features: Set<string>): string[] {
+  return Array.from(features).sort();
+}
+
+export function pluckSlugsAndSort(rows: ReadonlyArray<{ slug: string }>): string[] {
+  return rows.map((r) => r.slug).sort();
+}
+
+interface GroupTotals {
+  entries(): IterableIterator<[string, number]>;
+}
+
+export function topGroupKeys(groupTotals: GroupTotals, max: number): string[] {
+  return Array.from(groupTotals.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, max)
+    .map(([key]) => key)
+    .sort();
+}
+
+export function joinedFingerprint(parts: ReadonlyArray<string>): string {
+  return [...parts].sort().join(',');
+}

--- a/tests/fixtures/sample-js-project-positive/async-promise-function-callback-wrapper.ts
+++ b/tests/fixtures/sample-js-project-positive/async-promise-function-callback-wrapper.ts
@@ -1,0 +1,63 @@
+// Wrapping a callback-based API in `new Promise(...)` is the legitimate way
+// to bridge non-await-able code into the promise world. The function CAN'T
+// be rewritten as `async` because there is no Promise to await — the caller
+// passes a continuation that resolves later. Same applies to the
+// deferred-resolver pattern where `resolve` is stored for later invocation
+// by an unrelated code path.
+
+interface CallbackApi {
+  fetch(cb: (err: Error | null, value: number) => void, options: { dst: string }): void;
+}
+
+export function readValue(api: CallbackApi, dst: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    api.fetch(
+      (err, value) => {
+        if (err) return reject(err);
+        resolve(value);
+      },
+      { dst },
+    );
+  });
+}
+
+interface Listener {
+  listen(port: number, host: string, onReady: () => void): void;
+  close(onClosed: () => void): void;
+}
+
+export function startListener(inner: Listener, port: number, host: string): Promise<void> {
+  return new Promise((resolve) => {
+    inner.listen(port, host, () => {
+      resolve();
+    });
+  });
+}
+
+export function stopListener(inner: Listener): Promise<void> {
+  return new Promise((resolve) => {
+    inner.close(() => {
+      resolve();
+    });
+  });
+}
+
+type Resolver<T> = (value: T) => void;
+
+export class DeferredResolverPool<T> {
+  private readonly resolversById = new Map<string, Resolver<T>>();
+
+  awaitOne(id: string): Promise<T> {
+    return new Promise<T>((resolve) => {
+      this.resolversById.set(id, resolve);
+    });
+  }
+
+  fulfill(id: string, value: T): void {
+    const r = this.resolversById.get(id);
+    if (r) {
+      this.resolversById.delete(id);
+      r(value);
+    }
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/case-without-break-try-wrapped.ts
+++ b/tests/fixtures/sample-js-project-positive/case-without-break-try-wrapped.ts
@@ -1,0 +1,35 @@
+// A case body that wraps try/catch where every branch returns can never
+// fall through, so the rule shouldn't flag it.
+
+interface Request {
+  url: string;
+}
+interface Response {
+  status: number;
+}
+
+declare function getBody(req: Request): Promise<string>;
+
+export async function routeCheckpoint(req: Request): Promise<Response> {
+  switch (req.url) {
+    case '/checkpoint/duration': {
+      try {
+        await getBody(req);
+        return { status: 204 };
+      } catch {
+        return { status: 500 };
+      }
+    }
+    case '/checkpoint/manual': {
+      try {
+        await getBody(req);
+        return { status: 200 };
+      } catch {
+        return { status: 500 };
+      }
+    }
+    default: {
+      return { status: 404 };
+    }
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/event-listener-no-remove-lifecycle-managed.ts
+++ b/tests/fixtures/sample-js-project-positive/event-listener-no-remove-lifecycle-managed.ts
@@ -1,0 +1,33 @@
+// Event listeners whose lifetime is managed by their target (AbortSignal,
+// WebSocket-like sources, or terminal page-lifecycle events) don't need a
+// paired removeEventListener call — the host releases them on its own.
+
+interface SignalLike {
+  addEventListener(type: 'abort', listener: () => void, options?: { once?: boolean }): void;
+}
+
+interface SocketLike {
+  addEventListener(type: 'open' | 'close' | 'error', listener: (e: unknown) => void): void;
+}
+
+export function onAbort(signal: SignalLike, cleanup: () => void): void {
+  signal.addEventListener('abort', cleanup, { once: true });
+}
+
+export function bindSocket(ws: SocketLike, onOpen: (e: unknown) => void, onClose: (e: unknown) => void, onError: (e: unknown) => void): void {
+  ws.addEventListener('open', onOpen);
+  ws.addEventListener('close', onClose);
+  ws.addEventListener('error', onError);
+}
+
+interface FetchOptions {
+  signal?: SignalLike;
+}
+
+export function wireAbort(options: FetchOptions, onAbortInner: () => void): void {
+  options.signal?.addEventListener('abort', onAbortInner);
+}
+
+export function fireOnce(target: { addEventListener: (t: string, l: () => void, o?: { once?: boolean }) => void }): void {
+  target.addEventListener('custom', () => {}, { once: true });
+}

--- a/tests/fixtures/sample-js-project-positive/no-return-await-call-chain.ts
+++ b/tests/fixtures/sample-js-project-positive/no-return-await-call-chain.ts
@@ -1,0 +1,30 @@
+// `return await foo()` on a call / method chain is the modern preferred
+// shape — the await is what makes the stack trace include the current
+// function frame and lets errors throw in-frame instead of surfacing as
+// unhandled rejections. The rule should only flag the truly redundant
+// `return await variableHoldingPromise` shape.
+
+interface QueryClient {
+  findMany(args: { where: { orgId: string } }): Promise<{ id: string }[]>;
+  findFirst(args: { where: { token: string } }): Promise<{ id: string } | null>;
+}
+
+interface Runner {
+  x(cmd: string, argv: readonly string[]): Promise<{ stdout: string }>;
+}
+
+export async function listInvites(client: QueryClient, orgId: string): Promise<{ id: string }[]> {
+  return await client.findMany({ where: { orgId } });
+}
+
+export async function findInvite(client: QueryClient, token: string): Promise<{ id: string } | null> {
+  return await client.findFirst({ where: { token } });
+}
+
+export async function runAddInline(runner: Runner, container: string, src: string, dest: string): Promise<{ stdout: string }> {
+  return await runner.x('builder', ['add', container, src, dest]);
+}
+
+export async function runPushInline(runner: Runner, imageRef: string): Promise<{ stdout: string }> {
+  return await runner.x('builder', ['push', imageRef]);
+}


### PR DESCRIPTION
Closes #371
Closes #372
Closes #373
Closes #374
Closes #375

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `bugs/deterministic/array-sort-without-compare` | #371 | `tests/fixtures/sample-js-project-positive/array-sort-without-compare-string-array.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/array-sort-without-compare-tosorted.ts` |
| `code-quality/deterministic/async-promise-function` | #372 | `tests/fixtures/sample-js-project-positive/async-promise-function-callback-wrapper.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/async-promise-function-sync-resolve.ts` |
| `performance/deterministic/event-listener-no-remove` | #373 | `tests/fixtures/sample-js-project-positive/event-listener-no-remove-lifecycle-managed.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/event-listener-no-remove-window-resize.ts` |
| `code-quality/deterministic/no-return-await` | #374 | `tests/fixtures/sample-js-project-positive/no-return-await-call-chain.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/no-return-await-bare-identifier.ts` |
| `code-quality/deterministic/case-without-break` | #375 | `tests/fixtures/sample-js-project-positive/case-without-break-try-wrapped.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/case-without-break-falls-through.ts` |

## bugs/deterministic/array-sort-without-compare (#371)

Upstream samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/admin/FeatureFlagsDialog.tsx#L120
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/QueryResultsChart.tsx#L650
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/presenters/v3/EditSchedulePresenter.server.ts#L102

Positive fixture additions (paraphrased):
```ts
export function sortedFlagKeys(data: Catalog): string[] {
  return Object.keys(data.controlTypes).sort();
}
export function sortedTimezones(): string[] {
  return Intl.supportedValuesOf('timeZone').sort();
}
export function sortFeatureNames(features: Set<string>): string[] {
  return Array.from(features).sort();
}
export function pluckSlugsAndSort(rows: ReadonlyArray<{ slug: string }>): string[] {
  return rows.map((r) => r.slug).sort();
}
```

Negative fixture additions:
```ts
// VIOLATION: bugs/deterministic/array-sort-without-compare
export function toSortedNumeric(items: readonly number[]): number[] {
  return items.toSorted();
}
```

The visitor now uses `typeQuery.getTypeAtPosition` on the sort receiver and skips when the resolved type is a string-array shape (`string[]`, `readonly string[]`, `Array<string>`, or string-literal unions). Sorting strings without a comparator is lexicographic by design — the rule's concern is numeric arrays sorted as strings.

## code-quality/deterministic/async-promise-function (#372)

Upstream samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/utilities/gitMeta.ts#L47
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/core/src/v3/serverOnly/httpServer.ts#L239
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/core/src/v3/runtime/sharedRuntimeManager.ts#L89

Positive fixture additions cover three legitimate `new Promise(...)` wrappers: a callback-based API (`api.fetch(cb, opts)`), `server.listen`/`close` wrappers, and a deferred-resolver pool (`this.resolversById.set(id, resolve)`).

Negative fixture:
```ts
// VIOLATION: code-quality/deterministic/async-promise-function
export function wrapSync(value: number): Promise<number> {
  return new Promise((resolve) => {
    resolve(value * 2);
  });
}
```

The visitor now inspects the Promise executor body. It skips when `resolve`/`reject` is deferred — either inside a nested callback (call with `arrow_function` / `function_expression` argument) or passed by name as a call argument (the deferred-resolver pattern). Neither shape is rewritable as a simple async function.

## performance/deterministic/event-listener-no-remove (#373)

Upstream samples:
- `https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/services/realtime/redisRealtimeStreams.server.ts#L297`
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/authenticatedSocketConnection.server.ts#L58
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/core/src/v3/streams/asyncIterableStream.ts#L32

Positive fixture covers AbortSignal `'abort'` listeners (with and without `{ once: true }`), socket-like `'open'`/`'close'`/`'error'` listeners, and `options.signal?.addEventListener(...)` callsites.

Negative fixture:
```ts
// VIOLATION: performance/deterministic/event-listener-no-remove
export function wireResize(doc: DocumentLike, onResize: () => void): void {
  doc.addEventListener('resize', onResize);
}
```

The visitor skips lifecycle-managed listeners — `'abort'` (AbortSignal), `'close'` / `'error'` (WebSocket/EventSource), `'beforeunload'` / `'unload'` / `'visibilitychange'` (page lifecycle), any options object containing `once: true`, and receivers matching `signal` / `abortSignal` / `eventSource` / `ws` / `socket` shapes.

## code-quality/deterministic/no-return-await (#374)

Upstream samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/models/member.server.ts#L129
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/coordinator/src/exec.ts#L146
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/kubernetes-provider/src/podCleaner.ts#L90

Positive fixture covers `return await client.findMany(...)`, `return await runner.x(...)`, and similar real I/O method-chain shapes.

Negative fixture:
```ts
// VIOLATION: code-quality/deterministic/no-return-await
export async function passThroughPromise(promise: Promise<number>) {
  return await promise;
}
```

Aligned with the updated `@typescript-eslint/return-await` guidance: `return await foo()` on a real call/method chain is preferred for cleaner stack traces and reliable in-frame error propagation. The rule now only flags the truly redundant shapes — bare identifiers, `Promise.resolve(...)` / `Promise.reject(...)` / etc., and `new Promise(...)`. The existing inline tests were updated to match.

## code-quality/deterministic/case-without-break (#375)

Upstream samples:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/coordinator/src/index.ts#L1553
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/api.v1.schedules.%24scheduleId.ts#L38
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/account.tokens/route.tsx#L177

Positive fixture covers `case 'X': { try { return … } catch { return … } }` shapes that can never fall through.

Negative fixture:
```ts
export function describeFlag(flag: number): string {
  let label = '';
  switch (flag) {
    // VIOLATION: code-quality/deterministic/case-without-break
    case 0:
      label = 'zero';
    case 1:
      ...
  }
}
```

Both `case-without-break` and the sibling `bugs/deterministic/fallthrough-case` rule used to check only the last *direct* statement in a case body for termination. They now share a recursive `isTerminating` walk that descends into `statement_block`, `try_statement` (all branches must terminate), and `if_statement` (both `consequence` and `alternative` must terminate). The fallthrough-case rule got the same fix because the same paraphrased fixture exposed the same root cause there — leaving it broken would have re-flagged the wrapped-try cases under a different rule key.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `bugs/deterministic/array-sort-without-compare` | 27 | 8 | -19 |
| `code-quality/deterministic/async-promise-function` | 4 | 2 | -2 |
| `performance/deterministic/event-listener-no-remove` | 25 | 1 | -24 |
| `code-quality/deterministic/no-return-await` | 354 | 5 | -349 |
| `code-quality/deterministic/case-without-break` | 33 | 14 | -19 |
| **Total (these 5 rules)** | **443** | **30** | **-413** |
| **All-rules total on target** | **35673** | **35249** | **-424** |

(The extra delta beyond the 5 rules above is `bugs/deterministic/fallthrough-case`: 16 → 5 = -11, fixed alongside `case-without-break` since it shared the same termination-walk root cause.)

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01JohFjLViKGhG1qCiX79vVw)_