### PR TITLE
feat(llm): pluggable LLM transport — cli + agent (--llm-transport/--io)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,31 @@ The first `truecourse analyze` (or `truecourse add`) in a fresh repo asks whethe
 ## Prerequisites
 
 - Node.js >= 20
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI on your PATH. Deterministic rules run without it; LLM-powered rules and the Spec → Verify pipeline need it.
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI on your PATH — optional. The default `cli` transport spawns it for LLM-powered work; deterministic rules and the `agent` transport (below) don't need it.
+
+## LLM transport (`--llm-transport`)
+
+Every LLM-powered step — `analyze`'s LLM rules, and the whole Spec → Verify pipeline (`spec scan`, `spec resolve`, `contracts generate`) — reaches the model through a pluggable **transport**, chosen with `--llm-transport`:
+
+| Mode | How it reaches the model | Needs |
+|---|---|---|
+| **`cli`** *(default)* | spawns `claude -p …` per call | the `claude` binary on PATH, signed in. No API key. |
+| **`agent`** | a **filesystem mailbox** under `--io <dir>` | nothing — no `claude` binary, no API key |
+
+In **`agent`** mode the tool doesn't call the model itself: for each prompt it writes `requests/<id>.json` (`{ stage, system, user, schema, … }`) into the `--io` directory and waits for a matching `responses/<id>.json` (`{ text }`). An **orchestrating agent that is itself an LLM** — e.g. a [Claude Code routine](https://code.claude.com/docs/en/routines) — watches that directory and answers each prompt. This lets contract generation and `analyze`'s LLM rules run **inside a headless cloud session with no `claude` binary and no API key**.
+
+```bash
+# default: spawn the claude CLI
+truecourse analyze --llm
+truecourse contracts generate
+
+# agent transport: the tool parks prompts in ./io and an external agent answers them
+truecourse analyze --llm --llm-transport agent --io ./io
+truecourse spec scan          --llm-transport agent --io ./io
+truecourse contracts generate --llm-transport agent --io ./io
+```
+
+Accepted by: `analyze`, `spec scan`, `spec resolve`, `contracts generate`. (On `analyze`, `--llm` / `--no-llm` is a *separate* flag — it decides **whether** LLM rules run; `--llm-transport` decides **how** to reach the model.) Both modes send identical prompts and parse identical schema-validated JSON — only the delivery differs.
 
 ## Configuration
 

--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "tsx": "^4.19.0",
     "turbo": "^2.3.0",
     "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0",
