### PR TITLE
fix(verifier): fix 3 FPs — plugin routes, HttpResponse.json implicit 200, test-file exclusion

### DIFF
--- a/packages/contract-verifier/src/comparator/auth-requirement.ts
+++ b/packages/contract-verifier/src/comparator/auth-requirement.ts
@@ -37,6 +37,7 @@ export function compareAuthRequirement(input: AuthRequirementCompareInput): Cont
     if (!specOp) continue;
     if (!matchesOperation(input.contract.selector, op, specOp)) continue;
 
+    if (op.authExempt) continue; // route explicitly declares config.auth: false
     if (input.protectedFiles.has(op.filePath)) continue; // satisfied
 
     // `except` selectors — paths explicitly excluded from this requirement.

--- a/packages/contract-verifier/src/extractor/index.ts
+++ b/packages/contract-verifier/src/extractor/index.ts
@@ -8,7 +8,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { initParsers, parseFile } from '@truecourse/analyzer';
 import { loadTcIgnore } from '@truecourse/shared';
-import { extractOperationsFromFile, type ExtractedOperation } from './operation.js';
+import { extractOperationsFromFile, extractPluginStyleRoutesFromFile, type ExtractedOperation } from './operation.js';
 import { extractFastApiOperationsFromFile } from './operation-fastapi.js';
 import { eachParsedSource } from './source-walker.js';
 import { extractFileBasedRoutesFromDir } from './file-based-routes.js';
@@ -61,6 +61,14 @@ export type { ExtractedOperation } from './operation.js';
 
 const TS_EXT = new Set(['.ts', '.tsx', '.js', '.jsx']);
 
+function isTestFile(filePath: string): boolean {
+  const parts = filePath.replace(/\\/g, '/').split('/');
+  const fileName = parts[parts.length - 1];
+  if (/\.(test|spec)\.(t|j)sx?$/.test(fileName)) return true;
+  if (parts.includes('__tests__')) return true;
+  return false;
+}
+
 /**
  * Walk a directory recursively, parse each TS/JS file, and run the
  * Operation extractor over it. After the per-file pass, build a
@@ -88,12 +96,14 @@ export async function extractOperationsFromDir(rootDir: string): Promise<Extract
       if (!entry.isFile()) continue;
       const ext = path.extname(entry.name);
       if (!TS_EXT.has(ext)) continue;
+      if (isTestFile(full)) continue;
       const source = fs.readFileSync(full, 'utf-8');
       const lang =
         ext === '.ts' || ext === '.tsx' ? (ext === '.tsx' ? 'tsx' : 'typescript') : 'javascript';
       try {
         const tree = parseFile(full, source, lang);
         rawOps.push(...extractOperationsFromFile(full, source, tree));
+        rawOps.push(...extractPluginStyleRoutesFromFile(full, source, tree));
         fileAnalyses.push(analyzeRouterFile(full, source, tree));
       } catch {
         // Parse failures are silent — the verifier flags them via a

--- a/packages/contract-verifier/src/extractor/operation.ts
+++ b/packages/contract-verifier/src/extractor/operation.ts
@@ -66,6 +66,12 @@ export interface ExtractedOperation {
    */
   handlerBody?: SyntaxNode;
   handlerSource?: string;
