### PR TITLE
fix(spec): treat total extraction failure as an error, not success (#474)

### DIFF
--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.6.0",
+  "version": "0.6.0-next.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.6.0",
+  "version": "0.6.0-next.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/src/lib/cli-binary.ts
+++ b/packages/core/src/lib/cli-binary.ts
@@ -1,4 +1,5 @@
-import { sync as spawnSync } from 'cross-spawn';
+import { spawn, sync as spawnSync } from 'cross-spawn';
+import { isLikelyAuthFailure } from '@truecourse/spec-consolidator';
 
 export function isCliBinaryAvailable(binary: string): boolean {
   // cross-spawn resolves Windows `.cmd`/`.ps1` shims to their underlying
@@ -10,4 +11,96 @@ export function isCliBinaryAvailable(binary: string): boolean {
     timeout: 5_000,
   });
   return result.status === 0;
+}
+
+/**
+ * Outcome of a live `claude` CLI preflight.
+ *   - `not-found`        binary isn't installed / on PATH
+ *   - `unauthenticated`  the login is missing or expired (the common case)
+ *   - `error`            the binary ran but failed for some other reason
+ */
+export type ClaudeAuthResult =
+  | { ok: true }
+  | { ok: false; reason: 'not-found' | 'unauthenticated' | 'error'; detail?: string };
+
+export interface CheckClaudeAuthOptions {
+  /** Per-call timeout for the probe. Defaults to 60s. */
+  timeoutMs?: number;
+}
+
+/**
+ * Classify a probe subprocess's outcome. Pure so the policy is unit-tested
+ * without spawning.
+ *
+ * A non-zero exit on a trivial one-token prompt almost always means the login
+ * is gone — and an expired Claude login frequently exits with an *empty*
+ * stderr (so the message-pattern heuristic can't see it). We therefore treat
+ * "non-zero exit with nothing on stderr" as an auth problem, while a non-zero
+ * exit that *does* print something non-auth-looking is surfaced verbatim so the
+ * real error isn't masked.
+ */
+export function classifyClaudeProbe(code: number | null, stderr: string): ClaudeAuthResult {
+  if (code === 0) return { ok: true };
+  const detail = stderr.trim();
+  const looksAuth = detail === '' || isLikelyAuthFailure(`claude exited ${code}: ${detail}`);
+  return {
+    ok: false,
+    reason: looksAuth ? 'unauthenticated' : 'error',
+    detail: detail || undefined,
+  };
+}
+
+/**
+ * Live preflight for the `claude` CLI: confirm it's installed AND that the
+ * stored login still works, by issuing one tiny `claude -p` round-trip. Used to
+ * fail fast before a spec scan fans out hundreds of extraction subprocesses —
+ * an expired login makes every one of them error, and without this gate the
+ * user only learns that at the very end of a long run.
+ *
+ * The binary is resolved the same way the extraction runners resolve it
+ * (`CLAUDE_CODE_BIN`, else `claude` on PATH) so the probe and the real work
+ * agree on which binary they're testing.
+ *
+ * A timeout or a post-spawn hiccup resolves to `{ ok: true }` (inconclusive):
+ * the probe shouldn't block a legitimate scan over a slow network.
+ */
+export function checkClaudeAuth(
+  binary: string = process.env.CLAUDE_CODE_BIN ?? 'claude',
+  options: CheckClaudeAuthOptions = {},
+): Promise<ClaudeAuthResult> {
+  // Cheap synchronous existence check first — no point paying for a round trip
+  // when the binary isn't even on PATH.
+  if (!isCliBinaryAvailable(binary)) {
+    return Promise.resolve({ ok: false, reason: 'not-found' });
+  }
+
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  return new Promise<ClaudeAuthResult>((resolve) => {
+    // A one-token reply is the cheapest call that still exercises the real auth
+    // path (token validity, not just binary presence). No `--model` so we use
+    // the account default and never false-fail on a model-availability quirk.
+    const proc = spawn(binary, ['-p', 'Reply with the single word: ok', '--output-format', 'json'], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    const stderr: Buffer[] = [];
+    let settled = false;
+    const finish = (r: ClaudeAuthResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(r);
+    };
+    const timer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      finish({ ok: true });
+    }, timeoutMs);
+
+    proc.stderr?.on('data', (b: Buffer) => stderr.push(b));
+    // Already passed the availability check, so a spawn-time error here is an
+    // environmental hiccup, not a definitive auth failure — don't block.
+    proc.on('error', () => finish({ ok: true }));
+    proc.on('close', (code) =>
+      finish(classifyClaudeProbe(code, Buffer.concat(stderr).toString('utf-8'))),
+    );
+  });
 }

