### PR TITLE
fix(landing): remove hero eyebrow badge

### DIFF
--- a/apps/landing/src/components/Hero.tsx
+++ b/apps/landing/src/components/Hero.tsx
@@ -35,23 +35,15 @@ export function Hero() {
       </svg>
 
       <div className="wrap hero-inner">
-        <Reveal as="span" className="badge pulse">
-          <span className="spark">✦</span>
-          <span className="badge-text">
-            Verified knowledge for AI-native engineering teams{' '}
-            <span className="arr">· preview</span>
-          </span>
-        </Reveal>
-
-        <Reveal as="h1" delay={80}>
+        <Reveal as="h1">
           AI ships your code. We keep it <span className="hl">on course.</span>
         </Reveal>
 
-        <Reveal as="p" className="sub" delay={160}>
+        <Reveal as="p" className="sub" delay={80}>
           Every change, checked against what your team actually decided.
         </Reveal>
 
-        <Reveal className="cta-row" delay={240}>
+        <Reveal className="cta-row" delay={160}>
           <Link className="btn btn-primary" to="/request-access">
             Request access <span className="arr">→</span>
           </Link>

--- a/apps/landing/src/globals.css
+++ b/apps/landing/src/globals.css
@@ -382,26 +382,6 @@ header.site.scrolled {
   z-index: 1;
   max-width: 900px;
 }
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  letter-spacing: 0.02em;
-  color: var(--fg-dim);
-  border: 1px solid var(--line-strong);
-  border-radius: 999px;
-  padding: 7px 16px;
-  background: var(--bg-elev);
-}
-.badge .spark {
-  color: var(--accent);
-}
-.badge .arr {
-  color: var(--muted);
-  white-space: nowrap;
-}
 .hero h1 {
   font-family: var(--font-mono);
   font-weight: 700;
@@ -1035,22 +1015,6 @@ footer.site {
   transform: none;
 }
 
-/* badge pulse ring */
-@keyframes pulse-ring {
-  0%,
-  100% {
-    box-shadow: 0 0 0 0 oklch(0.83 0.16 152 / 0);
-  }
-  50% {
-    box-shadow:
-      0 0 0 5px oklch(0.83 0.16 152 / 0.14),
-      0 0 22px 0 oklch(0.83 0.16 152 / 0.22);
-  }
-}
-.badge.pulse {
-  animation: pulse-ring 3.4s ease-in-out infinite;
-}
-
 /* hero baseline draw-in */
 @keyframes draw-line {
   to {
@@ -1111,7 +1075,6 @@ footer.site {
     transform: none !important;
     transition: none !important;
   }
-  .badge.pulse,
   .callout .ico {
     animation: none !important;
   }


### PR DESCRIPTION
Follow-up to #466.

Removes the "Verified knowledge for AI-native engineering teams · preview" pill from the hero per feedback — the hero now leads straight with the headline. Also drops the now-dead badge styles (the `pulse-ring` keyframe and `.badge` rules).

Net: `+3 / −48` across `Hero.tsx` and `globals.css`.

Verified at 390px (mobile) and 1440px (desktop) in headless Chrome — hero renders correctly, no console errors, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)