### PR TITLE
fix(drift-fp): resolve 1 drift FP from strapi/strapi

### DIFF
--- a/packages/contract-verifier/src/comparator/named-constant.ts
+++ b/packages/contract-verifier/src/comparator/named-constant.ts
@@ -37,7 +37,19 @@ export interface NamedConstantCompareInput {
 export function compareNamedConstant(input: NamedConstantCompareInput): ContractDrift[] {
   const { ref, contract, codeConstants } = input;
   const target = normalizeName(ref.identity);
-  const matches = codeConstants.filter((c) => normalizeName(c.name) === target);
+  let matches = codeConstants.filter((c) => normalizeName(c.name) === target);
+
+  // For namespaced spec identities (e.g. "widget.EMBED_THEME"), fall back to
+  // matching the last segment ("EMBED_THEME") against window-global constants
+  // only. This covers browser globals declared as window.X in code but named
+  // with a namespace prefix in the spec.
+  if (matches.length === 0 && ref.identity.includes('.')) {
+    const lastPart = ref.identity.split('.').pop()!;
+    const lastTarget = normalizeName(lastPart);
+    matches = codeConstants.filter(
+      (c) => c.shape === 'window-global' && normalizeName(c.name) === lastTarget,
+    );
+  }
 
   if (matches.length === 0) {
     return [{
@@ -49,10 +61,16 @@ export function compareNamedConstant(input: NamedConstantCompareInput): Contract
       filePath: ref.identity,
       lineStart: 0,
       lineEnd: 0,
-      message: `Spec declares constant \`${ref.identity}\` (expected ${formatValue(contract.expectedValue)}), but no code-side constant matches by name.`,
+      message: `Spec declares constant \`${ref.identity}\` but no code-side constant matches by name.`,
       specSide: `expected: ${formatValue(contract.expectedValue)}`,
       codeSide: '<no match>',
     }];
+  }
+
+  // A contract without an explicit expected-value (undefined) only asserts
+  // presence; skip value comparison entirely.
+  if (contract.expectedValue === undefined) {
+    return [];
   }
 
   const drifts: ContractDrift[] = [];

--- a/packages/contract-verifier/src/extractor/constant/ts-constants.ts
+++ b/packages/contract-verifier/src/extractor/constant/ts-constants.ts
@@ -23,21 +23,38 @@ export function extractConstantsFromFile(
   tree: Tree,
 ): ExtractedConstant[] {
   const out: ExtractedConstant[] = [];
+  // Track window globals by name so each unique access is emitted once.
+  const seenWindowGlobals = new Set<string>();
   walk(tree.rootNode, (node) => {
     // 1. const/let declarator with literal initializer
     if (node.type === 'variable_declarator') {
       const result = extractDeclarator(node, filePath, source);
       out.push(...result);
-      // Don't recurse into a declarator we processed — its children
-      // are the same object/literal we already consumed.
       return true;
     }
-    // 3. default function params (arrow + regular + method)
+    // 2. default function params (arrow + regular + method)
     if (node.type === 'required_parameter' || node.type === 'optional_parameter' ||
         node.type === 'assignment_pattern') {
       const result = extractDefaultArg(node, filePath, source);
       if (result) out.push(result);
       return true;
+    }
+    // 3. window.X member-expression accesses (browser window globals)
+    if (node.type === 'member_expression') {
+      const objNode = node.childForFieldName('object');
+      const propNode = node.childForFieldName('property');
+      if (objNode?.text === 'window' && propNode?.type === 'property_identifier') {
+        const propName = propNode.text;
+        if (!seenWindowGlobals.has(propName)) {
+          seenWindowGlobals.add(propName);
+          out.push({
+            name: propName,
+            value: undefined,
+            shape: 'window-global',
+            source: mkLoc(node, filePath),
+          });
+        }
+      }
     }
     return true;
   });
@@ -88,6 +105,14 @@ function extractDeclarator(
       if (v === UNPARSEABLE) continue;
       out.push({
         name: k,
+        value: v,
+        shape: 'object-property',
+        source: mkLoc(kNode, filePath),
+      });
+      // Also emit the dotted form "OuterName.key" so specs that name
+      // a constant as "Obj.prop" can match via normal name normalization.
+      out.push({
+        name: `${name}.${k}`,
         value: v,
         shape: 'object-property',
         source: mkLoc(kNode, filePath),

--- a/packages/contract-verifier/src/extractor/constant/types.ts
+++ b/packages/contract-verifier/src/extractor/constant/types.ts
@@ -9,7 +9,8 @@ import type { SourceLocation } from '../../types/index.js';
 export type ConstantShape =
   | 'const-literal'   // const X = <literal>
   | 'object-property' // const X = { key: <literal>, ... }  — one record per property
-  | 'default-arg';    // function f(name = <literal>)
+  | 'default-arg'     // function f(name = <literal>)
+  | 'window-global';  // window.X access — value is undefined; matched by last-segment fallback
 
 export interface ExtractedConstant {
   name: string;

--- a/packages/contract-verifier/src/resolver/lifters/named-constant.ts
+++ b/packages/contract-verifier/src/resolver/lifters/named-constant.ts
@@ -39,7 +39,7 @@ const VALID_TYPES = new Set<NamedConstantContract['type']>([
 
 export function liftNamedConstant(body: StatementNode[]): NamedConstantContract {
   let type: NamedConstantContract['type'] = 'string';
-  let expectedValue: unknown = '';
+  let expectedValue: unknown = undefined;
 
   for (const stmt of body) {
     const h = stmt.head;

--- a/tests/fixtures/sample-js-project-il/code/src/services/embed-config.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/services/embed-config.ts
@@ -1,0 +1,13 @@
+// FP-GUARD: named-constant/no-code-counterpart — must NOT drift
+// Paraphrase of browser window globals that a host page can configure.
+// The spec names them under a "widget." namespace prefix; in code they
+// appear as window.X accesses (no namespace). The extractor must emit
+// these as named constants so the comparator can find them via the
+// last-segment fallback for namespaced spec identities.
+const darkMode  = window.EMBED_DARK_MODE ?? false;
+const locale    = window.EMBED_LOCALE    ?? 'en';
+
+// widget.EMBED_THEME is intentionally absent from code — regression:
+// the no-code-counterpart drift must still fire.
+// IL-DRIFT: NamedConstant:widget.EMBED_THEME / constant.widget.EMBED_THEME.no-code-counterpart
+export { darkMode, locale };

--- a/tests/fixtures/sample-js-project-il/code/src/services/permission-guard.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/services/permission-guard.ts
@@ -1,0 +1,13 @@
+// FP-GUARD: named-constant/no-code-counterpart — must NOT drift
+// Paraphrase of a permission object whose properties are named as
+// "Obj.prop" in the spec (dotted path). The extractor must emit the
+// dotted form CRUD_PERMS.read / CRUD_PERMS.create so the comparator
+// can match the spec identity without reporting no-code-counterpart.
+export const CRUD_PERMS = {
+  read:   'module::catalog.items.read',
+  create: 'module::catalog.items.create',
+} as const;
+
+// CRUD_PERMS.write is intentionally absent — regression: the
+// no-code-counterpart drift must still fire for this property.
+// IL-DRIFT: NamedConstant:CRUD_PERMS.write / constant.CRUD_PERMS.write.no-code-counterpart

--- a/tests/fixtures/sample-js-project-il/reference/contracts/_inferred/crud-perms/crudperms.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/_inferred/crud-perms/crudperms.tc
@@ -1,0 +1,8 @@
+enum CRUD_PERMS {
+  // inferred — enum defined in code but documented in no spec
+  inferred-from "src/services/permission-guard.ts" 6..9
+  confidence high
+  representation string-literal
+  closed
+  values [module::catalog.items.create, module::catalog.items.read]
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/named-constant-no-counterpart-dotted-prop.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/named-constant-no-counterpart-dotted-prop.tc
@@ -1,0 +1,17 @@
+constant CRUD_PERMS.read {
+  origin "reference/specs/modules/catalog/perms.md" "CRUD Permissions" 1..10
+  type string
+  expected-value "module::catalog.items.read"
+}
+
+constant CRUD_PERMS.create {
+  origin "reference/specs/modules/catalog/perms.md" "CRUD Permissions" 1..10
+  type string
+  expected-value "module::catalog.items.create"
+}
+
+constant CRUD_PERMS.write {
+  origin "reference/specs/modules/catalog/perms.md" "CRUD Permissions" 1..10
+  type string
+  expected-value "module::catalog.items.write"
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/named-constant-no-counterpart-window-global.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/named-constant-no-counterpart-window-global.tc
@@ -1,0 +1,14 @@
+constant widget.EMBED_DARK_MODE {
+  origin "reference/specs/widget/globals.md" "Window globals" 1..10
+  type boolean
+}
+
+constant widget.EMBED_LOCALE {
+  origin "reference/specs/widget/globals.md" "Window globals" 1..10
+  type string
+}
+
+constant widget.EMBED_THEME {
+  origin "reference/specs/widget/globals.md" "Window globals" 1..10
+  type string
+}


### PR DESCRIPTION
Closes #482

## Fixes

| drift_kind | issue | fp-guard fixture | regression fixture |
|---|---|---|---|
| `named-constant/no-code-counterpart` | #482 | `code/src/services/permission-guard.ts`, `code/src/services/embed-config.ts`, `fp-guards/named-constant-no-counterpart-dotted-prop.tc`, `fp-guards/named-constant-no-counterpart-window-global.tc` | same files (IL-DRIFT markers for `CRUD_PERMS.write` and `widget.EMBED_THEME`) |

## named-constant/no-code-counterpart

**OSS source URLs (paraphrased — not copied):**
- ACTIONS.* pattern: https://github.com/strapi/strapi/blob/b2ba15617de4c8ada9099789f7c774bb32328970/packages/core/content-manager/server/src/services/permission-checker.ts#L6
- preview.STRAPI_* pattern: https://github.com/strapi/strapi/blob/b2ba15617de4c8ada9099789f7c774bb32328970/packages/core/content-manager/admin/src/preview/utils/previewScript.ts#L6-L40

**Cited contracts:** `contracts/actions/actions.create.tc` … `actions.update.tc` (7 files), `contracts/preview/preview.strapidisablestegadecoding.tc` … `preview.strapihighlighthovercolor.tc` (3 files)

**Root cause — two sub-patterns:**

1. **Dotted object-property names (`ACTIONS.*`):** Contracts name constants as `ACTIONS.create`, `ACTIONS.delete`, etc. In code these are properties of a single exported object `const ACTIONS = { create: '...', ... }`. The extractor emitted only the bare key (`create`), not the dotted form (`ACTIONS.create`), so `normalizeName('ACTIONS.create') = 'actionscreate'` never matched `normalizeName('create') = 'create'`.

2. **Window globals (`preview.STRAPI_*`):** Constants accessed as `window.STRAPI_DISABLE_STEGA_DECODING` etc. The extractor had no recognition of `window.X` access patterns. Additionally, the spec names them under a `preview.` namespace prefix that has no code-side analogue.

**FP-guard fixture diff (dotted-prop):**
```diff
+++ b/tests/fixtures/sample-js-project-il/code/src/services/permission-guard.ts
+// FP-GUARD: named-constant/no-code-counterpart — must NOT drift
+export const CRUD_PERMS = {
+  read:   'module::catalog.items.read',
+  create: 'module::catalog.items.create',
+} as const;
+// IL-DRIFT: NamedConstant:CRUD_PERMS.write / constant.CRUD_PERMS.write.no-code-counterpart

+++ b/.../fp-guards/named-constant-no-counterpart-dotted-prop.tc
+constant CRUD_PERMS.read {
+  origin "reference/specs/modules/catalog/perms.md" "CRUD Permissions" 1..10
+  type string
+  expected-value "module::catalog.items.read"
+}
+constant CRUD_PERMS.create { ... expected-value "module::catalog.items.create" }
+constant CRUD_PERMS.write  { ... expected-value "module::catalog.items.write"  }
```

**FP-guard fixture diff (window-global):**
```diff
+++ b/tests/fixtures/sample-js-project-il/code/src/services/embed-config.ts
+// FP-GUARD: named-constant/no-code-counterpart — must NOT drift
+const darkMode = window.EMBED_DARK_MODE ?? false;
+const locale   = window.EMBED_LOCALE    ?? 'en';
+// IL-DRIFT: NamedConstant:widget.EMBED_THEME / constant.widget.EMBED_THEME.no-code-counterpart

+++ b/.../fp-guards/named-constant-no-counterpart-window-global.tc
+constant widget.EMBED_DARK_MODE { type boolean }
+constant widget.EMBED_LOCALE    { type string  }
+constant widget.EMBED_THEME     { type string  }  ← regression: absent from code
```

**Fix summary:** Three coordinated changes in `packages/contract-verifier/src/`:
1. `extractor/constant/ts-constants.ts` — For each object property `key` on a binding `Obj`, now also emits the dotted form `Obj.key` (alongside the bare `key`). Also added extraction of `window.X` member-expression accesses as `window-global`-shaped constants, deduplicated per unique property name per file.
2. `resolver/lifters/named-constant.ts` — Changed default `expectedValue` from `''` to `undefined`. A contract without `expected-value` now only asserts presence (not value).
3. `comparator/named-constant.ts` — Added last-segment fallback: when a namespaced spec identity `A.B` finds no full match, also try matching the last segment `B` against `window-global` constants only. Added guard to skip value comparison when `contract.expectedValue === undefined`.

## Drift-count delta (vs b2ba15617de4c8ada9099789f7c774bb32328970 on strapi/strapi, pinned contracts)

| Drift-kind | Before | After | Delta |
|---|---:|---:|---:|
| `named-constant/no-code-counterpart` (ACTIONS.* × 7) | 7 | 0 | **-7** |
| `named-constant/no-code-counterpart` (preview.STRAPI_* × 3) | 3 | 0 | **-3** |
| `named-constant/no-code-counterpart` (maxPendingReleases, borderline) | 1 | 1 | 0 |
| **Total (this kind)** | **11** | **1** | **-10** |
| **All-kinds total on target** | **34** | **24** | **-10** |

Note: `constant.maxPendingReleases.no-code-counterpart` remains — the issue flags this as borderline (magic number `|| 3` vs. named constant). Not a verifier FP.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7D2BpE74WQjexgTGMFVdn)_