### PR TITLE
drift-fp(strapi): widen code_dir to repo root (unblocks the stuck campaign, #491)

### DIFF
--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -43,7 +43,7 @@ campaigns:
   # ---- JS/TS — strongest validated drift fit (fit 88, strong) ----
   - target_repo: strapi/strapi
     tech_stack: [typescript, monorepo, knex]
-    code_dir: packages/core
+    code_dir: "."
     doc_scope:
       - docs/docs/docs/01-core/authentication
       - docs/docs/docs/01-core/content-manager


### PR DESCRIPTION
## Why

The strapi drift campaign stalled at `fp=5` ([#491](https://github.com/truecourse-ai/truecourse/issues/491)). All 5 remaining "FPs" are **not engine bugs** — they're a scope mismatch:

- The contracts were generated from strapi's **full-API docs** (`doc_scope` covers authentication, content-manager, content-releases, permissions).
- But `code_dir` was `packages/core`, so the verifier only looked there.
- 4 of the 5 routes are implemented **outside** `packages/core`:

  | Route | Lives in |
  |---|---|
  | `POST /api/auth/logout` | `packages/plugins/users-permissions/server/routes/content-api/auth.js` |
  | `POST /api/auth/refresh` | same |
  | `POST /api/auth/reset-password` | same |
  | `POST /api/auth/change-password` | same |

  I confirmed these are real declarations at the pinned ref `b2ba156` (paths `/auth/reset-password`, `/auth/change-password`, `/auth/refresh`, `/auth/logout`, mounted under `/api` at plugin registration).

The verifier was **correct** — it can't find code it was never pointed at. The doc scope already spans the full API, so the code scope should match.

## Fix

Widen `code_dir` from `packages/core` → `.` (repo root) — the same setting the feast and directus campaigns already use. This lets `verify` extract the `users-permissions` auth routes and resolve 4 of the 5.

**This does NOT regenerate contracts.** `code_dir` is a verify-time parameter only; the frozen contracts on the storage branch are untouched. The fast, reversible kind of fix.

## Two-part change

1. **`docs/drift-fp-automation/contracts/strapi-strapi/meta.yaml`** on the storage branch `claude/drift-fp-store/strapi-strapi` — **already committed + pushed** (commit `351e054`). This is the **authoritative** `code_dir` that `verify` reads (per `drift-fp-next-fix.md`: "trust meta.yaml").
2. **`docs/drift-fp-automation/campaigns.yaml`** (this PR) — bookkeeping copy, kept consistent.

## The 5th route

`GET /api/:collection` is generated at runtime from content-types — no static declaration exists, so no `code_dir` value can make static analysis see it. After this widening, if it's the only drift left, it's a documented static-analysis limitation to accept (not a suppressed bug). Deferred — we'll look at what's actually left after re-measuring.

## To re-measure after merge

Click **Run now on `drift-fp-next-fix`**. It re-runs the queue-empty path: fetches the updated `meta.yaml`, re-verifies strapi with `code_dir: .`, and reports the new `fp`. Expected: 4 auth FPs resolve, leaving at most the 1 dynamic-route drift to decide on.

Refs #491.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_