### PR TITLE
drift-fp-next-fix: open the batch PR with --label drift-fp-fix in one command (fixes #483 stall)

### DIFF
--- a/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
@@ -239,7 +239,17 @@ If step 1/2 throws, still write the section with `unavailable: <concrete reason>
       ```
       (or `unavailable: <reason>` if measurement failed).
     - End with `cc @mushgev`.
-  - Labels: `drift-fp-fix` (fires the next routine invocation on merge).
+  - **Open the PR with `--label drift-fp-fix` in the same `gh pr create` call.**
+    `drift-fp-next-fix` (the next iteration of this routine) triggers on this PR's merge filtered
+    by `Labels is-one-of drift-fp-fix`. If the PR is merged without the label, the trigger
+    doesn't fire and the inner loop stalls (this is what happened on PR #483: the label was
+    never applied, the PR was merged label-less, and the next batch had to be kicked manually).
+    Do **not** specify the label as a follow-up `gh pr edit --add-label` step — sessions have
+    silently dropped that second call.
+  - **Verify the label landed.** Right after `gh pr create` returns, check
+    `gh pr view <number> --json labels --jq '.labels[].name'`. If `drift-fp-fix` isn't in the
+    output, post a one-line failure note on the most recent fixed issue (`cc @mushgev`) and stop
+    — do **not** attempt a follow-up `--add-label` to recover. Surface to a human.
   - For each fixed issue: comment the PR URL, then remove `drift-fp-in-progress` (merge
     auto-closes via `Closes #N`).
 - End the session.


### PR DESCRIPTION
## Confirmed: PR #483 had no label at all

Pulled PR #483's metadata — its `labels` field is empty. Compare to PR #476 (`"labels":["drift-fp-store"]`) and PR #478 (`"labels":["drift-fp-discover"]`) where labels are present. The `drift-fp-fix` label was simply never applied to #483 — not a race, just a dropped second step.

The `drift-fp-next-fix` trigger filters on `Labels is-one-of drift-fp-fix` at merge time. No label → no match → no trigger fire → inner loop stalled.

## Root cause

`drift-fp-next-fix.md` listed `Labels: drift-fp-fix` as a one-line hint under the PR-body bullet. The session ran `gh pr create` and never made a follow-up `gh pr edit --add-label` call. The instruction wasn't binding enough; the session skipped it.

## Fix (one file, one section)

Only `drift-fp-next-fix.md`'s "Open the batched PR" step is changed. The new step:

- Writes the PR body to `/tmp/fix-pr-body.md` first (so multi-line markdown isn't inline-escaped).
- Uses one `gh pr create --label drift-fp-fix --body-file …` call. The example command is right there, with the head branch wired via `git rev-parse --abbrev-ref HEAD`.
- Explicitly prohibits a follow-up `gh pr edit --add-label`, with PR #483 named inline as the cautionary tale so the model can't quietly simplify back to the broken two-call shape.
- Adds a post-create `gh pr view --json labels` verification. If the label is missing, STOP and surface to a human — don't recover with a follow-up add.

## What is *not* in this PR (intentional)

- **`drift-fp-discover.md`** — discovery PR #478 was correctly labelled by the routine (verified via the API). The same prompt structure didn't fail in practice. Not changed.
- **`drift-fp-next-fix.md`'s queue-empty step 5 (campaign-close PR)** — hasn't run yet. Not changed.
- **`drift-fp-generate.md`** — already fixed in PR #477 for a different failure mode (race on `pull_request.opened`).

Narrow scope intentional: fix the actually-observed bug, leave the theoretical ones for if/when they happen.

## Unblocking the in-flight strapi run

Click **Run now on `drift-fp-next-fix`** after this merges. Its per-issue loop step 1 lists open `drift-fp-fix` issues for the current campaign (doesn't require a triggering PR), picks up #482 (named-constant), opens a properly-labelled fix PR via the new one-command form, and the chain self-fires from there.

cc @mushgev