### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/await-in-loop.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/await-in-loop.ts
@@ -77,6 +77,68 @@ function isIteratorProtocolAwait(awaitNode: SyntaxNode): boolean {
   return prop?.text === 'read' || prop?.text === 'next'
 }
 
+// Sleep / delay primitives are time-passing — the await *is* the loop's
+// pacing mechanism (retry backoff, polling interval, rate-limit gap).
+// Parallelising them is nonsensical: N concurrent sleeps just waste the
+// same wall-clock time without doing any extra work.
+const SLEEP_LIKE_CALL_NAMES = new Set([
+  'sleep', 'delay', 'wait', 'pause',
+  'setTimeout', 'setImmediate', 'setInterval',
+])
+function isSleepLikeAwait(awaitNode: SyntaxNode): boolean {
+  const call = awaitNode.namedChildren[0]
+  if (!call || call.type !== 'call_expression') return false
+  const fn = call.childForFieldName('function')
+  if (!fn) return false
+  let name: string | undefined
+  if (fn.type === 'identifier') name = fn.text
+  else if (fn.type === 'member_expression') {
+    const prop = fn.childForFieldName('property')
+    name = prop?.text
+  }
+  return name !== undefined && SLEEP_LIKE_CALL_NAMES.has(name)
+}
+
+// Cursor-based pagination: `do { ... cursor = result.next; } while (cursor)`.
+// Each iteration's input depends on the previous response's cursor token —
+// the API contract makes the calls sequential. Detect by: do-while whose
+// condition references an identifier that is reassigned inside the body.
+function isCursorPaginationLoop(loopNode: SyntaxNode): boolean {
+  if (loopNode.type !== 'do_statement') return false
+  const condition =
+    loopNode.childForFieldName('condition') ?? loopNode.childForFieldName('test')
+  if (!condition) return false
+  const condIdents = new Set<string>()
+  collectIdentifiers(condition, condIdents)
+  if (condIdents.size === 0) return false
+  const body = loopNode.childForFieldName('body')
+  if (!body) return false
+  return bodyReassignsAny(body, condIdents)
+}
+
+function collectIdentifiers(node: SyntaxNode, out: Set<string>): void {
+  if (node.type === 'identifier') {
+    out.add(node.text)
+    return
+  }
+  for (let i = 0; i < node.childCount; i++) {
+    const ch = node.child(i)
+    if (ch) collectIdentifiers(ch, out)
+  }
+}
+
+function bodyReassignsAny(node: SyntaxNode, names: Set<string>): boolean {
+  if (node.type === 'assignment_expression') {
+    const left = node.childForFieldName('left')
+    if (left?.type === 'identifier' && names.has(left.text)) return true
+  }
+  for (let i = 0; i < node.childCount; i++) {
+    const ch = node.child(i)
+    if (ch && bodyReassignsAny(ch, names)) return true
+  }
+  return false
+}
+
 // True if the awaited result is bound to a `const`/`let` declarator and an
 // `if (… <binding> …) { return | break | throw }` appears later in the same
 // loop body. This is a "search until found" loop where parallelisation