+  /**
+   * True when the route declares `config.auth: false` (Strapi/plugin-style
+   * explicit opt-out). The auth-requirement comparator skips these routes
+   * because they are intentionally unauthenticated.
+   */
+  authExempt?: boolean;
 }
 
 export interface HandlerObservations {
@@ -511,14 +517,17 @@ function describeResCall(call: SyntaxNode, source: string): ResEvent | null {
  *   `new Response(body, init?)` — Fetch API. Default status 200; if
  *   the second arg is an object literal with `status: <number>`, that
  *   wins.
+ *   `new HttpResponse(body, init?)` — MSW (Mock Service Worker), which
+ *   extends the Fetch API Response with the same constructor signature.
  *
- * Used by Astro, SvelteKit, Cloudflare Workers, and Next.js App Router
- * handlers that return a `Response` directly. Bun and Deno's HTTP
- * surface use the same constructor.
+ * Used by Astro, SvelteKit, Cloudflare Workers, Next.js App Router, and
+ * MSW handlers that return a Response directly.
  */
+const WEB_RESPONSE_CTORS = new Set(['Response', 'HttpResponse']);
+
 function describeWebResponseNew(node: SyntaxNode, source: string): ResEvent | null {
   const ctor = node.childForFieldName('constructor');
-  if (!ctor || ctor.type !== 'identifier' || sliceText(ctor, source) !== 'Response') return null;
+  if (!ctor || ctor.type !== 'identifier' || !WEB_RESPONSE_CTORS.has(sliceText(ctor, source))) return null;
   const args = node.childForFieldName('arguments');
   const status = readStatusFromInit(args?.namedChild(1) ?? null, source) ?? '200';
   const bodyArg = args?.namedChild(0) ?? undefined;
@@ -532,9 +541,12 @@ function describeWebResponseNew(node: SyntaxNode, source: string): ResEvent | nu
 }
 
 /**
- * Recognise the static `Response.json(body, init?)` and
- * `NextResponse.json(body, init?)` factories. Same shape as
- * `new Response(...)` — default 200, status overridable via init.
+ * Recognise the static `Response.json(body, init?)`,
+ * `NextResponse.json(body, init?)`, and `HttpResponse.json(body, init?)`
+ * factories. Same shape as `new Response(...)` — default 200, status
+ * overridable via init. `HttpResponse` is used by MSW (Mock Service Worker)
+ * and behaves identically to the Fetch API `Response` with respect to the
+ * default 200 status.
  */
 function describeWebResponseCall(call: SyntaxNode, source: string): ResEvent | null {
   const fn = call.childForFieldName('function');
@@ -545,7 +557,7 @@ function describeWebResponseCall(call: SyntaxNode, source: string): ResEvent | n
   if (sliceText(prop, source) !== 'json') return null;
   if (obj.type !== 'identifier') return null;
   const objName = sliceText(obj, source);
-  if (objName !== 'Response' && objName !== 'NextResponse') return null;
+  if (objName !== 'Response' && objName !== 'NextResponse' && objName !== 'HttpResponse') return null;
 
   const args = call.childForFieldName('arguments');
   const status = readStatusFromInit(args?.namedChild(1) ?? null, source) ?? '200';
@@ -752,4 +764,175 @@ function readStringLiteral(node: SyntaxNode, source: string): string | null {
     return source.slice(fragment.startIndex, fragment.endIndex);
   }
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin-style route extraction
+//
+// Some frameworks (Strapi, Keystone, and similar plugin architectures)
+// declare routes as static data objects exported from per-plugin route files
+// rather than imperative `router.method()` calls. Two shapes are handled:
+//
+//   1. `export default [{ method: 'POST', path: '/login' }, ...]`
+//      — plain array of route descriptors
+//
+//   2. `export default { type: 'admin', routes: [{ method: 'GET', path: '/:id' }] }`
+//      — plugin-style wrapper object with a `routes` array
+//
+// The mount prefix is inferred from the file path using the pattern:
+//   `/<plugin-name>/server(/src)?/routes/`
+// yielding `/<plugin-name>` as the prefix (e.g. `/admin`, `/content-releases`).
+// ---------------------------------------------------------------------------
+
+const PLUGIN_ROUTE_METHODS = new Set(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD']);
+
+interface PluginRouteDescriptor {
+  method: string;
+  path: string;
+  line: number;
+  authExempt?: boolean;
+}
+
+/**
+ * Infer the HTTP mount prefix from the file path for plugin-style route files.
+ * Matches `/<plugin>/server(/src)?/routes/` and returns `/<plugin>`.
+ */
+function inferPluginMountPrefix(filePath: string): string | null {
+  const normalized = filePath.replace(/\\/g, '/');
+  const m = normalized.match(/\/([^/]+)\/server(?:\/src)?\/routes\//);
+  if (!m) return null;
+  return '/' + m[1];
+}
+
+function joinPluginPath(prefix: string, routePath: string): string {
+  if (!routePath) return prefix || '/';
+  const a = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+  const b = routePath.startsWith('/') ? routePath : '/' + routePath;
+  return a + b;
+}
+
+function tryReadPluginRouteDescriptor(
+  obj: SyntaxNode,
+  source: string,
+): PluginRouteDescriptor | null {
+  let method: string | null = null;
+  let routePath: string | null = null;
+  let authExempt = false;
+  for (const child of obj.namedChildren) {
+    if (child.type !== 'pair') continue;
+    const key = child.childForFieldName('key');
+    const val = child.childForFieldName('value');
+    if (!key || !val) continue;
+    const keyName = key.text.replace(/^['"]|['"]$/g, '');
+    if (keyName === 'method') {
+      const v = readStringLiteral(val, source);
+      if (v && PLUGIN_ROUTE_METHODS.has(v.toUpperCase())) method = v.toUpperCase();
+    } else if (keyName === 'path') {
+      const v = readStringLiteral(val, source);
+      if (v !== null && v.startsWith('/')) routePath = v;
+    } else if (keyName === 'config' && val.type === 'object') {
+      // Detect auth configuration in plugin-style route `config` block.
+      for (const cfgChild of val.namedChildren) {
+        if (cfgChild.type !== 'pair') continue;
+        const cfgKey = cfgChild.childForFieldName('key');
+        const cfgVal = cfgChild.childForFieldName('value');
+        if (!cfgKey || !cfgVal) continue;
+        const cfgKeyName = cfgKey.text.replace(/^['"]|['"]$/g, '');
+        if (cfgKeyName === 'auth' && cfgVal.type === 'false') {
+          // `config: { auth: false }` — explicit public opt-out.
+          authExempt = true;
+        } else if (cfgKeyName === 'policies' && cfgVal.type === 'array' && cfgVal.namedChildCount > 0) {
+          // `config: { policies: [...] }` — route goes through access-control policies.
+          // The auth-requirement comparator's file-level middleware check doesn't apply here.
+          authExempt = true;
+        }
+      }
+    }
+  }
+  if (!method || routePath === null) return null;
+  return { method, path: routePath, line: obj.startPosition.row + 1, authExempt };
+}
+
+function collectPluginRouteDescriptors(node: SyntaxNode, source: string): PluginRouteDescriptor[] {
+  const out: PluginRouteDescriptor[] = [];
+
+  // Pattern 1: array of route objects at top level
+  if (node.type === 'array') {
+    for (const el of node.namedChildren) {
+      if (el.type === 'object') {
+        const desc = tryReadPluginRouteDescriptor(el, source);
+        if (desc) out.push(desc);
+      }
+    }
+    return out;
+  }
+
+  // Pattern 2: object with a `routes` property containing the array
+  if (node.type === 'object') {
+    for (const child of node.namedChildren) {
+      if (child.type !== 'pair') continue;
+      const key = child.childForFieldName('key');
+      const val = child.childForFieldName('value');
+      if (!key || !val) continue;
+      const keyName = key.text.replace(/^['"]|['"]$/g, '');
+      if (keyName === 'routes' && val.type === 'array') {
+        for (const el of val.namedChildren) {
+          if (el.type === 'object') {
+            const desc = tryReadPluginRouteDescriptor(el, source);
+            if (desc) out.push(desc);
+          }
+        }
+      }
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Extract routes from plugin-style route file exports. Handles both the
+ * plain-array form (`export default [{ method, path }]`) and the wrapped
+ * form (`export default { type: '...', routes: [...] }`). The mount prefix
+ * is inferred from the file path; files outside the `<plugin>/server(/src)?/routes/`
+ * pattern are skipped.
+ */
+export function extractPluginStyleRoutesFromFile(
+  filePath: string,
+  source: string,
+  tree: Tree,
+): ExtractedOperation[] {
+  const prefix = inferPluginMountPrefix(filePath);
+  if (!prefix) return [];
+
+  const out: ExtractedOperation[] = [];
+
+  const visit = (node: SyntaxNode): void => {
+    if (node.type === 'export_statement') {
+      const value = node.childForFieldName('value');
+      if (value) {
+        const descriptors = collectPluginRouteDescriptors(value, source);
+        for (const { method, path: routePath, line, authExempt } of descriptors) {
+          const fullPath = joinPluginPath(prefix, routePath);
+          out.push({
+            identity: `${method} ${fullPath}`,
+            contract: {
+              protocol: 'http',
+              method,
+              path: fullPath,
+              tags: [],
+              responses: [],
+            },
+            filePath,
+            declarationLine: line,
+            observed: { queryParams: [], numericClamps: [], hasClampCall: false },
+            ...(authExempt ? { authExempt: true } : {}),
+          });
+        }
+      }
+    }
+    for (const child of node.namedChildren) visit(child);
+  };
+  visit(tree.rootNode);
+
+  return out;
 }

--- a/tests/contract-verifier/operation-lifter.test.ts
+++ b/tests/contract-verifier/operation-lifter.test.ts
@@ -72,7 +72,7 @@ describe('Contract Operation lifter', () => {
   it('every Operation in the corpus has a lifted contract', () => {
     const r = loadAll();
     const ops = [...r.index.values()].filter((a) => a.ref.type === 'Operation');
-    expect(ops.length).toBe(10);
+    expect(ops.length).toBe(17);
     for (const op of ops) {
       expect(op.contract, `Operation:${op.ref.identity} missing contract`).toBeDefined();
     }

--- a/tests/contract-verifier/verify-end-to-end.test.ts
+++ b/tests/contract-verifier/verify-end-to-end.test.ts
@@ -79,12 +79,20 @@ describe('Contract verifier — end-to-end on fixture (Operation slice only)', (
     // The extractor must follow the call into `transitionEndpoint` and
     // attribute its responses back to the route — otherwise we'd emit
     // false-positive `implementation.missing` drifts for each.
+    //
+    // Intentional regression cases (marked with // IL-DRIFT: in fixture code)
+    // are excluded from the FP check — they are covered by the marker-set test.
+    const intentional = new Set(
+      parseIlDriftMarkers(path.join(FIXTURE_ROOT, 'code/src')),
+    );
     const result = await verify({
       contractsDir: path.join(FIXTURE_ROOT, 'reference/contracts'),
       codeDir: path.join(FIXTURE_ROOT, 'code'),
     });
-    const missing = result.drifts.filter((d) => d.obligationKey === 'implementation.missing');
-    expect(missing).toEqual([]);
+    const unexpectedMissing = result.drifts.filter(
+      (d) => d.obligationKey === 'implementation.missing' && !intentional.has(driftKey(d)),
+    );
+    expect(unexpectedMissing).toEqual([]);
   });
 });
 

--- a/tests/fixtures/sample-js-project-il/code/src/catalog/__tests__/catalog.test.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/catalog/__tests__/catalog.test.ts
@@ -1,0 +1,17 @@
+// FP-GUARD: auth-requirement/unprotected — must NOT drift
+// Paraphrase: MSW mock handlers in test files have no auth middleware.
+// The extractor must exclude test files so test mocks don't masquerade
+// as real route implementations — triggering false unprotected drifts
+// for routes that are actually auth-protected in real code.
+
+import { http, HttpResponse } from 'msw';
+
+// This handler mimics the pattern from the upstream case: a test-file
+// mock for a route that is auth-protected in real code.  Without test-file
+// exclusion, the extractor sees this mock, finds no auth middleware on
+// the containing file, and fires a spurious unprotected drift.
+export const catalogTestHandlers = [
+  http.get('/internal/catalog/:id', () => {
+    return HttpResponse.json({ id: '1', name: 'Item' });
+  }),
+];

--- a/tests/fixtures/sample-js-project-il/code/src/handlers/widget-handler.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/handlers/widget-handler.ts
@@ -1,0 +1,23 @@
+// FP-GUARD: operation/response-status — must NOT drift
+// Paraphrase of the pattern where a route handler returns HttpResponse.json()
+// (MSW / web-api style) without an explicit status argument. The extractor
+// must recognise HttpResponse.json() as an implicit-200 response, matching
+// the same rule it applies to Response.json() and NextResponse.json().
+
+import { http, HttpResponse } from 'msw';
+
+// MSW-style handler: HttpResponse.json() defaults to 200 — same contract
+// as Response.json() which the extractor already recognises.
+export const widgetHandlers = [
+  http.get('/v1/widgets/:id', () => {
+    return HttpResponse.json({ id: '1', name: 'Widget' });
+  }),
+];
+
+// The handler below emits a genuine non-200 response — regression guard.
+// IL-DRIFT: Operation:GET /v1/broken-widgets/{id} / response.200
+export const brokenWidgetHandlers = [
+  http.get('/v1/broken-widgets/:id', () => {
+    return new HttpResponse(null, { status: 404 });
+  }),
+];

--- a/tests/fixtures/sample-js-project-il/code/src/legacy/legacy.router.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/legacy/legacy.router.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+
+const router = express.Router();
+
+// Regression guard: this route genuinely has no auth middleware.
+// The auth requirement contract covers /internal/** — any unprotected
+// route there SHOULD fire a drift.
+// IL-DRIFT: AuthRequirement:auth.bearer.internal / GET /internal/legacy/{id}/unprotected
+router.get('/internal/legacy/:id', (req, res) => {
+  res.json({ id: req.params.id });
+});
+
+export default router;

--- a/tests/fixtures/sample-js-project-il/code/src/plugins/catalog/server/routes/entries.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/plugins/catalog/server/routes/entries.ts
@@ -1,0 +1,26 @@
+// FP-GUARD: operation/implementation-missing — must NOT drift
+// Paraphrase of plugin route files that export route descriptors as a
+// typed object (type + routes array) with paths relative to the plugin
+// mount prefix. The extractor must resolve prefix + relative path to the
+// full URL so it matches the spec identity.
+
+export default {
+  type: 'admin',
+  routes: [
+    {
+      method: 'POST',
+      path: '/',
+      handler: 'entries.create',
+      config: { policies: [] },
+    },
+    {
+      method: 'GET',
+      path: '/:id',
+      handler: 'entries.findOne',
+      config: { policies: [] },
+    },
+  ],
+};
+
+// The DELETE route is intentionally absent — regression guard.
+// IL-DRIFT: Operation:DELETE /catalog/{id} / implementation.missing

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/auth-bearer-internal.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/auth-bearer-internal.tc
@@ -1,0 +1,10 @@
+auth-requirement auth.bearer.internal {
+  origin "reference/specs/shared/auth.md" "Internal auth" 1..4
+  scheme Bearer
+  selector path-glob "/internal/**"
+  on-violation {
+    status 401
+    error-code unauthenticated
+    body ErrorEnvelope:error.envelope.standard
+  }
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/auth-req-unprotected-planned.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/auth-req-unprotected-planned.tc
@@ -1,0 +1,4 @@
+operation GET "/internal/catalog/{id}" {
+  status planned
+  origin "reference/specs/modules/catalog/endpoints.md" "GET /internal/catalog/{id}" 1..5
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/auth-req-unprotected-regression.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/auth-req-unprotected-regression.tc
@@ -1,0 +1,8 @@
+operation GET "/internal/legacy/{id}" {
+  origin "reference/specs/modules/legacy/endpoints.md" "GET /internal/legacy/{id}" 1..5
+  response 200 on success {
+    body {
+      id: string
+    }
+  }
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-plugin-prefix-delete.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-plugin-prefix-delete.tc
@@ -1,0 +1,3 @@
+operation DELETE "/catalog/{id}" {
+  origin "reference/specs/modules/catalog/endpoints.md" "DELETE /catalog/{id}" 1..5
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-plugin-prefix-get.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-plugin-prefix-get.tc
@@ -1,0 +1,3 @@
+operation GET "/catalog/{id}" {
+  origin "reference/specs/modules/catalog/endpoints.md" "GET /catalog/{id}" 1..5
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-plugin-prefix-post.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-plugin-prefix-post.tc
@@ -1,0 +1,3 @@
+operation POST "/catalog/" {
+  origin "reference/specs/modules/catalog/endpoints.md" "POST /catalog/" 1..5
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-response-status-msw-implicit.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-response-status-msw-implicit.tc
@@ -1,0 +1,9 @@
+operation GET "/v1/widgets/{id}" {
+  origin "reference/specs/modules/widgets/endpoints.md" "GET /v1/widgets/{id}" 1..5
+  response 200 on success {
+    body {
+      id: string
+      name: string
+    }
+  }
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-response-status-regression.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-response-status-regression.tc
@@ -1,0 +1,8 @@
+operation GET "/v1/broken-widgets/{id}" {
+  origin "reference/specs/modules/widgets/endpoints.md" "GET /v1/broken-widgets/{id}" 1..5
+  response 200 on success {
+    body {
+      id: string
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Batch fix for three false-positive drift issues. Each fix is paired with an IL fixture that locks in the correct behavior.

| # | Issue | FP type | Fix |
|---|-------|---------|-----|
| #479 | Plugin-style route declarations not extracted | `implementation.missing` | Add `extractPluginStyleRoutesFromFile`; infer mount prefix from `/<plugin>/server(/src)?/routes/` path; respect `config.auth: false` and `config.policies` (authExempt) |
| #480 | `HttpResponse.json()` not recognized as implicit-200 | `response.200` | Extend `describeWebResponseCall` / `describeWebResponseNew` to include `HttpResponse` alongside `Response` / `NextResponse` |
| #481 | MSW mock handlers in test files trigger auth-unprotected FPs | auth-requirement `unprotected` | Add `isTestFile()` guard in `extractOperationsFromDir`; skip `.test.ts`, `.spec.ts`, `__tests__/` files |

Closes #479
Closes #480
Closes #481

## Drift-count delta (strapi/strapi)

| Obligation key | Before | After | Δ |
|----------------|--------|-------|---|
| `implementation.missing` | 21 | 5 | **−16** ← main win |
| auth `unprotected` | 2 | 0 | **−2** |
| `response.200` | 1 | 15 | +14 ← known limitation† |
| enum / constant | 14 | 13 | −1 |
| **Total** | **38** | **33** | **−5** |

† Plugin route declarations (`export default [{ method, path, handler }]`) don't contain handler bodies, so the extractor can't observe which HTTP status codes the controller emits. The `response.200` increase is the cost of now recognizing these routes; a follow-up fix would follow handler references into controller files.

## Test plan

- [x] `tests/contract-verifier/verify-end-to-end.test.ts` — all 8 tests green (including new IL fixture cases)
- [x] `tests/contract-verifier/operation-lifter.test.ts` — all 6 tests green (corpus count updated 10→17)
- [x] Full test suite: 4198 passed, 5 pre-existing git-signing failures (unrelated to this PR)

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_0149stj5HMvNwygtzLJ1TjTd)_