### PR TITLE
drift-fp-generate: open the storage PR with the label atomically (fixes the trigger race that stalled #476)

### DIFF
--- a/docs/drift-fp-automation/prompts/drift-fp-generate.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-generate.md
@@ -139,16 +139,38 @@ contracts.
   cherry-pick or re-stage the commit from step 5, delete the wrong branch, then push. Pushing from
   the wrong branch produces a PR whose head doesn't match the `drift-fp-discover` trigger filter
   (`Head Branch starts-with claude/drift-fp-store/`), and the chain stalls before discover fires.
-- Open a PR with head `claude/drift-fp-store/<owner>-<repo>`, base `main`.
-- Title `chore(drift-fp): contracts store for <owner>/<repo> @ <short-sha>`.
-- **Label `drift-fp-store`** — opening this PR (a `pull_request.opened` event) is what fires
-  `drift-fp-discover`. **This PR is never merged**; it's pure storage + the discover trigger, and
+- **Open the PR with the `drift-fp-store` label applied atomically — in a single command.** The
+  `drift-fp-discover` routine triggers on `pull_request.opened` filtered by
+  `Labels is-one-of drift-fp-store`. GitHub fires `pull_request.opened` once, at the moment the
+  PR is created, with the labels present **at that moment**. If you `gh pr create` first and
+  `gh pr edit --add-label` second, the `opened` event carries no labels, the trigger never
+  matches, and discover never fires — the chain stalls. So use one command:
+
+  ```bash
+  gh pr create \
+    --base main \
+    --head claude/drift-fp-store/<owner>-<repo> \
+    --label drift-fp-store \
+    --title 'chore(drift-fp): contracts store for <owner>/<repo> @ <short-sha>' \
+    --body-file /tmp/storage-pr-body.md
+  ```
+
+  Write the body to a file first (next bullet) so you don't have to escape multi-line markdown
+  inline. Do **not** add the label as a separate step.
+- **PR body** (write to `/tmp/storage-pr-body.md` before the `gh pr create` call): a clear
+  "⚠️ DO NOT MERGE — storage branch for the <owner>/<repo> drift campaign; deleted automatically
+  at campaign close" banner, plus target_ref, doc_scope, artifact counts from `contracts list`
+  (e.g. "98 .tc: 21 operation, 3 enum, 21 named-constant, …"), and any `contracts validate`
+  warnings. End with `cc @mushgev`.
+- **This PR is never merged**; it's pure storage + the discover trigger.
   `drift-fp-campaign-close` closes it + deletes the branch when the campaign finishes.
-- Body: a clear "⚠️ DO NOT MERGE — storage branch for the <owner>/<repo> drift campaign; deleted
-  automatically at campaign close" banner, plus target_ref, doc_scope, artifact counts from
-  `contracts list` (e.g. "98 .tc: 21 operation, 3 enum, 21 named-constant, …"), and any
-  `contracts validate` warnings. End with `cc @mushgev`.
-- Stop. Opening the PR fires `drift-fp-discover`.
+- **Verify the label landed.** After `gh pr create` returns, immediately
+  `gh pr view <number> --json labels --jq '.labels[].name'`. If `drift-fp-store` isn't in the
+  output, the label-on-creation failed silently (rare — but if it does, the trigger won't fire).
+  In that case post a one-line failure note (`cc @mushgev`) and stop so a human can recover —
+  do **not** attempt a second `--add-label` call to recover, because the `pull_request.opened`
+  event has already fired without the label and the trigger has already missed it.
+- Stop. Opening the labeled PR fires `drift-fp-discover`.
 
 ## Hard constraints
 


### PR DESCRIPTION
## Why

PR #476 (the first drift-fp storage PR) didn't fire `drift-fp-discover`. The chain stalled before discover even started.

**Root cause: webhook race in `drift-fp-generate`.** Look at #476's metadata:
- `created_at: 03:22:11`
- `updated_at: 03:22:17`

The routine session ran two API calls:
1. `gh pr create …` at 03:22:11 (PR opens, **no labels yet**)
2. `gh pr edit --add-label drift-fp-store` at 03:22:17 (label added)

GitHub fires `pull_request.opened` **once**, at step 1, with the PR's labels at that moment — which was empty. The `drift-fp-discover` trigger filter is `Labels is-one-of drift-fp-store`, so it evaluated empty against the required label, didn't match, and the trigger never fired. The label appeared on the PR 6 seconds later, but that was a `pull_request.labeled` event the trigger isn't subscribed to.

The prompt previously listed the label as a separate bullet ("**Label `drift-fp-store`** — opening this PR is what fires …"), which the model naturally read as a follow-up step. Hence the race.

## Fix

Rewrite step 6 to force the label to land in the **same API call** as PR creation:

```bash
gh pr create \
  --base main \
  --head claude/drift-fp-store/<owner>-<repo> \
  --label drift-fp-store \
  --title 'chore(drift-fp): contracts store for <owner>/<repo> @ <short-sha>' \
  --body-file /tmp/storage-pr-body.md
```

The body gets written to `/tmp/storage-pr-body.md` first so multi-line markdown doesn't have to be inline-escaped. Added:
- A "do **not** add the label as a separate step" prohibition with the race explanation inline (so the model can't simplify the command back into two calls).
- A post-create `gh pr view --json labels` verification.
- Explicit guidance to **stop and fail** (not "recover via `--add-label`") if the label is missing — because by then `opened` has already fired without it and the trigger has already missed.

## Why only generate

Only `drift-fp-generate`'s storage PR is affected. The other three drift prompts (`discover`, `next-fix`, `campaign-close`) open PRs whose downstream triggers fire on `pull_request.closed (merged)`, which sees the PR's *final* label state at merge time — no race possible.

## Unblock for PR #476

This patch fixes future campaigns. To unblock the in-flight strapi run after this merges, **manually trigger** `drift-fp-discover` once for PR #476 (Run now in the Routines UI). From discover's PR-merge onward the chain self-sustains as designed.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_