@@ -164,6 +226,8 @@ export const awaitInLoopVisitor: CodeRuleVisitor = {
         if (isSerialChainWalk(current)) return null
         if (isInsideTransactionCallback(current)) return null
         if (isIteratorProtocolAwait(node)) return null
+        if (isSleepLikeAwait(node)) return null
+        if (isCursorPaginationLoop(current)) return null
         if (isAwaitUsedInEarlyExit(node, current)) return null
         // Make sure we're in the loop body (not the initializer/condition of a for loop)
         // and not inside a nested async function

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/base-to-string.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/base-to-string.ts
@@ -23,10 +23,16 @@ export const baseToStringVisitor: CodeRuleVisitor = {
     const obj = fn.childForFieldName('object')
     if (!obj) return null
 
+    // Pass the full span of `obj` so the type query resolves to the whole
+    // expression (e.g. `parsed.value`), not just the leading identifier
+    // (`parsed`) — otherwise the rule reads the parent object's type and
+    // mis-flags `parsed.value.toString()` when only `value` is the object.
     const typeStr = typeQuery.getTypeAtPosition(
       filePath,
       obj.startPosition.row,
       obj.startPosition.column,
+      obj.endPosition.row,
+      obj.endPosition.column,
     )
     if (!typeStr) return null
 

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/void-zero-argument.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/void-zero-argument.ts
@@ -22,6 +22,16 @@ function operandIsCall(operand: SyntaxNode | null | undefined): boolean {
   return false
 }
 
+// `void <identifier>;` / `void <obj.member>;` as its own statement is the
+// "mark as used" idiom — an explicit reference that pins a side-effect-only
+// import or silences unused-variable warnings. The value is never consumed,
+// so there's nothing to replace with `undefined`.
+function isMarkAsUsedStatement(node: SyntaxNode, operand: SyntaxNode | null | undefined): boolean {
+  if (!operand) return false
+  if (operand.type !== 'identifier' && operand.type !== 'member_expression') return false
+  return node.parent?.type === 'expression_statement'
+}
+
 export const voidZeroArgumentVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/void-zero-argument',
   languages: JS_LANGUAGES,
@@ -32,7 +42,10 @@ export const voidZeroArgumentVisitor: CodeRuleVisitor = {
 
     // Skip fire-and-forget `void promiseCall()` — replacing it with `undefined`
     // would drop the call entirely. Only flag literal/identifier operands.
-    if (operandIsCall(node.children[node.children.length - 1])) return null
+    const operand = node.children[node.children.length - 1]
+    if (operandIsCall(operand)) return null
+    // Skip the "mark as used" statement idiom: `void engine;`.
+    if (isMarkAsUsedStatement(node, operand)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'medium',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/complex-type-alias.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/complex-type-alias.ts
@@ -4,15 +4,61 @@ import { makeViolation } from '../../../types.js'
 
 // `A | B | C | D` parses as a left-leaning chain of nested union_types in
 // tree-sitter-typescript, not a flat list. Flatten the chain so we can
-// classify each member directly.
+// classify each member directly. Skip `comment` and `ERROR` nodes —
+// per-member trailing comments and leading-`|` artefacts otherwise leak
+// into the member list and defeat the simple-union check.
+const NON_MEMBER_NODE_TYPES = new Set(['comment', 'ERROR', 'MISSING'])
 function flattenUnionMembers(node: SyntaxNode): SyntaxNode[] {
   if (node.type !== 'union_type') return [node]
   const out: SyntaxNode[] = []
   for (const child of node.namedChildren) {
+    if (NON_MEMBER_NODE_TYPES.has(child.type)) continue
     if (child.type === 'union_type') out.push(...flattenUnionMembers(child))
     else out.push(child)
   }
   return out
+}
+
+// Idiomatic utility-type chains like
+// `NonNullable<Awaited<ReturnType<typeof method>>>` or
+// `Prettify<NonNullable<Awaited<ReturnType<...>>>>` are the canonical
+// way to derive a result type from an async method. They're read as a
+// single unit, not parsed structurally, so the bracket-depth heuristic
+// over-flags them.
+const UTILITY_TYPE_NAMES = new Set([
+  'Awaited', 'ReturnType', 'Parameters', 'ConstructorParameters',
+  'InstanceType', 'NonNullable', 'Required', 'Partial', 'Readonly',
+  'Pick', 'Omit', 'Exclude', 'Extract',
+  'Prettify', 'Simplify', 'Expand', 'DeepReadonly', 'DeepPartial',
+])
+function isUtilityTypeChain(node: SyntaxNode): boolean {
+  let cur: SyntaxNode | null = node
+  // Walk a generic-type chain: each level must be `<UtilityName><...>`
+  // and its single type argument is the next link. Bottoms out in a
+  // simple `typeof X`, `type_identifier`, or member/index lookup.
+  while (cur) {
+    if (cur.type !== 'generic_type') return false
+    const name = cur.childForFieldName('name') ?? cur.namedChildren[0]
+    if (!name || name.type !== 'type_identifier') return false
+    if (!UTILITY_TYPE_NAMES.has(name.text)) return false
+    const args: SyntaxNode | null = cur.childForFieldName('type_arguments') ?? cur.namedChildren[1] ?? null
+    if (!args) return false
+    const typeArgs: SyntaxNode[] = args.namedChildren.filter((c: SyntaxNode) => !NON_MEMBER_NODE_TYPES.has(c.type))
+    if (typeArgs.length !== 1) return false
+    const inner: SyntaxNode = typeArgs[0]!
+    if (inner.type === 'generic_type') {
+      cur = inner
+      continue
+    }
+    // Leaf: must be a simple reference, not a nested complex type.
+    return (
+      inner.type === 'type_identifier' ||
+      inner.type === 'predefined_type' ||
+      inner.type === 'type_query' ||
+      inner.type === 'literal_type'
+    )
+  }
+  return false
 }
 
 const SIMPLE_UNION_MEMBER_TYPES = new Set([
@@ -82,6 +128,9 @@ export const complexTypeAliasVisitor: CodeRuleVisitor = {
       const allSimple = members.every((m) => SIMPLE_UNION_MEMBER_TYPES.has(m.type))
       if (allSimple) return null
     }
+
+    // Skip idiomatic utility-type chains regardless of nesting depth.
+    if (typeValue.type === 'generic_type' && isUtilityTypeChain(typeValue)) return null
 
     if (depth >= DEPTH_THRESHOLD || members >= MEMBER_THRESHOLD) {
       const reason = depth >= DEPTH_THRESHOLD

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/no-void.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/no-void.ts
@@ -18,6 +18,17 @@ function operandIsCall(operand: SyntaxNode | null | undefined): boolean {
   return false
 }
 
+// `void <identifier>` / `void <member.access>` as its own statement is the
+// "mark as used" idiom: an explicit reference to a binding kept alive for
+// its side-effect import or to silence unused-variable warnings (e.g.
+// `void engine;` after `import { engine } from "./engine"`). It is never
+// a stand-in for `undefined` because the value isn't consumed.
+function isMarkAsUsedStatement(node: SyntaxNode, operand: SyntaxNode | null | undefined): boolean {
+  if (!operand) return false
+  if (operand.type !== 'identifier' && operand.type !== 'member_expression') return false
+  return node.parent?.type === 'expression_statement'
+}
+
 export const noVoidVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/no-void',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -30,6 +41,8 @@ export const noVoidVisitor: CodeRuleVisitor = {
 
     // Skip the fire-and-forget `void promiseCall()` idiom.
     if (operandIsCall(operand)) return null
+    // Skip the "mark as used" idiom: `void engine;` as a statement.
+    if (isMarkAsUsedStatement(node, operand)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/too-many-union-members.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/too-many-union-members.ts
@@ -20,12 +20,18 @@ export const tooManyUnionMembersVisitor: CodeRuleVisitor = {
       ancestor = ancestor.parent
     }
 
+    // Per-member trailing comments (`'a' // ...`) and leading-`|`
+    // artefacts show up as named children of `union_type` but aren't
+    // members. Don't let them inflate the count.
+    const NON_MEMBER_NODE_TYPES = new Set(['comment', 'ERROR', 'MISSING'])
     function countMembers(n: SyntaxNode): number {
       if (n.type !== 'union_type') return 1
       let total = 0
       for (let i = 0; i < n.namedChildCount; i++) {
         const child = n.namedChild(i)
-        if (child) total += countMembers(child)
+        if (!child) continue
+        if (NON_MEMBER_NODE_TYPES.has(child.type)) continue
+        total += countMembers(child)
       }
       return total
     }

--- a/packages/analyzer/src/rules/performance/visitors/javascript/_helpers.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/_helpers.ts
@@ -174,6 +174,21 @@ export function isLikelyServerComponent(filePath: string, sourceCode: string): b
 }
 
 /**
+ * Heuristic: is the file a React Email template?
+ *
+ * Templates built on `@react-email/components` (or sibling
+ * `@react-email/*` block packages) are rendered to HTML server-side
+ * before sending, not mounted in a browser. Inline object/function
+ * allocations in JSX props have no re-render cost — the template runs
+ * once per email and is discarded.
+ *
+ * Detection: any `import ... from '@react-email/...'` in the source.
+ */
+export function isReactEmailTemplate(sourceCode: string): boolean {
+  return /from\s+['"]@react-email\//.test(sourceCode)
+}
+
+/**
  * Heuristic: is the file a one-off script (CLI, seed, build tool) rather
  * than long-running server code? "In handler" performance rules don't
  * apply to scripts that run once and exit.

--- a/packages/analyzer/src/rules/performance/visitors/javascript/inline-object-in-jsx-prop.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/inline-object-in-jsx-prop.ts
@@ -1,6 +1,6 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
-import { isLikelyServerComponent } from './_helpers.js'
+import { isLikelyServerComponent, isReactEmailTemplate } from './_helpers.js'
 
 export const inlineObjectInJsxPropVisitor: CodeRuleVisitor = {
   ruleKey: 'performance/deterministic/inline-object-in-jsx-prop',
@@ -10,6 +10,8 @@ export const inlineObjectInJsxPropVisitor: CodeRuleVisitor = {
     // Server components don't re-render on the client — inline allocation has no perf impact.
     // Detect by: file is in a Next.js App Router path AND lacks 'use client' directive.
     if (isLikelyServerComponent(filePath, sourceCode)) return null
+    // React Email templates are rendered to HTML server-side; no re-render to optimize.
+    if (isReactEmailTemplate(sourceCode)) return null
 
     const value = node.namedChildren[1]
     if (!value) return null

--- a/tests/fixtures/sample-js-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-js-project-negative/expected-graph.json
@@ -121,6 +121,12 @@
       "layer": "service"
     },
     {
+      "name": "loadProfiles",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "loadUserPyramid",
       "service": "api-gateway",
       "kind": "standalone",
@@ -134,6 +140,18 @@
     },
     {
       "name": "logImplicitGlobalEvent",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "logPayload",
+      "service": "api-gateway",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "maybeIndex",
       "service": "api-gateway",
       "kind": "standalone",
       "layer": "service"
@@ -1522,6 +1540,12 @@
       "name": "BillingDashboard",
       "service": "web",
       "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "ClientCard",
+      "service": "web",
+      "kind": "standalone",
       "layer": "service"
     },
     {

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/await-in-loop-parallelizable.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/await-in-loop-parallelizable.ts
@@ -1,0 +1,18 @@
+/**
+ * Real await-in-loop bug — independent items fetched serially in a
+ * `for-of`. These calls don't share connections, don't have ordering
+ * constraints, and don't pace anything. They should be batched with
+ * Promise.all.
+ */
+
+declare function fetchProfile(id: string): Promise<{ id: string; name: string }>;
+
+export async function loadProfiles(ids: ReadonlyArray<string>): Promise<{ id: string; name: string }[]> {
+  const profiles: { id: string; name: string }[] = [];
+  for (const id of ids) {
+    // VIOLATION: bugs/deterministic/await-in-loop
+    const profile = await fetchProfile(id);
+    profiles.push(profile);
+  }
+  return profiles;
+}

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/base-to-string-plain-object.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/base-to-string-plain-object.ts
@@ -1,0 +1,10 @@
+/**
+ * Real base-to-string bug — calling `.toString()` on a plain object
+ * yields the literal string `"[object Object]"`. The caller almost
+ * certainly meant to serialise the object instead.
+ */
+
+export function logPayload(payload: { id: string; size: number }): string {
+  // VIOLATION: bugs/deterministic/base-to-string
+  return 'received: ' + payload.toString();
+}

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/complex-type-alias-overgrown.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/complex-type-alias-overgrown.ts
@@ -1,0 +1,13 @@
+/**
+ * Real complex-type-alias bug — deeply-nested chain of user-defined
+ * generics. Five levels of `WrappedMap<...>` exceeds the bracket-depth
+ * threshold and should be broken into named intermediate aliases.
+ */
+
+type WrappedMap<K, V> = Map<K, V>;
+
+// VIOLATION: code-quality/deterministic/complex-type-alias
+export type DeeplyNestedMap = WrappedMap<
+  string,
+  WrappedMap<string, WrappedMap<string, WrappedMap<string, WrappedMap<string, number>>>>
+>;

--- a/tests/fixtures/sample-js-project-negative/services/api-gateway/src/no-void-stand-in.ts
+++ b/tests/fixtures/sample-js-project-negative/services/api-gateway/src/no-void-stand-in.ts
@@ -1,0 +1,10 @@
+/**
+ * Real `no-void` bug — `void 1` used inside an expression as a confusing
+ * stand-in for `undefined`. The value IS consumed (returned to the caller),
+ * so this is not the harmless "mark as used" statement pattern.
+ */
+
+export function maybeIndex(value: number): number | undefined {
+  // VIOLATION: code-quality/deterministic/no-void
+  return value > 0 ? value : void 1;
+}

--- a/tests/fixtures/sample-js-project-negative/services/web/src/components/InlineObjectClient.tsx
+++ b/tests/fixtures/sample-js-project-negative/services/web/src/components/InlineObjectClient.tsx
@@ -1,0 +1,26 @@
+/**
+ * Real client component — inline object in JSX prop creates a new
+ * reference every render, causing children to re-render unnecessarily.
+ */
+
+'use client';
+
+import React from 'react';
+
+interface PanelProps {
+  readonly style: { background: string; padding: number };
+  readonly children: React.ReactNode;
+}
+
+function Panel(props: PanelProps) {
+  return <div style={props.style}>{props.children}</div>;
+}
+
+export function ClientCard({ label }: { label: string }) {
+  return (
+    // VIOLATION: performance/deterministic/inline-object-in-jsx-prop
+    <Panel style={{ background: '#fafafa', padding: 12 }}>
+      <span>{label}</span>
+    </Panel>
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/externals.d.ts
+++ b/tests/fixtures/sample-js-project-positive/externals.d.ts
@@ -134,6 +134,24 @@ declare module '@react-email/render' {
   export function render(node: unknown): Promise<string>;
 }
 
+declare module '@react-email/components' {
+  import type { ReactNode, CSSProperties } from 'react';
+  type EmailBlockProps = {
+    children?: ReactNode;
+    style?: CSSProperties;
+    [key: string]: unknown;
+  };
+  export const Html: (props: EmailBlockProps) => JSX.Element;
+  export const Head: (props: EmailBlockProps) => JSX.Element;
+  export const Body: (props: EmailBlockProps) => JSX.Element;
+  export const Container: (props: EmailBlockProps) => JSX.Element;
+  export const Text: (props: EmailBlockProps) => JSX.Element;
+  export const Section: (props: EmailBlockProps) => JSX.Element;
+  export const Heading: (props: EmailBlockProps) => JSX.Element;
+  export const Preview: (props: EmailBlockProps) => JSX.Element;
+  export const Link: (props: EmailBlockProps & { href?: string; target?: string }) => JSX.Element;
+}
+
 declare module 'big-math-toolkit-fake' {
   export function sum(values: ReadonlyArray<number>): number;
   export function mean(values: ReadonlyArray<number>): number;

--- a/tests/fixtures/sample-js-project-positive/src/await-in-loop-sleep-and-pagination.ts
+++ b/tests/fixtures/sample-js-project-positive/src/await-in-loop-sleep-and-pagination.ts
@@ -1,0 +1,45 @@
+/**
+ * Positive fixture for bugs/deterministic/await-in-loop.
+ *
+ * Two more FP shapes:
+ *
+ *   1. Sleep / wait / delay primitives. Awaiting `sleep(ms)` or
+ *      `this.wait()` is by definition a time-passing operation — there's
+ *      nothing to parallelise. The await *is* the loop's pacing
+ *      mechanism (retry backoff, polling interval).
+ *
+ *   2. Cursor-based pagination with a `do { ... } while (token)` shape.
+ *      Each request's `cursor` / `continuation` token comes from the
+ *      previous response, so the next call depends on the previous
+ *      one; the API contract enforces sequential.
+ */
+
+interface PageResponse {
+  readonly count: number;
+  readonly nextPageToken: string | undefined;
+}
+
+declare function fetchPage(token: string | undefined): Promise<PageResponse>;
+declare function attemptOnce(): Promise<{ ok: boolean }>;
+declare function recordPageCount(count: number): void;
+declare function wait(ms: number): Promise<void>;
+
+export async function retryWithBackoff(maxAttempts: number): Promise<boolean> {
+  let delayMs = 100;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const result = await attemptOnce();
+    if (result.ok) return true;
+    await wait(delayMs);
+    delayMs *= 2;
+  }
+  return false;
+}
+
+export async function walkAllPages(): Promise<void> {
+  let nextToken: string | undefined;
+  do {
+    const page = await fetchPage(nextToken);
+    recordPageCount(page.count);
+    nextToken = page.nextPageToken;
+  } while (nextToken);
+}

--- a/tests/fixtures/sample-js-project-positive/src/base-to-string-member-number.ts
+++ b/tests/fixtures/sample-js-project-positive/src/base-to-string-member-number.ts
@@ -1,0 +1,24 @@
+/**
+ * Positive fixture for bugs/deterministic/base-to-string.
+ *
+ * The FP: `obj.numericField.toString()` where the receiver is a
+ * `number`. The rule was resolving the type of the leading identifier
+ * (`obj`) instead of the full member expression (`obj.numericField`),
+ * so the receiver looked like a plain object (`{ ... }`) even though
+ * `.toString()` is actually being called on a primitive.
+ */
+
+interface ParsedDuration {
+  readonly value: number;
+  readonly unit: string;
+}
+
+declare function parseDuration(period: string): ParsedDuration | null;
+
+export function formatDuration(period: string): { value: string; unit: string } {
+  const parsed = parseDuration(period);
+  if (parsed) {
+    return { value: parsed.value.toString(), unit: parsed.unit };
+  }
+  return { value: '', unit: 'm' };
+}

--- a/tests/fixtures/sample-js-project-positive/src/complex-type-alias-utility-chain.ts
+++ b/tests/fixtures/sample-js-project-positive/src/complex-type-alias-utility-chain.ts
@@ -1,0 +1,29 @@
+/**
+ * Positive fixture for code-quality/deterministic/complex-type-alias.
+ *
+ * Two FP shapes:
+ *
+ *   1. Simple union of string literals declared with a leading `|`
+ *      separator and trailing per-member comments. The count of `|`
+ *      tokens at top level overshoots the real member count by one and
+ *      tips the rule's `>= 6` threshold even though there are five
+ *      literals. The shape is the standard "label set" alias.
+ *
+ *   2. The idiomatic utility-type chain
+ *      `NonNullable<Awaited<ReturnType<typeof method>>>` — the canonical
+ *      way to extract the result type of an async function or method
+ *      that may return `null`/`undefined`. The bracket-depth heuristic
+ *      flags it as "deeply nested," but readers recognise the chain at
+ *      a glance.
+ */
+
+declare function fetchRecord(): Promise<{ id: string; payload: string } | null>;
+
+export type CompletionLabel =
+  | 'identifier' // bare reference
+  | 'literal' // quoted value
+  | 'operator' // comparison or join token
+  | 'punctuation' // structural punctuation
+  | 'keyword'; // reserved word
+
+export type FetchedRecord = NonNullable<Awaited<ReturnType<typeof fetchRecord>>>;

--- a/tests/fixtures/sample-js-project-positive/src/inline-object-in-jsx-prop-email-template.tsx
+++ b/tests/fixtures/sample-js-project-positive/src/inline-object-in-jsx-prop-email-template.tsx
@@ -1,0 +1,56 @@
+/**
+ * React Email template — components from `@react-email/components` are
+ * rendered to HTML server-side before sending, so inline object/array
+ * literals in JSX props have no re-render cost. The template is invoked
+ * once per email.
+ */
+
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components';
+
+const page = { backgroundColor: '#f7f7f7', fontFamily: 'sans-serif' };
+const card = { padding: '24px', borderRadius: 8 };
+const heading = { fontSize: 20, color: '#111' };
+const paragraph = { color: '#333', lineHeight: 1.5 };
+const linkBase = { color: '#1d4ed8', textDecoration: 'underline' };
+
+interface NotificationEmailProps {
+  readonly recipientName: string;
+  readonly itemLabel: string;
+  readonly summary: string;
+  readonly itemHref: string;
+}
+
+export function NotificationEmail(props: NotificationEmailProps): JSX.Element {
+  const { recipientName, itemLabel, summary, itemHref } = props;
+  return (
+    <Html>
+      <Head />
+      <Preview>{`Update on ${itemLabel}`}</Preview>
+      <Body style={page}>
+        <Container style={card}>
+          <Heading style={heading}>Hello {recipientName}</Heading>
+          <Section style={{ marginBottom: 16 }}>
+            <Text style={paragraph}>{summary}</Text>
+          </Section>
+          <Link
+            href={itemHref}
+            target="_blank"
+            style={{ ...linkBase, display: 'block', marginTop: '24px' }}
+          >
+            View details
+          </Link>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/src/no-void-mark-as-used.ts
+++ b/tests/fixtures/sample-js-project-positive/src/no-void-mark-as-used.ts
@@ -1,0 +1,32 @@
+/**
+ * Positive fixture for code-quality/deterministic/no-void.
+ *
+ * `void <identifier>;` (or `void <obj.member>;`) as its own statement is
+ * the idiomatic "mark as used" pattern in TypeScript:
+ *
+ *   - Pins a side-effect-only import so the binding isn't tree-shaken
+ *     and the module-load side-effect runs.
+ *   - Silences `noUnusedParameters` / unused-variable warnings without
+ *     adding `_` prefixes that would change the public API.
+ *
+ * The value is never consumed, so it isn't a stand-in for `undefined`.
+ */
+
+declare const sideEffectModule: { ready: boolean };
+
+export function bootstrapWorker(): void {
+  // Pin the side-effect-only module so it isn't tree-shaken.
+  void sideEffectModule;
+}
+
+interface LifecycleHooks {
+  readonly onTeardown: (token: { id: string }) => void;
+}
+
+export const hooks: LifecycleHooks = {
+  onTeardown(token): void {
+    // Acknowledge the parameter — the contract requires it even though
+    // this implementation does no teardown work.
+    void token;
+  },
+};


### PR DESCRIPTION
Closes #376
Closes #377
Closes #378
Closes #379
Closes #380

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `performance/deterministic/inline-object-in-jsx-prop` | #376 | `tests/fixtures/sample-js-project-positive/src/inline-object-in-jsx-prop-email-template.tsx` | `tests/fixtures/sample-js-project-negative/services/web/src/components/InlineObjectClient.tsx` |
| `bugs/deterministic/await-in-loop` | #377 | `tests/fixtures/sample-js-project-positive/src/await-in-loop-sleep-and-pagination.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/await-in-loop-parallelizable.ts` |
| `code-quality/deterministic/no-void` | #378 | `tests/fixtures/sample-js-project-positive/src/no-void-mark-as-used.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/no-void-stand-in.ts` |
| `code-quality/deterministic/complex-type-alias` | #379 | `tests/fixtures/sample-js-project-positive/src/complex-type-alias-utility-chain.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/complex-type-alias-overgrown.ts` |
| `bugs/deterministic/base-to-string` | #380 | `tests/fixtures/sample-js-project-positive/src/base-to-string-member-number.ts` | `tests/fixtures/sample-js-project-negative/services/api-gateway/src/base-to-string-plain-object.ts` |

## `performance/deterministic/inline-object-in-jsx-prop`

OSS source:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/emails/emails/alert-attempt-failure.tsx#L83
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/emails/emails/alert-error-group.tsx#L99

Positive fixture (`tests/fixtures/sample-js-project-positive/src/inline-object-in-jsx-prop-email-template.tsx`):
```tsx
import { Body, Container, Head, Heading, Html, Link, Preview, Section, Text } from '@react-email/components';
// ...
<Link href={itemHref} target="_blank" style={{ ...linkBase, display: 'block', marginTop: '24px' }}>
  View details
</Link>
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/web/src/components/InlineObjectClient.tsx`):
```tsx
'use client';
// VIOLATION: performance/deterministic/inline-object-in-jsx-prop
<Panel style={{ background: '#fafafa', padding: 12 }}>
```

Added `isReactEmailTemplate(sourceCode)` helper that detects any `from '@react-email/...'` import. React Email templates are rendered to HTML server-side before sending — they don't mount in a browser, so inline object/array literals in JSX props have no re-render cost. The visitor now early-exits on those files.

## `bugs/deterministic/await-in-loop`

OSS source:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/coordinator/src/checkpointer.ts#L366
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/coordinator/src/cleaner.ts#L38
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/supervisor/src/services/podCleaner.ts#L72
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/models/vercelIntegration.server.ts#L713

Positive fixture (`tests/fixtures/sample-js-project-positive/src/await-in-loop-sleep-and-pagination.ts`):
```ts
for (let attempt = 0; attempt < maxAttempts; attempt++) {
  const result = await attemptOnce();
  if (result.ok) return true;
  await wait(delayMs);
  delayMs *= 2;
}
// ...
do {
  const page = await fetchPage(nextToken);
  recordPageCount(page.count);
  nextToken = page.nextPageToken;
} while (nextToken);
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/api-gateway/src/await-in-loop-parallelizable.ts`):
```ts
for (const id of ids) {
  // VIOLATION: bugs/deterministic/await-in-loop
  const profile = await fetchProfile(id);
  profiles.push(profile);
}
```

Added two new exemptions to the visitor:
1. **`isSleepLikeAwait`** — `await sleep(...)`, `await delay(...)`, `await wait(...)`, `await pause(...)`, `await setTimeout(...)`, `await setImmediate(...)`, `await setInterval(...)` (also matches the `this.X()` member form). Sleep primitives are time-passing; parallelising them is nonsensical.
2. **`isCursorPaginationLoop`** — a `do { ... } while (token)` where `token` is reassigned inside the body (continuation-cursor pattern). Each iteration's input depends on the previous response's cursor, so the calls are sequential by API contract.

## `code-quality/deterministic/no-void`

OSS source:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/batchTriggerWorker.server.ts#L25
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/trigger-sdk/src/v3/ai.ts#L6065
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/references/ai-chat/src/components/chat-app.tsx#L109

Positive fixture (`tests/fixtures/sample-js-project-positive/src/no-void-mark-as-used.ts`):
```ts
export function bootstrapWorker(): void {
  // Pin the side-effect-only module so it isn't tree-shaken.
  void sideEffectModule;
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/api-gateway/src/no-void-stand-in.ts`):
```ts
export function maybeIndex(value: number): number | undefined {
  // VIOLATION: code-quality/deterministic/no-void
  return value > 0 ? value : void 1;
}
```

Added the "mark as used" statement exemption to `no-void`: `void <identifier>;` / `void <obj.member>;` whose parent is `expression_statement` is the idiomatic pattern for pinning side-effect-only imports or silencing `noUnusedParameters`. The value isn't consumed, so it isn't a stand-in for `undefined`. Applied the same exemption to `bugs/deterministic/void-zero-argument`, which had the identical FP shape on the same code (bonus delta of -3 below).

## `code-quality/deterministic/complex-type-alias`

OSS source:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/tsql/tsqlCompletion.ts#L200
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/presenters/v3/WaitpointPresenter.server.ts#L9
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/models/workerDeployment.server.ts#L15

Positive fixture (`tests/fixtures/sample-js-project-positive/src/complex-type-alias-utility-chain.ts`):
```ts
export type CompletionLabel =
  | 'identifier' // bare reference
  | 'literal' // quoted value
  | 'operator' // comparison or join token
  | 'punctuation' // structural punctuation
  | 'keyword'; // reserved word

export type FetchedRecord = NonNullable<Awaited<ReturnType<typeof fetchRecord>>>;
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/api-gateway/src/complex-type-alias-overgrown.ts`):
```ts
// VIOLATION: code-quality/deterministic/complex-type-alias
export type DeeplyNestedMap = WrappedMap<
  string,
  WrappedMap<string, WrappedMap<string, WrappedMap<string, WrappedMap<string, number>>>>
>;
```

Two changes in the rule:
1. `flattenUnionMembers` now skips `comment` / `ERROR` / `MISSING` nodes. Per-member trailing comments (e.g. `'identifier' // bare reference`) were leaking into the union-member list as `comment` nodes, so the "all simple members" early-exit was failing on shapes like `tsqlCompletion`'s `CompletionContextType`.
2. New `isUtilityTypeChain` predicate skips `NonNullable<Awaited<ReturnType<...>>>` and similar single-arg generic chains over a fixed allowlist of standard utility types (`Awaited`, `ReturnType`, `Parameters`, `NonNullable`, `Partial`, `Pick`, `Omit`, `Prettify`, ...). Recognised at a glance by readers, so the bracket-depth heuristic shouldn't fire.

Also applied the same comment-skip fix to `code-quality/deterministic/too-many-union-members`, which counts union members the same way and had the same comment-inflation FP (bonus delta of -2 below).

## `bugs/deterministic/base-to-string`

OSS source:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/runs/v3/SharedFilters.tsx#L452
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/test/utils/marqs.ts#L60
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/core/src/v3/apiClient/runStream.ts#L408

Positive fixture (`tests/fixtures/sample-js-project-positive/src/base-to-string-member-number.ts`):
```ts
const parsed = parseDuration(period);
if (parsed) {
  return { value: parsed.value.toString(), unit: parsed.unit };
}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/services/api-gateway/src/base-to-string-plain-object.ts`):
```ts
export function logPayload(payload: { id: string; size: number }): string {
  // VIOLATION: bugs/deterministic/base-to-string
  return 'received: ' + payload.toString();
}
```

The visitor was passing only the start position of the receiver expression to `typeQuery.getTypeAtPosition(...)`. Without an end position, the resolver falls back to "smallest node containing the start position" — which for `parsed.value.toString()` is just the `parsed` identifier, not the `parsed.value` member expression. The rule then read the type of the parent object (`{ value: number; unit: string }`), saw the `{`-leading object literal, and fired even though `.toString()` was actually being called on a number. Fixed by passing both `startPosition` and `endPosition` of the receiver so the resolver picks the full member expression.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `performance/deterministic/inline-object-in-jsx-prop` | 45 | 16 | -29 |
| `bugs/deterministic/await-in-loop` | 446 | 394 | -52 |
| `code-quality/deterministic/no-void` | 3 | 0 | -3 |
| `code-quality/deterministic/complex-type-alias` | 23 | 20 | -3 |
| `bugs/deterministic/base-to-string` | 7 | 0 | -7 |
| **Total (these 5 rules)** | **524** | **430** | **-94** |
| **All-rules total on target** | **35249** | **35150** | **-99** |

Additional bonus deltas from the shared-shape fixes applied to sibling rules:

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `bugs/deterministic/void-zero-argument` | 3 | 0 | -3 |
| `code-quality/deterministic/too-many-union-members` | 55 | 53 | -2 |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_0134Yxm6dnzjD5rDyCbGVu9r)_