--- a/packages/spec-consolidator/src/extractor.ts
+++ b/packages/spec-consolidator/src/extractor.ts
@@ -123,6 +123,95 @@ export async function extractClaims(
 }
 
 // ---------------------------------------------------------------------------
+// Failure summarization
+//
+// `extractClaims` never throws on a per-block failure — a transient
+// subprocess error, a parse miss, or an expired `claude` login all land in
+// `failures[]` so a partial scan still yields whatever claims succeeded.
+// That's correct for a few stragglers, but a *total* failure (every block
+// errored → zero claims) is indistinguishable from "clean repo" unless the
+// caller inspects the failures. This helper classifies them so the CLI and
+// dashboard can surface an actionable message instead of a misleading
+// success.
+// ---------------------------------------------------------------------------
+
+/**
+ * Patterns that mark a `claude` subprocess failure as an authentication
+ * problem (expired/missing login, invalid key) rather than a transient
+ * error. Matched case-insensitively against the failure message, which for
+ * subprocess exits is `claude exited <code>: <stderr>`.
+ */
+const AUTH_FAILURE_PATTERNS: RegExp[] = [
+  /\b401\b/,
+  /unauthor/i, // unauthorized / unauthorised
+  /authenticat/i, // authentication / authenticate / unauthenticated
+  /\blog(?:ged)? ?in\b/i, // login / "log in" / "logged in"
+  /\/login\b/i, // the `/login` slash command Claude Code suggests
+  /invalid (?:api )?key/i,
+  /\bapi key\b/i,
+  /oauth/i,
+  /(?:token|session|credentials?) (?:has |have )?expired/i,
+  /\bcredentials?\b/i,
+];
+
+/** True when a failure message looks like an auth problem (see patterns). */
+export function isLikelyAuthFailure(message: string): boolean {
+  return AUTH_FAILURE_PATTERNS.some((re) => re.test(message));
+}
+
+export interface FailureSample {
+  /** The failure message. */
+  message: string;
+  /** How many blocks failed with this exact message. */
+  count: number;
+}
+
+export interface ExtractionFailureReport {
+  /** Total failed blocks. */
+  total: number;
+  /** True when at least one block was attempted and every one failed. */
+  allFailed: boolean;
+  /** True when a majority of the failures look like an auth problem. */
+  likelyAuth: boolean;
+  /** Distinct failure messages, most frequent first, capped to `sampleLimit`. */
+  samples: FailureSample[];
+}
+
+/**
+ * Classify an extraction's failures for user-facing reporting: collapse
+ * duplicate messages (152 identical auth errors → one line with a count),
+ * flag a total wipeout, and detect the auth signature so callers can prompt
+ * a re-login. Pure — safe to call on every scan.
+ */
+export function summarizeExtractionFailures(
+  result: { failures: ReadonlyArray<{ error: string }>; blocksAttempted: number },
+  opts: { sampleLimit?: number } = {},
+): ExtractionFailureReport {
+  const { failures, blocksAttempted } = result;
+  const sampleLimit = opts.sampleLimit ?? 3;
+
+  const counts = new Map<string, number>();
+  let authMatches = 0;
+  for (const f of failures) {
+    counts.set(f.error, (counts.get(f.error) ?? 0) + 1);
+    if (isLikelyAuthFailure(f.error)) authMatches++;
+  }
+  const samples: FailureSample[] = [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, sampleLimit)
+    .map(([message, count]) => ({ message, count }));
+
+  return {
+    total: failures.length,
+    allFailed: blocksAttempted > 0 && failures.length === blocksAttempted,
+    // Majority rule so one coincidental "login" mention among many unrelated
+    // errors doesn't mislabel the batch as an auth failure.
+    likelyAuth: failures.length > 0 && authMatches * 2 >= failures.length,
+    samples,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Claim assembly
 // ---------------------------------------------------------------------------
 

--- a/packages/spec-consolidator/src/index.ts
+++ b/packages/spec-consolidator/src/index.ts
@@ -56,8 +56,17 @@ export {
 } from './prompt.js';
 export type { LlmExtraction, LlmClaim } from './prompt.js';
 
-export { extractClaims } from './extractor.js';
-export type { ExtractOptions, ExtractResult } from './extractor.js';
+export {
+  extractClaims,
+  summarizeExtractionFailures,
+  isLikelyAuthFailure,
+} from './extractor.js';
+export type {
+  ExtractOptions,
+  ExtractResult,
+  ExtractionFailureReport,
+  FailureSample,
+} from './extractor.js';
 
 export { mergeClaims, candidateFingerprint } from './merger.js';
 export type { MergeResult, DecidedConflict } from './merger.js';

--- a/tests/cli/spec-scan.test.ts
+++ b/tests/cli/spec-scan.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { decideScanOutcome } from '../../tools/cli/src/commands/spec';
+import type { ExtractionFailureReport } from '@truecourse/spec-consolidator';
+
+/**
+ * Policy for how `truecourse spec scan` ends (issue #474): a total extraction
+ * wipeout must exit non-zero instead of reporting success, and the
+ * `contracts generate` CTA must not appear when there's nothing to generate.
+ * `decideScanOutcome` is pure, so the rules are pinned here directly without
+ * mocking clack / process.exit / the pipeline.
+ */
+function report(over: Partial<ExtractionFailureReport> = {}): ExtractionFailureReport {
+  return { total: 0, allFailed: false, likelyAuth: false, samples: [], ...over };
+}
+
+describe('decideScanOutcome', () => {
+  it('exits 1 and aborts when every block failed', () => {
+    const outcome = decideScanOutcome({
+      blocksAttempted: 152,
+      claims: 0,
+      openConflicts: 0,
+      failures: report({ total: 152, allFailed: true, likelyAuth: true }),
+    });
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.outro).toBe('Aborted — all 152 blocks failed, no claims extracted.');
+    expect(outcome.showAuthHint).toBe(true);
+    expect(outcome.outro).not.toContain('contracts generate');
+  });
+
+  it('surfaces the auth hint on a total wipeout only when it looks like auth', () => {
+    const outcome = decideScanOutcome({
+      blocksAttempted: 10,
+      claims: 0,
+      openConflicts: 0,
+      failures: report({ total: 10, allFailed: true, likelyAuth: false }),
+    });
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.showAuthHint).toBe(false);
+  });
+
+  it('does not suggest contracts generate when zero claims were extracted', () => {
+    const outcome = decideScanOutcome({
+      blocksAttempted: 3,
+      claims: 0,
+      openConflicts: 0,
+      failures: report(),
+    });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.outro).toBe('No claims extracted — nothing to generate yet.');
+    expect(outcome.outro).not.toContain('contracts generate');
+  });
+
+  it('suggests contracts generate on a clean scan with claims and no conflicts', () => {
+    const outcome = decideScanOutcome({
+      blocksAttempted: 10,
+      claims: 9,
+      openConflicts: 0,
+      failures: report({ total: 1 }), // a straggler failure, not a wipeout
+    });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.outro).toBe('No open conflicts — run `truecourse contracts generate`.');
+  });
+
+  it('reports the open-conflict count when conflicts remain', () => {
+    const outcome = decideScanOutcome({
+      blocksAttempted: 10,
+      claims: 9,
+      openConflicts: 4,
+      failures: report(),
+    });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.outro).toBe('4 open.');
+  });
+
+  it('propagates the auth hint on a partial (non-fatal) failure', () => {
+    const outcome = decideScanOutcome({
+      blocksAttempted: 10,
+      claims: 5,
+      openConflicts: 0,
+      failures: report({ total: 5, likelyAuth: true }),
+    });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.showAuthHint).toBe(true);
+  });
+});

