### PR TITLE
drift-fp-automation: drift FP detection campaign loop (docs + prompts + TG wiring)

### DIFF
--- a/.github/workflows/notify-routine-activity.yml
+++ b/.github/workflows/notify-routine-activity.yml
@@ -112,15 +112,79 @@ jobs:
             --data-urlencode "text=${MESSAGE}" \
             > /dev/null
 
+  # Same debounce-rollup pattern for drift-fp-fix issues filed by
+  # drift-fp-discover / drift-fp-next-fix. Independent concurrency
+  # group from the analysis fp-fix burst so the two never cancel
+  # each other when both chains happen to be active.
+  notify-drift-fp-fix-burst:
+    if: >
+      github.event_name == 'issues' &&
+      contains(github.event.issue.labels.*.name, 'drift-fp-fix')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: drift-fp-fix-burst
+      cancel-in-progress: true
+    steps:
+      - name: Wait for burst to settle
+        run: sleep 60
+
+      - name: Send rollup Telegram message
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+            echo "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID secret not set — skipping notification."
+            exit 0
+          fi
+
+          since=$(date -u -d '10 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')
+          issues_json=$(gh issue list \
+            --repo "$REPO" \
+            --label drift-fp-fix \
+            --state open \
+            --search "created:>${since}" \
+            --json number,title \
+            --limit 200)
+
+          count=$(echo "$issues_json" | jq 'length')
+          if [ "$count" -eq 0 ]; then
+            echo "No drift-fp-fix issues opened in window — nothing to roll up."
+            exit 0
+          fi
+
+          sample=$(echo "$issues_json" | jq -r '.[0:5][] | "• #\(.number) \(.title)"')
+          first_num=$(echo "$issues_json" | jq -r '.[0].number')
+          first_url="https://github.com/${REPO}/issues/${first_num}"
+
+          if [ "$count" -eq 1 ]; then
+            MESSAGE=$(printf "📋 1 new drift-fp-fix issue filed\n\n%s\n\n%s" \
+              "$sample" "$first_url")
+          else
+            MESSAGE=$(printf "📋 %s new drift-fp-fix issues filed\n\n%s\n\n%s" \
+              "$count" "$sample" "$first_url")
+          fi
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" \
+            > /dev/null
+
   # Campaign-level alerts filed individually and rarely — no rollup,
-  # fire per-issue. Covers close-time failures ([fp-campaign-close])
-  # and the "all remaining issues blocked, can't self-progress"
-  # tracking issue ([fp-campaign-stuck]).
+  # fire per-issue. Covers close-time failures ([fp-campaign-close] /
+  # [drift-fp-campaign-close]), the "all remaining issues blocked,
+  # can't self-progress" tracking issues ([fp-campaign-stuck] /
+  # [drift-fp-campaign-stuck]), and drift campaigns that hit an
+  # unrecoverable state in discover/generate ([drift-campaign-broken]).
   notify-campaign-alert:
     if: >
       github.event_name == 'issues' &&
       (startsWith(github.event.issue.title, '[fp-campaign-close]') ||
-       startsWith(github.event.issue.title, '[fp-campaign-stuck]'))
+       startsWith(github.event.issue.title, '[fp-campaign-stuck]') ||
+       startsWith(github.event.issue.title, '[drift-fp-campaign-close]') ||
+       startsWith(github.event.issue.title, '[drift-fp-campaign-stuck]') ||
+       startsWith(github.event.issue.title, '[drift-campaign-broken]'))
     runs-on: ubuntu-latest
     steps:
       - name: Send Telegram message

