### PR TITLE
fix(drift-fp): resolve 1 drift FP from strapi/strapi

### DIFF
--- a/packages/contract-verifier/src/comparator/operation.ts
+++ b/packages/contract-verifier/src/comparator/operation.ts
@@ -42,6 +42,13 @@ export function compareOperation(input: CompareInput): ContractDrift[] {
   const codeByStatus = new Map<string, ResponseContract>();
   for (const r of input.code.responses) codeByStatus.set(r.status, r);
 
+  // Plugin-style route descriptors reference handlers by string name; the
+  // extractor produces responses:[] because no handler body is walked (cross-
+  // handler tracing is out of v1 scope). Treat that as "unverifiable" — skip
+  // response-status, header, and body checks rather than emitting false-
+  // positive response.N drifts for every such route.
+  if (input.code.responses.length === 0) return out;
+
   for (const specResp of input.spec.responses) {
     // 401/403 inherited responses are validated by the cross-cutting
     // comparator (`AuthRequirement` / `AuthorizationRule`), not here.

--- a/tests/contract-verifier/operation-lifter.test.ts
+++ b/tests/contract-verifier/operation-lifter.test.ts
@@ -72,7 +72,7 @@ describe('Contract Operation lifter', () => {
   it('every Operation in the corpus has a lifted contract', () => {
     const r = loadAll();
     const ops = [...r.index.values()].filter((a) => a.ref.type === 'Operation');
-    expect(ops.length).toBe(17);
+    expect(ops.length).toBe(20);
     for (const op of ops) {
       expect(op.contract, `Operation:${op.ref.identity} missing contract`).toBeDefined();
     }

--- a/tests/fixtures/sample-js-project-il/code/src/handlers/items-handler.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/handlers/items-handler.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+
+const router = express.Router();
+
+// Regression: inline handler explicitly emits only 201; the contract declares
+// response 200 on success. Comparator must still fire response.200 because the
+// code-side responses list is non-empty (it has 201) — the "skip when empty"
+// fix must not suppress drifts where response facts were actually extracted.
+// IL-DRIFT: Operation:GET /catalog/items/broken / response.200
+router.get('/catalog/items/broken', (req, res) => {
+  res.status(201).json({ created: true });
+});
+
+export default router;

--- a/tests/fixtures/sample-js-project-il/code/src/plugins/catalog/server/routes/items.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/plugins/catalog/server/routes/items.ts
@@ -1,0 +1,22 @@
+// FP-GUARD: operation/response-200 — must NOT drift
+// Paraphrase of plugin-style route descriptors where each route references a
+// named handler string rather than an inline function body.
+// extractPluginStyleRoutesFromFile builds OperationContract with responses:[]
+// because no handler body is walked (cross-handler tracing is out of v1 scope).
+// The comparator must treat an empty code-side response list as "unverifiable",
+// not "response 200 was never emitted".
+
+export default [
+  {
+    method: 'GET',
+    path: '/items',
+    handler: 'items.findAll',
+    config: { policies: ['auth::isAuthenticated'] },
+  },
+  {
+    method: 'POST',
+    path: '/items',
+    handler: 'items.create',
+    config: { policies: ['auth::isAuthenticated'] },
+  },
+];

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-response-200-plugin-descriptor-get.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-response-200-plugin-descriptor-get.tc
@@ -1,0 +1,5 @@
+operation GET "/catalog/items" {
+  origin "reference/specs/modules/catalog/items.md" "GET /catalog/items" 1..5
+  response 200 on success {
+  }
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-response-200-plugin-descriptor-post.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-response-200-plugin-descriptor-post.tc
@@ -1,0 +1,5 @@
+operation POST "/catalog/items" {
+  origin "reference/specs/modules/catalog/items.md" "POST /catalog/items" 1..5
+  response 200 on success {
+  }
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-response-200-regression.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-response-200-regression.tc
@@ -1,0 +1,5 @@
+operation GET "/catalog/items/broken" {
+  origin "reference/specs/modules/catalog/items.md" "GET /catalog/items/broken" 1..5
+  response 200 on success {
+  }
+}


### PR DESCRIPTION
Closes #488

## Fixes

| drift_kind | issue | fp-guard fixture | regression fixture |
|---|---|---|---|
| operation/response-200 | #488 | `code/src/plugins/catalog/server/routes/items.ts` + `fp-guards/operation-response-200-plugin-descriptor-{get,post}.tc` | `code/src/handlers/items-handler.ts` + `fp-guards/operation-response-200-regression.tc` |

## operation/response-200

**OSS source (FP samples):**
- https://github.com/strapi/strapi/blob/b2ba15617de4c8ada9099789f7c774bb32328970/packages/core/admin/server/src/routes/authentication.ts#L2 — `POST /admin/login`
- https://github.com/strapi/strapi/blob/b2ba15617de4c8ada9099789f7c774bb32328970/packages/core/admin/server/src/routes/authentication.ts#L52 — `POST /admin/logout`
- https://github.com/strapi/strapi/blob/b2ba15617de4c8ada9099789f7c774bb32328970/packages/core/content-releases/server/src/routes/release.ts#L52 — `GET /content-releases/`
- https://github.com/strapi/strapi/blob/b2ba15617de4c8ada9099789f7c774bb32328970/packages/core/content-releases/server/src/routes/release-action.ts#L36 — `GET /content-releases/{releaseId}/actions`

**Cited contract:** `contracts/admin/operations/post-admin-login.tc` (representative)

**Root cause:** After the mount-prefix fix (PR #486), plugin-style Strapi route descriptors are now correctly matched to their contracts. However, `extractPluginStyleRoutesFromFile` builds `OperationContract` objects with `responses: []` because the route descriptor `{ method, path, handler: 'controller.action', config }` contains no inline handler body to walk — cross-handler tracing is deliberately out of v1 scope. The `compareOperation` comparator was treating `responses: []` as "emits no responses" and firing `response.N` drift for every matched plugin route.

**Fix:** Added an early return in `compareOperation` when `input.code.responses.length === 0`:

```diff
+  // Plugin-style route descriptors reference handlers by string name; the
+  // extractor produces responses:[] because no handler body is walked (cross-
+  // handler tracing is out of v1 scope). Treat that as "unverifiable" — skip
+  // response-status, header, and body checks rather than emitting false-
+  // positive response.N drifts for every such route.
+  if (input.code.responses.length === 0) return out;
+
   for (const specResp of input.spec.responses) {
```

**FP-guard fixture diff** (`tests/fixtures/sample-js-project-il/code/src/plugins/catalog/server/routes/items.ts` — new):
```typescript
// FP-GUARD: operation/response-200 — must NOT drift
// Paraphrase of plugin-style route descriptors where each route references a
// named handler string rather than an inline function body.
// extractPluginStyleRoutesFromFile builds OperationContract with responses:[],
// so the comparator must treat empty code-side responses as "unverifiable",
// not "response 200 was never emitted".

export default [
  {
    method: 'GET',
    path: '/items',
    handler: 'items.findAll',
    config: { policies: ['auth::isAuthenticated'] },
  },
  {
    method: 'POST',
    path: '/items',
    handler: 'items.create',
    config: { policies: ['auth::isAuthenticated'] },
  },
];
```

**FP-guard contracts** (`fp-guards/operation-response-200-plugin-descriptor-{get,post}.tc` — new):
```
operation GET "/catalog/items" {
  origin "reference/specs/modules/catalog/items.md" "GET /catalog/items" 1..5
  response 200 on success {
  }
}
```
```
operation POST "/catalog/items" {
  origin "reference/specs/modules/catalog/items.md" "POST /catalog/items" 1..5
  response 200 on success {
  }
}
```

**Regression fixture diff** (`tests/fixtures/sample-js-project-il/code/src/handlers/items-handler.ts` — new):
```typescript
import express from 'express';

const router = express.Router();

// Regression: inline handler explicitly emits only 201; the contract declares
// response 200 on success. Comparator must still fire response.200 because the
// code-side responses list is non-empty (it has 201) — the "skip when empty"
// fix must not suppress drifts where response facts were actually extracted.
// IL-DRIFT: Operation:GET /catalog/items/broken / response.200
router.get('/catalog/items/broken', (req, res) => {
  res.status(201).json({ created: true });
});
```

**Regression contract** (`fp-guards/operation-response-200-regression.tc` — new):
```
operation GET "/catalog/items/broken" {
  origin "reference/specs/modules/catalog/items.md" "GET /catalog/items/broken" 1..5
  response 200 on success {
  }
}
```

**fix_summary:** Added an early return in `compareOperation` when `input.code.responses.length === 0`. Plugin-style route descriptors reference handlers by string name so `extractPluginStyleRoutesFromFile` produces empty responses arrays; the comparator was treating "no facts extracted" as "no responses emitted" and firing false-positive `response.N` drifts for all 15 plugin routes matched by the mount-prefix fix. The regression guard verifies that routes where response facts ARE extracted (explicit `res.status(201)`) still drift correctly when 200 is expected.

## Drift-count delta (vs b2ba15617de4c8ada9099789f7c774bb32328970 on strapi/strapi, pinned contracts)

| Drift-kind | Before | After | Delta |
|---|---:|---:|---:|
| operation/response-200 | 15 | 0 | -15 |
| **Total (these 1 kinds)** | 15 | 0 | **-15** |
| **All-kinds total on target** | 24 | 9 | **-15** |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dw1u3UJz6XGYJJgmNFBJDd)_