### PR TITLE
chore(drift-fp): close strapi/strapi campaign, bump to v0.6.2

### DIFF
--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -51,13 +51,14 @@ campaigns:
       - docs/docs/docs/01-core/permissions
       - docs/docs/rfcs
     priority: 1
-    status: discovering
+    status: done
     baseline: { verified_at: "2026-06-04", target_ref: "b2ba15617de4c8ada9099789f7c774bb32328970", total_drifts: 38, tp: 0, fp: 29, info: 9, fp_rate: 1.00 }
-    final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    final:    { verified_at: "2026-06-05", target_ref: "b2ba15617de4c8ada9099789f7c774bb32328970", total_drifts: 18, tp: 0, fp: 5, info: 13, fp_rate: 1.00 }
     notes:
       - "Validation run found 44 drift items, ~0 genuine: 20 Operation implementation.missing FPs (relative-path plugin routes mounted under a prefix; extractor doesn't reconstruct the mount), 13 NamedConstant ACTIONS value-mismatch FPs (bare-name collision, no module scoping), 11 no-code-counterpart info notes. PublicationFilter enum verified cleanly (true negative). Strong first FP corpus: operation mount-prefix + named-constant module-scoping."
       - "Default branch is develop, not main — pin target_ref off develop."
       - "Discovery run (2026-06-04): 38 drifts, 29 FP, 0 TP, 9 info. FP kinds: operation/implementation-missing (16 FPs — mount-prefix not reconstructed; 5 contract-quality for routes outside packages/core), operation/response-status (1 FP — route matched in test mock), auth-requirement/unprotected (2 FPs — same test-mock root cause), named-constant/no-code-counterpart (10 FPs — ACTIONS.* dotted-path object props + preview.STRAPI_* window globals). Info: enum/extra-value PublicationFilter (contract missed published-with-draft), enum/no-code-counterpart ReleaseStatus (case mismatch), maxPendingReleases (inline literal, not named constant)."
+      - "Closed manually at fp=5 (not the routine's fp==0 gate). Iterations through the fix loop drove total_drifts 38→18 and fp 29→5 via FP-GUARD coverage in the comparator + named-constant extractor; the remaining 5 are all operation/implementation-missing on plugin content-api routes that strapi mounts under `/api/` (4 auth routes: GET/POST /api/auth/* under packages/core/admin/server/src/routes/content-api/authentication.ts, plus 1 runtime-generated `/api/content-manager/:collection` route). The plugin-mount extractor only reconstructs `/<plugin>` prefixes from `<plugin>/server/routes/` paths; strapi's content-api convention (`/api/` prefix, `routes/content-api/*` subdirs) and runtime-built routes are not lifted. Fixing this generically (mount-tolerant matching: method + path suffix + signature fingerprint) is queued — revisit after feast/directus campaigns reveal what conventions are worth handling. These 5 are documented limitations, not engine regressions."
 
   # ---- Python — best validated Python drift fit (fit 78, strong) ----
   - target_repo: feast-dev/feast

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -63,7 +63,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.6.1")
+  .version("0.6.2")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## Manual campaign close — not the routine's `fp == 0` gate

Closing strapi/strapi at **fp = 5** with documented limitations rather than continuing to iterate. The remaining FPs are all the same shape: routes the plugin-mount extractor can't reconstruct. Fixing it generically is real comparator design work, queued for after the next two campaigns expose what conventions are worth handling.

## Numbers

| Stage      | total_drifts | tp | fp | info | fp_rate |
|------------|--------------|----|----|------|---------|
| baseline   | 38           | 0  | 29 | 9    | 1.00    |
| **final**  | **18**       | 0  | **5**  | 13   | 1.00    |

Iterations through `drift-fp-next-fix` drove `total_drifts` 38→18 and `fp` 29→5 via FP-GUARD coverage in the comparator + the named-constant extractor.

`target_ref`: `b2ba15617de4c8ada9099789f7c774bb32328970` (develop, not main)

## What's left, and why we're accepting it

All 5 remaining FPs are `operation/implementation-missing` on plugin content-api routes that strapi mounts under `/api/`:

- **4 auth routes** (`GET /api/auth/renew`, `POST /api/auth/login`, `POST /api/auth/registration`, `POST /api/auth/registration-info`) — defined in `packages/core/admin/server/src/routes/content-api/authentication.ts` with relative paths; strapi's runtime mounts the file under `/api/`.
- **1 runtime-generated route** — `/api/content-manager/:collection`, built from a router factory rather than declared statically.

The plugin-mount extractor (`packages/contract-verifier/src/extractor/operation.ts` → `inferPluginMountPrefix`) only reconstructs `/<plugin>` prefixes from `<plugin>/server/routes/` paths. Strapi's content-api convention (`/api/` prefix, `routes/content-api/*` subdirs) and runtime-built routes are outside that pattern. These are **documented coverage limitations of the lifter, not engine regressions** — the contracts are correct, the code exists, the comparator just can't bridge the path shapes.

## What's queued instead of a hardcode

A user-rejected option was to add a strapi-specific prefix rule to the extractor. The right fix is generic: **mount-tolerant matching** in the comparator — method + path suffix + signature fingerprint, so the comparator can pair a documented `/api/auth/login` operation with a code-side `POST /auth/login` handler regardless of how the runtime mounts it. That's design work, not a one-line patch, and the better time to do it is after running feast and directus — those will tell us which conventions (FastAPI APIRouter prefixes? Knex/Express subrouter mounts? runtime-built routers?) actually need handling, instead of guessing from strapi alone.

## Version bump

`0.6.1` → `0.6.2` in all four canonical locations:

- `tools/cli/package.json`
- `packages/core/package.json`
- `apps/dashboard/server/package.json`
- `tools/cli/src/index.ts` (the `.version("0.6.2")` argument)

## On merge

`drift-fp-campaign-close` fires, pushes `v0.6.2`, closes the storage PR for strapi/strapi, deletes `claude/drift-fp-store/strapi-strapi`. `drift-fp-generate` fires on the same merge and picks up `feast-dev/feast` (next `pending` campaign).

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_