+    "zod": "^3.23.8"
   },
   "packageManager": "pnpm@9.15.0",
   "engines": {

--- a/packages/contract-extractor/package.json
+++ b/packages/contract-extractor/package.json
@@ -53,7 +53,8 @@
     "@truecourse/spec-consolidator": "workspace:*",
     "js-yaml": "^4.1.0",
     "p-limit": "^7.3.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@truecourse/shared": "workspace:*"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/packages/contract-extractor/src/claude-runner.ts
+++ b/packages/contract-extractor/src/claude-runner.ts
@@ -1,23 +1,28 @@
 /**
- * Claude Code subprocess runner. Spawns `claude -p` for each cache-miss
- * slice, with a concurrency cap controlled by `TRUECOURSE_MAX_CONCURRENCY`
- * (defaults to `min(os.cpus().length, 4)`).
+ * Per-slice extraction runner. For each cache-miss slice it builds a
+ * system + user prompt and hands it to an `LlmTransport` (cli = spawn
+ * `claude -p`, agent = filesystem mailbox), then validates the response
+ * against `ExtractionResultSchema`. Concurrency is capped by
+ * `TRUECOURSE_MAX_CONCURRENCY` (defaults to `min(os.cpus().length, 4)`).
  *
- * The runner is interface-shaped so tests can pass a stub instead of
- * spawning real subprocesses. The default implementation (`spawnRunner`)
- * uses `claude` from PATH with `--output-format json` and feeds the
- * system prompt via `--append-system-prompt`.
+ * The transport is injected — tests pass a stub that returns canned
+ * outputs without touching the transport at all. Concurrency lives here
+ * (p-limit); the transport is a single-request function.
  */
 
 import os from 'node:os';
-import { spawn } from 'node:child_process';
 import pLimit from 'p-limit';
+import { cliTransport, stripCodeFences, type LlmTransport } from '@truecourse/shared/llm';
 import type { ExtractionResult, SpecSlice } from './types.js';
 import { ExtractionResultSchema } from './types.js';
 import { buildUserPrompt, SYSTEM_PROMPT } from './prompt.js';
-import { buildModelArgs } from './model-args.js';
 
 export interface ClaudeRunnerOptions {
+  /**
+   * LLM transport. Defaults to `cliTransport()` (spawns `claude -p`). The
+   * CLI/dashboard pass `agentTransport(io)` for headless/routine runs.
+   */
+  transport?: LlmTransport;
   /** Override the binary; defaults to `claude` (resolved via PATH). */
   bin?: string;
   /** Model name passed to `claude --model`. Resolved per-stage by the caller. */
@@ -28,9 +33,9 @@ export interface ClaudeRunnerOptions {
   concurrency?: number;
   /** Per-call timeout in milliseconds. */
   timeoutMs?: number;
-  /** Hook fired before each subprocess spawn — useful for progress UIs. */
+  /** Hook fired before each request — useful for progress UIs. */
   onSliceStart?: (slice: SpecSlice) => void;
-  /** Hook fired after each subprocess completes (success or failure). */
+  /** Hook fired after each request completes (success or failure). */
   onSliceDone?: (slice: SpecSlice, ok: boolean) => void;
 }
 
@@ -56,15 +61,14 @@ export function defaultConcurrency(): number {
 }
 
 /**
- * Build a runner that spawns `claude -p` for each slice. Each subprocess
- * is independent — failures don't abort the batch; the orchestrator
- * decides whether to surface or retry.
+ * Build a runner that calls the transport once per slice. Each request is
+ * independent — failures don't abort the batch; the orchestrator decides
+ * whether to surface or retry.
  */
 export function spawnRunner(opts: ClaudeRunnerOptions = {}): SliceRunner {
-  const bin = opts.bin ?? process.env.CLAUDE_CODE_BIN ?? 'claude';
+  const transport = opts.transport ?? cliTransport({ bin: opts.bin });
   const concurrency = opts.concurrency ?? defaultConcurrency();
   const timeoutMs = opts.timeoutMs ?? 600_000;
-  const modelArgs = buildModelArgs(opts.model, opts.fallbackModel);
   const limit = pLimit(concurrency);
 
   return async (slices: SpecSlice[]): Promise<SliceRunResult[]> => {
@@ -74,7 +78,7 @@ export function spawnRunner(opts: ClaudeRunnerOptions = {}): SliceRunner {
           opts.onSliceStart?.(slice);
           const t0 = Date.now();
           try {
-            const result = await runOne(bin, slice, timeoutMs, modelArgs);
+            const result = await runOne(transport, slice, timeoutMs, opts.model, opts.fallbackModel);
             opts.onSliceDone?.(slice, true);
             return { slice, result, durationMs: Date.now() - t0 };
           } catch (e) {
@@ -89,69 +93,23 @@ export function spawnRunner(opts: ClaudeRunnerOptions = {}): SliceRunner {
 }
 
 async function runOne(
-  bin: string,
+  transport: LlmTransport,
   slice: SpecSlice,
   timeoutMs: number,
-  modelArgs: string[],
+  model?: string,
+  fallbackModel?: string,
 ): Promise<ExtractionResult> {
   const userPrompt = buildUserPrompt(slice);
-  const args = [
-    '-p',
-    userPrompt,
-    ...modelArgs,
-    '--output-format',
-    'json',
-    '--append-system-prompt',
-    SYSTEM_PROMPT,
-    '--setting-sources',
-    'project',
-  ];
-
-  return new Promise<ExtractionResult>((resolve, reject) => {
-    const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-    const timer = setTimeout(() => {
-      proc.kill('SIGKILL');
-      reject(new Error(`claude timed out after ${timeoutMs}ms for slice ${slice.id}`));
-    }, timeoutMs);
-
-    proc.stdout.on('data', (b: Buffer) => stdout.push(b));
-    proc.stderr.on('data', (b: Buffer) => stderr.push(b));
-    proc.on('error', (err) => {
-      clearTimeout(timer);
-      reject(err);
-    });
-    proc.on('close', (code) => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        reject(new Error(`claude exited ${code}: ${Buffer.concat(stderr).toString('utf-8')}`));
-        return;
-      }
-      try {
-        // Claude Code's --output-format json wraps the model's response in
-        // an envelope. The actual model text lives at .result on stdout.
-        const envelope = JSON.parse(Buffer.concat(stdout).toString('utf-8'));
-        const text = typeof envelope === 'string' ? envelope : envelope.result;
-        if (typeof text !== 'string') {
-          reject(new Error(`claude returned no text for slice ${slice.id}`));
-          return;
-        }
-        const inner = JSON.parse(stripCodeFences(text));
-        resolve(ExtractionResultSchema.parse(inner));
-      } catch (e) {
-        reject(e instanceof Error ? e : new Error(String(e)));
-      }
-    });
+  const raw = await transport({
+    id: `contract.extract:${slice.id}`,
+    stage: 'contract.extract',
+    model,
+    fallbackModel,
+    system: SYSTEM_PROMPT,
+    user: userPrompt,
+    responseFormat: 'json',
+    timeoutMs,
   });
-}
-
-/**
- * Some models wrap JSON in markdown code fences even when told not to.
- * Strip a single leading ```...``` fence (with or without lang tag).
- */
-function stripCodeFences(text: string): string {
-  const trimmed = text.trim();
-  const fenceMatch = /^```(?:json|JSON)?\s*\n([\s\S]*?)\n```$/.exec(trimmed);
-  return fenceMatch ? fenceMatch[1] : trimmed;
+  const inner = JSON.parse(stripCodeFences(raw));
+  return ExtractionResultSchema.parse(inner);
 }

--- a/packages/contract-extractor/src/index.ts
+++ b/packages/contract-extractor/src/index.ts
@@ -37,6 +37,7 @@ import { normalizeMergedArtifacts } from './normalizer.js';
 import { repair, type RepairProgress } from './repair.js';
 import { validateMerged, type ValidationIssue } from './validator.js';
 import { writeContracts, type WriteResult } from './writer.js';
+import type { LlmTransport } from '@truecourse/shared/llm';
 import { spawnRunner, type SliceRunner, type SliceRunResult } from './claude-runner.js';
 import type { Manifest, SpecSlice } from './types.js';
 import crypto from 'node:crypto';
@@ -57,6 +58,12 @@ export interface ExtractModels {
 export interface GenerateOptions {
   /** Repo root — `.truecourse/specs/` and `.truecourse/contracts/` live here. */
   repoRoot: string;
+  /**
+   * LLM transport for the auto-created slice runner + the repair pass. Defaults
+   * to the cli transport (spawn `claude -p`). The CLI/dashboard pass an agent
+   * transport for headless runs. An explicit `runner` override ignores this.
+   */
+  transport?: LlmTransport;
   /** Override the runner; defaults to `spawnRunner()`. Tests pass a stub. */
   runner?: SliceRunner;
   /** Per-stage model overrides (extract / repair / fallback). */
@@ -116,6 +123,7 @@ export async function generateContracts(opts: GenerateOptions): Promise<Generate
   opts.onSlicesReady?.(slices.length);
   const models = opts.models ?? {};
   const runner = opts.runner ?? spawnRunner({
+    transport: opts.transport,
     onSliceStart: opts.onSliceStart,
     onSliceDone: opts.onSliceDone,
     model: models.extract,
@@ -208,6 +216,7 @@ export async function generateContracts(opts: GenerateOptions): Promise<Generate
   // directly and would bypass any injected stub runner.
   if (slices.length > 0 && !dryRun && !opts.disableRepair) {
     const repaired = await repair(merged.artifacts, slices, {
+      transport: opts.transport,
       model: models.repair,
       fallbackModel: models.fallback,
       onProgress: opts.onRepairProgress,

--- a/packages/contract-extractor/src/repair.ts
+++ b/packages/contract-extractor/src/repair.ts
@@ -19,11 +19,10 @@
  * structural element the comparator requires", it doesn't belong here.
  */
 
-import { spawn } from 'node:child_process';
+import { cliTransport, stripCodeFences, type LlmTransport } from '@truecourse/shared/llm';
 import type { MergedArtifact } from './merger.js';
 import type { Fragment, SpecSlice } from './types.js';
 import { ExtractionResultSchema } from './types.js';
-import { buildModelArgs } from './model-args.js';
 import { SYSTEM_PROMPT } from './prompt.js';
 
 export interface RepairIssue {
@@ -47,6 +46,11 @@ export interface RepairProgress {
 }
 
 export interface RepairOptions {
+  /**
+   * LLM transport. Defaults to `cliTransport()` (spawns `claude -p`). The
+   * CLI/dashboard pass `agentTransport(io)` for headless/routine runs.
+   */
+  transport?: LlmTransport;
   bin?: string;
   /** Model passed to `claude --model`. */
   model?: string;
@@ -321,9 +325,10 @@ interface FixRequest {
 
 async function runFixOne(
   req: FixRequest,
-  bin: string,
+  transport: LlmTransport,
   timeoutMs: number,
-  modelArgs: string[],
+  model?: string,
+  fallbackModel?: string,
 ): Promise<Fragment[] | null> {
   const userPrompt = buildFixUserPrompt(req);
   // Prepend the main extraction system prompt so the repair pass has
@@ -332,50 +337,26 @@ async function runFixOne(
   // headings, wrong casing (`AuthRequirement` vs `auth-requirement`),
   // or comment characters, all of which fail downstream parsing.
   const repairSystemPrompt = `${SYSTEM_PROMPT}\n\n${FIX_SYSTEM_PROMPT}`;
-  const args = [
-    '-p',
-    userPrompt,
-    ...modelArgs,
-    '--output-format',
-    'json',
-    '--append-system-prompt',
-    repairSystemPrompt,
-    '--setting-sources',
-    'project',
-  ];
-  return new Promise<Fragment[] | null>((resolve) => {
-    const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-    const stdout: Buffer[] = [];
-    const timer = setTimeout(() => {
-      proc.kill('SIGKILL');
-      resolve(null);
-    }, timeoutMs);
-    proc.stdout.on('data', (b: Buffer) => stdout.push(b));
-    proc.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
+  const id = req.previousArtifact
+    ? `${req.previousArtifact.kind}:${req.previousArtifact.identity}`
+    : (req.missingKey ?? 'unknown');
+  try {
+    const raw = await transport({
+      id: `contract.repair:${id}`,
+      stage: 'contract.repair',
+      model,
+      fallbackModel,
+      system: repairSystemPrompt,
+      user: userPrompt,
+      responseFormat: 'json',
+      timeoutMs,
     });
-    proc.on('close', (code) => {
-      clearTimeout(timer);
-      if (code !== 0) return resolve(null);
-      try {
-        const envelope = JSON.parse(Buffer.concat(stdout).toString('utf-8'));
-        const text = typeof envelope === 'string' ? envelope : envelope.result;
-        if (typeof text !== 'string') return resolve(null);
-        const inner = JSON.parse(stripCodeFences(text));
-        const parsed = ExtractionResultSchema.parse(inner);
-        resolve(parsed.fragments);
-      } catch {
-        resolve(null);
-      }
-    });
-  });
-}
-
-function stripCodeFences(text: string): string {
-  const trimmed = text.trim();
-  const m = /^```(?:json|JSON)?\s*\n([\s\S]*?)\n```$/.exec(trimmed);
-  return m ? m[1] : trimmed;
+    const inner = JSON.parse(stripCodeFences(raw));
+    const parsed = ExtractionResultSchema.parse(inner);
+    return parsed.fragments;
+  } catch {
+    return null;
+  }
 }
 
 function buildFixUserPrompt(req: FixRequest): string {
@@ -406,9 +387,8 @@ export async function repair(
   slices: SpecSlice[],
   opts: RepairOptions = {},
 ): Promise<RepairOutcome> {
-  const bin = opts.bin ?? process.env.CLAUDE_CODE_BIN ?? 'claude';
+  const transport = opts.transport ?? cliTransport({ bin: opts.bin });
   const timeoutMs = opts.timeoutMs ?? 600_000;
-  const modelArgs = buildModelArgs(opts.model, opts.fallbackModel);
   const log: string[] = [];
   const allIssues: RepairIssue[] = [];
 
@@ -437,9 +417,10 @@ export async function repair(
     opts.onProgress?.({ done, total, message });
     const fragments = await runFixOne(
       { previousArtifact: null, missingKey: issue.artifactKey, slice, issues: [issue.detail] },
-      bin,
+      transport,
       timeoutMs,
-      modelArgs,
+      opts.model,
+      opts.fallbackModel,
     );
     if (!fragments) {
       log.push(`repair: re-prompt failed for ${issue.artifactKey}.`);
@@ -503,9 +484,10 @@ export async function repair(
     opts.onProgress?.({ done, total, message });
     const fragments = await runFixOne(
       { previousArtifact: artifact, slice, issues: issues.map((i) => i.detail) },
-      bin,
+      transport,
       timeoutMs,
-      modelArgs,
+      opts.model,
+      opts.fallbackModel,
     );
     if (!fragments || fragments.length === 0) {
       log.push(`repair: re-prompt failed for ${k}.`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/src/commands/analyze-core.ts
+++ b/packages/core/src/commands/analyze-core.ts
@@ -26,6 +26,7 @@ import { buildGraph } from '../services/analysis-persistence.service.js';
 import { detectFlows } from '../services/flow.service.js';
 import { runViolationPipeline } from '../services/violation-pipeline.service.js';
 import { createLLMProvider, type LLMProvider } from '../services/llm/provider.js';
+import type { LlmTransport } from '@truecourse/shared/llm';
 import { toUsageRecords } from '../services/usage.service.js';
 import { readLatest } from '../lib/analysis-store.js';
 import {
@@ -69,6 +70,12 @@ export interface AnalyzeCoreOptions {
   onLlmEstimate?: (estimate: LlmEstimate) => Promise<boolean>;
   onLlmResolved?: (proceed: boolean) => void;
   provider?: LLMProvider;
+  /**
+   * LLM transport for the auto-created provider. Defaults to spawning the
+   * `claude` CLI; pass an agent transport to run LLM rules headless. Ignored
+   * when an explicit `provider` is supplied (tests inject one that way).
+   */
+  transport?: LlmTransport;
   signal?: AbortSignal;
 }
 
@@ -284,7 +291,7 @@ export async function analyzeCore(
     // ------------------------------------------------------------
     // Violation pipeline
     // ------------------------------------------------------------
-    const provider = options.provider ?? (effectiveLlmRules ? createLLMProvider() : undefined);
+    const provider = options.provider ?? (effectiveLlmRules ? createLLMProvider(options.transport) : undefined);
     if (provider) {
       provider.setAnalysisId(analysisId);
       provider.setRepoPath(project.path);

--- a/packages/core/src/commands/analyze-in-process.ts
+++ b/packages/core/src/commands/analyze-in-process.ts
@@ -8,6 +8,7 @@
 import { removeFromHistory } from '../lib/analysis-store.js';
 import type { RegistryEntry } from '../config/registry.js';
 import type { LLMProvider } from '../services/llm/provider.js';
+import type { LlmTransport } from '@truecourse/shared/llm';
 import type { StepTracker } from '../progress.js';
 import { analyzeCore, type LlmEstimate } from './analyze-core.js';
 import { persistFullAnalysis, type PersistFullResult } from './analyze-persist.js';
@@ -41,6 +42,8 @@ export interface AnalyzeInProcessOptions {
   onLlmEstimate?: (estimate: LlmEstimate) => Promise<boolean>;
   onLlmResolved?: (proceed: boolean) => void;
   provider?: LLMProvider;
+  /** LLM transport for the auto-created provider (cli default; agent for headless). */
+  transport?: LlmTransport;
   signal?: AbortSignal;
   /**
    * Adapter that triggered this run. Auto-emitted in the telemetry payload so

--- a/packages/core/src/commands/spec-in-process.ts
+++ b/packages/core/src/commands/spec-in-process.ts
@@ -40,6 +40,7 @@ import {
   type GenerateResult,
 } from '@truecourse/contract-extractor';
 import { resolveFallbackModel, resolveModel } from '../config/llm-models.js';
+import { agentTransport, type LlmTransport } from '@truecourse/shared/llm';
 
 // Debug timing — gated behind TRUECOURSE_DEBUG_TIMING=1.
 function perfNow(): number {
@@ -223,11 +224,33 @@ export interface SpecInProcessOptions {
    * telemetry (e.g. tests, internal re-scans).
    */
   source?: TelemetrySource;
+  /**
+   * LLM transport mode. `cli` (default) spawns `claude -p`; `agent` uses a
+   * filesystem mailbox under `io` so an orchestrating agent answers the
+   * prompts (no `claude` binary, no API key). `agent` requires `io`.
+   */
+  llm?: 'cli' | 'agent';
+  /** I/O dir for the agent transport's request/response mailbox. */
+  io?: string;
 }
 
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Build the LLM transport for a run. `cli` (default) → undefined, so each
+ * runner factory falls back to its built-in cli transport (spawn `claude -p`),
+ * preserving today's behavior exactly. `agent` → a filesystem-mailbox transport
+ * under `options.io` (required).
+ */
+function resolveTransport(options: SpecInProcessOptions): LlmTransport | undefined {
+  if (options.llm !== 'agent') return undefined;
+  if (!options.io) {
+    throw new Error('--llm agent requires --io <dir> (the request/response mailbox directory)');
+  }
+  return agentTransport(options.io);
+}
 
 /**
  * Marker file stamped after a successful `contracts generate` run. The
@@ -356,6 +379,7 @@ export async function scanInProcess(
       chainRunner: options.chainRunner,
       disableLlmChainDetection: options.disableLlmChainDetection,
       skipGit: options.skipGit,
+      transport: resolveTransport(options),
       models: resolveConsolidateModels(repoRoot),
       onRelevanceProgress: (doneCount, total) => {
         // Numbered progress while "Discovering docs" runs (LLM relevance
@@ -520,6 +544,7 @@ export async function resolveAllDefaultsInProcess(
     chainRunner: options.chainRunner,
     disableLlmChainDetection: options.disableLlmChainDetection,
     skipGit: options.skipGit,
+    transport: resolveTransport(options),
     models: resolveConsolidateModels(repoRoot),
   };
 
@@ -667,9 +692,12 @@ export async function generateContractsInProcess(
 
   try {
     const extractModels = resolveExtractModels(repoRoot);
+    const transport = resolveTransport(options);
     const il = await generateContracts({
       repoRoot,
+      transport,
       runner: spawnExtractorRunner({
+        transport,
         concurrency: defaultExtractorConcurrency(),
         model: extractModels.extract,
         fallbackModel: extractModels.fallback,

--- a/packages/core/src/services/llm/cli-provider.ts
+++ b/packages/core/src/services/llm/cli-provider.ts
@@ -10,6 +10,7 @@ import { registerChildProcess, unregisterChildProcess } from '../analysis-regist
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { ZodType } from 'zod';
 import type { Violation } from '@truecourse/shared';
+import type { LlmTransport } from '@truecourse/shared/llm';
 import { config } from '../../config/index.js';
 import {
   getPrompt,
@@ -91,6 +92,12 @@ export abstract class BaseCLIProvider implements LLMProvider {
   private _repoPath: string | null = null;
   private _abortSignal: AbortSignal | null = null;
   private _usageRecords: UsageRecord[] = [];
+  /**
+   * When set, LLM calls go through this transport (the agent file-mailbox)
+   * instead of spawning the CLI. Lets `analyze` run LLM rules headless — no
+   * `claude` binary, no API key (see @truecourse/shared/llm).
+   */
+  protected transport?: LlmTransport;
 
   setAnalysisId(id: string): void {
     this._analysisId = id;
@@ -133,7 +140,8 @@ export abstract class BaseCLIProvider implements LLMProvider {
     });
   }
 
-  constructor() {
+  constructor(transport?: LlmTransport) {
+    this.transport = transport;
     if (process.env.TRUECOURSE_CLI_DEBUG) {
       this.debugDir = join(tmpdir(), 'truecourse-cli-debug');
       mkdirSync(this.debugDir, { recursive: true });
@@ -177,6 +185,23 @@ export abstract class BaseCLIProvider implements LLMProvider {
 
     const timeout = opts?.timeoutMs ?? config.claudeCodeTimeoutMs ?? 120_000;
     const label = opts?.label ?? 'call';
+
+    // Agent transport: hand the prompt + schema to the mailbox instead of
+    // spawning the CLI. The answer is the raw JSON the model produced; wrap it
+    // as a `{ result }` envelope so `parseAndValidate` extracts + Zod-validates
+    // it exactly as it does for the CLI's `result` field.
+    if (this.transport) {
+      return this.transport({
+        stage: `analyze.${label}`,
+        user: prompt,
+        system: '',
+        schema: jsonSchemaStr,
+        responseFormat: 'json',
+        model: this.modelFlag[1],
+        timeoutMs: timeout,
+      }).then((text) => JSON.stringify({ result: text }));
+    }
+
     const args = [
       ...this.baseArgs,
       ...this.modelFlag,

--- a/packages/core/src/services/llm/provider.ts
+++ b/packages/core/src/services/llm/provider.ts
@@ -1,5 +1,6 @@
 import type { Violation } from '@truecourse/shared';
 import { ClaudeCodeProvider } from './cli-provider.js';
+import type { LlmTransport } from '@truecourse/shared/llm';
 import type { FlowEnrichmentContext } from './prompts.js';
 import type { UsageData } from '../usage.service.js';
 
@@ -264,6 +265,11 @@ export interface LLMProvider {
 // Factory — Claude Code CLI is the only supported provider.
 // ---------------------------------------------------------------------------
 
-export function createLLMProvider(): LLMProvider {
-  return new ClaudeCodeProvider();
+/**
+ * Build the LLM provider. Pass an `LlmTransport` to route every LLM call
+ * through it (e.g. the agent file-mailbox, for headless/routine runs); omit it
+ * to spawn the `claude` CLI (the default).
+ */
+export function createLLMProvider(transport?: LlmTransport): LLMProvider {
+  return new ClaudeCodeProvider(transport);
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./llm": {
+      "types": "./dist/llm/transport.d.ts",
+      "import": "./dist/llm/transport.js"
     }
   },
   "scripts": {

--- a/packages/shared/src/llm/transport.ts
+++ b/packages/shared/src/llm/transport.ts
@@ -1,0 +1,221 @@
+/**
+ * LLM transport — the single seam through which every LLM-powered runner
+ * (spec-consolidator's block/conflict/relevance/chain runners,
+ * contract-extractor's slice runner + repair pass) reaches the model.
+ *
+ * A transport is a single-request function `(req) => Promise<rawText>`: it
+ * takes a system + user prompt and returns the model's raw assistant text.
+ * The caller does its own fence-stripping + JSON.parse + Zod validation, so
+ * the transport is content-agnostic. Concurrency stays in each runner (its
+ * existing p-limit), so a single-request transport composes naturally.
+ *
+ * Two backends:
+ *   - `cliTransport` — spawns `claude -p …` (the default; same behavior the
+ *     runners had inline). Needs the `claude` binary on PATH.
+ *   - `agentTransport` — a filesystem mailbox: writes each prompt to
+ *     `<io>/requests/<id>.json` and waits for `<io>/responses/<id>.json`. An
+ *     orchestrating agent that is *already an LLM* (a Claude Code routine)
+ *     answers the prompts, so contracts can be generated with no `claude`
+ *     subprocess and no API key.
+ */
+
+import { spawn } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface LlmRequest {
+  /** Stable id (the runner's natural id, e.g. `spec.claimExtract:<block.id>`).
+   *  Falls back to a content hash when absent. */
+  id?: string;
+  /** Pipeline stage, e.g. `spec.claimExtract` / `contract.extract` — informational. */
+  stage?: string;
+  /** Primary model (cli passes `--model`; agent treats it as a hint). */
+  model?: string;
+  /** Fallback model (cli passes `--fallback-model`). */
+  fallbackModel?: string;
+  system: string;
+  user: string;
+  /** What the answer should be: a JSON object the caller will parse, or free text.
+   *  A hint for the agent answerer; the cli path ignores it. Defaults to 'json'. */
+  responseFormat?: 'json' | 'text';
+  /** Optional JSON-schema string the JSON answer must satisfy (agent hint). */
+  schema?: string;
+  /** Per-call timeout in ms. */
+  timeoutMs?: number;
+}
+
+/** Returns the model's raw assistant text. The caller strips fences + parses. */
+export type LlmTransport = (req: LlmRequest) => Promise<string>;
+
+/**
+ * Strip a single leading ```...``` fence (some models wrap JSON in fences even
+ * when told not to). Shared so every runner strips identically.
+ */
+export function stripCodeFences(text: string): string {
+  const trimmed = text.trim();
+  const fence = /^```(?:json|JSON)?\s*\n([\s\S]*?)\n```$/.exec(trimmed);
+  return fence ? fence[1] : trimmed;
+}
+
+// ---------------------------------------------------------------------------
+// cli backend — spawn `claude -p`
+// ---------------------------------------------------------------------------
+
+export interface CliTransportOptions {
+  /** Binary; defaults to `CLAUDE_CODE_BIN` env or `claude`. */
+  bin?: string;
+}
+
+export function cliTransport(opts: CliTransportOptions = {}): LlmTransport {
+  const bin = opts.bin ?? process.env.CLAUDE_CODE_BIN ?? 'claude';
+  return (req) =>
+    new Promise<string>((resolve, reject) => {
+      const modelArgs: string[] = [];
+      if (req.model) modelArgs.push('--model', req.model);
+      if (req.fallbackModel) modelArgs.push('--fallback-model', req.fallbackModel);
+      const args = [
+        '-p',
+        req.user,
+        ...modelArgs,
+        '--output-format',
+        'json',
+        '--append-system-prompt',
+        req.system,
+        '--setting-sources',
+        'project',
+      ];
+      const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      const out: Buffer[] = [];
+      const err: Buffer[] = [];
+      const timer = req.timeoutMs
+        ? setTimeout(() => {
+            proc.kill('SIGKILL');
+            reject(new Error(`claude timed out after ${req.timeoutMs}ms`));
+          }, req.timeoutMs)
+        : null;
+      proc.stdout.on('data', (b: Buffer) => out.push(b));
+      proc.stderr.on('data', (b: Buffer) => err.push(b));
+      proc.on('error', (e) => {
+        if (timer) clearTimeout(timer);
+        reject(e);
+      });
+      proc.on('close', (code) => {
+        if (timer) clearTimeout(timer);
+        if (code !== 0) {
+          reject(new Error(`claude exited ${code}: ${Buffer.concat(err).toString('utf-8')}`));
+          return;
+        }
+        try {
+          const envelope = JSON.parse(Buffer.concat(out).toString('utf-8'));
+          const text = typeof envelope === 'string' ? envelope : envelope.result;
+          if (typeof text !== 'string') {
+            reject(new Error('claude returned no text'));
+            return;
+          }
+          resolve(text);
+        } catch (e) {
+          reject(e instanceof Error ? e : new Error(String(e)));
+        }
+      });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// agent backend — filesystem mailbox
+// ---------------------------------------------------------------------------
+
+export interface AgentTransportOptions {
+  /** Poll interval in ms (default 200). */
+  pollMs?: number;
+  /** Timeout used when a request omits `timeoutMs` (default 600000). */
+  defaultTimeoutMs?: number;
+}
+
+/**
+ * Mailbox protocol under `ioDir`:
+ *   requests/<id>.json   { id, stage, model, fallbackModel, responseFormat, schema, system, user }
+ *   responses/<id>.json  { text } | { error }
+ * Both files are written atomically (write-tmp + rename) so neither side reads
+ * a partial file. Each concurrent transport call owns one id; the runner's own
+ * concurrency drives how many requests are in flight.
+ */
+export function agentTransport(ioDir: string, opts: AgentTransportOptions = {}): LlmTransport {
+  const reqDir = path.join(ioDir, 'requests');
+  const resDir = path.join(ioDir, 'responses');
+  fs.mkdirSync(reqDir, { recursive: true });
+  fs.mkdirSync(resDir, { recursive: true });
+  const pollMs = opts.pollMs ?? 200;
+  const defaultTimeout = opts.defaultTimeoutMs ?? 600_000;
+
+  return async (req) => {
+    const id = sanitizeId(req.id ?? deriveId(req));
+    const reqPath = path.join(reqDir, `${id}.json`);
+    const resPath = path.join(resDir, `${id}.json`);
+
+    // Resume-friendly: if an answer is already present (e.g. a re-run after a
+    // crash), consume it without re-writing the request.
+    if (!fs.existsSync(resPath)) {
+      atomicWrite(
+        reqPath,
+        JSON.stringify(
+          {
+            id,
+            stage: req.stage,
+            model: req.model,
+            fallbackModel: req.fallbackModel,
+            responseFormat: req.responseFormat ?? 'json',
+            schema: req.schema,
+            system: req.system,
+            user: req.user,
+          },
+          null,
+          2,
+        ),
+      );
+    }
+
+    const deadline = Date.now() + (req.timeoutMs ?? defaultTimeout);
+    for (;;) {
+      if (fs.existsSync(resPath)) {
+        let parsed: { text?: string; error?: string };
+        try {
+          parsed = JSON.parse(fs.readFileSync(resPath, 'utf-8'));
+        } catch {
+          // partial write — retry
+          await sleep(pollMs);
+          continue;
+        }
+        if (parsed.error) throw new Error(`agent answer error for ${id}: ${parsed.error}`);
+        if (typeof parsed.text === 'string') return parsed.text;
+        throw new Error(`agent answer for ${id} missing "text"`);
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`agent transport timed out (${id}) waiting for ${resPath}`);
+      }
+      await sleep(pollMs);
+    }
+  };
+}
+
+function deriveId(req: LlmRequest): string {
+  return createHash('sha256')
+    .update(`${req.stage ?? ''}\0${req.system}\0${req.user}`)
+    .digest('hex')
+    .slice(0, 24);
+}
+
+/** Keep request/response filenames portable: only word chars, dot, and dash. */
+function sanitizeId(id: string): string {
+  return id.replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 200);
+}
+
+function atomicWrite(filePath: string, data: string): void {
+  const tmp = `${filePath}.tmp-${randomUUID()}`;
+  fs.writeFileSync(tmp, data);
+  fs.renameSync(tmp, filePath);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/packages/spec-consolidator/src/chain-recheck.ts
+++ b/packages/spec-consolidator/src/chain-recheck.ts
@@ -19,16 +19,15 @@
  * supersession sticks across re-runs.
  */
 
-import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
+import { cliTransport, stripCodeFences, type LlmTransport } from '@truecourse/shared/llm';
 import type { Conflict, DocKind } from './types.js';
 import type { DocCandidate } from './discovery.js';
 import type { VersionChain } from './version-chain.js';
 import { cachePaths, ensureCacheDirs } from './cache.js';
-import { buildModelArgs } from './model-args.js';
 
 const CACHE_FILE = 'chain-recheck.json';
 
@@ -89,6 +88,12 @@ export type ChainRecheckRunner = (
 export interface ChainRecheckOptions {
   /** Override the runner. Defaults to spawning the Claude CLI. */
   runner?: ChainRecheckRunner;
+  /**
+   * LLM transport for the default runner. Defaults to `cliTransport()`
+   * (spawns `claude -p`). The CLI/dashboard pass `agentTransport(io)` for
+   * headless/routine runs.
+   */
+  transport?: LlmTransport;
   /** When false, skip the LLM calls entirely. Useful for tests. */
   enabled?: boolean;
   /** Cap on concurrent LLM calls (default: 2). */
@@ -195,7 +200,11 @@ export async function runChainRecheck(
 
   const runner =
     opts.runner ??
-    spawnChainRecheckRunner({ model: opts.model, fallbackModel: opts.fallbackModel });
+    spawnChainRecheckRunner({
+      transport: opts.transport,
+      model: opts.model,
+      fallbackModel: opts.fallbackModel,
+    });
   const confirmedChains: VersionChain[] = [];
 
   for (const pair of pairs) {
@@ -314,64 +323,30 @@ const ChainRecheckResultSchema = z.object({
 });
 
 function spawnChainRecheckRunner(
-  opts: { bin?: string; timeoutMs?: number; model?: string; fallbackModel?: string } = {},
+  opts: {
+    transport?: LlmTransport;
+    bin?: string;
+    timeoutMs?: number;
+    model?: string;
+    fallbackModel?: string;
+  } = {},
 ): ChainRecheckRunner {
-  const bin = opts.bin ?? process.env.CLAUDE_CODE_BIN ?? 'claude';
+  const transport = opts.transport ?? cliTransport({ bin: opts.bin });
   const timeoutMs = opts.timeoutMs ?? 180_000;
-  const modelArgs = buildModelArgs(opts.model, opts.fallbackModel);
-  return (input: ChainRecheckRunnerInput): Promise<ChainRecheckResult> => {
-    const args = [
-      '-p',
-      buildChainRecheckUserPrompt(input),
-      ...modelArgs,
-      '--output-format',
-      'json',
-      '--append-system-prompt',
-      CHAIN_RECHECK_SYSTEM_PROMPT,
-      '--setting-sources',
-      'project',
-    ];
-    return new Promise<ChainRecheckResult>((resolve, reject) => {
-      const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-      const stdout: Buffer[] = [];
-      const stderr: Buffer[] = [];
-      const timer = setTimeout(() => {
-        proc.kill('SIGKILL');
-        reject(new Error(`chain-recheck: claude timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      proc.stdout.on('data', (b: Buffer) => stdout.push(b));
-      proc.stderr.on('data', (b: Buffer) => stderr.push(b));
-      proc.on('error', (err) => {
-        clearTimeout(timer);
-        reject(err);
-      });
-      proc.on('close', (code) => {
-        clearTimeout(timer);
-        if (code !== 0) {
-          reject(new Error(`chain-recheck: claude exited ${code}: ${Buffer.concat(stderr).toString('utf-8')}`));
-          return;
-        }
-        try {
-          const envelope = JSON.parse(Buffer.concat(stdout).toString('utf-8'));
-          const text = typeof envelope === 'string' ? envelope : envelope.result;
-          if (typeof text !== 'string') {
-            reject(new Error('chain-recheck: claude returned no text'));
-            return;
-          }
-          const inner = JSON.parse(stripCodeFences(text));
-          resolve(ChainRecheckResultSchema.parse(inner));
-        } catch (e) {
-          reject(e instanceof Error ? e : new Error(String(e)));
-        }
-      });
+  return async (input: ChainRecheckRunnerInput): Promise<ChainRecheckResult> => {
+    const raw = await transport({
+      id: `spec.chainRecheck:${input.pair.conflictId}`,
+      stage: 'spec.chainRecheck',
+      model: opts.model,
+      fallbackModel: opts.fallbackModel,
+      system: CHAIN_RECHECK_SYSTEM_PROMPT,
+      user: buildChainRecheckUserPrompt(input),
+      responseFormat: 'json',
+      timeoutMs,
     });
+    const inner = JSON.parse(stripCodeFences(raw));
+    return ChainRecheckResultSchema.parse(inner);
   };
-}
-
-function stripCodeFences(text: string): string {
-  const trimmed = text.trim();
-  const m = /^```(?:json|JSON)?\s*\n([\s\S]*?)\n```$/.exec(trimmed);
-  return m ? m[1] : trimmed;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/spec-consolidator/src/conflict-explainer.ts
+++ b/packages/spec-consolidator/src/conflict-explainer.ts
@@ -13,14 +13,13 @@
  * explanation.
  */
 
-import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
+import { cliTransport, type LlmTransport } from '@truecourse/shared/llm';
 import type { Conflict } from './types.js';
 import { cachePaths, ensureCacheDirs } from './cache.js';
-import { buildModelArgs } from './model-args.js';
 
 const CACHE_FILE = 'conflict-explanations.json';
 
@@ -35,6 +34,12 @@ export type ConflictExplainerRunner = (
 export interface ConflictExplainerOptions {
   /** Override the runner. Tests pass a stub. */
   runner?: ConflictExplainerRunner;
+  /**
+   * LLM transport forwarded to the default runner. Defaults to `cliTransport()`
+   * (spawns `claude -p`). The CLI/dashboard pass `agentTransport(io)` for
+   * headless/routine runs.
+   */
+  transport?: LlmTransport;
   /** When false, skip the LLM calls entirely. */
   enabled?: boolean;
   /** Cap on concurrent LLM calls (default: 4). */
@@ -71,7 +76,11 @@ export async function explainConflicts(
   if (conflicts.length === 0) return;
   const runner =
     opts.runner ??
-    spawnConflictExplainerRunner({ model: opts.model, fallbackModel: opts.fallbackModel });
+    spawnConflictExplainerRunner({
+      transport: opts.transport,
+      model: opts.model,
+      fallbackModel: opts.fallbackModel,
+    });
   const concurrency = opts.concurrency ?? 4;
   opts.onStart?.(conflicts.length);
 
@@ -290,59 +299,25 @@ function truncateJson(value: unknown, max = 1500): string {
 }
 
 function spawnConflictExplainerRunner(
-  opts: { bin?: string; timeoutMs?: number; model?: string; fallbackModel?: string } = {},
+  opts: { transport?: LlmTransport; bin?: string; timeoutMs?: number; model?: string; fallbackModel?: string } = {},
 ): ConflictExplainerRunner {
-  const bin = opts.bin ?? process.env.CLAUDE_CODE_BIN ?? 'claude';
+  const transport = opts.transport ?? cliTransport({ bin: opts.bin });
   const timeoutMs = opts.timeoutMs ?? 90_000;
-  const modelArgs = buildModelArgs(opts.model, opts.fallbackModel);
-  return (input: ConflictExplainerInput): Promise<string> => {
+  return async (input: ConflictExplainerInput): Promise<string> => {
     const chain = isChainConflict(input.conflict);
-    const args = [
-      '-p',
-      chain
+    const raw = await transport({
+      id: `spec.conflictExplain:${input.conflict.id}`,
+      stage: 'spec.conflictExplain',
+      model: opts.model,
+      fallbackModel: opts.fallbackModel,
+      system: chain ? CHAIN_EXPLAINER_SYSTEM_PROMPT : CONFLICT_EXPLAINER_SYSTEM_PROMPT,
+      user: chain
         ? buildChainExplainerUserPrompt(input.conflict)
         : buildExplainerUserPrompt(input.conflict),
-      ...modelArgs,
-      '--output-format',
-      'json',
-      '--append-system-prompt',
-      chain ? CHAIN_EXPLAINER_SYSTEM_PROMPT : CONFLICT_EXPLAINER_SYSTEM_PROMPT,
-      '--setting-sources',
-      'project',
-    ];
-    return new Promise<string>((resolve, reject) => {
-      const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-      const stdout: Buffer[] = [];
-      const stderr: Buffer[] = [];
-      const timer = setTimeout(() => {
-        proc.kill('SIGKILL');
-        reject(new Error(`conflict-explainer: claude timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      proc.stdout.on('data', (b: Buffer) => stdout.push(b));
-      proc.stderr.on('data', (b: Buffer) => stderr.push(b));
-      proc.on('error', (err) => {
-        clearTimeout(timer);
-        reject(err);
-      });
-      proc.on('close', (code) => {
-        clearTimeout(timer);
-        if (code !== 0) {
-          reject(new Error(`conflict-explainer: claude exited ${code}: ${Buffer.concat(stderr).toString('utf-8')}`));
-          return;
-        }
-        try {
-          const envelope = JSON.parse(Buffer.concat(stdout).toString('utf-8'));
-          const text = typeof envelope === 'string' ? envelope : envelope.result;
-          if (typeof text !== 'string') {
-            reject(new Error('conflict-explainer: claude returned no text'));
-            return;
-          }
-          resolve(text);
-        } catch (e) {
-          reject(e instanceof Error ? e : new Error(String(e)));
-        }
-      });
+      responseFormat: 'text',
+      timeoutMs,
     });
+    return raw;
   };
 }
 

--- a/packages/spec-consolidator/src/conflict-resolver.ts
+++ b/packages/spec-consolidator/src/conflict-resolver.ts
@@ -19,14 +19,13 @@
  * not persisted to disk — every scan regenerates it from cache.
  */
 
-import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
+import { cliTransport, stripCodeFences, type LlmTransport } from '@truecourse/shared/llm';
 import type { Conflict } from './types.js';
 import { cachePaths, ensureCacheDirs } from './cache.js';
-import { buildModelArgs } from './model-args.js';
 
 const CACHE_FILE = 'conflict-resolutions.json';
 
@@ -47,6 +46,11 @@ export type ConflictResolverRunner = (
 export interface ConflictResolverOptions {
   /** Override the runner. Tests pass a stub. */
   runner?: ConflictResolverRunner;
+  /**
+   * LLM transport forwarded to the default spawn runner. Defaults to
+   * `cliTransport()` (spawns `claude -p`).
+   */
+  transport?: LlmTransport;
   /** When false, skip the LLM call entirely. */
   enabled?: boolean;
   /** Cap on concurrent LLM calls (default: 2 — these are Opus, slower). */
@@ -88,7 +92,11 @@ export async function resolveConflicts(
   if (opts.enabled === false || conflicts.length === 0) return [];
   const runner =
     opts.runner ??
-    spawnConflictResolverRunner({ model: opts.model, fallbackModel: opts.fallbackModel });
+    spawnConflictResolverRunner({
+      transport: opts.transport,
+      model: opts.model,
+      fallbackModel: opts.fallbackModel,
+    });
   const concurrency = opts.concurrency ?? 2;
   opts.onStart?.(conflicts.length);
   const tBatchStart = perfNow();
@@ -284,64 +292,24 @@ const ConflictResolutionSchema = z.object({
 });
 
 function spawnConflictResolverRunner(
-  opts: { bin?: string; timeoutMs?: number; model?: string; fallbackModel?: string } = {},
+  opts: { transport?: LlmTransport; bin?: string; timeoutMs?: number; model?: string; fallbackModel?: string } = {},
 ): ConflictResolverRunner {
-  const bin = opts.bin ?? process.env.CLAUDE_CODE_BIN ?? 'claude';
+  const transport = opts.transport ?? cliTransport({ bin: opts.bin });
   const timeoutMs = opts.timeoutMs ?? 240_000;
-  const modelArgs = buildModelArgs(opts.model, opts.fallbackModel);
-  return (input: ConflictResolverInput): Promise<ConflictResolution> => {
-    const args = [
-      '-p',
-      buildResolverUserPrompt(input.conflict),
-      ...modelArgs,
-      '--output-format',
-      'json',
-      '--append-system-prompt',
-      CONFLICT_RESOLVER_SYSTEM_PROMPT,
-      '--setting-sources',
-      'project',
-    ];
-    return new Promise<ConflictResolution>((resolve, reject) => {
-      const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-      const stdout: Buffer[] = [];
-      const stderr: Buffer[] = [];
-      const timer = setTimeout(() => {
-        proc.kill('SIGKILL');
-        reject(new Error(`conflict-resolver: claude timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      proc.stdout.on('data', (b: Buffer) => stdout.push(b));
-      proc.stderr.on('data', (b: Buffer) => stderr.push(b));
-      proc.on('error', (err) => {
-        clearTimeout(timer);
-        reject(err);
-      });
-      proc.on('close', (code) => {
-        clearTimeout(timer);
-        if (code !== 0) {
-          reject(new Error(`conflict-resolver: claude exited ${code}: ${Buffer.concat(stderr).toString('utf-8')}`));
-          return;
-        }
-        try {
-          const envelope = JSON.parse(Buffer.concat(stdout).toString('utf-8'));
-          const text = typeof envelope === 'string' ? envelope : envelope.result;
-          if (typeof text !== 'string') {
-            reject(new Error('conflict-resolver: claude returned no text'));
-            return;
-          }
-          const inner = JSON.parse(stripCodeFences(text));
-          resolve(ConflictResolutionSchema.parse(inner));
-        } catch (e) {
-          reject(e instanceof Error ? e : new Error(String(e)));
-        }
-      });
+  return async (input: ConflictResolverInput): Promise<ConflictResolution> => {
+    const raw = await transport({
+      id: `spec.conflictResolve:${input.conflict.id}`,
+      stage: 'spec.conflictResolve',
+      model: opts.model,
+      fallbackModel: opts.fallbackModel,
+      system: CONFLICT_RESOLVER_SYSTEM_PROMPT,
+      user: buildResolverUserPrompt(input.conflict),
+      responseFormat: 'json',
+      timeoutMs,
     });
+    const inner = JSON.parse(stripCodeFences(raw));
+    return ConflictResolutionSchema.parse(inner);
   };
-}
-
-function stripCodeFences(text: string): string {
-  const trimmed = text.trim();
-  const m = /^```(?:json|JSON)?\s*\n([\s\S]*?)\n```$/.exec(trimmed);
-  return m ? m[1] : trimmed;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/spec-consolidator/src/orchestrator.ts
+++ b/packages/spec-consolidator/src/orchestrator.ts
@@ -21,6 +21,7 @@ import { detectModules, SHARED_MODULE, type DetectedModule } from './module-dete
 import { extractClaims, type ExtractResult } from './extractor.js';
 import { mergeClaims, type DecidedConflict, type MergeResult } from './merger.js';
 import { spawnRunner, type BlockRunner, type BlockRunResult } from './runner.js';
+import type { LlmTransport } from '@truecourse/shared/llm';
 import type { Block } from './slicer.js';
 import {
   DecisionsFileSchema,
@@ -95,6 +96,13 @@ export interface ConsolidateOptions {
    * overrides take precedence (tests inject stubs that way).
    */
   models?: ConsolidateModels;
+  /**
+   * LLM transport for the auto-created runners (block extraction, relevance,
+   * chain, conflict explain/resolve). Defaults to the cli transport (spawn
+   * `claude -p`). The CLI/dashboard pass an agent transport for headless runs.
+   * Explicit `*Runner` overrides (test stubs) ignore this.
+   */
+  transport?: LlmTransport;
   /** Override block-extraction runner. Tests pass a stub. */
   blockRunner?: BlockRunner;
   /**
@@ -237,6 +245,7 @@ export async function consolidate(
     runner: opts.relevanceRunner,
     enabled: opts.disableRelevanceFilter !== true,
     manualIncludes: decisions.manualIncludes ?? [],
+    transport: opts.transport,
     model: models.relevance,
     fallbackModel,
     onProgress: opts.onRelevanceProgress,
@@ -254,6 +263,7 @@ export async function consolidate(
   const llmChains = await detectVersionChainsViaLlm(repoRoot, docs, {
     runner: opts.chainRunner,
     enabled: opts.disableLlmChainDetection !== true,
+    transport: opts.transport,
     model: models.chainDetect,
     fallbackModel,
   });
@@ -272,6 +282,7 @@ export async function consolidate(
     repoRoot,
     opts.blockRunner ??
       spawnRunner({
+        transport: opts.transport,
         onBlockDone: () => opts.onBlockDone?.(),
         model: models.claimExtract,
         fallbackModel,
@@ -314,6 +325,7 @@ export async function consolidate(
   const recheckChains = await runChainRecheck(repoRoot, recheckPairs, {
     runner: opts.chainRecheckRunner,
     enabled: opts.disableChainRecheck !== true,
+    transport: opts.transport,
     model: models.chainRecheck,
     fallbackModel,
   });
@@ -356,6 +368,7 @@ export async function consolidate(
   await explainConflicts(repoRoot, stitchedMerge.openConflicts, {
     runner: opts.conflictExplainerRunner,
     enabled: opts.disableConflictExplanations !== true,
+    transport: opts.transport,
     model: models.conflictExplain,
     fallbackModel,
     onStart: opts.onExplainStart,
@@ -376,6 +389,7 @@ export async function consolidate(
   const autoResolved = await resolveConflicts(repoRoot, stitchedMerge.openConflicts, {
     runner: opts.conflictResolverRunner,
     enabled: opts.disableConflictResolution !== true,
+    transport: opts.transport,
     model: models.conflictResolve,
     fallbackModel,
     onStart: opts.onResolveStart,

--- a/packages/spec-consolidator/src/relevance-filter.ts
+++ b/packages/spec-consolidator/src/relevance-filter.ts
@@ -19,14 +19,13 @@
  * to keep noise than silently drop a real spec doc).
  */
 
-import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
+import { cliTransport, stripCodeFences, type LlmTransport } from '@truecourse/shared/llm';
 import type { DocCandidate } from './discovery.js';
 import { cachePaths, ensureCacheDirs } from './cache.js';
-import { buildModelArgs } from './model-args.js';
 
 const CACHE_FILE = 'relevance.json';
 
@@ -48,6 +47,8 @@ export type RelevanceRunner = (input: RelevanceRunnerInput) => Promise<Relevance
 export interface RelevanceFilterOptions {
   /** Override the runner. Tests pass a stub. */
   runner?: RelevanceRunner;
+  /** LLM transport for the auto-created runner (defaults to cli). */
+  transport?: LlmTransport;
   /** When false, skip the LLM call entirely; every doc stays included. */
   enabled?: boolean;
   /**
@@ -92,7 +93,7 @@ export async function filterByRelevance(
   const manualSet = new Set(opts.manualIncludes ?? []);
   const runner =
     opts.runner ??
-    spawnRelevanceRunner({ model: opts.model, fallbackModel: opts.fallbackModel });
+    spawnRelevanceRunner({ transport: opts.transport, model: opts.model, fallbackModel: opts.fallbackModel });
   const concurrency = opts.concurrency ?? 4;
 
   const total = docs.length;
@@ -217,65 +218,32 @@ const RelevanceVerdictSchema = z.object({
 });
 
 function spawnRelevanceRunner(
-  opts: { bin?: string; timeoutMs?: number; model?: string; fallbackModel?: string } = {},
+  opts: {
+    /** LLM transport. Defaults to `cliTransport()` (spawns `claude -p`). */
+    transport?: LlmTransport;
+    bin?: string;
+    timeoutMs?: number;
+    model?: string;
+    fallbackModel?: string;
+  } = {},
 ): RelevanceRunner {
-  const bin = opts.bin ?? process.env.CLAUDE_CODE_BIN ?? 'claude';
+  const transport = opts.transport ?? cliTransport({ bin: opts.bin });
   const timeoutMs = opts.timeoutMs ?? 60_000;
-  const modelArgs = buildModelArgs(opts.model, opts.fallbackModel);
-  return (input: RelevanceRunnerInput): Promise<RelevanceVerdict> => {
-    const args = [
-      '-p',
-      buildRelevanceUserPrompt(input.doc),
-      ...modelArgs,
-      '--output-format',
-      'json',
-      '--append-system-prompt',
-      RELEVANCE_SYSTEM_PROMPT,
-      '--setting-sources',
-      'project',
-    ];
-    return new Promise<RelevanceVerdict>((resolve, reject) => {
-      const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-      const stdout: Buffer[] = [];
-      const stderr: Buffer[] = [];
-      const timer = setTimeout(() => {
-        proc.kill('SIGKILL');
-        reject(new Error(`relevance: claude timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      proc.stdout.on('data', (b: Buffer) => stdout.push(b));
-      proc.stderr.on('data', (b: Buffer) => stderr.push(b));
-      proc.on('error', (err) => {
-        clearTimeout(timer);
-        reject(err);
-      });
-      proc.on('close', (code) => {
-        clearTimeout(timer);
-        if (code !== 0) {
-          reject(new Error(`relevance: claude exited ${code}: ${Buffer.concat(stderr).toString('utf-8')}`));
-          return;
-        }
-        try {
-          const envelope = JSON.parse(Buffer.concat(stdout).toString('utf-8'));
-          const text = typeof envelope === 'string' ? envelope : envelope.result;
-          if (typeof text !== 'string') {
-            reject(new Error('relevance: claude returned no text'));
-            return;
-          }
-          const inner = JSON.parse(stripCodeFences(text));
-          const parsed = RelevanceVerdictSchema.parse(inner);
-          resolve({ path: input.doc.path, include: parsed.include, reason: parsed.reason });
-        } catch (e) {
-          reject(e instanceof Error ? e : new Error(String(e)));
-        }
-      });
+  return async (input: RelevanceRunnerInput): Promise<RelevanceVerdict> => {
+    const raw = await transport({
+      id: `spec.relevance:${input.doc.path}`,
+      stage: 'spec.relevance',
+      model: opts.model,
+      fallbackModel: opts.fallbackModel,
+      system: RELEVANCE_SYSTEM_PROMPT,
+      user: buildRelevanceUserPrompt(input.doc),
+      responseFormat: 'json',
+      timeoutMs,
     });
+    const inner = JSON.parse(stripCodeFences(raw));
+    const parsed = RelevanceVerdictSchema.parse(inner);
+    return { path: input.doc.path, include: parsed.include, reason: parsed.reason };
   };
-}
-
-function stripCodeFences(text: string): string {
-  const trimmed = text.trim();
-  const m = /^```(?:json|JSON)?\s*\n([\s\S]*?)\n```$/.exec(trimmed);
-  return m ? m[1] : trimmed;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/spec-consolidator/src/runner.ts
+++ b/packages/spec-consolidator/src/runner.ts
@@ -1,18 +1,18 @@
 /**
- * Per-block extraction runner. Spawns one `claude -p` subprocess per
- * block, parses Claude Code's JSON envelope, validates the inner
- * payload against `LlmExtractionSchema`, and returns a typed result.
+ * Per-block extraction runner. For each block it builds a system + user
+ * prompt and hands it to an `LlmTransport` (cli = spawn `claude -p`, agent =
+ * filesystem mailbox), then validates the response against
+ * `LlmExtractionSchema`.
  *
- * The runner is injected — tests pass a stub that returns canned
- * outputs without touching the subprocess at all. Same pattern the
- * contract-extractor uses; keeps the orchestrator pure.
+ * The runner is injected — tests pass a stub that returns canned outputs
+ * without touching the transport at all. Concurrency lives here (p-limit);
+ * the transport is a single-request function.
  */
 
-import { spawn } from 'node:child_process';
 import os from 'node:os';
 import pLimit from 'p-limit';
+import { cliTransport, stripCodeFences, type LlmTransport } from '@truecourse/shared/llm';
 import type { Block } from './slicer.js';
-import { buildModelArgs } from './model-args.js';
 import {
   LlmExtractionSchema,
   SYSTEM_PROMPT,
@@ -24,7 +24,7 @@ export interface BlockRunResult {
   block: Block;
   /** Parsed extraction on success. */
   extraction?: LlmExtraction;
-  /** Error message on failure (subprocess exit, parse, schema fail). */
+  /** Error message on failure (transport error, parse, schema fail). */
   error?: string;
   durationMs: number;
 }
@@ -32,7 +32,12 @@ export interface BlockRunResult {
 export type BlockRunner = (blocks: Block[]) => Promise<BlockRunResult[]>;
 
 export interface SpawnRunnerOptions {
-  /** Path to the claude binary. Defaults to `CLAUDE_CODE_BIN` env or 'claude'. */
+  /**
+   * LLM transport. Defaults to `cliTransport()` (spawns `claude -p`). The
+   * CLI/dashboard pass `agentTransport(io)` for headless/routine runs.
+   */
+  transport?: LlmTransport;
+  /** Path to the claude binary (cli transport only). Defaults to `CLAUDE_CODE_BIN` env or 'claude'. */
   bin?: string;
   /**
    * Model name passed to `claude --model`. When unset, the CLI default
@@ -42,13 +47,13 @@ export interface SpawnRunnerOptions {
   model?: string;
   /** Optional fallback model passed to `claude --fallback-model`. */
   fallbackModel?: string;
-  /** Concurrent subprocesses. Defaults to min(cpus, 4). */
+  /** Concurrent requests. Defaults to min(cpus, 4). */
   concurrency?: number;
-  /** Per-call timeout. Defaults to 240000ms (matches contract-extractor's bumped timeout). */
+  /** Per-call timeout. Defaults to 240000ms. */
   timeoutMs?: number;
-  /** Hook fired before each subprocess spawn — useful for progress UIs. */
+  /** Hook fired before each request — useful for progress UIs. */
   onBlockStart?: (block: Block) => void;
-  /** Hook fired after each subprocess completes (success or failure). */
+  /** Hook fired after each request completes (success or failure). */
   onBlockDone?: (block: Block, ok: boolean) => void;
 }
 
@@ -62,14 +67,13 @@ export function defaultConcurrency(): number {
 }
 
 /**
- * Build a runner that spawns `claude -p` for each block. Each
- * subprocess is independent — failures don't abort the batch.
+ * Build a runner that calls the transport once per block. Each request is
+ * independent — failures don't abort the batch.
  */
 export function spawnRunner(opts: SpawnRunnerOptions = {}): BlockRunner {
-  const bin = opts.bin ?? process.env.CLAUDE_CODE_BIN ?? 'claude';
+  const transport = opts.transport ?? cliTransport({ bin: opts.bin });
   const concurrency = opts.concurrency ?? defaultConcurrency();
   const timeoutMs = opts.timeoutMs ?? 240_000;
-  const modelArgs = buildModelArgs(opts.model, opts.fallbackModel);
   const limit = pLimit(concurrency);
 
   return async (blocks: Block[]): Promise<BlockRunResult[]> => {
@@ -79,7 +83,7 @@ export function spawnRunner(opts: SpawnRunnerOptions = {}): BlockRunner {
           opts.onBlockStart?.(block);
           const t0 = Date.now();
           try {
-            const extraction = await runOne(bin, block, timeoutMs, modelArgs);
+            const extraction = await runOne(transport, block, timeoutMs, opts.model, opts.fallbackModel);
             opts.onBlockDone?.(block, true);
             return { block, extraction, durationMs: Date.now() - t0 };
           } catch (e) {
@@ -94,10 +98,11 @@ export function spawnRunner(opts: SpawnRunnerOptions = {}): BlockRunner {
 }
 
 async function runOne(
-  bin: string,
+  transport: LlmTransport,
   block: Block,
   timeoutMs: number,
-  modelArgs: string[],
+  model?: string,
+  fallbackModel?: string,
 ): Promise<LlmExtraction> {
   const userPrompt = buildUserPrompt({
     filePath: block.filePath,
@@ -105,62 +110,16 @@ async function runOne(
     startLine: block.startLine,
     text: block.text,
   });
-  const args = [
-    '-p',
-    userPrompt,
-    ...modelArgs,
-    '--output-format',
-    'json',
-    '--append-system-prompt',
-    SYSTEM_PROMPT,
-    '--setting-sources',
-    'project',
-  ];
-
-  return new Promise<LlmExtraction>((resolve, reject) => {
-    const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-    const timer = setTimeout(() => {
-      proc.kill('SIGKILL');
-      reject(new Error(`claude timed out after ${timeoutMs}ms for block ${block.id}`));
-    }, timeoutMs);
-
-    proc.stdout.on('data', (b: Buffer) => stdout.push(b));
-    proc.stderr.on('data', (b: Buffer) => stderr.push(b));
-    proc.on('error', (err) => {
-      clearTimeout(timer);
-      reject(err);
-    });
-    proc.on('close', (code) => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        reject(new Error(`claude exited ${code}: ${Buffer.concat(stderr).toString('utf-8')}`));
-        return;
-      }
-      try {
-        const envelope = JSON.parse(Buffer.concat(stdout).toString('utf-8'));
-        const text = typeof envelope === 'string' ? envelope : envelope.result;
-        if (typeof text !== 'string') {
-          reject(new Error(`claude returned no text for block ${block.id}`));
-          return;
-        }
-        const inner = JSON.parse(stripCodeFences(text));
-        resolve(LlmExtractionSchema.parse(inner));
-      } catch (e) {
-        reject(e instanceof Error ? e : new Error(String(e)));
-      }
-    });
+  const raw = await transport({
+    id: `spec.claimExtract:${block.id}`,
+    stage: 'spec.claimExtract',
+    model,
+    fallbackModel,
+    system: SYSTEM_PROMPT,
+    user: userPrompt,
+    responseFormat: 'json',
+    timeoutMs,
   });
+  const inner = JSON.parse(stripCodeFences(raw));
+  return LlmExtractionSchema.parse(inner);
 }
-
-/**
- * Some models wrap JSON in markdown code fences even when told not to.
- * Strip a single leading ```...``` fence (with or without lang tag).
- */
-function stripCodeFences(text: string): string {
-  const trimmed = text.trim();
-  const fenceMatch = /^```(?:json|JSON)?\s*\n([\s\S]*?)\n```$/.exec(trimmed);
-  return fenceMatch ? fenceMatch[1] : trimmed;
-}
-

--- a/packages/spec-consolidator/src/version-chain-llm.ts
+++ b/packages/spec-consolidator/src/version-chain-llm.ts
@@ -18,15 +18,14 @@
  * — re-running a scan with unchanged docs costs zero LLM calls.
  */
 
-import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
+import { cliTransport, stripCodeFences, type LlmTransport } from '@truecourse/shared/llm';
 import type { DocCandidate } from './discovery.js';
 import type { VersionChain } from './version-chain.js';
 import { cachePaths, ensureCacheDirs } from './cache.js';
-import { buildModelArgs } from './model-args.js';
 
 const CACHE_FILE = 'chain-detection.json';
 
@@ -38,6 +37,11 @@ export interface ChainDetectionInput {
 }
 
 export interface ChainRunnerOptions {
+  /**
+   * LLM transport. Defaults to `cliTransport()` (spawns `claude -p`). The
+   * CLI/dashboard pass `agentTransport(io)` for headless/routine runs.
+   */
+  transport?: LlmTransport;
   bin?: string;
   /** Model passed to `claude --model`. Resolved by CLI/dashboard via core. */
   model?: string;
@@ -57,6 +61,8 @@ export type ChainRunner = (
 export interface DetectChainsOptions {
   /** Override the runner. Defaults to spawning the Claude CLI. */
   runner?: ChainRunner;
+  /** LLM transport for the auto-created runner (defaults to cli). */
+  transport?: LlmTransport;
   /** When false, skip the LLM call entirely. Useful for tests. */
   enabled?: boolean;
   /** Model name forwarded to the default spawn runner. */
@@ -116,7 +122,7 @@ export async function detectVersionChainsViaLlm(
   if (cached) return materializeChains(cached, docs);
 
   const runner =
-    opts.runner ?? spawnChainRunner({ model: opts.model, fallbackModel: opts.fallbackModel });
+    opts.runner ?? spawnChainRunner({ transport: opts.transport, model: opts.model, fallbackModel: opts.fallbackModel });
   let result: DetectedChainOutput;
   try {
     result = await runner(inputs);
@@ -187,62 +193,23 @@ export function buildChainDetectionUserPrompt(inputs: ChainDetectionInput[]): st
 // ---------------------------------------------------------------------------
 
 function spawnChainRunner(opts: ChainRunnerOptions = {}): ChainRunner {
-  const bin = opts.bin ?? process.env.CLAUDE_CODE_BIN ?? 'claude';
+  const transport = opts.transport ?? cliTransport({ bin: opts.bin });
   const timeoutMs = opts.timeoutMs ?? 120_000;
-  const modelArgs = buildModelArgs(opts.model, opts.fallbackModel);
   return async (inputs) => {
-    const args = [
-      '-p',
-      buildChainDetectionUserPrompt(inputs),
-      ...modelArgs,
-      '--output-format',
-      'json',
-      '--append-system-prompt',
-      CHAIN_DETECTION_SYSTEM_PROMPT,
-      '--setting-sources',
-      'project',
-    ];
-    return new Promise<DetectedChainOutput>((resolve, reject) => {
-      const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-      const stdout: Buffer[] = [];
-      const stderr: Buffer[] = [];
-      const timer = setTimeout(() => {
-        proc.kill('SIGKILL');
-        reject(new Error(`chain-detection: claude timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      proc.stdout.on('data', (b: Buffer) => stdout.push(b));
-      proc.stderr.on('data', (b: Buffer) => stderr.push(b));
-      proc.on('error', (err) => {
-        clearTimeout(timer);
-        reject(err);
-      });
-      proc.on('close', (code) => {
-        clearTimeout(timer);
-        if (code !== 0) {
-          reject(new Error(`chain-detection: claude exited ${code}: ${Buffer.concat(stderr).toString('utf-8')}`));
-          return;
-        }
-        try {
-          const envelope = JSON.parse(Buffer.concat(stdout).toString('utf-8'));
-          const text = typeof envelope === 'string' ? envelope : envelope.result;
-          if (typeof text !== 'string') {
-            reject(new Error('chain-detection: claude returned no text'));
-            return;
-          }
-          const inner = JSON.parse(stripCodeFences(text));
-          resolve(DetectedChainOutputSchema.parse(inner));
-        } catch (e) {
-          reject(e instanceof Error ? e : new Error(String(e)));
-        }
-      });
+    // No single natural id for a batched call over all docs — omit `id` and
+    // let the transport hash the content.
+    const raw = await transport({
+      stage: 'spec.chainDetect',
+      model: opts.model,
+      fallbackModel: opts.fallbackModel,
+      system: CHAIN_DETECTION_SYSTEM_PROMPT,
+      user: buildChainDetectionUserPrompt(inputs),
+      responseFormat: 'json',
+      timeoutMs,
     });
+    const inner = JSON.parse(stripCodeFences(raw));
+    return DetectedChainOutputSchema.parse(inner);
   };
-}
-
-function stripCodeFences(text: string): string {
-  const trimmed = text.trim();
-  const fenceMatch = /^```(?:json|JSON)?\s*\n([\s\S]*?)\n```$/.exec(trimmed);
-  return fenceMatch ? fenceMatch[1] : trimmed;
 }
 
 // ---------------------------------------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
 
   apps/dashboard/client:
     dependencies:
@@ -366,6 +369,9 @@ importers:
       '@truecourse/contract-verifier':
         specifier: workspace:*
         version: link:../contract-verifier
+      '@truecourse/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@truecourse/spec-consolidator':
         specifier: workspace:*
         version: link:../spec-consolidator

--- a/tests/core/llm-agent-transport.test.ts
+++ b/tests/core/llm-agent-transport.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { BaseCLIProvider } from '../../packages/core/src/services/llm/cli-provider.js';
+import { agentTransport, type LlmTransport } from '../../packages/shared/src/llm/transport.js';
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Minimal concrete provider exposing the protected spawn+parse for testing. */
+class TestProvider extends BaseCLIProvider {
+  get binaryName(): string {
+    return 'claude';
+  }
+  get baseArgs(): string[] {
+    return [];
+  }
+  get modelFlag(): string[] {
+    return [];
+  }
+  run<T>(prompt: string, schema: z.ZodType<T>): Promise<{ data: T }> {
+    return this.spawnAndParse(prompt, schema, { label: 'unit' });
+  }
+}
+
+describe('analyze LLM provider — agent transport', () => {
+  it('routes the call through the transport (no claude spawn) and validates the answer', async () => {
+    const seen: Array<{ stage?: string; user: string; schema?: string }> = [];
+    const transport: LlmTransport = async (req) => {
+      seen.push({ stage: req.stage, user: req.user, schema: req.schema });
+      return JSON.stringify({ ok: true, n: 7 });
+    };
+    const provider = new TestProvider(transport);
+    const schema = z.object({ ok: z.boolean(), n: z.number() });
+
+    const { data } = await provider.run('THE PROMPT', schema);
+
+    expect(data).toEqual({ ok: true, n: 7 });
+    expect(seen[0].user).toBe('THE PROMPT');
+    expect(seen[0].stage).toBe('analyze.unit');
+    expect(seen[0].schema).toContain('ok'); // the JSON-schema string is forwarded to the answerer
+  });
+
+  it('works end-to-end through the agentTransport filesystem mailbox', async () => {
+    const io = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-analyze-io-'));
+    const provider = new TestProvider(agentTransport(io, { pollMs: 10 }));
+    const schema = z.object({ value: z.string() });
+
+    const pending = provider.run('P', schema);
+
+    // play the answering agent: find the request, write a schema-valid answer
+    const reqDir = path.join(io, 'requests');
+    for (let i = 0; i < 200; i++) {
+      if (fs.existsSync(reqDir) && fs.readdirSync(reqDir).length > 0) break;
+      await sleep(5);
+    }
+    const file = fs.readdirSync(reqDir)[0];
+    fs.writeFileSync(
+      path.join(io, 'responses', file),
+      JSON.stringify({ text: JSON.stringify({ value: 'hi' }) }),
+    );
+
+    const { data } = await pending;
+    expect(data).toEqual({ value: 'hi' });
+  });
+});

--- a/tests/shared/llm-transport.test.ts
+++ b/tests/shared/llm-transport.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  agentTransport,
+  stripCodeFences,
+  type LlmTransport,
+} from '../../packages/shared/src/llm/transport.js';
+import { spawnRunner } from '../../packages/spec-consolidator/src/runner.js';
+import type { Block } from '../../packages/spec-consolidator/src/slicer.js';
+
+function tmpIo(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tc-llmio-'));
+}
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe('stripCodeFences', () => {
+  it('strips a fenced JSON block', () => {
+    expect(stripCodeFences('```json\n{"a":1}\n```')).toBe('{"a":1}');
+    expect(stripCodeFences('```\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+  it('passes unfenced text through (trimmed)', () => {
+    expect(stripCodeFences('  {"a":1}  ')).toBe('{"a":1}');
+  });
+});
+
+describe('agentTransport (filesystem mailbox)', () => {
+  it('writes a request file and returns the answered text', async () => {
+    const io = tmpIo();
+    const transport = agentTransport(io, { pollMs: 5 });
+    const pending = transport({
+      id: 'test-1',
+      stage: 'test',
+      model: 'haiku',
+      system: 'SYS',
+      user: 'USER',
+      responseFormat: 'json',
+    });
+
+    // act as the answering agent: wait for the request, then write the response
+    const reqPath = path.join(io, 'requests', 'test-1.json');
+    for (let i = 0; i < 200 && !fs.existsSync(reqPath); i++) await sleep(5);
+    const req = JSON.parse(fs.readFileSync(reqPath, 'utf-8'));
+    expect(req).toMatchObject({ id: 'test-1', stage: 'test', system: 'SYS', user: 'USER', responseFormat: 'json' });
+    fs.writeFileSync(path.join(io, 'responses', 'test-1.json'), JSON.stringify({ text: '{"ok":true}' }));
+
+    expect(await pending).toBe('{"ok":true}');
+  });
+
+  it('throws when the agent reports an error', async () => {
+    const io = tmpIo();
+    // pre-seed the answer (resume path), so the call resolves immediately
+    fs.mkdirSync(path.join(io, 'responses'), { recursive: true });
+    fs.writeFileSync(path.join(io, 'responses', 'err-1.json'), JSON.stringify({ error: 'boom' }));
+    await expect(agentTransport(io, { pollMs: 5 })({ id: 'err-1', system: 's', user: 'u' })).rejects.toThrow(/boom/);
+  });
+
+  it('reuses an existing response without re-writing the request (resume)', async () => {
+    const io = tmpIo();
+    fs.mkdirSync(path.join(io, 'responses'), { recursive: true });
+    fs.writeFileSync(path.join(io, 'responses', 'r-1.json'), JSON.stringify({ text: 'cached' }));
+    const text = await agentTransport(io, { pollMs: 5 })({ id: 'r-1', system: 's', user: 'u' });
+    expect(text).toBe('cached');
+    // request file should NOT have been written, since the answer already existed
+    expect(fs.existsSync(path.join(io, 'requests', 'r-1.json'))).toBe(false);
+  });
+
+  it('times out when no answer appears', async () => {
+    const io = tmpIo();
+    await expect(
+      agentTransport(io, { pollMs: 5 })({ id: 'slow-1', system: 's', user: 'u', timeoutMs: 40 }),
+    ).rejects.toThrow(/timed out/);
+  });
+});
+
+describe('runner ↔ transport seam', () => {
+  it('block runner parses the transport response into an extraction', async () => {
+    const transport: LlmTransport = async (req) => {
+      // the runner should pass the block's prompt through
+      expect(req.stage).toBe('spec.claimExtract');
+      expect(req.user).toContain('hello world');
+      return '```json\n{"topics":[],"claims":[]}\n```';
+    };
+    const block: Block = {
+      id: 'b1',
+      filePath: 'a.md',
+      headingPath: ['Intro'],
+      startLine: 1,
+      text: 'hello world',
+    } as Block;
+    const runner = spawnRunner({ transport });
+    const [result] = await runner([block]);
+    expect(result.error).toBeUndefined();
+    expect(result.extraction).toEqual({ topics: [], claims: [] });
+  });
+});

--- a/tests/spec-consolidator/agent-transport-integration.test.ts
+++ b/tests/spec-consolidator/agent-transport-integration.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { consolidate } from '../../packages/spec-consolidator/src/index.js';
+import { agentTransport } from '../../packages/shared/src/llm/transport.js';
+
+/**
+ * Drives the full consolidator pipeline through the **agent** transport — no
+ * `claude` subprocess. A concurrent "answerer" plays the routine's role: it
+ * watches the mailbox and writes a schema-valid response per request stage.
+ * Proves the transport seam threads orchestrator → every runner end-to-end.
+ */
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  for (const c of cleanups.splice(0)) c();
+});
+
+function tmp(prefix: string): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  cleanups.push(() => fs.rmSync(d, { recursive: true, force: true }));
+  return d;
+}
+
+function answerFor(stage: string | undefined, responseFormat: string | undefined): string {
+  switch (stage) {
+    case 'spec.relevance':
+      return JSON.stringify({ include: true, reason: 'spec source' });
+    case 'spec.claimExtract':
+      return JSON.stringify({ topics: [], claims: [] });
+    case 'spec.chainDetect':
+      return JSON.stringify({ chains: [] });
+    case 'spec.chainRecheck':
+      return JSON.stringify({ superseded: false, reason: 'distinct' });
+    case 'spec.conflictResolve':
+      return JSON.stringify({ pick: 0, confidence: 'low', reasoning: 'n/a' });
+    case 'spec.conflictExplain':
+      return 'no material conflict';
+    default:
+      return responseFormat === 'text' ? '' : '{}';
+  }
+}
+
+/** Mailbox pump: answer any request that doesn't yet have a response. */
+function startAnswerer(io: string): () => void {
+  const reqDir = path.join(io, 'requests');
+  const resDir = path.join(io, 'responses');
+  const seen = new Set<string>();
+  const timer = setInterval(() => {
+    if (!fs.existsSync(reqDir)) return;
+    for (const f of fs.readdirSync(reqDir)) {
+      if (!f.endsWith('.json') || seen.has(f)) continue;
+      const resPath = path.join(resDir, f);
+      if (fs.existsSync(resPath)) { seen.add(f); continue; }
+      let req: { stage?: string; responseFormat?: string };
+      try { req = JSON.parse(fs.readFileSync(path.join(reqDir, f), 'utf-8')); } catch { continue; }
+      const tmpPath = `${resPath}.tmp`;
+      fs.writeFileSync(tmpPath, JSON.stringify({ text: answerFor(req.stage, req.responseFormat) }));
+      fs.renameSync(tmpPath, resPath);
+      seen.add(f);
+    }
+  }, 10);
+  return () => clearInterval(timer);
+}
+
+describe('agent transport — full consolidate pipeline', () => {
+  it('scans a repo end-to-end with no claude subprocess', async () => {
+    const repo = tmp('tc-agent-repo-');
+    const io = tmp('tc-agent-io-');
+    fs.writeFileSync(
+      path.join(repo, 'spec.md'),
+      '# Orders API\n\n## Create order\n\n`POST /api/orders` creates an order and returns 201 with the id.\n',
+    );
+
+    const stop = startAnswerer(io);
+    try {
+      const result = await consolidate(repo, {
+        transport: agentTransport(io, { pollMs: 10 }),
+        skipGit: true,
+      });
+      // The pipeline ran to completion driven entirely by mailbox answers.
+      expect(result.extract.docsScanned).toBeGreaterThan(0);
+      expect(result.extract.blocksAttempted).toBeGreaterThan(0);
+      expect(Array.isArray(result.claimEntries)).toBe(true);
+      // claims.json was materialized.
+      expect(fs.existsSync(path.join(repo, '.truecourse/specs/claims.json'))).toBe(true);
+    } finally {
+      stop();
+    }
+  }, 30_000);
+});

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/commands/analyze.ts
+++ b/tools/cli/src/commands/analyze.ts
@@ -1,5 +1,6 @@
 import * as p from "@clack/prompts";
 import path from "node:path";
+import { agentTransport } from "@truecourse/shared/llm";
 import { analyzeInProcess } from "@truecourse/core/commands/analyze-in-process";
 import { StepTracker, buildAnalysisSteps, type AnalysisStep } from "@truecourse/core/progress";
 import { ensureRepoTruecourseDir, resolveRepoDir, wipeLegacyPostgresData } from "@truecourse/core/config/paths";
@@ -128,8 +129,12 @@ function stopSpinner(): void {
  * Same shape as `installSkills` below.
  */
 export interface AnalyzeOptions {
-  /** Override `enableLlmRules` for this run. */
+  /** Override `enableLlmRules` for this run (whether LLM rules run at all). */
   llm?: boolean;
+  /** How to reach the LLM: `cli` (spawn claude -p, default) or `agent` (filesystem mailbox under `io`). */
+  llmTransport?: "cli" | "agent";
+  /** I/O dir for the `agent` transport's request/response mailbox. */
+  io?: string;
   /**
    * Stash decision override.
    *   - `true`  → pre-approve stashing dirty working tree (no prompt).
@@ -286,9 +291,17 @@ export async function runAnalyze(options: AnalyzeOptions = {}): Promise<void> {
   };
   process.on("SIGINT", onSigint);
 
+  if (options.llmTransport === "agent" && !options.io) {
+    p.log.error("--llm-transport agent requires --io <dir> (the request/response mailbox directory).");
+    process.exit(1);
+  }
+  const transport =
+    options.llmTransport === "agent" ? agentTransport(options.io as string) : undefined;
+
   try {
     const result = await analyzeInProcess(project, {
       tracker,
+      transport,
       signal: abortController.signal,
       skipStash: stashDecision.skipStash,
       enabledCategoriesOverride: enabledCategories,

--- a/tools/cli/src/commands/contracts.ts
+++ b/tools/cli/src/commands/contracts.ts
@@ -8,6 +8,7 @@ import {
   hasCanonicalSpec,
   spawnRunner,
 } from "@truecourse/contract-extractor";
+import { agentTransport } from "@truecourse/shared/llm";
 import { stampGeneratedMarker } from "@truecourse/core/commands/spec-in-process";
 import { trackEvent, bucketFileCount, bucketDuration } from "@truecourse/core/services/telemetry";
 import { resolveFallbackModel, resolveModel } from "@truecourse/core/config/llm-models";
@@ -19,6 +20,10 @@ export interface RunContractsGenerateOptions {
   diff?: boolean;
   /** Override the repo root; defaults to cwd. */
   cwd?: string;
+  /** LLM transport: `cli` (default, spawn `claude -p`) or `agent` (filesystem mailbox under `io`). */
+  llm?: "cli" | "agent";
+  /** I/O dir for the `agent` transport's request/response mailbox. */
+  io?: string;
 }
 
 export async function runContractsGenerate(
@@ -53,7 +58,15 @@ export async function runContractsGenerate(
   // completions makes the count reflect real, finished work.
   let totalSlices = 0;
   let doneSlices = 0;
+  if (options.llm === "agent" && !options.io) {
+    p.log.error("--llm agent requires --io <dir> (the request/response mailbox directory).");
+    p.outro("Aborted.");
+    process.exit(1);
+  }
+  const transport =
+    options.llm === "agent" ? agentTransport(options.io as string) : undefined;
   const runner = spawnRunner({
+    transport,
     concurrency,
     model: extractModel,
     fallbackModel,
@@ -68,6 +81,7 @@ export async function runContractsGenerate(
   try {
     result = await generateContracts({
       repoRoot,
+      transport,
       runner,
       models: { extract: extractModel, repair: repairModel, fallback: fallbackModel },
       dryRun: !!options.diff,

--- a/tools/cli/src/commands/spec.ts
+++ b/tools/cli/src/commands/spec.ts
@@ -35,6 +35,10 @@ import { requireGitRepo } from "./git-guard.js";
 
 export interface RunSpecOptions {
   cwd?: string;
+  /** LLM transport: `cli` (default, spawn `claude -p`) or `agent` (filesystem mailbox under `io`). */
+  llm?: "cli" | "agent";
+  /** I/O dir for the `agent` transport's request/response mailbox. */
+  io?: string;
 }
 
 const repoRoot = (opts: RunSpecOptions = {}): string => opts.cwd ?? process.cwd();
@@ -55,7 +59,7 @@ export async function runSpecScan(opts: RunSpecOptions = {}): Promise<void> {
   await requireGitRepo(root);
   const { renderer, tracker } = withTracker(SCAN_STEPS);
   try {
-    const { consolidate } = await scanInProcess(root, { tracker, source: "cli" });
+    const { consolidate } = await scanInProcess(root, { tracker, source: "cli", llm: opts.llm, io: opts.io });
     renderer.dispose();
     const { extract, merge } = consolidate;
     p.log.step(`docs        ${extract.docsScanned}`);
@@ -117,7 +121,7 @@ export async function runSpecResolve(opts: RunSpecResolveOptions = {}): Promise<
   await requireGitRepo(root);
   const { renderer, tracker } = withTracker(RESOLVE_STEPS);
   try {
-    const { additions } = await resolveAllDefaultsInProcess(root, { tracker });
+    const { additions } = await resolveAllDefaultsInProcess(root, { tracker, llm: opts.llm, io: opts.io });
     renderer.dispose();
     p.log.step(`accepted    ${additions} default${additions === 1 ? "" : "s"}`);
     p.log.step(`written     ${path.relative(root, decisionsRelPath(root))}`);
@@ -141,7 +145,7 @@ export async function runSpecStatus(opts: RunSpecOptions = {}): Promise<void> {
   p.intro("Spec status");
   const { renderer, tracker } = withTracker(SCAN_STEPS);
   try {
-    const { consolidate } = await scanInProcess(root, { tracker });
+    const { consolidate } = await scanInProcess(root, { tracker, llm: opts.llm, io: opts.io });
     renderer.dispose();
     const { extract, merge, skippedDocs } = consolidate;
     const rows: Array<[string, string]> = [

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -63,7 +63,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.6.0")
+  .version("0.6.1")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -136,6 +136,8 @@ program
   // undefined (falls through to config / interactive prompt).
   .option("--llm", "Run LLM-powered rules (pre-approves the cost estimate)")
   .option("--no-llm", "Skip LLM-powered rules for this run")
+  .option("--llm-transport <mode>", "How to reach the LLM: 'cli' (spawn claude -p, default) or 'agent' (filesystem mailbox)")
+  .option("--io <dir>", "Mailbox dir for --llm-transport agent (request/response files)")
   .option("--stash", "Pre-approve stashing pending changes before analysis")
   .option("--no-stash", "Analyze the working tree as-is without stashing")
   .option("--install-skills", "Install Claude Code skills without prompting")
@@ -144,10 +146,11 @@ program
     const llm: boolean | undefined = typeof options.llm === "boolean" ? options.llm : undefined;
     const stash: boolean | undefined = typeof options.stash === "boolean" ? options.stash : undefined;
     const installSkills = resolveInstallSkills(options);
+    const common = { llm, stash, installSkills, llmTransport: options.llmTransport, io: options.io };
     if (options.diff) {
-      await runAnalyzeDiff({ llm, stash, installSkills });
+      await runAnalyzeDiff(common);
     } else {
-      await runAnalyze({ llm, stash, installSkills });
+      await runAnalyze(common);
     }
   });
 
@@ -192,8 +195,10 @@ contractsCmd
   .command("generate")
   .description("Extract .tc artifacts from prose specs (LLM, cached)")
   .option("--diff", "Dry run — show what would change without writing")
+  .option("--llm-transport <mode>", "How to reach the LLM: 'cli' (spawn claude -p, default) or 'agent' (filesystem mailbox)")
+  .option("--io <dir>", "Mailbox dir for --llm-transport agent (request/response files)")
   .action(async (options) => {
-    await runContractsGenerate({ diff: !!options.diff });
+    await runContractsGenerate({ diff: !!options.diff, llm: options.llmTransport, io: options.io });
   });
 
 contractsCmd
@@ -220,16 +225,20 @@ const specCmd = program
 specCmd
   .command("scan")
   .description("Walk docs, extract claims, surface conflicts (no writes)")
-  .action(async () => {
-    await runSpecScan();
+  .option("--llm-transport <mode>", "How to reach the LLM: 'cli' (spawn claude -p, default) or 'agent' (filesystem mailbox)")
+  .option("--io <dir>", "Mailbox dir for --llm-transport agent (request/response files)")
+  .action(async (options) => {
+    await runSpecScan({ llm: options.llmTransport, io: options.io });
   });
 
 specCmd
   .command("resolve")
   .description("Resolve open conflicts (interactive runs in the dashboard)")
   .option("--all-defaults", "Accept the engine's pre-pick on every open conflict")
+  .option("--llm-transport <mode>", "How to reach the LLM: 'cli' (spawn claude -p, default) or 'agent' (filesystem mailbox)")
+  .option("--io <dir>", "Mailbox dir for --llm-transport agent (request/response files)")
   .action(async (options) => {
-    await runSpecResolve({ allDefaults: !!options.allDefaults });
+    await runSpecResolve({ allDefaults: !!options.allDefaults, llm: options.llmTransport, io: options.io });
   });
 
 specCmd


### PR DESCRIPTION
## What

Adds a pluggable **LLM transport** seam so every command that calls the model can run one of two ways:

| `--llm-transport` | Behaviour |
| --- | --- |
| `cli` (default) | Spawn the `claude` CLI (`claude -p …`). Byte-for-byte the same as before. |
| `agent` | Filesystem **mailbox** — write `requests/<id>.json`, poll `responses/<id>.json`. No `claude` binary needed, so the spec→contract→verify and analyze pipelines can run headless inside a cloud routine. |

Accepted by **`analyze`**, **`spec scan`**, **`spec resolve`**, **`contracts generate`**, each gaining `--llm-transport <cli|agent>` + `--io <dir>`.

> `analyze` keeps its existing `--llm` / `--no-llm` boolean (*whether* LLM rules run) — that's separate from `--llm-transport` (*how* the model is reached). No flag collision.

## How

- **shared:** new `@truecourse/shared/llm` subpath export (kept out of the browser-bundled index so `node:child_process` never reaches the dashboard client). Provides `cliTransport` and `agentTransport(ioDir)` — atomic tmp+rename writes, resume-friendly polling, per-request timeout.
- **spec consolidator + contract extractor:** every runner factory accepts an injected `transport?`, defaulting to `cliTransport`. Concurrency stays inside each runner; the transport is single-request.
- **analyze:** `BaseCLIProvider` routes its one spawn site (`spawnCLI`) through the transport when present (answer wrapped as `{result}` so the existing `--json-schema` parse path is untouched). Threaded `CLI → analyzeInProcess → analyzeCore → createLLMProvider(transport)` — one injection point covers the whole CLI analyze LLM path.
- **README:** new common **LLM transport** section documenting the mailbox protocol + examples.

## Mailbox protocol

```
<io>/requests/<id>.json   { stage, model, system, user, schema, responseFormat }
<io>/responses/<id>.json  { text }   |   { error }
```

The caller writes a request and polls for the matching response; an external agent (the cloud routine) reads requests, answers the model, and writes responses.

## Tests

- `tests/shared/llm-transport.test.ts` — cli + agent transport units.
- `tests/spec-consolidator/agent-transport-integration.test.ts` — runner end-to-end through the mailbox.
- `tests/core/llm-agent-transport.test.ts` — analyze provider routes through a fake transport (+ Zod validation) and end-to-end through the real `agentTransport`.

Full suite green except the 2 known macOS-local analyzer files (case-insensitive-FS layer classification — green in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)