--- a/tests/cli/spec-scan.test.ts
+++ b/tests/cli/spec-scan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decideScanOutcome } from '../../tools/cli/src/commands/spec';
+import { decideScanOutcome, describeClaudePreflightFailure } from '../../tools/cli/src/commands/spec';
 import type { ExtractionFailureReport } from '@truecourse/spec-consolidator';
 
 /**
@@ -81,5 +81,39 @@ describe('decideScanOutcome', () => {
     });
     expect(outcome.exitCode).toBe(0);
     expect(outcome.showAuthHint).toBe(true);
+  });
+});
+
+/**
+ * The up-front `claude` CLI preflight (before "Discovering docs") maps each
+ * failure reason to an actionable headline + next step. Pure mapping, pinned
+ * here without spawning or driving clack.
+ */
+describe('describeClaudePreflightFailure', () => {
+  it('points at installation when the binary is missing', () => {
+    const m = describeClaudePreflightFailure({ ok: false, reason: 'not-found' });
+    expect(m.title).toContain('PATH');
+    expect(m.hint).toContain('CLAUDE_CODE_BIN');
+  });
+
+  it('points at re-login when unauthenticated', () => {
+    const m = describeClaudePreflightFailure({ ok: false, reason: 'unauthenticated' });
+    expect(m.title.toLowerCase()).toContain('logged in');
+    expect(m.hint).toContain('/login');
+  });
+
+  it('surfaces the detail for a generic error', () => {
+    const m = describeClaudePreflightFailure({
+      ok: false,
+      reason: 'error',
+      detail: 'error: unknown flag --frobnicate',
+    });
+    expect(m.hint).toContain('unknown flag --frobnicate');
+  });
+
+  it('handles a generic error with no detail', () => {
+    const m = describeClaudePreflightFailure({ ok: false, reason: 'error' });
+    expect(m.title).toContain('failed a test call');
+    expect(m.hint).toContain('retry');
   });
 });

