### PR TITLE
drift-fp: switch close routine to notify human for tag push instead of pushing

### DIFF
--- a/docs/drift-fp-automation/prompts/drift-fp-campaign-close.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-campaign-close.md
@@ -2,12 +2,20 @@
 
 You are the **drift-fp-campaign-close** routine. You run inside an Anthropic-managed
 cloud session, autonomously, with no human in the loop. Your job is small and
-well-defined: when a `drift-fp-campaign-complete` PR merges to `main`, push a release tag.
+well-defined: when a `drift-fp-campaign-complete` PR merges to `main`, clean up the
+just-closed campaign's storage branch and ask the human to push the release tag.
 
 The **`fp == 0`** gate (no false-positive drifts remain) was already checked **pre-merge** by
 `drift-fp-next-fix` against the local dist build (deterministic `verify` on the pinned
 contracts) — the artifact publish.yml is about to ship. So merging the campaign-close PR is the
-campaign's "done" signal, and your only remaining job is tagging.
+campaign's "done" signal.
+
+The tag push itself is **manual**: the cloud session's git proxy denies pushes to tag refs
+(branches under `claude/*` work, tags don't — `git push origin v<version>` returns HTTP 403).
+Rather than fight the proxy on every close, the routine opens a `[drift-fp-campaign-close]
+tag v<version> ready to push` tracking issue that fires the Telegram `notify-campaign-alert`
+hook, and the human runs `git tag v<version> && git push origin v<version>` locally;
+publish.yml takes it from there.
 
 `drift-fp-generate` fires on the same merge event in parallel and starts the next pending
 campaign (generate → storage PR → discover → …) — you don't chain to it. The two run **race-free
@@ -27,18 +35,16 @@ different, still-`pending` campaign (its `done` status + your branch deletion ca
   - `packages/core/package.json`
   - `apps/dashboard/server/package.json`
   - `tools/cli/src/index.ts` — the `.version("X.Y.Z")` argument
-- If any of the four disagree: do **not** push. Open an issue titled `[drift-fp-campaign-close]
-  version mismatch after merge` with the four observed values + merge SHA, end the body with
-  `cc @mushgev`, end the session.
+- If any of the four disagree: do **not** open the tag-ready issue. Open an issue titled
+  `[drift-fp-campaign-close] version mismatch after merge` with the four observed values + merge
+  SHA, end the body with `cc @mushgev`, end the session. (Storage branch cleanup is still
+  fine to do — branch deletion doesn't depend on the version being right — but the tag
+  notification would be misleading, so hold it.)
+- Check the tag doesn't already exist on the remote:
+  `git ls-remote --tags origin "v<version>"` empty. If it already exists (e.g. a prior re-fire
+  already triggered the human push), skip step 3 — still do step 2.
 
-### 2. Push the tag
-
-- Verify `v<version>` doesn't already exist: `git tag -l "v<version>"` is empty (if it exists,
-  end without pushing).
-- `git tag v<version> && git push origin v<version>`. The existing
-  `.github/workflows/publish.yml` triggers, ships `dist/` to npm, creates the GitHub Release.
-
-### 3. Clean up the campaign's storage branch
+### 2. Clean up the campaign's storage branch
 
 - Find the `<owner>/<repo>` for the campaign that just closed: read the merged campaign-close PR's
   head branch (`claude/drift-fp-campaign-close/<owner>-<repo>`) or `campaigns.yaml` (the entry just
@@ -49,24 +55,43 @@ different, still-`pending` campaign (its `done` status + your branch deletion ca
   campaign-scaffolding — they never belong on `main` and are done now.
 - If the storage branch/PR is already gone, that's fine — continue.
 
+### 3. Open the tag-ready notification
+
+- Open an issue on `truecourse-ai/truecourse`:
+  - **Title**: `[drift-fp-campaign-close] tag v<version> ready to push`
+    (the `[drift-fp-campaign-close]` prefix is what `notify-campaign-alert` matches to fire
+    Telegram — don't change it).
+  - **Body**: short and copy-pasteable — what the human runs and what fires next. Include:
+    - The version + the merge SHA of the campaign-close PR.
+    - The exact command: `git tag v<version> && git push origin v<version>`.
+    - That `publish.yml` fires on the tag push and ships dist/ to npm + creates the GitHub
+      Release, so no further action is needed after the push.
+    - Confirmation that the storage branch + PR were cleaned up in step 2.
+    - End with `cc @mushgev`.
+- Do **not** label the issue. (No routine consumes this — it's a human notification only.)
+
 ### 4. End
 
-- Post: `Released v<version>; cleaned up storage branch. publish.yml is handling npm + GitHub Release.` End.
+- Post: `Storage branch cleaned up. Filed [drift-fp-campaign-close] tag v<version> ready to push (#<issue>) — Telegram alert fires; push the tag locally to release.` End.
 
 ## Failure modes
 
-- **Tag push fails**: do not retry. Open an issue `[drift-fp-campaign-close] tag push failed for
-  v<version>` with the error, end the body `cc @mushgev`, end.
-- **Version mismatch**: see step 1. Open the mismatch issue, end.
+- **Version mismatch**: see step 1. Open the mismatch issue, end. Storage cleanup may have run.
+- **Storage branch cleanup fails**: don't retry. Open an issue
+  `[drift-fp-campaign-close] storage cleanup failed for <owner>/<repo>` with the error tail,
+  end the body `cc @mushgev`, end. Still proceed to step 3 if the version check passed — the
+  tag-ready notification and the storage cleanup are independent.
 
 ## Hard constraints
 
-- Never modify repo files in this session. Your only writes are: push the **tag**, close the
-  **storage PR**, and delete the **storage branch**. Never push to any branch.
+- Never modify repo files in this session. Your only writes are: close the **storage PR**,
+  delete the **storage branch**, and open the **tag-ready notification issue**. Never push
+  to any branch. **Never push tags** — the proxy denies it, and the human pushes the tag
+  manually after the Telegram alert.
 - Never run `truecourse verify`, `spec scan`, `contracts generate`, tests, or builds. The
   pre-merge `drift-fp-next-fix` queue-empty path already verified `fp == 0` against the exact
   dist artifact publish.yml will ship.
 - **Never use `npx truecourse` or `npm install truecourse`.** This routine doesn't run
   truecourse at all.
-- One tag push per session; delete only the storage branch for the campaign that just closed. If
-  anything is unexpected, open an issue and end. Do not invent state.
+- One tag-ready issue per session; delete only the storage branch for the campaign that just
+  closed. If anything is unexpected, open an issue and end. Do not invent state.


### PR DESCRIPTION
## Why

The cloud session's git proxy denies any push to tag refs (HTTP 403). Probed directly: pushes to branches under `claude/*` succeed, pushes to `refs/tags/*` fail unconditionally — even a throwaway `claude-tag-probe`. So the previous `drift-fp-campaign-close` routine step 2 (`git tag v<version> && git push origin v<version>`) was guaranteed to fail on every close, file a `[drift-fp-campaign-close] tag push failed` issue, and leave `publish.yml` unfired.

Issue #495 (filed on PR #494 merge) is the first concrete example of this. Without this change, every future close lands there.

## What

The routine no longer tries to push the tag. It still:

- Checks version consistency across the 4 canonical locations.
- Cleans up the storage PR + branch (proxy allows branch deletes).

…and now opens a `[drift-fp-campaign-close] tag v<version> ready to push` issue with the exact command to run. That title prefix is already matched by `notify-campaign-alert` in `notify-routine-activity.yml`, so Telegram fires automatically. The human runs `git tag v<version> && git push origin v<version>` from their own machine; `publish.yml` triggers on the tag push exactly as before — ships dist/ to npm + creates the GitHub Release.

## Notable details

- **Steps reordered**: cleanup happens before the notification, so the issue body can honestly confirm cleanup ran.
- **Failure modes trimmed**: "tag push fails" is gone (the routine no longer pushes). "Storage branch cleanup fails" added — and is independent of the tag notification (one can fail without blocking the other).
- **Hard constraints updated**: "Never push tags" is now explicit; the writes list (`storage PR close`, `branch delete`, `tag-ready issue`) replaces the old one with "push the tag".

## What about the analysis side?

The analysis-side `fp-campaign-close.md` has the same `git push origin v<version>` step (same prompt shape, same proxy). Checked the evidence: the most recent close was documenso (PR #338, merged 2026-06-02, bumping to `v0.5.13`) — but `v0.5.13` **does not exist on the remote** (tags go `v0.5.10`, `v0.5.11`, `v0.5.12`, then jump to `v0.6.0`), and no `[fp-campaign-close] tag push failed` issue was ever filed. So `fp-campaign-close` either never fired for that merge or bombed out before reaching either the tag push or its own failure-mode issue.

Either way it's the same proxy and the same code path — almost certainly the same outcome, just less visible because it never reached the failure-mode branch. **Mirroring this change to `fp-campaign-close.md` is queued as a follow-up** — keeping it out of this PR to keep the diff narrow, and so the analysis-side change can carry its own honest investigation rather than riding on this one's coattails.

cc @mushgev