--- a/docs/drift-fp-automation/README.md
+++ b/docs/drift-fp-automation/README.md
@@ -1,0 +1,566 @@
+# Drift-FP Detection Automation — Design
+
+A loop that runs Truecourse's **drift verifier** against open-source repos,
+identifies false-positive **drifts** (the verifier flagged a spec↔code divergence
+that isn't real), and converts each one into an IL-fixture case + comparator/extractor
+fix, one PR at a time. It is the **drift-engine sibling** of
+[`docs/fp-automation`](../fp-automation/README.md) (which does the same for the
+deterministic analysis rules).
+
+Routines are **stateless** cloud sessions, so all cross-session state lives in GitHub:
+- **`campaigns.yaml`** (on `main`) — the ordered target list + status + results.
+- **GitHub issues** — one per drift-kind with FPs (the fix queue), exactly like the analysis loop.
+- A **per-campaign storage branch** `claude/drift-fp-store/<owner>-<repo>` — holds the generated
+  specs + contracts for the campaign's lifetime. It's opened as a **storage PR that is never
+  merged** (pure storage + the discover trigger) and is **deleted at campaign close**. The
+  contracts therefore **never land on `main`** — they live and die on that branch, like the FP
+  issues. Only the engine fixes (fixtures + comparator changes) merge to `main`.
+
+The loop runs on **[Claude Code Routines](https://code.claude.com/docs/en/routines)** —
+Anthropic-managed cloud sessions triggered by GitHub events. No self-hosted runners.
+
+## How drift FP detection differs from analysis FP detection
+
+The analysis loop runs `analyze --no-llm` — fully deterministic, no setup. The drift
+pipeline is **two-phase**: stages 1–2 (`spec scan`, `contracts generate`) use an LLM (the
+`claude` CLI) to turn prose specs into `.tc` contracts; stage 3 (`verify`) is deterministic
+tree-sitter comparison. **All drift false positives live in stage 3** — the comparators
+(`packages/contract-verifier/src/comparator/`) and code extractors
+(`packages/contract-verifier/src/extractor/`). The LLM stages only produce the contracts the
+deterministic stage checks against.
+
+So the design **generates the contracts once and freezes them on the storage branch**:
+
+> Contracts are generated **once per campaign** (the LLM step) by `drift-fp-generate` and
+> **committed to the campaign's storage branch** `claude/drift-fp-store/<owner>-<repo>`. Every
+> later routine session — discover, fix, close — fetches that branch and runs only the
+> **deterministic `verify`** against those frozen contracts. No routine ever re-runs `spec scan` /
+> `contracts generate`, so the verify result for a frozen (contracts, code@`target_ref`) pair is
+> reproducible byte-for-byte — the drift analog of `analyze --no-llm`. Freezing (not regenerating
+> each session) is what makes the FP-count delta measurable across a fix.
+
+Generation happens **once per campaign**, up front, in the **`drift-fp-generate`** routine, which
+runs the LLM stages via the **`--llm-transport agent`** transport (the routine answers the prompts
+itself — no `claude` binary or key needed). See
+[Generating & storing contracts](#generating--storing-contracts).
+
+> **Why generate once and freeze, instead of regenerating each session?** Determinism. The inner
+> loop is *freeze contracts → change the verifier → re-run `verify` → measure the drift-count
+> delta*. That only works if the contracts are a fixed baseline. If they were LLM-regenerated each
+> session, the baseline would shift run-to-run and "did my fix reduce FPs?" becomes unanswerable —
+> the same reason the analysis loop runs `analyze --no-llm`. So generation is a one-time step
+> (`drift-fp-generate`, the only LLM routine), and its output is frozen on the storage branch for
+> the rest of the campaign.
+
+| | analysis FP loop | drift FP loop |
+|---|---|---|
+| target run | `analyze --no-llm` (deterministic) | `verify` against **frozen contracts** on the storage branch (deterministic) |
+| LLM | never | once per campaign, in `drift-fp-generate` (`--llm-transport agent`); the discover/fix/close loop is LLM-free |
+| contract storage | n/a | per-campaign branch `claude/drift-fp-store/<owner>-<repo>` (never merged; deleted at close) |
+| FP source | a **rule** (`packages/analyzer/src/rules/…`) | a **comparator / extractor** (`packages/contract-verifier/src/…`) |
+| issue unit | one `(rule, repo)` | one `(drift-kind, repo)` |
+| target clone | `--depth=1` at HEAD; `target_ref` = whatever HEAD is | **full** clone + `git checkout <target_ref>` (verify needs a real git repo at the *pinned* SHA the contracts were generated against) |
+| convergence gate | `tp_rate >= 0.90` | **`fp == 0`** (tp≈0 here, so a TP-rate gate is meaningless) |
+| fixture host | `sample-{js,python}-project-{positive,negative}` | `sample-{js,python}-project-il` (one fixture, bidirectional markers) |
+| FP marker | add to `…-positive` (asserts zero violations) | add **unmarked** `// FP-GUARD:` code+contract to the IL fixture (asserts no drift) |
+| TP/regression marker | `// VIOLATION: <rule-key>` in `…-negative` | `// IL-DRIFT: <drift-key>` in the IL fixture |
+
+## Goal
+
+Targets and order are defined in `docs/drift-fp-automation/campaigns.yaml`. The flow is **one
+LLM "generate" step at the front, then a fully-deterministic verify loop.** All routine sessions
+run `node $TRUECOURSE_DIR/dist/cli.mjs` from a fresh `pnpm build:dist` (the bytes publish.yml
+ships; never `npx truecourse`).
+
+1. **drift-fp-generate** (the only LLM routine) picks the next `pending` campaign with no storage
+   branch yet, clones the target, scopes its `.md` specs with a `.truecourseignore`, runs
+   `spec scan → spec resolve --all-defaults → contracts generate` **via the `--llm-transport agent`
+   transport** (the routine answers the prompts itself — no `claude` subprocess, no key), and
+   **commits** the generated **specs + `.tc` contracts + scope +
+   `meta.yaml`** onto a new branch **`claude/drift-fp-store/<owner>-<repo>`**. It opens a **storage
+   PR** (base `main`) labelled `drift-fp-store`. **This PR is never merged** — it just holds the
+   contracts and fires discover when it opens.
+2. **Opening the storage PR** fires **drift-fp-discover** (no human review of contracts): it
+   fetches `claude/drift-fp-store/<owner>-<repo>`, clones the target at the `target_ref` from
+   `meta.yaml`, copies the contracts into `/tmp/target/.truecourse/contracts/`, runs
+   `verify --no-stash` (deterministic, no LLM), and reads
+   `/tmp/target/.truecourse/verifier/LATEST.json` `.drifts[]`.
+3. Triage drifts into TPs (genuine spec↔code divergence) / FPs (extraction or comparison
+   artifact) / borderline.
+4. For every **drift-kind** with ≥1 FP, file one GitHub issue labelled `drift-fp-fix`
+   (drift-kind = comparator + obligation family, e.g. `operation/implementation-missing`,
+   `named-constant/value-mismatch`, `enum/no-code-counterpart`). Open a discovery PR (to `main`)
+   labelled `drift-fp-discover` updating `campaigns.yaml` with `status: discovering` + baseline
+   `fp`/`fp_rate`. The user merges it to start the inner loop.
+5. **Merging the discovery PR** fires `drift-fp-next-fix-bootstrap` (the same prompt as
+   `drift-fp-next-fix`, just a second trigger). The fix loop consumes open
+   `drift-fp-fix` issues in **batches of up to 5 per session**. For each issue:
+   a. Paraphrase the FP-triggering **(contract, code) pair** into the IL fixture
+      (`sample-{js,python}-project-il`) **without** an `// IL-DRIFT:` marker (and with a
+      `// FP-GUARD: <drift-kind>` header) — the IL end-to-end test asserts the verifier's drift
+      set equals the marker set *exactly*, so an unmarked case that drifts fails the test until
+      the comparator/extractor is fixed.
+   b. Add a paraphrased genuine-drift counterpart with `// IL-DRIFT: <drift-key>` so the fix
+      doesn't over-correct and silence real drift.
+   c. Fix the comparator / extractor under `packages/contract-verifier/src/` until both the
+      FP-guard (no drift) and the regression (still drifts) hold and full `pnpm test` is green.
+   At the end of the batch: commit, push `claude/drift-fp-fix/batch-<YYYYMMDDHHMM>`, open one
+   PR that closes all N issues + a `## Drift-count delta` table.
+6. Each batched **fix PR targets `main`** (engine fixes land on `main`, exactly like analysis);
+   its merge fires the next batch. The storage branch is never touched by fix PRs.
+7. When no `drift-fp-fix` issues remain, `drift-fp-next-fix` **re-runs verify against the
+   freshly-built dist** (with all merged fixes) on the frozen contracts (fetched from the storage
+   branch) and re-triages. If **no false-positive drifts remain (`fp == 0`)**, it opens a
+   **campaign-close PR** to `main` (bumps version, flips `status: done`). If FPs remain (`fp > 0`),
+   it files new `drift-fp-fix` issues; the campaign continues.
+8. When the campaign-close PR merges, two routines fire in parallel:
+   `drift-fp-campaign-close` pushes `vX.Y.Z` (publish.yml ships from dist) **and closes the
+   storage PR + deletes `claude/drift-fp-store/<owner>-<repo>`** (the contracts were scaffolding —
+   they never reach `main`); and **`drift-fp-generate` starts the next pending campaign**
+   (generate → storage PR → discover → …).
+
+### TP/FP rubric (shared by discover and the close gate)
+
+Classify each sampled drift as exactly one of:
+- **TP** — a genuine spec↔code divergence the verifier correctly flags.
+- **FP** — the verifier is wrong (symbol exists in a shape it didn't lift; collided two unrelated
+  symbols; didn't reconstruct a route mount).
+- **info / borderline** — chiefly `*.no-code-counterpart` (the verifier honestly reports it
+  couldn't bind a documented symbol). Tracked as `info`; **excluded from the ratio** until a
+  human confirms it FP or TP.
+
+Then: `fp` = FP count, `tp` = TP count, `info` = the excluded bucket, and
+`fp_rate = fp / (tp + fp)` (define `fp_rate = 0` when `tp + fp == 0`).
+
+**Convergence is `fp == 0`, not a TP-rate threshold.** These targets have ~0 genuine drift
+(tp≈0), so a "tp_rate ≥ 0.90" gate (as the analysis loop uses) is unreachable/meaningless here —
+`0/(0+fp) = 0`. The loop drives the verifier toward **emitting no false positives**. The campaign
+closes when a re-verify yields `fp == 0` (every remaining drift is a genuine TP or a
+human-accepted `info`). `tp_rate` is reported for parity (define `= 1.0` when `fp == 0`).
+
+### Campaign-close PR
+
+When `drift-fp-next-fix`'s queue-empty path measures **`fp == 0`** against the freshly-built
+dist, it opens a campaign-close PR that:
+
+- Sets `status: done` for the campaign in `docs/drift-fp-automation/campaigns.yaml` and fills
+  `final.*` (verified_at, target_ref, total_drifts, tp, fp, info, fp_rate).
+- Bumps the **patch** version (drift FP fixes are bug fixes) in all four required places, per
+  CLAUDE.md "Releasing":
+  1. `tools/cli/package.json`
+  2. `packages/core/package.json`
+  3. `apps/dashboard/server/package.json`
+  4. `tools/cli/src/index.ts` — the `.version("X.Y.Z")` call
+- Carries label **`drift-fp-campaign-complete`**.
+- Branch `claude/drift-fp-campaign-close/<owner>-<repo>`.
+
+On merge, `drift-fp-campaign-close` pushes the tag and `drift-fp-generate` fires on the same
+event to start the next pending campaign (generate → pin → discover → …) — both in parallel,
+each doing one job.
+
+### Drift-kind grouping (the issue unit)
+
+A **drift-kind** is the *shape* of a failure, independent of which specific identity/value
+triggered it — so every `constant.<X>.value-mismatch` collapses into one fixable kind. Derive it
+as `<artifact-type-slug>/<obligation-family>`:
+
+- `<artifact-type-slug>` = `artifactRef.type` kebab-cased (`Operation`→`operation`,
+  `NamedConstant`→`named-constant`, `Enum`→`enum`, `StateMachine`→`state-machine`,
+  `QueryRule`→`query-rule`, …).
+- `<obligation-family>` = the `obligationKey` with the artifact **identity and any specific
+  value stripped out**, reduced to its descriptive tail. Concretely:
+
+  | Example `obligationKey` (from the engine) | drift-kind |
+  |---|---|
+  | `implementation.missing` | `operation/implementation-missing` |
+  | `response.201.headers.location` | `operation/response-header` |
+  | `response.2xx` / `response.200` | `operation/response-status` |
+  | `constant.ACTIONS.value-mismatch` | `named-constant/value-mismatch` |
+  | `constant.maxPendingReleases.no-code-counterpart` | `named-constant/no-code-counterpart` |
+  | `enum.ReleaseStatus.no-code-counterpart` | `enum/no-code-counterpart` |
+  | `enum.OrderStatus.extra-value.archived` | `enum/extra-value` |
+  | `transition.illegal.shipped-to-paid` | `state-machine/illegal-transition` |
+  | `query.predicate.missing.tenant_id` | `query-rule/predicate-missing` |
+
+  Rule of thumb: drop the segment that is the artifact identity (`ACTIONS`, `ReleaseStatus`, …)
+  and any trailing concrete value (`archived`, `tenant_id`, a status number); keep the verb/family
+  (`value-mismatch`, `no-code-counterpart`, `extra-value`, `missing-value`, `implementation-missing`,
+  `illegal-transition`, `predicate-missing`, `response-status`, `response-header`). When unsure,
+  list `obligationKey` samples in the issue so the family is auditable.
+
+### Borderline drifts
+
+If a session is uncertain whether a drift is a TP or FP, it does **not** auto-fix. It posts a
+comment tagged `borderline:` (on the discovery PR, or on a `drift-fp-fix` issue if one exists for
+the kind) with the drift key, the code URL **if any** (see the carve-out below), the contract
+path, and a one-paragraph case each way. A human adds `drift-fp-confirmed` (→ the maintainer or
+next discover run files it as a normal `drift-fp-fix` issue the loop then consumes) or
+`drift-tp-confirmed` (→ accepted as genuine; not fixed). The loop never auto-fixes an unconfirmed
+borderline — it only consumes plain `drift-fp-fix` issues.
+
+**`*.no-code-counterpart` carve-out.** These are the most common borderline shape: the verifier
+reports it couldn't bind a documented enum/constant to a *named* code symbol. Two engine facts
+the prompts must respect: (1) such a drift sets `filePath` to the **spec symbol name** (not a code
+file) and `lineStart: 0`, so there is **no code URL / file:line** to cite — say "no code location
+(coverage gap)" instead; (2) the fixture language is decided from the campaign's
+`tech_stack`/`code_dir`, not from the drift's `filePath`. Whether it's an FP (extractor coverage
+gap — the symbol exists in a shape we don't lift, e.g. a strapi inline schema enum) or a real
+omission needs judgement; treat as `info`/borderline unless clearly one.
+
+### Comparator / extractor refactors
+
+If fixing a drift-kind requires a refactor beyond the comparator/extractor itself — a new
+mount-graph pass, threading new resolver state, a new code-fact channel — the session does
+**not** attempt it. It opens the PR with the fixture additions and a `## Refactor needed`
+section, labels it `needs-design`, and ends. The user decides whether to greenlight it.
+
+### Fixture convention (confirmed against the repo)
+
+The drift fixtures use **one project per language** with a bidirectional marker test, instead
+of the analysis loop's two `positive`/`negative` projects.
+
+`tests/contract-verifier/verify-end-to-end.test.ts` (and `verify-python-end-to-end.test.ts`):
+> Parses every `// IL-DRIFT: <drift-key>` marker in the fixture's code tree, runs the verifier,
+> and asserts the verifier's drift set **equals the marker set exactly** — no missing (false
+> negative), no extras (false positive). `drift-key` is `<ArtifactType>:<identity> / <obligationKey>`.
+
+Marker-scan roots differ by language: the **JS** test scans `code/src/`, the **Python** test
+scans the whole `code/` tree. So author fixture code under the language's existing layout — JS
+under `code/src/`, Python under `code/app/` (the Python fixture has no `src/`) — and keep markers
+inside those roots, or the engine will fire a drift the marker parser doesn't count (an
+"unexpected drift" failure).
+
+So a drift FP fix means, in `tests/fixtures/sample-{js,python}-project-il/`:
+
+- **FP-guard case** — add the paraphrased FP code under `code/src/` **with no `// IL-DRIFT:`
+  marker** and a `// FP-GUARD: <drift-kind>` header comment, plus the matching `.tc` contract
+  under `reference/contracts/` that the verifier (wrongly) drifts against. Before the fix, the
+  verifier fires an *unexpected* drift → the "no extras" assertion fails.
+- **Regression case** — add a paraphrased genuine-drift code shape with `// IL-DRIFT:
+  <drift-key>` and its contract, so the comparator/extractor must **still** fire for the real
+  divergence (guards against over-correcting into a false negative).
+- After the comparator/extractor fix: the FP-guard case yields no drift, the regression case
+  still drifts, and the marker set matches exactly.
+
+(The existing IL fixture already contains a precedent FP-guard test — *"traces single-file
+delegation handlers (no implementation.missing FPs)"* — asserting zero `implementation.missing`
+drifts for delegated route handlers. New FP-guards follow the same spirit.)
+
+## Architecture
+
+Each box is a routine. Arrows are GitHub events: the generate→discover hop is a `pull_request.opened`
+(the storage PR); every other hop is a `pull_request.closed` (merged), filtered by head-branch
+prefix + label. The only LLM work is the first box; everything else is deterministic `verify`.
+
+```
+   [Run now / campaign-close merge]
+              │
+              ▼
+┌──────────────────────────────────────────────┐
+│ Routine: drift-fp-generate   (ONLY LLM step)  │
+│ pick next pending campaign w/ no store branch;│
+│ spec scan + contracts generate via --llm-transport agent│
+│ (routine answers prompts); commit specs+      │
+│ contracts onto a NEW branch.                  │
+│ → STORAGE PR  claude/drift-fp-store/<o>-<r>   │
+│   label drift-fp-store   (NEVER merged)        │
+└───────────────┬──────────────────────────────┘
+                │ storage PR OPENED  (pull_request.opened)
+                ▼
+┌──────────────────────────────────────────────┐
+│ Routine: drift-fp-discover                    │
+│ fetch store branch; clone @ meta.target_ref;  │
+│ copy contracts; verify --no-stash (NO LLM);   │
+│ triage TP/FP; file drift-fp-fix issues.       │
+│ → PR (to main) claude/drift-fp-discover/…     │
+│   label drift-fp-discover                      │
+└───────────────┬──────────────────────────────┘
+                │ merge discovery PR → fires drift-fp-next-fix-bootstrap
+                ▼
+┌──────────────────────────────────────────────┐
+│ Routines: drift-fp-next-fix (+ -bootstrap)    │
+│ fetch store branch for contracts. Batched ≤5  │
+│ fixes (cap 10). Per issue: lock, paraphrase FP│
+│ (contract+code) into IL fixture UNMARKED      │
+│ (+FP-GUARD), add IL-DRIFT regression, fix     │
+│ comparator/extractor, tests green.            │
+│ → PR (to MAIN) claude/drift-fp-fix/batch-<ts> │
+│   label drift-fp-fix; Closes #N + delta table │
+│ ── queue empty & fp==0 → campaign-close PR    │
+│ ── queue empty & fp >0 → re-discover          │
+└───────────────┬──────────────────────────────┘
+                │ each fix-PR merge → next batch; when fp==0:
+                │ PR (to main) claude/drift-fp-campaign-close/… label drift-fp-campaign-complete
+                ▼
+┌──────────────────────────────────────────────┐
+│ Routine: drift-fp-campaign-close              │
+│  (∥ drift-fp-generate — same trigger)         │
+│ read version, check 4 locations, git tag &    │
+│ push (publish.yml ships). CLOSE the storage   │
+│ PR + delete claude/drift-fp-store/<o>-<r>.    │
+│ No verify — next-fix already measured fp==0.  │
+└───────────────┬──────────────────────────────┘
+                │ same merge also fires drift-fp-generate → next campaign
+                └────────────────────► (loop)
+```
+
+## Generating & storing contracts
+
+Generation happens **once per campaign** by `drift-fp-generate`, and the output is **committed to
+the storage branch `claude/drift-fp-store/<owner>-<repo>` — never to `main`.** The branch is the
+durable, campaign-scoped store every later session reads from; it's deleted when the campaign
+closes. On that branch, `docs/drift-fp-automation/contracts/<owner>-<repo>/` holds:
+
+```
+specs/                # claims.json + decisions.json — the frozen consolidated spec
+contracts/            # the generated .tc tree (verify reads this)
+truecourseignore      # the doc-scope used (provenance)
+meta.yaml             # { target_repo, target_ref, code_dir, generated_at, doc_scope[], tool_version, llm }
+```
+
+(Storing `specs/` too means contracts can be re-derived later — after an extractor improvement —
+without re-running the expensive `spec scan`.) This path does **not** exist on `main`; the
+per-campaign content lives only on storage branches.
+
+Later sessions read it with `git fetch origin claude/drift-fp-store/<owner>-<repo>` and copy
+`contracts/` into `/tmp/target/.truecourse/contracts/`, then run `verify --code-dir <meta.code_dir>`
+— no regeneration.
+
+**Maintainer fallback** (to seed a campaign by hand instead of letting `drift-fp-generate` run):
+generate the stages locally where `claude` is signed in and push the same storage branch + open
+the storage PR:
+
+```bash
+pnpm install && pnpm build:dist
+git clone https://github.com/<owner>/<repo>.git /tmp/<repo>
+cd /tmp/<repo> && git rev-parse HEAD                      # record as target_ref
+# write /tmp/<repo>/.truecourseignore (the doc scope; gitignore semantics)
+node $TRUECOURSE_DIR/dist/cli.mjs spec scan               # --llm cli uses the local claude login
+node $TRUECOURSE_DIR/dist/cli.mjs spec resolve --all-defaults
+node $TRUECOURSE_DIR/dist/cli.mjs contracts generate
+node $TRUECOURSE_DIR/dist/cli.mjs contracts validate
+# on a NEW branch claude/drift-fp-store/<owner>-<repo>, commit specs/ + contracts/ + truecourseignore
+#   + meta.yaml under docs/drift-fp-automation/contracts/<owner>-<repo>/, push, and open the
+#   storage PR (base main, label drift-fp-store) — do NOT merge it.
+```
+
+## State: one issue per drift-kind
+
+Each `drift-fp-fix` issue is the source of truth for one `(drift-kind, target repo)` pair. Body
+is a machine-readable YAML block followed by a human-readable section.
+
+```yaml
+target_repo: strapi/strapi
+target_ref: e666ee2…                  # the SHA the contracts were generated at (from meta.yaml)
+contracts_branch: claude/drift-fp-store/strapi-strapi   # storage branch holding the contracts
+contracts_path: docs/drift-fp-automation/contracts/strapi-strapi   # path within that branch
+drift_kind: operation/implementation-missing   # comparator + obligation family
+comparator: packages/contract-verifier/src/extractor/operation.ts   # likely fix site
+fp_count: 20
+samples:                               # up to 5 representative FP drifts
+  - drift_key: 'Operation:GET /content-releases/{id} / implementation.missing'
+    code_url: https://github.com/strapi/strapi/blob/e666ee2/packages/core/content-releases/server/src/routes/release.ts#L20
+    contract: content-releases/operations/get-content-releases-id.tc
+    why_fp: "route exists as relative path '/:id' mounted under /content-releases; extractor doesn't reconstruct the mount prefix"
+  - …
+status: open                           # open | in_review | merged | skipped | blocked
+pr: null
+```
+
+Labels:
+- `drift-fp-fix` — gates the **drift-fp-next-fix** routine.
+- `drift-fp-target:<owner>-<repo>` — groups issues by campaign; used to detect "campaign done".
+- `drift-fp-in-progress` — concurrency lock; set the moment a session picks an issue.
+- `drift-fp-skipped` / `drift-fp-blocked` — set when bailing out.
+
+The Claude session is the only writer. Ordering is "oldest open issue without
+`drift-fp-in-progress` first".
+
+## Triggers: five Routines
+
+The chain is **generate → storage PR opened → discover → discovery PR merge → fix loop →
+campaign-close PR merge → (close tags + cleans up + generate starts next)**. Every hop is a
+`pull_request.closed` (merged) event, **except** generate→discover which is `pull_request.opened`
+(the storage PR is never merged). All filtered by **head-branch prefix + label**:
+
+| PR event | Branch | Label | Fires |
+|---|---|---|---|
+| **opened** | `claude/drift-fp-store/` | `drift-fp-store` | `drift-fp-discover` |
+| merged | `claude/drift-fp-discover/` | `drift-fp-discover` | `drift-fp-next-fix-bootstrap` |
+| merged | `claude/drift-fp-fix/` | `drift-fp-fix` | `drift-fp-next-fix` |
+| merged | `claude/drift-fp-campaign-close/` | `drift-fp-campaign-complete` | `drift-fp-campaign-close` (tag + cleanup) **+** `drift-fp-generate` (next campaign) |
+
+The very first campaign is bootstrapped with **Run now** on `drift-fp-generate`.
+
+All run as Anthropic-managed cloud sessions on the **Default** environment. Configured at
+[claude.ai/code/routines](https://claude.ai/code/routines). As in the analysis loop,
+`drift-fp-next-fix` and `drift-fp-next-fix-bootstrap` are two routines sharing one prompt (the
+Routines UI allows one GitHub trigger per routine).
+
+**Prompt convention**: the routine config holds a tiny bootstrap pointer; the real instructions
+live under `docs/drift-fp-automation/prompts/<routine>.md` (source of truth, edited via PR).
+
+Bootstrap pointer (paste into each routine's prompt field, substituting the file name):
+
+```
+Execute the instructions in `docs/drift-fp-automation/prompts/<routine>.md` from the cloned
+`truecourse-ai/truecourse` repository. Treat that file as the authoritative prompt; follow
+every step exactly. If the file is missing or unreadable, post a short failure note in the
+session and end.
+```
+
+### 1. `drift-fp-generate` (the only LLM routine)
+
+| Field | Value |
+|---|---|
+| **Trigger** | `pull_request.closed` on `truecourse-ai/truecourse` |
+| **Filters** | `Is merged` = `true` AND `Head Branch` starts-with `claude/drift-fp-campaign-close/` AND `Labels` is-one-of `drift-fp-campaign-complete` |
+| **Bootstrap** | First-time run is **Run now** (no campaign-close PR has merged yet). |
+| **Environment** | Default |
+| **Prompt** | pointer → `drift-fp-generate.md` |
+
+Shares its trigger with `drift-fp-campaign-close` — both fire in parallel on each campaign-close
+merge (close tags + cleans up the finished campaign; generate starts the next). Picks the first
+`pending` campaign **with no `claude/drift-fp-store/<owner>-<repo>` branch yet** (branch existence,
+not a yaml flag, is the "already generated" signal), runs the LLM stages via `--llm-transport agent`, commits
+specs + contracts to a new `claude/drift-fp-store/…` branch, and opens the storage PR (label
+`drift-fp-store`, **never merged**).
+
+### 2. `drift-fp-discover`
+
+| Field | Value |
+|---|---|
+| **Trigger** | `pull_request.opened` on `truecourse-ai/truecourse` |
+| **Filters** | `Head Branch` starts-with `claude/drift-fp-store/` AND `Labels` is-one-of `drift-fp-store` |
+| **Environment** | Default |
+| **Prompt** | pointer → `drift-fp-discover.md` |
+
+Fires when the storage PR is **opened** (contracts are now on the storage branch — no human review).
+Fetches `claude/drift-fp-store/<owner>-<repo>`, clones the target at `meta.target_ref`, runs
+deterministic `verify` against the contracts, triages, files `drift-fp-fix` issues, and opens the
+discovery PR to `main` (`claude/drift-fp-discover/…`, label `drift-fp-discover`).
+
+### 3. `drift-fp-next-fix` (+ `-bootstrap`)
+
+| Field | `drift-fp-next-fix` | `drift-fp-next-fix-bootstrap` |
+|---|---|---|
+| **Trigger** | `pull_request.closed` | `pull_request.closed` |
+| **Filters** | merged=true AND Head Branch starts-with `claude/drift-fp-fix/` AND Labels is-one-of `drift-fp-fix` | merged=true AND Head Branch starts-with `claude/drift-fp-discover/` AND Labels is-one-of `drift-fp-discover` |
+| **Environment** | Default | Default |
+| **Prompt** | pointer → `drift-fp-next-fix.md` | pointer → `drift-fp-next-fix.md` |
+
+Batched: up to 5 successful fixes (cap 10 attempts) per session; one PR at the end. See
+`prompts/drift-fp-next-fix.md` for the full per-issue mechanics.
+
+### 4. `drift-fp-campaign-close`
+
+| Field | Value |
+|---|---|
+| **Trigger** | `pull_request.closed` on `truecourse-ai/truecourse` |
+| **Filters** | merged=true AND Head Branch starts-with `claude/drift-fp-campaign-close/` AND Labels is-one-of `drift-fp-campaign-complete` |
+| **Environment** | Default |
+| **Prompt** | pointer → `drift-fp-campaign-close.md` |
+
+Reads the new version, sanity-checks the four locations, tags `vX.Y.Z`, and **cleans up the
+finished campaign**: closes the storage PR and deletes `claude/drift-fp-store/<owner>-<repo>`.
+`drift-fp-generate` fires on the same event in parallel to start the next campaign.
+
+## Setup checklist
+
+1. **Install the Claude GitHub App** on `truecourse-ai/truecourse`.
+2. **Enable "Automatically delete head branches"** in repo settings.
+3. **Add the first campaign** to `campaigns.yaml` (`status: pending`, with `code_dir` + `doc_scope`).
+4. **Create the five routines** at claude.ai/code/routines, each with a bootstrap pointer
+   (substitute the file name) on the **Default** environment (Trusted network covers GitHub +
+   the OSS repos we clone; `pnpm install && pnpm build:dist` runs as the prompt's first step; no
+   env vars or API keys). The five (trigger = the PR event/branch/label from the table above):
+   - `drift-fp-generate` → `drift-fp-generate.md`; trigger **merged** `claude/drift-fp-campaign-close/`
+     + `drift-fp-campaign-complete` (+ Run now to bootstrap). The **only** routine doing LLM work
+     (via `--llm-transport agent`).
+   - `drift-fp-discover` → `drift-fp-discover.md`; trigger **opened** `claude/drift-fp-store/` +
+     `drift-fp-store` (note: `pull_request.opened`, not merged).
+   - `drift-fp-next-fix` → `drift-fp-next-fix.md`; trigger **merged** `claude/drift-fp-fix/` + `drift-fp-fix`.
+   - `drift-fp-next-fix-bootstrap` → **same pointer** (`drift-fp-next-fix.md`); trigger **merged**
+     `claude/drift-fp-discover/` + `drift-fp-discover`. **Two routines share one prompt**,
+     differing only in trigger (the Routines UI allows one GitHub trigger per routine) — don't
+     point it at a different file or the inner loop won't kick off on the discovery-PR merge.
+   - `drift-fp-campaign-close` → `drift-fp-campaign-close.md`; trigger **merged**
+     `claude/drift-fp-campaign-close/` + `drift-fp-campaign-complete` (shares the trigger with `drift-fp-generate`).
+   Verbatim pointer to paste (swap the filename):
+   > Execute the instructions in `docs/drift-fp-automation/prompts/<routine>.md` from the cloned
+   > `truecourse-ai/truecourse` repository. Treat that file as the authoritative prompt; follow
+   > every step exactly. If the file is missing or unreadable, post a short failure note and end.
+5. **Bootstrap** by clicking **Run now** on `drift-fp-generate`. It generates the contracts and
+   opens the storage PR — which immediately fires `drift-fp-discover` (no merge needed).
+6. From there it's **automatic**: storage PR opened → discover files issues + opens the discovery
+   PR → **merge the discovery PR** → fix loop. The only human gate is reviewing + merging the
+   discovery PR and each fix PR (contracts are not reviewed).
+7. **Loops are automatic**: inner loop per fix-PR merge; outer loop per campaign-close merge (which
+   tags, cleans up the storage branch, and fires `drift-fp-generate` for the next campaign).
+
+## Acceptance criteria
+
+A **drift-fp-fix PR** is mergeable when:
+
+- Contains 1–5 drift-kind fixes (typically 5).
+- For each: a new **FP-guard** IL-fixture case (code with no `// IL-DRIFT:` marker + its `.tc`
+  contract; verifier emits no drift), a new **regression** case (code with `// IL-DRIFT:
+  <drift-key>` + contract; verifier still drifts), and a scoped comparator/extractor edit under
+  `packages/contract-verifier/src/`.
+- Full `pnpm test` green (the IL end-to-end marker test included).
+- Body has one `Closes #N` per fixed issue, per-drift-kind sections with OSS source URLs (URL
+  only — no paste), fixture diffs, and a `## Drift-count delta` table (verify on the frozen
+  contracts before/after, per drift-kind).
+- Branch `claude/drift-fp-fix/batch-<YYYYMMDDHHMM>` **(base `main`)**, label `drift-fp-fix`.
+
+A **campaign-close PR** is mergeable when:
+
+- The campaign in `campaigns.yaml` is `status: done` with `final.*` filled.
+- Patch version bumped consistently in all four locations.
+- No other file changes (no contracts — those never reach `main`).
+- Branch `claude/drift-fp-campaign-close/<owner>-<repo>`, label `drift-fp-campaign-complete`.
+
+## Resolved decisions
+
+1. **Generate once, freeze on a storage branch.** The LLM stage (`spec scan` + `contracts
+   generate`) runs once per campaign in `drift-fp-generate` (via `--llm-transport agent`) and is committed to
+   `claude/drift-fp-store/<owner>-<repo>` — **never to `main`** (the storage PR is never merged;
+   the branch is deleted at close). Every other routine fetches that branch and runs only
+   deterministic `verify`. Freezing (not regenerating) is what makes the FP-count delta measurable.
+2. **FP source is the verifier, not the contracts.** Fixes land in
+   `packages/contract-verifier/src/{comparator,extractor,resolver}/` and merge to `main`. A wrong
+   contract (LLM mis-extraction) is *not* a drift FP — it's a contract-generation issue; flag it
+   `needs-design` and skip, don't "fix" the verifier to paper over it.
+3. **Verification is pre-release**, against the local `dist/` build (`pnpm build:dist` →
+   `dist/cli.mjs`, byte-equal to what publish.yml ships). Never `npx truecourse`.
+4. **No contract review.** `drift-fp-discover` fires on the storage PR *opening* — the generated
+   contracts are not human-reviewed. Human review is on the discovery PR and each fix PR.
+5. **Borderline drifts** (esp. `*.no-code-counterpart`): not auto-fixed; `borderline:` comment +
+   human label. **Refactors**: not auto-attempted; `## Refactor needed` + `needs-design`.
+6. **Cost control**: only `drift-fp-generate` uses the LLM (once per campaign, bounded by the
+   `.truecourseignore` doc-scope); discover/fix/close are LLM-free.
+7. **Branch hygiene**: `claude/`-prefixed branches; auto-delete on merge. The storage branch is the
+   exception — never merged, explicitly deleted by `drift-fp-campaign-close`.
+8. **Concurrency**: `drift-fp-in-progress` lock before any work on an issue.
+9. **Target order**: `campaigns.yaml` is the source of truth; `drift-fp-generate` picks the first
+   `pending`, non-`skipped` campaign whose storage branch doesn't exist yet.
+
+## Selecting targets
+
+A repo is only worth a campaign if drift can actually surface — i.e. its **non-dot `.md` specs**
+overlap **liftable code** (Prisma entities; TS/Zod/str-Enum enums; Express/FastAPI routes;
+Knex/Prisma queries; named constants). Vet each candidate empirically:
+
+1. Shallow-clone it and run `truecourse infer --dry-run` to see what the extractors actually lift.
+2. Read its non-dot `.md` docs and check they describe the *same* enums/entities/constants/routes.
+3. Score the overlap; only seed a campaign if it's real.
+
+Of 24 repos scouted / 10 probed this way, only **`strapi/strapi`** (JS) and **`feast-dev/feast`**
+(Python) cleared the bar as "strong" fits — both seeded in `campaigns.yaml`. Most repos fail it:
+specs in a separate repo, `.mdx`/`.rst` docs (invisible to the tool), or non-Prisma ORMs the
+extractors don't lift. Add new campaigns the same way.
+
+## What's next
+
+1. Walk the setup checklist; create the five routines on the Default environment.
+2. **Run now** on `drift-fp-generate` to start the first campaign (strapi/strapi).

--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -1,0 +1,86 @@
+# Drift-FP campaigns — source of truth for which repos we run the drift verifier
+# against, in what order, and the results.
+#
+# Owned by the drift-fp-automation routines. Humans add/reorder entries; routine
+# sessions update `status`, `baseline`, `final`, and `notes`. Always read the
+# latest from `main`. The CONTRACTS themselves are NOT stored here — they live on
+# per-campaign storage branches `claude/drift-fp-store/<owner>-<repo>` (generated
+# once by drift-fp-generate, deleted at close). See README "Generating & storing
+# contracts".
+#
+# Status values (no `in_progress` — a campaign stays `discovering` from issue
+# filing through the whole fix loop until it closes):
+#   pending      — not yet started. drift-fp-generate picks the first `pending`
+#                  campaign whose storage branch doesn't exist yet (branch
+#                  existence, not a yaml flag, is the "already generated" signal).
+#   discovering  — drift-fp-discover has run / the fix loop is in progress
+#                  (set by the discovery PR that merges to main).
+#   done         — drift-fp-next-fix verified NO false-positive drifts remain
+#                  (fp == 0); campaign-close PR merged; vX.Y.Z tagged; storage
+#                  branch deleted.
+#   skipped      — manually deprioritized; note explains why
+#
+# Convergence is driven toward fp == 0 (not "tp_rate >= 0.90" — these targets
+# have ~0 genuine drift, so tp≈0 and a TP-rate gate is meaningless). The close
+# gate is "no false-positive drift-kinds remain". See README "TP/FP rubric".
+#
+# Per-campaign fields:
+#   target_repo      — owner/repo
+#   tech_stack       — informational
+#   code_dir         — passed to `verify --code-dir` (relative to repo root; "." = root).
+#                      Authoritative copy lives in the storage branch's meta.yaml.
+#   doc_scope        — the .md dirs the `.truecourseignore` keeps (drift-fp-generate uses this)
+#   priority         — pick order
+#   baseline/final   — drift snapshots: { verified_at, target_ref, total_drifts, tp, fp, info, fp_rate }
+#                      target_ref MUST equal the storage branch's meta.yaml target_ref.
+#
+# Each campaign also writes its open issues with label
+# `drift-fp-target:<owner>-<repo>` so a session can find them without crawling this file.
+# Targets are vetted empirically (clone + `infer --dry-run` probe of spec↔code
+# overlap) before seeding — see README "Selecting targets".
+
+campaigns:
+  # ---- JS/TS — strongest validated drift fit (fit 88, strong) ----
+  - target_repo: strapi/strapi
+    tech_stack: [typescript, monorepo, knex]
+    code_dir: packages/core
+    doc_scope:
+      - docs/docs/docs/01-core/authentication
+      - docs/docs/docs/01-core/content-manager
+      - docs/docs/docs/01-core/content-releases
+      - docs/docs/docs/01-core/permissions
+      - docs/docs/rfcs
+    priority: 1
+    status: pending
+    baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    notes:
+      - "Validation run found 44 drift items, ~0 genuine: 20 Operation implementation.missing FPs (relative-path plugin routes mounted under a prefix; extractor doesn't reconstruct the mount), 13 NamedConstant ACTIONS value-mismatch FPs (bare-name collision, no module scoping), 11 no-code-counterpart info notes. PublicationFilter enum verified cleanly (true negative). Strong first FP corpus: operation mount-prefix + named-constant module-scoping."
+      - "Default branch is develop, not main — pin target_ref off develop."
+
+  # ---- Python — best validated Python drift fit (fit 78, strong) ----
+  - target_repo: feast-dev/feast
+    tech_stack: [python, feature-store]
+    code_dir: "."
+    doc_scope: []        # fill before generating (keep the behavioral docs/ .md; drop the 93 .rst)
+    priority: 2
+    status: pending
+    baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    notes: ["Probe histogram: NamedConstant 189, Operation 71, Enum 20, Formula 6, Pagination present. Has 93 .rst (invisible to the tool) alongside .md."]
+
+  # ---- JS/TS — secondary validated fit (fit 42, 'maybe') ----
+  - target_repo: directus/directus
+    tech_stack: [typescript, knex]
+    code_dir: "."
+    doc_scope: []        # narrow: Directus's behavioral .md is sparse (api/src/ai/tools/*/prompt.md); fill before generating
+    priority: 3
+    status: pending
+    baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    notes: ["Narrow but real overlap: Flows TriggerType/accountability/status enums in prompt.md ↔ code enums. Docs mostly live in a separate repo, so spec surface is thin."]
+
+  # ---- Add more campaigns below once validated (probe via `infer --dry-run`) ----
+  # Bar: concrete .md specs in REAL (non-dot) folders that OVERLAP liftable app
+  # code (Prisma entities / TS|Zod|str-Enum enums / Express|FastAPI routes /
+  # Knex|Prisma queries / named constants). See README "Selecting targets".

--- a/docs/drift-fp-automation/prompts/drift-fp-campaign-close.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-campaign-close.md
@@ -1,0 +1,72 @@
+# drift-fp-campaign-close routine prompt
+
+You are the **drift-fp-campaign-close** routine. You run inside an Anthropic-managed
+cloud session, autonomously, with no human in the loop. Your job is small and
+well-defined: when a `drift-fp-campaign-complete` PR merges to `main`, push a release tag.
+
+The **`fp == 0`** gate (no false-positive drifts remain) was already checked **pre-merge** by
+`drift-fp-next-fix` against the local dist build (deterministic `verify` on the pinned
+contracts) — the artifact publish.yml is about to ship. So merging the campaign-close PR is the
+campaign's "done" signal, and your only remaining job is tagging.
+
+`drift-fp-generate` fires on the same merge event in parallel and starts the next pending
+campaign (generate → storage PR → discover → …) — you don't chain to it. The two run **race-free
+on disjoint campaigns**: you clean up the just-`done` campaign's storage branch; generate picks a
+different, still-`pending` campaign (its `done` status + your branch deletion can't collide).
+
+## Inputs
+
+- `truecourse-ai/truecourse` is cloned at `main` at the merge commit.
+
+## Step-by-step
+
+### 1. Read the new version
+
+- Read `version` from `tools/cli/package.json` (the version the merged PR bumped to).
+- Sanity-check it matches:
+  - `packages/core/package.json`
+  - `apps/dashboard/server/package.json`
+  - `tools/cli/src/index.ts` — the `.version("X.Y.Z")` argument
+- If any of the four disagree: do **not** push. Open an issue titled `[drift-fp-campaign-close]
+  version mismatch after merge` with the four observed values + merge SHA, end the body with
+  `cc @mushgev`, end the session.
+
+### 2. Push the tag
+
+- Verify `v<version>` doesn't already exist: `git tag -l "v<version>"` is empty (if it exists,
+  end without pushing).
+- `git tag v<version> && git push origin v<version>`. The existing
+  `.github/workflows/publish.yml` triggers, ships `dist/` to npm, creates the GitHub Release.
+
+### 3. Clean up the campaign's storage branch
+
+- Find the `<owner>/<repo>` for the campaign that just closed: read the merged campaign-close PR's
+  head branch (`claude/drift-fp-campaign-close/<owner>-<repo>`) or `campaigns.yaml` (the entry just
+  flipped to `status: done`).
+- **Close the storage PR** (`gh pr close` the open PR on head `claude/drift-fp-store/<owner>-<repo>`,
+  label `drift-fp-store`) **and delete the branch**:
+  `git push origin --delete claude/drift-fp-store/<owner>-<repo>`. The contracts were
+  campaign-scaffolding — they never belong on `main` and are done now.
+- If the storage branch/PR is already gone, that's fine — continue.
+
+### 4. End
+
+- Post: `Released v<version>; cleaned up storage branch. publish.yml is handling npm + GitHub Release.` End.
+
+## Failure modes
+
+- **Tag push fails**: do not retry. Open an issue `[drift-fp-campaign-close] tag push failed for
+  v<version>` with the error, end the body `cc @mushgev`, end.
+- **Version mismatch**: see step 1. Open the mismatch issue, end.
+
+## Hard constraints
+
+- Never modify repo files in this session. Your only writes are: push the **tag**, close the
+  **storage PR**, and delete the **storage branch**. Never push to any branch.
+- Never run `truecourse verify`, `spec scan`, `contracts generate`, tests, or builds. The
+  pre-merge `drift-fp-next-fix` queue-empty path already verified `fp == 0` against the exact
+  dist artifact publish.yml will ship.
+- **Never use `npx truecourse` or `npm install truecourse`.** This routine doesn't run
+  truecourse at all.
+- One tag push per session; delete only the storage branch for the campaign that just closed. If
+  anything is unexpected, open an issue and end. Do not invent state.

--- a/docs/drift-fp-automation/prompts/drift-fp-discover.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-discover.md
@@ -1,0 +1,191 @@
+# drift-fp-discover routine prompt
+
+You are the **drift-fp-discover** routine. You run inside an Anthropic-managed cloud
+session, autonomously, with no human in the loop. Your job: run Truecourse's **drift
+verifier** against one target OSS repo using its **pinned contracts**, classify each
+drift as a true-positive (TP, a genuine spec↔code divergence) or false-positive (FP, an
+extraction/comparison artifact), and file one GitHub issue per **drift-kind** that has
+FPs so `drift-fp-next-fix` can consume them.
+
+Run exactly one campaign per invocation. Do **not** loop across campaigns.
+
+You run only the **deterministic `verify`** — never `spec scan` or `contracts generate`. The
+contracts were generated and committed upstream by `drift-fp-generate` onto the campaign's
+**storage branch** `claude/drift-fp-store/<owner>-<repo>`; you fetch them and consume them as-is.
+
+## Inputs
+
+- `truecourse-ai/truecourse` is cloned at the default branch.
+- Fires when a **storage PR is opened** (`pull_request.opened`, head-branch starts-with
+  `claude/drift-fp-store/`, label `drift-fp-store`) — so the campaign's contracts now exist on that
+  branch. Derive `<owner>-<repo>` from the head branch name; no human review of the contracts.
+
+## Step-by-step
+
+### 1. Identify the campaign + fetch its contracts
+
+- The storage branch is the head of the PR that fired you: `claude/drift-fp-store/<owner>-<repo>`.
+  Fetch it: `git fetch origin claude/drift-fp-store/<owner>-<repo>`.
+- Read `docs/drift-fp-automation/contracts/<owner>-<repo>/meta.yaml` **from that branch** (e.g.
+  `git show origin/claude/drift-fp-store/<owner>-<repo>:docs/drift-fp-automation/contracts/<owner>-<repo>/meta.yaml`).
+  It's the **authoritative** source of `target_ref` + `code_dir`.
+- Then branch on state (don't dead-end silently):
+  - **meta.yaml missing/malformed** → comment a `[drift-campaign-broken] <owner>/<repo>` tracking
+    issue (`cc @mushgev`) and stop.
+  - **campaign absent from `campaigns.yaml`, or `status: done`/`skipped`** → comment the same
+    `[drift-campaign-broken]` issue and stop (a store PR for a finished/unknown campaign is unexpected).
+  - **`status: pending`** → first legitimate run; proceed.
+  - **`status: discovering`** → this is a re-fire (idempotent); proceed, but **update the existing
+    discovery PR** instead of opening a second one.
+
+### 2. Mark the campaign `discovering`
+
+- On a new branch `claude/drift-fp-discover/<owner>-<repo>`, set the campaign's
+  `status: discovering` in `campaigns.yaml`.
+- Open a PR titled `chore(drift-fp): start discovery for <owner>/<repo>`. Body explains you're
+  starting a drift discovery run. End the body with `cc @mushgev`.
+- **Apply label `drift-fp-discover` to this PR** — this is what fires `drift-fp-next-fix` when
+  the PR merges. Without it, the chain doesn't start.
+- Do **not** wait for merge. Continue with verify + issue filing; keep pushing commits to this PR.
+
+### 3. Build truecourse from local source
+
+- `pnpm install && pnpm build:dist`. Produces `dist/cli.mjs`, the **same artifact** publish.yml
+  ships. Always use this — never `npx truecourse` or `npm install truecourse`.
+
+### 4. Clone the target and run verify against the stored contracts
+
+- Use the `target_ref` and `code_dir` you read from the storage branch's **meta.yaml** (step 1) —
+  the **authoritative** source. The code MUST be verified at exactly the SHA the contracts were
+  generated against.
+- `git clone https://github.com/<owner>/<repo>.git /tmp/target` and
+  `git -C /tmp/target checkout <target_ref>`. (Full clone, not `--depth=1`: `verify` runs inside
+  a git repo and the pinned `target_ref` must be checkout-able.)
+- Extract the contracts **from the storage branch into `/tmp`** (never into the truecourse working
+  tree — you're on a `claude/drift-fp-discover/` branch and must not commit the contracts):
+  ```
+  P=docs/drift-fp-automation/contracts/<owner>-<repo>
+  mkdir -p /tmp/extract /tmp/target/.truecourse
+  git -C $TRUECOURSE_DIR archive origin/claude/drift-fp-store/<owner>-<repo> "$P/contracts" \
+      | tar -x -C /tmp/extract
+  cp -R /tmp/extract/$P/contracts /tmp/target/.truecourse/contracts
+  ```
+  Read contracts from the storage branch only — `main` doesn't have them. (Read `meta.yaml` the
+  same git-stdout way as step 1 — never `git checkout … -- <path>`, which would write into the
+  working tree and risk committing the contracts.)
+- Run verify **from inside the target repo** (deterministic; no LLM):
+  ```
+  cd /tmp/target && \
+    node $TRUECOURSE_DIR/dist/cli.mjs verify --no-stash --code-dir <code_dir>
+  ```
+  (`<code_dir>` is the campaign's `code_dir`, e.g. `packages/core` or `.`.)
+- Read results from `/tmp/target/.truecourse/verifier/LATEST.json`. The field you care about is
+  `.drifts[]`; each entry has `artifactRef {type, identity}`, `obligationKey`, `severity`,
+  `filePath`, `lineStart`, `message`. The drift key is
+  `<artifactRef.type>:<artifactRef.identity> / <obligationKey>`.
+  - **Caveat:** `filePath`/`lineStart` are a real code location **only** for drifts that bind to
+    code. For `*.no-code-counterpart` drifts the engine sets `filePath` to the spec **symbol
+    name** and `lineStart: 0` — there is no code file/line for those (see step 5/6).
+- If verify fails (non-zero exit, or LATEST.json missing): comment the error tail on the
+  discovery PR, file/refresh a `[drift-campaign-broken] <owner>/<repo>` issue (`cc @mushgev`), and
+  end. Leave `status: discovering` — there is no `blocked` status (the only states are pending /
+  discovering / done / skipped); the tracking issue is the human signal.
+
+### 5. Triage drifts
+
+- Group drifts by **drift-kind** = `<artifact-type-slug>/<obligation-family>`, per the explicit
+  recipe in README "Drift-kind grouping": kebab the `artifactRef.type`, strip the artifact
+  identity and any specific value out of `obligationKey`, keep the descriptive family. E.g.
+  `constant.ACTIONS.value-mismatch` → `named-constant/value-mismatch`;
+  `enum.ReleaseStatus.no-code-counterpart` → `enum/no-code-counterpart`; `implementation.missing`
+  → `operation/implementation-missing`; `transition.illegal.<…>` → `state-machine/illegal-transition`.
+  All drifts of the same shape collapse to one kind regardless of identity/value.
+- For each drift-kind with ≥1 drift:
+  1. Take up to 10 samples (you'll record up to 5 representative ones on the issue in step 6).
+  2. Classify each:
+     - **TP** — the code genuinely diverges from a documented rule (e.g. an enum value the docs
+       require is truly absent; a constant whose code value really differs).
+     - **FP** — the verifier is wrong: the thing it claims is missing/mismatched actually exists
+       in a shape it failed to lift, or it collided two unrelated symbols, or it didn't
+       reconstruct a route mount. Open the cited `filePath` in the target and check.
+     - **borderline** — could go either way. `*.no-code-counterpart` (info) drifts are usually
+       borderline: confirm whether the documented symbol exists in code in *some* shape.
+  3. **Distinguish FP from a bad contract.** If the drift is wrong because the *pinned contract*
+     misread the spec (the LLM extracted a value the doc never stated), that is **not** a
+     verifier FP — it's a contract-generation issue. Do not file a `drift-fp-fix` issue for it;
+     note it on the discovery PR as a `contract-quality:` bullet for human review.
+  4. Compute the FP rate (FP count / sampled count) for the drift-kind.
+
+### 6. File one issue per drift-kind with FPs
+
+For each drift-kind with **≥1 clear FP** in the triaged sample (file on any clear FP — don't gate
+on a percentage):
+
+- Open a GitHub issue on `truecourse-ai/truecourse`:
+  - **Title**: `[drift-fp-fix] <drift-kind> in <owner>/<repo>`
+  - **Labels**: `drift-fp-fix`, `drift-fp-target:<owner>-<repo>` (replace `/` with `-`).
+  - **Body**:
+
+    ````
+    ```yaml
+    target_repo: <owner>/<repo>
+    target_ref: <full-sha>
+    contracts_branch: claude/drift-fp-store/<owner>-<repo>   # storage branch holding the contracts
+    contracts_path: docs/drift-fp-automation/contracts/<owner>-<repo>   # path within that branch
+    code_dir: <code_dir>
+    drift_kind: <comparator-family>/<obligation-family>
+    comparator: packages/contract-verifier/src/<comparator-or-extractor file you believe is the fix site>
+    fp_count: <FPs observed in the triaged sample (the up-to-10 samples) for this drift-kind>
+    samples:                               # up to 5 representative FP drifts
+      - drift_key: '<ArtifactType>:<identity> / <obligationKey>'
+        code_url: https://github.com/<owner>/<repo>/blob/<sha>/<path>#L<line>   # omit / set "none (coverage gap)" for *.no-code-counterpart (filePath is a symbol name, lineStart 0)
+        contract: <repo-relative .tc path under the pinned contracts dir>
+        why_fp: <one-line reason this is an FP, not a real divergence>
+    status: open
+    pr: null
+    ```
+
+    ## Borderline cases
+
+    <Either "None" or a bulleted list, each with the drift key, code URL, contract path, and a
+    one-paragraph case for each interpretation. A human adds drift-fp-confirmed or
+    drift-tp-confirmed.>
+    ````
+
+For drift-kinds where every sample is borderline (no clear FP), do **not** file an issue — add a
+comment on the discovery PR listing them for human triage.
+
+### 7. Update baseline in campaigns.yaml
+
+Use the shared TP/FP rubric (README "TP/FP rubric"):
+  - `total_drifts`: count from `.drifts[]`.
+  - `tp`: total TPs across sampled drift-kinds.
+  - `fp`: total FPs across sampled drift-kinds.
+  - `info`: `*.no-code-counterpart` / borderline drifts you judged neither tp nor fp (**excluded
+    from the ratio**, tracked separately).
+  - `fp_rate`: fp / (tp + fp), 2 decimals (`0` when tp+fp == 0).
+- On the same branch, fill the campaign's `baseline.*`: `verified_at` (ISO date), `target_ref`
+  (= the meta.yaml SHA you verified at), `total_drifts`, `tp`, `fp`, `info`, `fp_rate`. Leave
+  `status: discovering` (the campaign stays `discovering` through the whole fix loop until close).
+  Commit, push to the existing PR.
+
+### 8. End
+
+- Post a final comment on the discovery PR: issues filed, baseline `fp` count + `fp_rate` (+ the
+  `info` bucket size), target ref, any `contract-quality:` notes. Stop.
+
+`drift-fp-next-fix` fires automatically when the discovery PR merges.
+
+## Hard constraints
+
+- One campaign per session. Never verify a second repo.
+- **Never run `spec scan`, `contracts generate`, or `infer`.** Discovery is deterministic
+  `verify` only, against pinned contracts. If contracts are missing, end with the
+  not-pinned note (step 1).
+- Never push outside `claude/`-prefixed branches.
+- **Never use `npx truecourse` or `npm install truecourse`.** Always `node dist/cli.mjs` from a
+  fresh `pnpm build:dist`.
+- Never paste OSS code into issue bodies — link by URL only.
+- A wrong contract (LLM mis-extraction) is **not** a verifier FP — `contract-quality:` note, not
+  an issue.
+- If anything is ambiguous, comment on the discovery PR and stop. Do not invent state.

--- a/docs/drift-fp-automation/prompts/drift-fp-discover.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-discover.md
@@ -40,12 +40,22 @@ contracts were generated and committed upstream by `drift-fp-generate` onto the 
 
 ### 2. Mark the campaign `discovering`
 
-- On a new branch `claude/drift-fp-discover/<owner>-<repo>`, set the campaign's
-  `status: discovering` in `campaigns.yaml`.
+- **Create the discovery branch FIRST**, before editing `campaigns.yaml`. The routine starts the
+  session on a default randomly-named branch (e.g. `claude/<adjective-noun-XXXX>`); pushing from
+  that branch will **not** match the discovery PR trigger filter, and the chain stalls. Run:
+  ```
+  git fetch origin main && \
+    git checkout -b claude/drift-fp-discover/<owner>-<repo> origin/main
+  ```
+  All commits this step makes go on this branch.
+- Set the campaign's `status: discovering` in `campaigns.yaml` and commit on that branch.
 - Open a PR titled `chore(drift-fp): start discovery for <owner>/<repo>`. Body explains you're
   starting a drift discovery run. End the body with `cc @mushgev`.
 - **Apply label `drift-fp-discover` to this PR** — this is what fires `drift-fp-next-fix` when
   the PR merges. Without it, the chain doesn't start.
+- **Verify your branch before pushing.** Run `git rev-parse --abbrev-ref HEAD` and confirm it is
+  exactly `claude/drift-fp-discover/<owner>-<repo>`. If it isn't, STOP, recreate the correct branch
+  from `origin/main`, cherry-pick the commit, delete the wrong branch, then push.
 - Do **not** wait for merge. Continue with verify + issue filing; keep pushing commits to this PR.
 
 ### 3. Build truecourse from local source

--- a/docs/drift-fp-automation/prompts/drift-fp-generate.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-generate.md
@@ -57,28 +57,54 @@ Run exactly one campaign per invocation. Do **not** loop across campaigns.
 
 ### 4. Generate contracts via the agent transport
 
-Run the three LLM stages with `--llm-transport agent`, driving the prompt I/O yourself:
+Run the three LLM stages with `--llm-transport agent`. Each stage runs **in the background** and
+hands you its prompts through a filesystem mailbox at `--io /tmp/llm-io`; you answer them by hand
+until the stage process exits.
 
-- Start a stage in the background with an I/O dir, e.g.:
-  ```
-  cd /tmp/target && node $TRUECOURSE_DIR/dist/cli.mjs spec scan --llm-transport agent --io /tmp/llm-io &
-  ```
-- **Answer loop** (while the tool process is alive): poll `/tmp/llm-io/req/` for request files
-  with no matching `/tmp/llm-io/res/<id>.json` answer. For each, read `{system, user, schema}`,
-  produce JSON that **strictly satisfies `schema`**, and write it to `/tmp/llm-io/res/<id>.json`.
-  Answer batches in parallel; keep going until the tool exits (it writes the stage's output and
-  finishes).
-- Repeat for the remaining stages, in order:
-  ```
-  node $TRUECOURSE_DIR/dist/cli.mjs spec resolve --all-defaults --llm-transport agent --io /tmp/llm-io
-  node $TRUECOURSE_DIR/dist/cli.mjs contracts generate --llm-transport agent --io /tmp/llm-io
-  node $TRUECOURSE_DIR/dist/cli.mjs contracts validate   # deterministic, no LLM
-  ```
-  (`spec resolve --all-defaults` re-runs the scan internally, so most prompts are **cache hits** —
-  expect few or no new request files; just wait for the process to exit. `contracts validate` is
-  deterministic — no prompts.)
-- Produce only schema-valid answers; do not invent fields. If a stage errors, capture the tail
-  for the PR/issue and stop (don't pin partial contracts).
+**The mailbox protocol** (this is exactly what the `agent` transport reads/writes — match it
+precisely):
+
+- The tool writes each prompt to **`/tmp/llm-io/requests/<id>.json`** — a JSON object with fields
+  `{ id, stage, model, fallbackModel, responseFormat, schema, system, user }`.
+- You answer by writing **`/tmp/llm-io/responses/<id>.json`** — **same filename** — with body
+  **`{ "text": "<your answer>" }`**. `text` **must be a JSON string**.
+  - When `responseFormat` is `"json"` (the default), the tool does `JSON.parse(text)` after
+    stripping any code fence — so `text` must be the **schema-satisfying JSON serialized as a
+    string** (e.g. `{"text": "{\"claims\": [ … ]}"}`), **not** a nested JSON object. Satisfy the
+    request's `schema` exactly; invent no fields.
+  - When `responseFormat` is `"text"`, `text` is free-form.
+  - To surface an unrecoverable answer failure, write `{ "error": "<reason>" }` instead — the tool
+    will abort that stage.
+- The tool polls every 200ms and times out a single unanswered request after 10 min, so keep the
+  loop running continuously until the **process exits**.
+
+**The answer loop** (run for each stage):
+
+```
+mkdir -p /tmp/llm-io/requests /tmp/llm-io/responses
+cd /tmp/target && node $TRUECOURSE_DIR/dist/cli.mjs spec scan --llm-transport agent --io /tmp/llm-io &
+```
+
+While that background process is alive: poll `/tmp/llm-io/requests/` for any `<id>.json` that has
+no matching `/tmp/llm-io/responses/<id>.json`. For each, read `{system, user, schema,
+responseFormat}`, produce the answer, and write `/tmp/llm-io/responses/<id>.json` as
+`{"text": "…"}`. Answer batches in parallel. Keep going until the process exits (it writes the
+stage's output and finishes).
+
+Repeat the same background-run + answer-loop for the remaining stages, **in order**:
+
+```
+node $TRUECOURSE_DIR/dist/cli.mjs spec resolve --all-defaults --llm-transport agent --io /tmp/llm-io &
+node $TRUECOURSE_DIR/dist/cli.mjs contracts generate --llm-transport agent --io /tmp/llm-io &
+node $TRUECOURSE_DIR/dist/cli.mjs contracts validate   # deterministic, no LLM, foreground
+```
+
+(`spec resolve --all-defaults` re-runs the scan internally, so most prompts are **cache hits** —
+expect few or no new request files; just keep the loop ready and wait for the process to exit.
+`contracts validate` is deterministic — no prompts, runs in the foreground.)
+
+If a stage errors (non-zero exit), capture the tail for the PR/issue and stop — don't pin partial
+contracts.
 
 ### 5. Commit specs + contracts onto the storage branch
 

--- a/docs/drift-fp-automation/prompts/drift-fp-generate.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-generate.md
@@ -107,6 +107,12 @@ Run the three LLM stages with `--llm-transport agent`, driving the prompt I/O yo
 
 ### 6. Open the storage PR (never merged)
 
+- **Verify your branch before pushing.** Run `git rev-parse --abbrev-ref HEAD` and confirm it is
+  exactly `claude/drift-fp-store/<owner>-<repo>`. If it isn't (e.g. you're still on the routine's
+  default `claude/<random>` branch), STOP. Recreate the correct branch from `origin/main`,
+  cherry-pick or re-stage the commit from step 5, delete the wrong branch, then push. Pushing from
+  the wrong branch produces a PR whose head doesn't match the `drift-fp-discover` trigger filter
+  (`Head Branch starts-with claude/drift-fp-store/`), and the chain stalls before discover fires.
 - Open a PR with head `claude/drift-fp-store/<owner>-<repo>`, base `main`.
 - Title `chore(drift-fp): contracts store for <owner>/<repo> @ <short-sha>`.
 - **Label `drift-fp-store`** — opening this PR (a `pull_request.opened` event) is what fires

--- a/docs/drift-fp-automation/prompts/drift-fp-generate.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-generate.md
@@ -1,0 +1,131 @@
+# drift-fp-generate routine prompt
+
+You are the **drift-fp-generate** routine — the **front of the chain**. You run inside an
+Anthropic-managed cloud session, autonomously. Your job: for one target repo, run the **LLM
+stages once** (`spec scan` + `contracts generate`) via the **agent LLM transport**, **commit the
+generated specs + `.tc` contracts onto a per-campaign storage branch**, and open a **storage PR
+that is never merged**. Opening that PR fires `drift-fp-discover`; everything downstream runs only
+deterministic `verify` against the contracts on that branch.
+
+This is the only routine that does LLM work. It uses the **`--llm-transport agent`** transport (the
+tool hands each prompt to *you* via files — no `claude` subprocess, no API key). You generate the
+contracts **once**; freezing them on the storage branch is what makes the rest of the loop
+deterministic. The contracts **never reach `main`** — the branch is deleted when the campaign
+closes.
+
+Run exactly one campaign per invocation. Do **not** loop across campaigns.
+
+## Inputs
+
+- `truecourse-ai/truecourse` is cloned at the default branch.
+- Fires from **Run now** (first-time bootstrap) or a `pull_request.closed` campaign-close merge
+  (it shares that trigger with `drift-fp-campaign-close`, which tags + cleans up the just-finished
+  campaign while you start the next one). The campaign is determined by reading `campaigns.yaml`.
+
+## Step-by-step
+
+### 1. Pick the campaign
+
+- Read `campaigns.yaml`. Pick the first campaign with `status: pending` **whose storage branch
+  doesn't exist yet** — check with `git ls-remote --heads origin
+  claude/drift-fp-store/<owner>-<repo>` (empty = not generated). Branch existence, not a yaml flag,
+  is the "already generated" signal (you can't flip a `main` flag — you never merge to `main`).
+- If none: post "no campaigns need contract generation" and stop.
+
+### 2. Build truecourse from local source
+
+- `pnpm install && pnpm build:dist` → `dist/cli.mjs` (the artifact publish.yml ships; never
+  `npx truecourse`).
+
+### 3. Clone the target and scope the spec corpus
+
+- `git clone https://github.com/<owner>/<repo>.git /tmp/target`. **If the campaign note says the
+  default branch isn't `main`** (e.g. strapi → `develop`), `git -C /tmp/target checkout <that-branch>`
+  first. Then record `git -C /tmp/target rev-parse HEAD` as `target_ref` (full SHA) — this exact
+  SHA goes in `meta.yaml` and is what discover/next-fix verify against, so it must be a real commit
+  on the branch you generated from.
+- Write `/tmp/target/.truecourseignore` from the campaign's `doc_scope`: ignore all `*.md`, then
+  re-include only the listed spec dirs, so `spec scan` stays focused and cheap. Example (strapi):
+  ```
+  *.md
+  !docs/docs/docs/01-core/authentication/**
+  !docs/docs/docs/01-core/content-manager/**
+  !docs/docs/docs/01-core/content-releases/**
+  !docs/docs/docs/01-core/permissions/**
+  !docs/docs/rfcs/**
+  ```
+
+### 4. Generate contracts via the agent transport
+
+Run the three LLM stages with `--llm-transport agent`, driving the prompt I/O yourself:
+
+- Start a stage in the background with an I/O dir, e.g.:
+  ```
+  cd /tmp/target && node $TRUECOURSE_DIR/dist/cli.mjs spec scan --llm-transport agent --io /tmp/llm-io &
+  ```
+- **Answer loop** (while the tool process is alive): poll `/tmp/llm-io/req/` for request files
+  with no matching `/tmp/llm-io/res/<id>.json` answer. For each, read `{system, user, schema}`,
+  produce JSON that **strictly satisfies `schema`**, and write it to `/tmp/llm-io/res/<id>.json`.
+  Answer batches in parallel; keep going until the tool exits (it writes the stage's output and
+  finishes).
+- Repeat for the remaining stages, in order:
+  ```
+  node $TRUECOURSE_DIR/dist/cli.mjs spec resolve --all-defaults --llm-transport agent --io /tmp/llm-io
+  node $TRUECOURSE_DIR/dist/cli.mjs contracts generate --llm-transport agent --io /tmp/llm-io
+  node $TRUECOURSE_DIR/dist/cli.mjs contracts validate   # deterministic, no LLM
+  ```
+  (`spec resolve --all-defaults` re-runs the scan internally, so most prompts are **cache hits** —
+  expect few or no new request files; just wait for the process to exit. `contracts validate` is
+  deterministic — no prompts.)
+- Produce only schema-valid answers; do not invent fields. If a stage errors, capture the tail
+  for the PR/issue and stop (don't pin partial contracts).
+
+### 5. Commit specs + contracts onto the storage branch
+
+- Create a fresh branch off `main`: `git checkout -b claude/drift-fp-store/<owner>-<repo> origin/main`.
+- Copy the generated **specs and contracts** into the campaign dir:
+  ```
+  mkdir -p docs/drift-fp-automation/contracts/<owner>-<repo>
+  cp -R /tmp/target/.truecourse/specs      docs/drift-fp-automation/contracts/<owner>-<repo>/specs
+  cp -R /tmp/target/.truecourse/contracts  docs/drift-fp-automation/contracts/<owner>-<repo>/contracts
+  cp     /tmp/target/.truecourseignore     docs/drift-fp-automation/contracts/<owner>-<repo>/truecourseignore
+  ```
+  (The committed `truecourseignore` intentionally drops the leading dot — it's provenance, never
+  re-applied; only the live `/tmp/target/.truecourseignore` is an active ignore file.)
+- Write `docs/drift-fp-automation/contracts/<owner>-<repo>/meta.yaml`:
+  ```yaml
+  target_repo: <owner>/<repo>
+  target_ref: <full-sha>          # AUTHORITATIVE — discover/next-fix verify at this SHA
+  code_dir: <campaign code_dir>
+  generated_at: "<ISO date>"
+  tool_version: <version from tools/cli/package.json>
+  llm: agent                      # transport used
+  doc_scope: [ <the campaign's doc_scope dirs> ]
+  ```
+- Commit and push this branch. (Do **not** touch `campaigns.yaml` — you never merge to `main`;
+  `drift-fp-discover`'s PR is what flips the campaign to `discovering`.)
+
+### 6. Open the storage PR (never merged)
+
+- Open a PR with head `claude/drift-fp-store/<owner>-<repo>`, base `main`.
+- Title `chore(drift-fp): contracts store for <owner>/<repo> @ <short-sha>`.
+- **Label `drift-fp-store`** — opening this PR (a `pull_request.opened` event) is what fires
+  `drift-fp-discover`. **This PR is never merged**; it's pure storage + the discover trigger, and
+  `drift-fp-campaign-close` closes it + deletes the branch when the campaign finishes.
+- Body: a clear "⚠️ DO NOT MERGE — storage branch for the <owner>/<repo> drift campaign; deleted
+  automatically at campaign close" banner, plus target_ref, doc_scope, artifact counts from
+  `contracts list` (e.g. "98 .tc: 21 operation, 3 enum, 21 named-constant, …"), and any
+  `contracts validate` warnings. End with `cc @mushgev`.
+- Stop. Opening the PR fires `drift-fp-discover`.
+
+## Hard constraints
+
+- One campaign per session. Generate contracts for exactly one repo.
+- LLM work happens **only** through `--llm-transport agent` (you answer the prompts). Never rely on a
+  `claude` subprocess being present; never use `npx truecourse` / `npm install truecourse`.
+- Never push outside `claude/`-prefixed branches. **Never merge the storage PR.** Never commit
+  the contracts to `main`.
+- Commit **complete, validated** contracts only — if any stage failed, don't push the storage
+  branch or open the PR; report and stop.
+- Never paste OSS code into the PR body — link by URL only.
+- If anything is ambiguous, post the blocker (`cc @mushgev`) and stop. Do not invent state.

--- a/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
@@ -1,0 +1,317 @@
+# drift-fp-next-fix routine prompt
+
+You are the **drift-fp-next-fix** routine. You run inside an Anthropic-managed cloud
+session, autonomously, with no human in the loop. Your job: take a **batch of up to 5
+open `drift-fp-fix` issues**, paraphrase each FP into the verifier's IL test fixtures, fix
+each comparator/extractor, and open a single PR with all the fixes.
+
+The 15-sessions-per-day routine cap is the binding constraint, so each session does
+batch work. With N = 5, 15 sessions/day = ~75 fixes/day.
+
+You run only the **deterministic `verify`** against the campaign's **frozen contracts** (fetched
+from the storage branch `claude/drift-fp-store/<owner>-<repo>`) —
+never `spec scan` / `contracts generate` / `infer`. The fix always lands in
+`packages/contract-verifier/src/` (comparator / extractor / resolver) — never in the
+contracts and never in the analyzer rules.
+
+Per invocation:
+- Process issues until **5 successful fixes**, OR **10 attempts**, OR the queue is empty.
+- Issues that can't produce a fix (malformed YAML / FP no longer reproduces / bad contract /
+  refactor required) are skipped; they count toward the 10-attempt cap, not the 5-success cap.
+- Open ONE PR at the end with all successful fixes (or end with no PR if zero successes).
+
+## Inputs
+
+- `truecourse-ai/truecourse` is cloned.
+- The triggering event is `pull_request.closed` (merged) on either a previous drift-fp-fix PR
+  (main trigger) or the campaign's discovery PR (`-bootstrap`). The merge is just the cue to run.
+
+## Session setup (once)
+
+- **Create the batch branch FIRST.** The session starts on a default `claude/<random>` branch;
+  pushing from it will NOT fire the main trigger (filter `Head Branch starts-with
+  claude/drift-fp-fix/`). Run:
+  ```
+  git fetch origin main && \
+    git checkout -b claude/drift-fp-fix/batch-$(date -u +%Y%m%d%H%M) origin/main
+  ```
+  All commits this session go on this branch.
+- Counters: `successes = 0`, `attempts = 0`, `fixed_issues = []` of
+  `(issue_number, drift_kind, fp_guard_paths, regression_paths, fix_summary)`. Also
+  `before_counts` (`drift_kind → count`) and `before_total`, populated after the initial verify.
+- Build once: `pnpm install && pnpm build:dist`. Always verify against this dist; never
+  `npx truecourse`.
+- **Lazily** (only after the first issue is picked + parsed in step 3 — these values come from that
+  issue's YAML) clone the target and run verify against the frozen contracts on the storage branch.
+  All `drift-fp-fix` issues in a campaign share `target_repo` + `target_ref` + `contracts_branch` +
+  `contracts_path` + `code_dir`, so do this once. **Extract contracts to `/tmp`, never into the
+  truecourse working tree** (you're on the `claude/drift-fp-fix/batch-…` branch and must not commit
+  the contracts):
+  ```
+  # fetch + extract the contracts from the storage branch (they are NOT on main)
+  git -C $TRUECOURSE_DIR fetch origin <contracts_branch>
+  mkdir -p /tmp/extract /tmp/target/.truecourse
+  git -C $TRUECOURSE_DIR archive origin/<contracts_branch> "<contracts_path>/contracts" \
+      | tar -x -C /tmp/extract
+  git clone https://github.com/<owner>/<repo>.git /tmp/target
+  git -C /tmp/target checkout <target_ref>
+  cp -R /tmp/extract/<contracts_path>/contracts /tmp/target/.truecourse/contracts
+  cd /tmp/target && node $TRUECOURSE_DIR/dist/cli.mjs verify --no-stash --code-dir <code_dir>
+  ```
+  (`<contracts_branch>` = `claude/drift-fp-store/<owner>-<repo>`, `<contracts_path>` =
+  `docs/drift-fp-automation/contracts/<owner>-<repo>` — both from the issue YAML. The `git archive
+  | tar` extracts to `/tmp` only, so nothing lands in your batch branch / the fix PR.)
+- **Snapshot the before-state**: copy `/tmp/target/.truecourse/verifier/LATEST.json` to
+  `/tmp/target-before.json`. Populate `before_counts` by grouping `.drifts[]` into drift-kinds
+  (`<artifactRef.type>` + leading `obligationKey` segments, same grouping as discovery) and
+  counting; `before_total` = total `.drifts[]` length.
+- **Pick the language**: `…-il` JS fixture vs Python fixture is decided per issue by the
+  target's code language at the drift's `filePath` (TS/JS → `sample-js-project-il`; `.py` →
+  `sample-python-project-il`).
+
+## Per-issue loop
+
+Repeat while `successes < 5 AND attempts < 10`. Each iteration is one attempt.
+
+### 1. Pick the next issue
+
+- List open issues with label `drift-fp-fix`, excluding `drift-fp-in-progress`,
+  `drift-fp-blocked`, `drift-fp-skipped`, and any already in `fixed_issues`.
+- If none (pickable queue empty — **including when all remaining open issues are blocked**):
+  - `successes >= 1` → break, go to "Open the batched PR".
+  - `successes == 0` → go to the **Queue-empty path** (re-measure the campaign; never end silently).
+- Otherwise pick the **oldest** by `created_at`.
+
+### 2. Take the concurrency lock
+
+- Add `drift-fp-in-progress` to the picked issue **before** anything else. Re-fetch; if it was
+  already present (another session won), skip to the next oldest (max 3 collision retries).
+
+### 3. Parse the issue
+
+- Parse the YAML block. Extract `target_repo`, `target_ref`, `contracts_branch`, `contracts_path`, `code_dir`,
+  `drift_kind`, `comparator`, `samples[]`.
+- Malformed → comment "malformed YAML — needs human review", add `drift-fp-blocked`, remove
+  `drift-fp-in-progress`, `attempts++`, continue.
+- If `target_repo`/`target_ref`/`contracts_branch` differs from an earlier issue this session,
+  comment the mismatch, `drift-fp-blocked`, unlock, `attempts++`, continue.
+
+### 4. Confirm the FP still reproduces
+
+- Filter `/tmp/target/.truecourse/verifier/LATEST.json` `.drifts[]` to the issue's `drift_kind`.
+  Cross-reference at least one `samples[].drift_key` and open its `code_url` location in
+  `/tmp/target` to confirm the verifier is wrong (the symbol/route/constant it flags really does
+  exist in a shape it failed to handle, or it collided two unrelated symbols).
+- If no drifts remain for this drift-kind (upstream changed, or an earlier fix in this batch
+  resolved it): close the issue ("FP no longer reproduces at `<target_ref>`"), unlock,
+  `attempts++`, continue.
+- **If it turns out to be a real divergence (TP) or a bad-contract artifact, not a verifier FP**:
+  comment with the evidence, add `drift-fp-blocked` (and `contract-quality` if it's a bad
+  contract), unlock, `attempts++`, continue. Do not bend the verifier to silence a real drift.
+
+### 5. Add a paraphrased FP-guard case to the IL fixture
+
+The IL end-to-end test (`tests/contract-verifier/verify-end-to-end.test.ts` /
+`verify-python-end-to-end.test.ts`) asserts the verifier's drift set equals the
+`// IL-DRIFT:` marker set **exactly** — so an **unmarked** case that drifts fails the test.
+
+- Read ~30 lines around the FP's `code_url` in `/tmp/target`, and the cited `.tc` contract in the
+  extracted contracts (`/tmp/extract/<contracts_path>/contracts/`, from setup).
+- **Paraphrase a minimal (contract, code) pair** that reproduces the same drift-kind — keep the
+  *shape* that triggers it (the relative-path-mounted route, the same-named-but-unrelated
+  constant, the inline-schema enum, …); rename identifiers; drop unrelated context.
+- Add the **code** under the fixture's code tree at the language's existing layout: **JS** →
+  `sample-js-project-il/code/src/` (the JS marker test scans `code/src`); **Python** →
+  `sample-python-project-il/code/app/` (the Python fixture has no `src/`; its marker test scans
+  the whole `code/`). Put markers inside those roots.
+  - **no `// IL-DRIFT:` marker**, and a header comment `// FP-GUARD: <drift_kind> — must NOT
+    drift` (`# FP-GUARD: …` in Python) so intent is explicit.
+  - If the route/symbol needs a mount/registration to reproduce (e.g. a plugin route array
+    mounted under a prefix), include that wiring in the fixture so the *shape* matches the
+    upstream cause.
+- Add the matching **contract** under
+  `tests/fixtures/sample-{js,python}-project-il/reference/contracts/` — a minimal valid `.tc`
+  mirroring an existing fixture contract of that kind (so it parses/resolves with no new
+  unresolved refs). Its `origin` may reference a fixture spec path or a synthetic location.
+- **Anonymization (committed to a public repo):** filenames, paths, identifiers, and comments
+  must not name the upstream OSS owner/repo, its source filenames, or upstream-themed
+  identifiers. Filename `<drift-kind-slug>-<pattern-shape>.{ts,py,tc}` (e.g.
+  `operation-implementation-missing-mounted-relative.ts`). Linking the OSS URL in the PR body is
+  fine. Remember the paths as `fp_guard_paths`.
+
+### 6. Add a true-drift regression case
+
+- Construct a small, paraphrased example where the code genuinely **does** diverge from the
+  contract for this drift-kind. Add the code (same code tree as step 5 — `code/src/` for JS,
+  `code/app/` for Python) with `// IL-DRIFT: <drift-key>` on the offending line (the key the
+  verifier should emit), plus its matching `.tc` contract under
+  `sample-{js,python}-project-il/reference/contracts/`.
+- Same anonymization rules. Remember the paths as `regression_paths`.
+- This guards against over-correcting: after your fix the verifier must STILL fire here.
+
+### 7. Confirm expected pre-fix state
+
+- Run the IL e2e test:
+  `pnpm test -- verify-end-to-end 2>&1 | tee /tmp/test-<drift-kind-slug>.log`. (Vitest treats the
+  arg as a filename substring, so `verify-end-to-end` runs **both** `verify-end-to-end.test.ts`
+  (JS) and `verify-python-end-to-end.test.ts` (Python) — that's fine, both IL marker tests run.)
+- Expected pre-fix:
+  - The **FP-guard** case shows up as an *unexpected* drift → the "no extras" assertion fails.
+  - The **regression** case is detected → its `// IL-DRIFT:` marker matches.
+- Earlier-batch FP-guards may still fail here (their fixes aren't in yet) — tolerated until step 9.
+- If the regression case is NOT detected pre-fix: the contract/code pair doesn't actually
+  exercise the drift-kind — revert **this issue's** fixture files, comment, `drift-fp-blocked`,
+  unlock, `attempts++`, continue.
+
+### 8. Fix the comparator / extractor
+
+- Edit only under `packages/contract-verifier/src/` — the comparator
+  (`comparator/<kind>.ts`), the code extractor (`extractor/…`), or the resolver if the fix is in
+  identity resolution. No unrelated refactors.
+- If you can't fix it without a refactor crossing module boundaries (new mount-graph pass, new
+  resolver state, new code-fact channel): revert this issue's fixture additions, post a
+  `## Refactor needed` comment, add `drift-fp-blocked`, unlock, `attempts++`, continue.
+
+### 9. Re-run tests, confirm green
+
+- `pnpm test 2>&1 | tee /tmp/test-after-<drift-kind-slug>.log`.
+- Required: full suite green — the FP-guard case now yields **no** drift, the regression case
+  **still** drifts, the marker set matches exactly, and all earlier-batch fixes still pass.
+- Any unexpected failure: revert this issue's comparator/extractor change AND its fixture files,
+  comment, `drift-fp-blocked`, unlock, `attempts++`, continue.
+
+### 10. Mark success
+
+- Append `(issue_number, drift_kind, fp_guard_paths, regression_paths, fix_summary)` to
+  `fixed_issues` (`fix_summary` = 2–3 sentences on what you changed and why).
+- `successes++` AND `attempts++`. Keep `drift-fp-in-progress` until the batch PR opens.
+- If `successes == 5` or `attempts == 10`: break. Else continue.
+
+## After the loop: measure the drift-count delta on the target (REQUIRED)
+
+Skip only if `successes == 0`. Otherwise, every batched PR MUST include the `## Drift-count
+delta` section — table on success, or `unavailable: <one-line reason>` on failure.
+
+1. **Rebuild dist** with the new fixes: `cd $TRUECOURSE_DIR && pnpm build:dist`.
+2. **Re-verify the same target ref against the same frozen contracts.** The clone is already at
+   `target_ref` and the contracts are already extracted in `/tmp/extract/<contracts_path>/contracts`
+   (from setup); just wipe the verifier output and re-run:
+   ```
+   cd /tmp/target && rm -rf .truecourse/verifier && \
+     cp -R /tmp/extract/<contracts_path>/contracts /tmp/target/.truecourse/contracts && \
+     node $TRUECOURSE_DIR/dist/cli.mjs verify --no-stash --code-dir <code_dir>
+   ```
+3. **Compute after-state**: from the new LATEST.json, build `after_counts` (`drift_kind →
+   count`) and `after_total`.
+4. **Compute deltas** per fixed drift-kind: `delta = after_counts[k] - before_counts[k]`. Also
+   the cross-kind subtotal and the all-kinds total (`after_total - before_total`). A negative
+   delta is progress; a `0` delta on a fixed kind is a smell (the upstream FP didn't actually
+   go away — note it).
+
+If step 1/2 throws, still write the section with `unavailable: <concrete reason>`.
+
+## Open the batched PR
+
+- `successes == 0` → do **not** end here; go to the **Queue-empty path** (the queue drained
+  mid-session).
+- `successes >= 1`:
+  - **Verify your branch** starts with `claude/drift-fp-fix/batch-`. If not, create it and move
+    your commits before pushing (the wrong branch won't fire the trigger).
+  - **Verify the drift-count delta was measured** (`after_counts` populated). The PR body MUST
+    contain `## Drift-count delta`.
+  - Commit message / PR title: `fix(drift-fp): resolve <N> drift FPs from <owner>/<repo>`.
+  - PR body:
+    - One `Closes #<issue-number>` per fixed issue (own line each).
+    - A `## Fixes` table: `drift_kind | issue | fp-guard fixture | regression fixture`.
+    - One `## <drift_kind>` section per fixed issue: OSS source URL(s) from `samples[].code_url`,
+      the cited contract path, inline diff of the FP-guard fixture (code + `.tc`), inline diff of
+      the regression fixture, and the `fix_summary`.
+    - A `## Skipped this batch` section (only if `attempts > successes`): one line per skipped
+      issue with reason (malformed / no-reproduce / real-TP / bad-contract / refactor-required).
+    - A `## Drift-count delta (vs <target_ref> on <target_repo>, pinned contracts)` table:
+      ```
+      | Drift-kind | Before | After | Delta |
+      |---|---:|---:|---:|
+      | <kind_1>                       | <b1> | <a1> | <d1> |
+      | ...                            | ...  | ...  | ...  |
+      | **Total (these N kinds)**      | <Bn> | <An> | <Dn> |
+      | **All-kinds total on target**  | <BT> | <AT> | <DT> |
+      ```
+      (or `unavailable: <reason>` if measurement failed).
+    - End with `cc @mushgev`.
+  - Labels: `drift-fp-fix` (fires the next routine invocation on merge).
+  - For each fixed issue: comment the PR URL, then remove `drift-fp-in-progress` (merge
+    auto-closes via `Closes #N`).
+- End the session.
+
+## Queue-empty path
+
+Enter when the **pickable** queue is empty AND `successes == 0` (includes all-remaining-blocked).
+
+1. Find the campaign in `campaigns.yaml` with `status: discovering` (exactly one — there is no
+   `in_progress` state; a campaign stays `discovering` until it closes to `done`).
+2. Rebuild dist if not already this session: `pnpm install && pnpm build:dist`.
+3. Derive the storage-branch coordinates from the campaign (don't assume an issue was parsed — a
+   bootstrap session may reach here with zero issues): for the `status: discovering` campaign,
+   `<owner>-<repo>` → `contracts_branch = claude/drift-fp-store/<owner>-<repo>`,
+   `contracts_path = docs/drift-fp-automation/contracts/<owner>-<repo>`. Read `target_ref` +
+   `code_dir` from `git show origin/<contracts_branch>:<contracts_path>/meta.yaml` (authoritative;
+   if `baseline.target_ref` disagrees, trust meta.yaml). Then fetch + extract the contracts to
+   `/tmp` (as in setup), re-clone the target at `target_ref` if needed, and verify:
+   ```
+   git -C $TRUECOURSE_DIR fetch origin <contracts_branch>
+   mkdir -p /tmp/extract && git -C $TRUECOURSE_DIR archive origin/<contracts_branch> \
+     "<contracts_path>/contracts" | tar -x -C /tmp/extract
+   cd /tmp/target && rm -rf .truecourse/verifier && \
+     cp -R /tmp/extract/<contracts_path>/contracts /tmp/target/.truecourse/contracts && \
+     node $TRUECOURSE_DIR/dist/cli.mjs verify --no-stash --code-dir <code_dir>
+   ```
+   Read `.drifts[]`.
+4. Classify and compute final `tp`, `fp`, `info`, `fp_rate` with the discovery/README TP/FP rubric.
+5. **If `fp == 0`** (no false-positive drifts remain — every drift is a genuine TP or a
+   human-accepted `info`) — open a campaign-close PR:
+   - Branch `claude/drift-fp-campaign-close/<owner>-<repo>`.
+   - `campaigns.yaml`: `status: done`, fill `final.*` (verified_at, target_ref, total_drifts,
+     tp, fp, info, fp_rate — `fp_rate: 0`, `tp_rate: 1.0` by convention when fp==0).
+   - **Patch-bump** the version in all four CLAUDE.md locations:
+     `tools/cli/package.json`, `packages/core/package.json`,
+     `apps/dashboard/server/package.json`, and the `.version("X.Y.Z")` in `tools/cli/src/index.ts`.
+   - **No** fixture/comparator changes.
+   - Title `chore(drift-fp): close <owner>/<repo> campaign, bump to vX.Y.Z`.
+   - Labels `drift-fp-campaign-complete`. Body: merged drift-fp-fix PRs (search label
+     `drift-fp-target:<owner>-<repo>`, state merged), baseline→final `fp` (e.g. `fp: 33 → 0`),
+     new version, note that `fp == 0` was measured against `node dist/cli.mjs` on the pinned
+     contracts. End `cc @mushgev`.
+   - End. Merge fires `drift-fp-campaign-close` (tags) + `drift-fp-generate` (next campaign).
+6. **If `fp > 0`** — leave `status: discovering`, no close PR. File new issues, **dedupe
+   first**: for each drift-kind still showing FPs, skip if an open `drift-fp-fix` issue
+   (any label, including `drift-fp-blocked`) already exists; else file one (discovery shape).
+   - Filed ≥1 new issue → continue into the per-issue loop this session.
+   - Filed 0 (every FP-kind already tracked, all blocked) → file/update a single
+     `[drift-fp-campaign-stuck] <owner>/<repo>` tracking issue (current `fp` count + `fp_rate`,
+     the close gate `fp == 0`, checklist of open `drift-fp-blocked` issues, `cc @mushgev`), then
+     end. Never dead-end silently.
+
+If the queue empties **after** ≥1 success, ship the batch PR instead — don't run this path in a
+session that already produced fixes.
+
+## Hard constraints
+
+- At most one PR-opening per session. At most 5 successes / 10 attempts.
+- **Every PR body has a `## Drift-count delta` section** — table or `unavailable: <reason>`.
+- **Never run `spec scan` / `contracts generate` / `infer`.** Deterministic `verify` only,
+  against the pinned contracts.
+- Never push outside `claude/`-prefixed branches. Never `npx truecourse` / `npm install
+  truecourse` — always `node dist/cli.mjs` from a fresh `pnpm build:dist`.
+- Never copy-paste OSS code — paraphrase only; link the source by URL in the PR body.
+- **No OSS-project identity in committed code.** Fixture filenames, paths, identifiers, comments
+  must look generic.
+- Fix PRs target **`main`** (`claude/drift-fp-fix/batch-…` off `origin/main`). Fix lands ONLY in
+  `packages/contract-verifier/src/` (comparator / extractor / resolver) and
+  `tests/fixtures/sample-*-il/`; the queue-empty path also touches `campaigns.yaml` + the four
+  version-bump locations. **Never** commit the fetched contracts into the fix PR (discard them
+  after copying), never edit the analyzer rules, types/file discovery (unless the drift-kind
+  genuinely lives there and it's a scoped edit), or anything else. Never touch the storage branch.
+- A skipped issue reverts **only its own** fixture/comparator changes, never earlier-batch work.
+- If anything is ambiguous, document it on the issue and continue (or end the loop if
+  session-wide). Do not invent state, skip steps, or "try one more thing."


### PR DESCRIPTION
## What

Adds **`docs/drift-fp-automation/`** — the drift-engine sibling of [`docs/fp-automation`](../fp-automation/README.md). A [Claude Code Routines](https://code.claude.com/docs/en/routines) loop that runs `truecourse verify` against OSS repos, triages drift **false positives**, and fixes the comparators/extractors one batched PR at a time.

Builds on the **`--llm-transport agent`** transport already shipped in #473 — `drift-fp-generate` (the only LLM routine) drives the contract-generation stages via that transport, no `claude` subprocess, no API key needed.

## The flow

```
generate → storage PR (opened) → discover → discovery PR (merge) → fix loop → campaign-close
```

- **`drift-fp-generate`** (the only LLM routine) generates specs + `.tc` contracts **once** via `--llm-transport agent` and freezes them on a per-campaign **storage branch** `claude/drift-fp-store/<owner>-<repo>` — opened as a **storage PR that is never merged** and **deleted at close**. Contracts never touch `main`.
- **`drift-fp-discover`** fires on the storage PR *opening* (no contract review), runs **deterministic `verify`** against the frozen contracts, and files one `drift-fp-fix` issue per drift-kind with FPs.
- **`drift-fp-next-fix`** batches ≤5 fixes: drops the FP `(contract, code)` pair into the IL fixture **unmarked** (the bidirectional `// IL-DRIFT:` test fails on the unexpected drift), adds a marked regression case, fixes the comparator/extractor under `packages/contract-verifier/src/`, and opens a fix PR **to `main`**.
- **`drift-fp-campaign-close`** tags the release and cleans up the storage branch. Convergence gate is **`fp == 0`** (these targets have ~0 genuine drift, so a TP-rate gate is meaningless).

All cross-session state is in GitHub: `campaigns.yaml` (status) + issues (fix queue) + the storage branch (contracts) — each cleaned up per campaign. Routines run **no LLM** except generate.

## What's in this PR (7 files)

- `docs/drift-fp-automation/README.md` — full design, flow diagram, trigger table, setup checklist.
- `docs/drift-fp-automation/campaigns.yaml` — 3 vetted `pending` campaigns (strapi/strapi P1, feast-dev/feast P2, directus/directus P3).
- `docs/drift-fp-automation/prompts/drift-fp-generate.md` — LLM-driven generation via `--llm-transport agent`.
- `docs/drift-fp-automation/prompts/drift-fp-discover.md` — deterministic verify + issue filing.
- `docs/drift-fp-automation/prompts/drift-fp-next-fix.md` — batched ≤5 fix loop with mandatory drift-count delta.
- `docs/drift-fp-automation/prompts/drift-fp-campaign-close.md` — tag release + storage-branch cleanup.
- `.github/workflows/notify-routine-activity.yml` — Telegram pings for `drift-fp-fix` issue bursts and `[drift-fp-campaign-*]` / `[drift-campaign-broken]` alerts (independent concurrency groups from the existing fp-automation jobs).

## Battle-test discipline baked in

These mirror what we learned shaking down `fp-automation` (`#214`, `#316`, `#333`, `#336`, etc.) so the drift chain doesn't repeat those failure modes:

- **Branch creation as the first session-setup step** — `git fetch origin main && git checkout -b claude/drift-fp-…/<slug> origin/main` plus a `git rev-parse --abbrev-ref HEAD` sanity check before every PR opens (otherwise the routine pushes from the default random branch and the trigger filter misses it).
- **Batched ≤5/≤10 mechanics** in next-fix; mandatory `## Drift-count delta` section with `unavailable: <reason>` fallback.
- **Queue-empty path** distinguishes pickable-empty (incl. all-blocked) from truly-zero; re-runs verify, recomputes the gate, ships campaign-close (`fp == 0`), re-files deduped issues, or raises a single `[drift-fp-campaign-stuck]` tracking issue.
- **Anonymization** — fixture filenames and content must not name the upstream OSS project (PR-body URLs are fine).
- **`cc @mushgev`** at the end of every PR/issue body the routine opens.
- **TG rollup** debounced per chain so a 30-issue discovery burst is one Telegram message, not 30.

## Validation behind it

Targets are vetted empirically (clone + `infer --dry-run` probe of spec↔code overlap; see the README's "Selecting targets"). The strapi run that motivated the first campaign found 44 drift items, ~0 genuine: 20 Operation `implementation.missing` FPs (plugin route-mount prefix not reconstructed) + 13 NamedConstant `value-mismatch` FPs (bare-name collision) + 11 cautious `no-code-counterpart` info notes; the documented `PublicationFilter` enum verified cleanly (true negative).

## To set up after merge

1. Configure the 5 routines per the README's "Triggers: five Routines" table.
2. Add `TRUECOURSE_TELEMETRY=0` to the Default routine environment (so cloud runs don't pollute the telemetry stream — same lesson as fp-automation).
3. Click **Run now** on `drift-fp-generate` to start the strapi/strapi campaign.

cc @mushgev