--- a/tests/core/cli-binary.test.ts
+++ b/tests/core/cli-binary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isCliBinaryAvailable } from '../../packages/core/src/lib/cli-binary.js';
+import { classifyClaudeProbe, isCliBinaryAvailable } from '../../packages/core/src/lib/cli-binary.js';
 
 // We don't mock cross-spawn — the helper is thin and the contract we care
 // about is "does it correctly recognize available vs missing binaries on the
@@ -16,5 +16,36 @@ describe('isCliBinaryAvailable', () => {
 
   it('returns false for an absolute path that does not exist', () => {
     expect(isCliBinaryAvailable('/no/such/path/claude-cli')).toBe(false);
+  });
+});
+
+// Pure classification of the `claude` login probe's outcome — the part that
+// decides whether a failing test call is an expired login vs some other error,
+// tested without spawning a real subprocess.
+describe('classifyClaudeProbe', () => {
+  it('treats a clean exit as logged in', () => {
+    expect(classifyClaudeProbe(0, '')).toEqual({ ok: true });
+    expect(classifyClaudeProbe(0, 'some noise on stderr')).toEqual({ ok: true });
+  });
+
+  it('treats a non-zero exit with empty stderr as an auth problem', () => {
+    // The real-world expired-login case: `claude exited 1` with nothing on
+    // stderr. The message-pattern heuristic alone would miss it.
+    expect(classifyClaudeProbe(1, '')).toEqual({ ok: false, reason: 'unauthenticated', detail: undefined });
+    expect(classifyClaudeProbe(1, '   \n  ')).toEqual({ ok: false, reason: 'unauthenticated', detail: undefined });
+  });
+
+  it('classifies an auth-looking stderr as unauthenticated and keeps the detail', () => {
+    const r = classifyClaudeProbe(1, 'Error: 401 Unauthorized — please run /login');
+    expect(r).toEqual({
+      ok: false,
+      reason: 'unauthenticated',
+      detail: 'Error: 401 Unauthorized — please run /login',
+    });
+  });
+
+  it('surfaces a non-auth error verbatim instead of masking it as login', () => {
+    const r = classifyClaudeProbe(2, 'error: unknown flag --frobnicate');
+    expect(r).toEqual({ ok: false, reason: 'error', detail: 'error: unknown flag --frobnicate' });
   });
 });

--- a/tests/spec-consolidator/extractor.test.ts
+++ b/tests/spec-consolidator/extractor.test.ts
@@ -4,6 +4,8 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   extractClaims,
+  summarizeExtractionFailures,
+  isLikelyAuthFailure,
   type BlockRunner,
   type LlmExtraction,
   type LlmClaim,
@@ -232,6 +234,104 @@ describe('extractClaims — progress hooks', () => {
       onBlockFailure: (block, error) => failures.push(`${block.headingPath.at(-1)}: ${error}`),
     });
     expect(failures).toEqual(['A: boom']);
+  });
+});
+
+describe('summarizeExtractionFailures', () => {
+  const fail = (error: string, n = 1) => Array.from({ length: n }, () => ({ error }));
+
+  it('reports nothing when there are no failures', () => {
+    const r = summarizeExtractionFailures({ failures: [], blocksAttempted: 10 });
+    expect(r).toEqual({ total: 0, allFailed: false, likelyAuth: false, samples: [] });
+  });
+
+  it('flags allFailed only when every attempted block failed', () => {
+    expect(
+      summarizeExtractionFailures({ failures: fail('boom', 10), blocksAttempted: 10 }).allFailed,
+    ).toBe(true);
+    expect(
+      summarizeExtractionFailures({ failures: fail('boom', 4), blocksAttempted: 10 }).allFailed,
+    ).toBe(false);
+  });
+
+  it('never flags allFailed when no blocks were attempted', () => {
+    const r = summarizeExtractionFailures({ failures: [], blocksAttempted: 0 });
+    expect(r.allFailed).toBe(false);
+  });
+
+  it('collapses duplicate messages into samples with counts, most frequent first', () => {
+    const r = summarizeExtractionFailures({
+      failures: [...fail('A', 5), ...fail('B', 2), ...fail('C', 1)],
+      blocksAttempted: 8,
+    });
+    expect(r.total).toBe(8);
+    expect(r.samples).toEqual([
+      { message: 'A', count: 5 },
+      { message: 'B', count: 2 },
+      { message: 'C', count: 1 },
+    ]);
+  });
+
+  it('caps samples at the limit (default 3, overridable)', () => {
+    const failures = [
+      ...fail('A', 4),
+      ...fail('B', 3),
+      ...fail('C', 2),
+      ...fail('D', 1),
+    ];
+    expect(summarizeExtractionFailures({ failures, blocksAttempted: 10 }).samples).toHaveLength(3);
+    expect(
+      summarizeExtractionFailures({ failures, blocksAttempted: 10 }, { sampleLimit: 2 }).samples,
+    ).toHaveLength(2);
+  });
+
+  it('detects auth failures when the majority of messages match', () => {
+    const authMsg = 'claude exited 1: Invalid API key · Please run /login';
+    const r = summarizeExtractionFailures({
+      failures: fail(authMsg, 152),
+      blocksAttempted: 152,
+    });
+    expect(r.likelyAuth).toBe(true);
+    expect(r.allFailed).toBe(true);
+  });
+
+  it('does not flag auth when only a minority of failures look like auth', () => {
+    const r = summarizeExtractionFailures({
+      failures: [...fail('claude exited 1: unauthorized', 1), ...fail('claude timed out', 9)],
+      blocksAttempted: 10,
+    });
+    expect(r.likelyAuth).toBe(false);
+  });
+
+  it('does not mislabel ordinary errors as auth', () => {
+    const r = summarizeExtractionFailures({
+      failures: [...fail('claude timed out after 240000ms', 3), ...fail('claude returned no text', 2)],
+      blocksAttempted: 5,
+    });
+    expect(r.likelyAuth).toBe(false);
+  });
+});
+
+describe('isLikelyAuthFailure', () => {
+  it.each([
+    'claude exited 1: 401 Unauthorized',
+    'Error: invalid API key',
+    'OAuth token has expired',
+    'Please run /login to authenticate',
+    'You are not logged in',
+    'Authentication required',
+    'session expired — credentials missing',
+  ])('classifies %j as an auth failure', (msg) => {
+    expect(isLikelyAuthFailure(msg)).toBe(true);
+  });
+
+  it.each([
+    'claude timed out after 240000ms for block abc',
+    'claude returned no text for block abc',
+    'Unexpected token < in JSON at position 0',
+    'ENOENT: command not found',
+  ])('does not classify %j as an auth failure', (msg) => {
+    expect(isLikelyAuthFailure(msg)).toBe(false);
   });
 });
 

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.6.0",
+  "version": "0.6.0-next.11",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/commands/spec.ts
+++ b/tools/cli/src/commands/spec.ts
@@ -16,7 +16,11 @@
 
 import * as p from "@clack/prompts";
 import path from "node:path";
-import { type Conflict } from "@truecourse/spec-consolidator";
+import {
+  summarizeExtractionFailures,
+  type Conflict,
+  type ExtractionFailureReport,
+} from "@truecourse/spec-consolidator";
 import { StepTracker } from "@truecourse/core/progress";
 import {
   RESOLVE_STEPS,
@@ -54,44 +58,118 @@ export async function runSpecScan(opts: RunSpecOptions = {}): Promise<void> {
   p.intro("Spec scan");
   await requireGitRepo(root);
   const { renderer, tracker } = withTracker(SCAN_STEPS);
-  try {
-    const { consolidate } = await scanInProcess(root, { tracker, source: "cli" });
-    renderer.dispose();
-    const { extract, merge } = consolidate;
-    p.log.step(`docs        ${extract.docsScanned}`);
-    p.log.step(`blocks      ${extract.blocksAttempted}  (${extract.failures.length} failures)`);
-    p.log.step(`claims      ${extract.claims.length}`);
-    p.log.step(`resolved    ${merge.resolvedClaims.length}`);
-    p.log.step(`decided     ${merge.decidedConflicts.length}`);
-    p.log.step(`open        ${merge.openConflicts.length}`);
+  // A hard failure inside the pipeline must exit non-zero — otherwise the
+  // command reports success on a scan that produced nothing. The `.catch`
+  // handler returns `never` (process.exit), so `consolidate` is always
+  // assigned past this point.
+  const { consolidate } = await scanInProcess(root, { tracker, source: "cli" }).catch(
+    (e: unknown) => {
+      renderer.dispose();
+      p.cancel(`Failed: ${(e as Error).message}`);
+      process.exit(1);
+    },
+  );
+  renderer.dispose();
+  const { extract, merge } = consolidate;
+  p.log.step(`docs        ${extract.docsScanned}`);
+  p.log.step(`blocks      ${extract.blocksAttempted}  (${extract.failures.length} failures)`);
+  p.log.step(`claims      ${extract.claims.length}`);
+  p.log.step(`resolved    ${merge.resolvedClaims.length}`);
+  p.log.step(`decided     ${merge.decidedConflicts.length}`);
+  p.log.step(`open        ${merge.openConflicts.length}`);
 
-    if (merge.openConflicts.length > 0) {
-      p.log.message("");
-      p.log.message("Open conflicts:");
-      for (const c of merge.openConflicts.slice(0, 10)) {
-        p.log.message(`  • ${c.subject}  (${c.candidates.length} candidates, default: ${c.candidates[c.defaultPick].claim.provenance.file})`);
-        p.log.message(`    id: ${c.id}`);
-      }
-      if (merge.openConflicts.length > 10) {
-        p.log.message(`  … (+${merge.openConflicts.length - 10} more — run \`truecourse spec conflicts list\`)`);
-      }
-      p.log.message("");
-      p.log.message("Resolve them:");
-      p.log.message("  • dashboard:        truecourse dashboard            (Spec tab)");
-      p.log.message("  • per conflict:     truecourse spec conflicts show <id>");
-      p.log.message("                      truecourse spec conflicts pick <id> <candidateIndex>");
-      p.log.message('                      truecourse spec conflicts custom <id> --text "…"');
-      p.log.message("  • accept defaults:  truecourse spec resolve --all-defaults");
+  // A count alone hides actionable errors (e.g. an expired `claude` login).
+  // Surface the most common distinct messages and, when the failures look
+  // like an auth problem, point the user at re-authenticating.
+  const failures = summarizeExtractionFailures(extract);
+  const outcome = decideScanOutcome({
+    blocksAttempted: extract.blocksAttempted,
+    claims: extract.claims.length,
+    openConflicts: merge.openConflicts.length,
+    failures,
+  });
+  if (failures.total > 0) {
+    p.log.message("");
+    p.log.warn(`${failures.total} block${failures.total === 1 ? "" : "s"} failed to extract:`);
+    for (const s of failures.samples) {
+      p.log.message(`  • ${oneLine(s.message)}${s.count > 1 ? `  (×${s.count})` : ""}`);
     }
-    p.outro(
-      merge.openConflicts.length === 0
-        ? "No open conflicts — run `truecourse contracts generate`."
-        : `${merge.openConflicts.length} open.`,
-    );
-  } catch (e) {
-    renderer.dispose();
-    p.cancel(`Failed: ${(e as Error).message}`);
+    if (outcome.showAuthHint) {
+      p.log.message("");
+      p.log.warn("This looks like an authentication problem with the `claude` CLI.");
+      p.log.message("  Your Claude login may have expired — run `claude` to re-authenticate (e.g. `/login`), then retry.");
+    }
   }
+
+  // Every block failing means zero claims — that's an error, not a clean
+  // repo. Bail with the failure outro and a non-zero exit before suggesting
+  // any downstream command.
+  if (outcome.exitCode !== 0) {
+    p.outro(outcome.outro);
+    process.exit(outcome.exitCode);
+  }
+
+  if (merge.openConflicts.length > 0) {
+    p.log.message("");
+    p.log.message("Open conflicts:");
+    for (const c of merge.openConflicts.slice(0, 10)) {
+      p.log.message(`  • ${c.subject}  (${c.candidates.length} candidates, default: ${c.candidates[c.defaultPick].claim.provenance.file})`);
+      p.log.message(`    id: ${c.id}`);
+    }
+    if (merge.openConflicts.length > 10) {
+      p.log.message(`  … (+${merge.openConflicts.length - 10} more — run \`truecourse spec conflicts list\`)`);
+    }
+    p.log.message("");
+    p.log.message("Resolve them:");
+    p.log.message("  • dashboard:        truecourse dashboard            (Spec tab)");
+    p.log.message("  • per conflict:     truecourse spec conflicts show <id>");
+    p.log.message("                      truecourse spec conflicts pick <id> <candidateIndex>");
+    p.log.message('                      truecourse spec conflicts custom <id> --text "…"');
+    p.log.message("  • accept defaults:  truecourse spec resolve --all-defaults");
+  }
+  p.outro(outcome.outro);
+}
+
+export interface ScanOutcome {
+  /** Process exit code — non-zero when the scan effectively failed. */
+  exitCode: 0 | 1;
+  /** Final outro line. */
+  outro: string;
+  /** Whether to print the re-authentication hint. */
+  showAuthHint: boolean;
+}
+
+/**
+ * Decide how a scan ends: its exit code, outro line, and whether to nudge the
+ * user to re-authenticate. Pure so the policy is unit-tested without driving
+ * clack/process.exit. Two failure-aware rules sit on top of the old
+ * open-conflicts/outro logic:
+ *   - every attempted block failed → exit 1 (a total wipeout is an error, not
+ *     a clean repo).
+ *   - zero claims (but not a wipeout) → don't suggest `contracts generate`;
+ *     there's nothing to generate yet.
+ */
+export function decideScanOutcome(input: {
+  blocksAttempted: number;
+  claims: number;
+  openConflicts: number;
+  failures: ExtractionFailureReport;
+}): ScanOutcome {
+  const { failures } = input;
+  if (failures.allFailed) {
+    return {
+      exitCode: 1,
+      outro: `Aborted — all ${input.blocksAttempted} blocks failed, no claims extracted.`,
+      showAuthHint: failures.likelyAuth,
+    };
+  }
+  const outro =
+    input.openConflicts > 0
+      ? `${input.openConflicts} open.`
+      : input.claims === 0
+        ? "No claims extracted — nothing to generate yet."
+        : "No open conflicts — run `truecourse contracts generate`.";
+  return { exitCode: 0, outro, showAuthHint: failures.likelyAuth };
 }
 
 // ---------------------------------------------------------------------------
@@ -345,4 +423,10 @@ function summarizeConflicts(label: string, conflicts: Conflict[]): void {
 
 function decisionsRelPath(root: string): string {
   return path.join(root, ".truecourse", "specs", "decisions.json");
+}
+
+/** Collapse whitespace and cap length so a multi-line stderr stays one tidy line. */
+function oneLine(s: string, max = 200): string {
+  const collapsed = s.replace(/\s+/g, " ").trim();
+  return collapsed.length <= max ? collapsed : `${collapsed.slice(0, max - 1)}…`;
 }

--- a/tools/cli/src/commands/spec.ts
+++ b/tools/cli/src/commands/spec.ts
@@ -34,6 +34,7 @@ import {
   INFER_STEPS,
 } from "@truecourse/core/commands/spec-in-process";
 import { createStdoutStepRenderer } from "../lib/stdout-step-renderer.js";
+import { checkClaudeAuth, type ClaudeAuthResult } from "@truecourse/core/lib/cli-binary";
 import { resolveStashDecision } from "./analyze.js";
 import { requireGitRepo } from "./git-guard.js";
 
@@ -57,6 +58,13 @@ export async function runSpecScan(opts: RunSpecOptions = {}): Promise<void> {
   const root = repoRoot(opts);
   p.intro("Spec scan");
   await requireGitRepo(root);
+  // Extraction shells out to the `claude` CLI once per doc block, so a large
+  // repo can run for a while. If the login has expired every block fails — and
+  // the failure summary below only prints once the whole run is done, so the
+  // user sits through the entire scan just to learn their login was the
+  // problem. Probe the CLI up front and bail with an actionable message before
+  // discovering a single doc.
+  await preflightClaudeOrExit();
   const { renderer, tracker } = withTracker(SCAN_STEPS);
   // A hard failure inside the pipeline must exit non-zero — otherwise the
   // command reports success on a scan that produced nothing. The `.catch`
@@ -170,6 +178,62 @@ export function decideScanOutcome(input: {
         ? "No claims extracted — nothing to generate yet."
         : "No open conflicts — run `truecourse contracts generate`.";
   return { exitCode: 0, outro, showAuthHint: failures.likelyAuth };
+}
+
+// ---------------------------------------------------------------------------
+// claude CLI preflight
+// ---------------------------------------------------------------------------
+
+/**
+ * Probe the `claude` CLI before the scan fans out hundreds of extraction
+ * subprocesses, and exit non-zero with an actionable message if it isn't ready.
+ * Returns normally when the CLI is installed and its login works.
+ *
+ * Set `TRUECOURSE_SKIP_CLAUDE_CHECK=1` to skip the probe (CI where auth is known
+ * good, or to avoid the tiny round-trip call).
+ */
+async function preflightClaudeOrExit(): Promise<void> {
+  if (process.env.TRUECOURSE_SKIP_CLAUDE_CHECK) return;
+  const s = p.spinner();
+  s.start("Checking the `claude` CLI is logged in");
+  const result = await checkClaudeAuth();
+  if (result.ok) {
+    s.stop("`claude` CLI ready");
+    return;
+  }
+  s.stop("`claude` CLI not ready");
+  const { title, hint } = describeClaudePreflightFailure(result);
+  p.log.error(title);
+  p.log.message(hint);
+  p.cancel("Aborted before scanning — fix the `claude` CLI and retry.");
+  process.exit(1);
+}
+
+/**
+ * Map a failed `claude` preflight to a headline + actionable next step. Pure so
+ * the wording is unit-tested without spawning or driving clack.
+ */
+export function describeClaudePreflightFailure(
+  result: Extract<ClaudeAuthResult, { ok: false }>,
+): { title: string; hint: string } {
+  switch (result.reason) {
+    case "not-found":
+      return {
+        title: "The `claude` CLI isn't installed or isn't on your PATH.",
+        hint: "Install Claude Code (https://docs.anthropic.com/en/docs/claude-code), or set CLAUDE_CODE_BIN to its name/path, then retry.",
+      };
+    case "unauthenticated":
+      return {
+        title: "The `claude` CLI isn't logged in — your Claude login may have expired.",
+        hint: "Run `claude` and authenticate (e.g. `/login`), then retry.",
+      };
+    case "error":
+    default:
+      return {
+        title: "The `claude` CLI failed a test call.",
+        hint: `${result.detail ? `${oneLine(result.detail)}\n  ` : ""}Confirm \`claude\` works on its own, then retry.`,
+      };
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -63,7 +63,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.6.0")
+  .version("0.6.0-next.11")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
Fixes #474.

## Problem

`truecourse spec scan` shells out to the user's `claude` CLI per block and collects per-block failures as non-fatal. That's right for a few stragglers, but when **every** block fails (e.g. an expired Claude login) the command printed `(N failures)` yet still showed the success outro, suggested `contracts generate`, and **exited 0** — hiding the real, actionable error.

## Changes

- **New classifier** in `@truecourse/spec-consolidator` — `summarizeExtractionFailures` / `isLikelyAuthFailure`: collapses duplicate messages into samples-with-counts, flags a total wipeout (`allFailed`), and detects auth signatures (401, `/login`, invalid key, expired token…) by majority rule.
- **`runSpecScan`** now:
  - surfaces the most common distinct failure messages (instead of just a count),
  - prints a re-authentication hint when failures look like auth,
  - exits `1` when every block fails, and exits `1` on a hard pipeline error (previously exit `0`),
  - gates the `contracts generate` suggestion on `claims > 0` ("No claims extracted — nothing to generate yet.").
- Exit-code / outro / hint policy extracted into a pure, unit-tested `decideScanOutcome`.

## Tests

- 10 unit tests for the failure classifier (auth detection, majority rule, sample collapsing, `allFailed`).
- 6 unit tests for the scan-outcome policy.
- Full suite: **4210 passing**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)