### PR TITLE
chore(drift-fp): contracts store for feast-dev/feast @ 276b6df

### DIFF
--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/_shared/auth.kubernetes.rbac.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/_shared/auth.kubernetes.rbac.tc
@@ -1,0 +1,6 @@
+auth-requirement auth.kubernetes.rbac {
+  origin "docs/getting-started/components/authz_manager.md" "Kubernetes RBAC Authorization" 141..180
+  status shipped
+  scheme Bearer
+  selector path-glob "/**"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/_shared/auth.oidc.bearer.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/_shared/auth.oidc.bearer.tc
@@ -1,0 +1,6 @@
+auth-requirement auth.oidc.bearer {
+  origin "docs/getting-started/components/authz_manager.md" "OIDC Authorization" 39..117
+  status shipped
+  scheme Bearer
+  selector path-glob "/**"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/arch/arch.feature-store.components.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/arch/arch.feature-store.components.tc
@@ -1,0 +1,4 @@
+architecture-decision arch.feature-store.components {
+  origin "docs/getting-started/components/overview.md" "Components" 1..30
+  decision "Feast consists of Registry, Offline Store, Online Store, Feature Server, and Compute Engine components"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/arch/arch.permissions.enforcement-boundary.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/arch/arch.permissions.enforcement-boundary.tc
@@ -1,0 +1,4 @@
+architecture-decision arch.permissions.enforcement-boundary {
+  origin "docs/getting-started/concepts/permission.md" "Permission" 1..30
+  decision "Permission authorization enforcement is performed only when requests are executed through Feast Python servers (online feature server REST, offline feature server Arrow Flight, registry server gRPC); no enforcement for local provider"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/auth/auth.type.kubernetes.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/auth/auth.type.kubernetes.tc
@@ -1,0 +1,5 @@
+constant auth.type.kubernetes {
+  origin "docs/getting-started/components/authz_manager.md" "Kubernetes RBAC Authorization" 141..160
+  type string
+  expected-value "kubernetes"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/auth/auth.type.noauth.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/auth/auth.type.noauth.tc
@@ -1,0 +1,5 @@
+constant auth.type.no_auth {
+  origin "docs/getting-started/components/authz_manager.md" "No Authorization" 30..38
+  type string
+  expected-value "no_auth"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/auth/auth.type.oidc.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/auth/auth.type.oidc.tc
@@ -1,0 +1,5 @@
+constant auth.type.oidc {
+  origin "docs/getting-started/components/authz_manager.md" "OIDC Authorization" 39..60
+  type string
+  expected-value "oidc"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/cli/cli.command.serveregistry.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/cli/cli.command.serveregistry.tc
@@ -1,0 +1,5 @@
+constant cli.command.serve_registry {
+  origin "docs/reference/feature-servers/registry-server.md" "CLI" 981..1011
+  type string
+  expected-value "feast serve_registry"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/cli/cli.flag.skip-feature-view-validation.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/cli/cli.flag.skip-feature-view-validation.tc
@@ -1,0 +1,5 @@
+constant cli.flag.skip-feature-view-validation {
+  origin "docs/reference/feast-cli-commands.md" "Apply" 48..80
+  type string
+  expected-value "--skip-feature-view-validation"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/cli/cli.flag.skip-source-validation.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/cli/cli.flag.skip-source-validation.tc
@@ -1,0 +1,5 @@
+constant cli.flag.skip-source-validation {
+  origin "docs/reference/feast-cli-commands.md" "Apply" 48..80
+  type string
+  expected-value "--skip-source-validation"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.auth.envvar.localk8stoken.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.auth.envvar.localk8stoken.tc
@@ -1,0 +1,5 @@
+constant config.auth.env_var.local_k8s_token {
+  origin "docs/getting-started/components/authz_manager.md" "Kubernetes RBAC Authorization" 141..180
+  type string
+  expected-value "LOCAL_K8S_TOKEN"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.auth.envvar.oidctoken.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.auth.envvar.oidctoken.tc
@@ -1,0 +1,5 @@
+constant config.auth.env_var.oidc_token {
+  origin "docs/getting-started/components/authz_manager.md" "Client-Side Configuration" 88..140
+  type string
+  expected-value "FEAST_OIDC_TOKEN"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.batchengine.type.spark.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.batchengine.type.spark.tc
@@ -1,0 +1,5 @@
+constant config.batch_engine.type.spark {
+  origin "docs/getting-started/components/compute-engine.md" "Batch Engine" 31..58
+  type string
+  expected-value "spark.engine"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.materialization.onlinewritebatchsize.default.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.materialization.onlinewritebatchsize.default.tc
@@ -1,0 +1,5 @@
+constant config.materialization.online_write_batch_size.default {
+  origin "docs/reference/feature-repository/feature-store-yaml.md" "materialization configuration / online_write_batch_size" 52..90
+  type integer
+  expected-value null
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.materialization.pulllatestfeatures.default.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.materialization.pulllatestfeatures.default.tc
@@ -1,0 +1,5 @@
+constant config.materialization.pull_latest_features.default {
+  origin "docs/reference/feature-repository/feature-store-yaml.md" "materialization configuration / pull_latest_features" 91..130
+  type boolean
+  expected-value false
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.remoteofflinestore.port.default.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.remoteofflinestore.port.default.tc
@@ -1,0 +1,5 @@
+constant config.remote_offline_store.port.default {
+  origin "docs/reference/offline-stores/remote-offline-store.md" "How to configure the client" 1..50
+  type integer
+  expected-value 8815
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.remoteregistry.port.default.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/config/config.remoteregistry.port.default.tc
@@ -1,0 +1,5 @@
+constant config.remote_registry.port.default {
+  origin "docs/reference/registries/remote.md" "How to configure the client" 1..50
+  type integer
+  expected-value 6570
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/apply.behavior.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/apply.behavior.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation apply.behavior {
+  origin "docs/reference/feast-cli-commands.md" "Apply" 48..80
+  reason "feast apply scans Python files for Feast objects, validates them, syncs metadata to registry, and creates feature store infrastructure — behavior depends on provider configuration"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/architecture.architecture.overview.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/architecture.architecture.overview.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation architecture.overview.0 {
+  origin "docs/reference/offline-stores/ray.md" "Architecture" 70..100
+  reason "Overview narrative — Architecture"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/components.components.overview.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/components.components.overview.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation components.overview.0 {
+  origin "docs/getting-started/components/compute-engine.md" "Components" 97..127
+  reason "Overview narrative — Components"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/configuration.configuration.overview.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/configuration.configuration.overview.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation configuration.overview.0 {
+  origin "docs/reference/alpha-feature-view-versioning.md" "Configuration" 40..70
+  reason "Overview narrative — Configuration"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/contributing.contributing.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/contributing.contributing.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation contributing.contributing {
+  origin "docs/reference/alpha-static-artifacts.md" "Contributing" 305..325
+  reason "Narrative overview — Contributing"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/delete.delete.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/delete.delete.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation delete.delete {
+  origin "docs/reference/feast-cli-commands.md" "Delete" 112..132
+  reason "Narrative overview — Delete"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/demo.demo.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/demo.demo.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation demo.demo {
+  origin "docs/reference/feature-servers/go-feature-server.md" "Demo" 49..69
+  reason "Narrative overview — Demo"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/description.description.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/description.description.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation description.description {
+  origin "docs/reference/data-sources/mongodb.md" "Description" 3..23
+  reason "Narrative overview — Description"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/disclaimer.disclaimer.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/disclaimer.disclaimer.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation disclaimer.disclaimer {
+  origin "docs/reference/offline-stores/athena.md" "Disclaimer" 8..28
+  reason "Narrative overview — Disclaimer"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/documentation.documentation.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/documentation.documentation.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation documentation.documentation {
+  origin "docs/reference/feature-servers/python-feature-server.md" "Documentation" 588..608
+  reason "Narrative overview — Documentation"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/entities.entities.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/entities.entities.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation entities.entities {
+  origin "docs/reference/feast-cli-commands.md" "Entities" 187..207
+  reason "Narrative overview — Entities"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/example.example.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/example.example.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation example.example {
+  origin "docs/reference/beta-on-demand-feature-view.md" "Example" 108..128
+  reason "Narrative overview — Example"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/examples.examples.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/examples.examples.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation examples.examples {
+  origin "docs/reference/data-sources/mongodb.md" "Examples" 7..27
+  reason "Narrative overview — Examples"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/features.features.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/features.features.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation features.features {
+  origin "docs/reference/online-stores/mongodb.md" "Features" 7..27
+  reason "Narrative overview — Features"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/field.field.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/field.field.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation field.field {
+  origin "docs/getting-started/concepts/feature-view.md" "Field" 143..163
+  reason "Narrative overview — Field"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/functionality.functionality.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/functionality.functionality.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation functionality.functionality {
+  origin "docs/reference/data-sources/overview.md" "Functionality" 3..23
+  reason "Narrative overview — Functionality"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/indexing.indexing.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/indexing.indexing.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation indexing.indexing {
+  origin "docs/reference/online-stores/elasticsearch.md" "Indexing" 77..97
+  reason "Narrative overview — Indexing"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/init.init.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/init.init.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation init.init {
+  origin "docs/reference/feast-cli-commands.md" "Init" 233..253
+  reason "Narrative overview — Init"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/installation.installation.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/installation.installation.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation installation.installation {
+  origin "docs/reference/openlineage.md" "Installation" 14..34
+  reason "Narrative overview — Installation"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/integration.integration.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/integration.integration.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation integration.integration {
+  origin "docs/reference/alpha-vector-database.md" "Integration" 7..27
+  reason "Narrative overview — Integration"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/limitation.limitation.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/limitation.limitation.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation limitation.limitation {
+  origin "docs/reference/offline-stores/snowflake.md" "Limitation" 38..58
+  reason "Narrative overview — Limitation"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/limitations.limitations.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/limitations.limitations.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation limitations.limitations {
+  origin "docs/reference/offline-stores/ray.md" "Limitations" 599..619
+  reason "Narrative overview — Limitations"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/materialize.materialize.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/materialize.materialize.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation materialize.materialize {
+  origin "docs/reference/feast-cli-commands.md" "Materialize" 265..285
+  reason "Narrative overview — Materialize"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/motivation.motivation.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/motivation.motivation.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation motivation.motivation {
+  origin "docs/reference/type-system.md" "Motivation" 3..23
+  reason "Narrative overview — Motivation"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/options.options.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/options.options.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation options.options {
+  origin "docs/reference/feature-repository/feature-store-yaml.md" "Options" 18..38
+  reason "Narrative overview — Options"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/overview.feast.purpose.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/overview.feast.purpose.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation overview.feast.purpose {
+  origin "docs/getting-started/concepts/overview.md" "Overview" 1..30
+  reason "Feast is a feature store for managing and serving ML features — overall system purpose, not structurally verifiable"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/overview.overview.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/overview.overview.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation overview.overview {
+  origin "docs/reference/feature-servers/python-feature-server.md" "Overview" 3..23
+  reason "Narrative overview — Overview"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/permissions.permissions.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/permissions.permissions.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation permissions.permissions {
+  origin "docs/reference/online-stores/dynamodb.md" "Permissions" 66..86
+  reason "Narrative overview — Permissions"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/pgvector.pgvector.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/pgvector.pgvector.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation pgvector.pgvector {
+  origin "docs/reference/online-stores/postgres.md" "PGVector" 65..85
+  reason "Narrative overview — PGVector"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/preparations.preparations.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/preparations.preparations.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation preparations.preparations {
+  origin "docs/reference/dqm.md" "Preparations" 24..44
+  reason "Narrative overview — Preparations"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/prerequisites.prerequisites.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/prerequisites.prerequisites.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation prerequisites.prerequisites {
+  origin "docs/reference/denormalized.md" "Prerequisites" 7..27
+  reason "Narrative overview — Prerequisites"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/project.project.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/project.project.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation project.project {
+  origin "docs/getting-started/concepts/project.md" "Project" 1..21
+  reason "Narrative overview — Project"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/protobufs.protobufs.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/protobufs.protobufs.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation protobufs.protobufs {
+  origin "docs/reference/codebase-structure.md" "Protobufs" 123..143
+  reason "Narrative overview — Protobufs"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/provider.provider.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/provider.provider.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation provider.provider {
+  origin "docs/getting-started/components/provider.md" "Provider" 1..21
+  reason "Narrative overview — Provider"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/reference.reference.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/reference.reference.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation reference.reference {
+  origin "docs/reference/feature-servers/go-feature-server.md" "Reference" 52..72
+  reason "Narrative overview — Reference"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/resources.resources.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/resources.resources.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation resources.resources {
+  origin "docs/reference/online-stores/scylladb.md" "Resources" 90..110
+  reason "Narrative overview — Resources"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/summary.summary.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/summary.summary.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation summary.summary {
+  origin "docs/getting-started/concepts/tiling.md" "Summary" 288..308
+  reason "Narrative overview — Summary"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/teardown.teardown.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/teardown.teardown.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation teardown.teardown {
+  origin "docs/reference/feast-cli-commands.md" "Teardown" 486..506
+  reason "Narrative overview — Teardown"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/terminology.terminology.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/terminology.terminology.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation terminology.terminology {
+  origin "docs/specs/offline_store_format.md" "Terminology" 15..35
+  reason "Narrative overview — Terminology"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/troubleshooting.troubleshooting.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/troubleshooting.troubleshooting.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation troubleshooting.troubleshooting {
+  origin "docs/reference/beta-on-demand-feature-view.md" "Troubleshooting" 348..368
+  reason "Narrative overview — Troubleshooting"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/usage.usage.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/usage.usage.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation usage.usage {
+  origin "docs/reference/openlineage.md" "Usage" 64..84
+  reason "Narrative overview — Usage"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/version.version.tc
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/contracts/unenforceable/version.version.tc
@@ -1,0 +1,4 @@
+unenforceable-obligation version.version {
+  origin "docs/reference/feast-cli-commands.md" "Version" 494..514
+  reason "Narrative overview — Version"
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/meta.yaml
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/meta.yaml
@@ -1,0 +1,11 @@
+target_repo: feast-dev/feast
+target_ref: 276b6df562e16fefba7efb493736ff32046d4a76
+code_dir: "."
+generated_at: "2026-06-05"
+tool_version: "0.6.2"
+llm: agent
+doc_scope:
+  - docs/getting-started/concepts
+  - docs/getting-started/components
+  - docs/reference
+  - docs/specs

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/specs/claims.json
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/specs/claims.json
@@ -1,0 +1,10255 @@
+{
+  "version": 1,
+  "generatedAt": "2026-06-05T02:49:48.139Z",
+  "modules": [
+    {
+      "name": "_shared",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/getting-started/components/authz_manager.md",
+        "docs/getting-started/components/compute-engine.md",
+        "docs/getting-started/components/feature-server.md",
+        "docs/getting-started/components/offline-store.md",
+        "docs/getting-started/components/online-store.md",
+        "docs/getting-started/components/open-telemetry.md",
+        "docs/getting-started/components/registry.md",
+        "docs/getting-started/components/stream-processor.md",
+        "docs/getting-started/concepts/batch-feature-view.md",
+        "docs/getting-started/concepts/data-ingestion.md",
+        "docs/getting-started/concepts/dataset.md",
+        "docs/getting-started/concepts/entity.md",
+        "docs/getting-started/concepts/feast-types.md",
+        "docs/getting-started/concepts/feature-repo.md",
+        "docs/getting-started/concepts/feature-retrieval.md",
+        "docs/getting-started/concepts/feature-view.md",
+        "docs/getting-started/concepts/overview.md",
+        "docs/getting-started/concepts/permission.md",
+        "docs/getting-started/concepts/point-in-time-joins.md",
+        "docs/getting-started/concepts/stream-feature-view.md",
+        "docs/getting-started/concepts/tiling.md",
+        "docs/reference/alpha-feature-view-versioning.md",
+        "docs/reference/alpha-static-artifacts.md",
+        "docs/reference/alpha-vector-database.md",
+        "docs/reference/alpha-web-ui.md",
+        "docs/reference/auth/kubernetes_auth_setup.md",
+        "docs/reference/auth/user_token_provisioning.md",
+        "docs/reference/beta-on-demand-feature-view.md",
+        "docs/reference/codebase-structure.md",
+        "docs/reference/compute-engine/ray.md",
+        "docs/reference/compute-engine/spark.md",
+        "docs/reference/data-sources/kafka.md",
+        "docs/reference/data-sources/kinesis.md",
+        "docs/reference/data-sources/mongodb.md",
+        "docs/reference/data-sources/push.md",
+        "docs/reference/data-sources/ray.md",
+        "docs/reference/data-sources/spark.md",
+        "docs/reference/data-sources/table-formats.md",
+        "docs/reference/denormalized.md",
+        "docs/reference/dqm.md",
+        "docs/reference/feast-cli-commands.md",
+        "docs/reference/feature-repository.md",
+        "docs/reference/feature-repository/feast-ignore.md",
+        "docs/reference/feature-repository/feature-store-yaml.md",
+        "docs/reference/feature-servers/go-feature-server.md",
+        "docs/reference/feature-servers/mcp-feature-server.md",
+        "docs/reference/feature-servers/offline-feature-server.md",
+        "docs/reference/feature-servers/python-feature-server.md",
+        "docs/reference/feature-servers/registry-server.md",
+        "docs/reference/feature-store-yaml.md",
+        "docs/reference/mlflow.md",
+        "docs/reference/offline-stores/mongodb.md",
+        "docs/reference/offline-stores/mssql.md",
+        "docs/reference/offline-stores/ray.md",
+        "docs/reference/offline-stores/redshift.md",
+        "docs/reference/offline-stores/remote-offline-store.md",
+        "docs/reference/online-stores/cassandra.md",
+        "docs/reference/online-stores/couchbase.md",
+        "docs/reference/online-stores/dragonfly.md",
+        "docs/reference/online-stores/dynamodb.md",
+        "docs/reference/online-stores/elasticsearch.md",
+        "docs/reference/online-stores/hybrid.md",
+        "docs/reference/online-stores/mongodb.md",
+        "docs/reference/online-stores/mysql.md",
+        "docs/reference/online-stores/overview.md",
+        "docs/reference/online-stores/redis.md",
+        "docs/reference/online-stores/remote.md",
+        "docs/reference/online-stores/scylladb.md",
+        "docs/reference/online-stores/snowflake.md",
+        "docs/reference/openlineage.md",
+        "docs/reference/providers/google-cloud-platform.md",
+        "docs/reference/registries/hdfs.md",
+        "docs/reference/registries/remote.md",
+        "docs/reference/registries/sql.md",
+        "docs/reference/registry/registry-permissions.md",
+        "docs/reference/type-system.md",
+        "docs/specs/offline_store_format.md",
+        "docs/specs/online_store_format.md"
+      ],
+      "scope": {
+        "tags": [
+          "shared"
+        ]
+      }
+    },
+    {
+      "name": "apply",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feast-cli-commands.md"
+      ],
+      "scope": {
+        "tags": [
+          "apply"
+        ]
+      }
+    },
+    {
+      "name": "architecture",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/offline-stores/ray.md"
+      ],
+      "scope": {
+        "tags": [
+          "architecture"
+        ]
+      }
+    },
+    {
+      "name": "cli",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feature-servers/registry-server.md"
+      ],
+      "scope": {
+        "tags": [
+          "cli"
+        ]
+      }
+    },
+    {
+      "name": "components",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/getting-started/components/compute-engine.md"
+      ],
+      "scope": {
+        "tags": [
+          "components"
+        ]
+      }
+    },
+    {
+      "name": "configuration",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/alpha-feature-view-versioning.md"
+      ],
+      "scope": {
+        "tags": [
+          "configuration"
+        ]
+      }
+    },
+    {
+      "name": "contributing",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/alpha-static-artifacts.md"
+      ],
+      "scope": {
+        "tags": [
+          "contributing"
+        ]
+      }
+    },
+    {
+      "name": "delete",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feast-cli-commands.md"
+      ],
+      "scope": {
+        "tags": [
+          "delete"
+        ]
+      }
+    },
+    {
+      "name": "demo",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feature-servers/go-feature-server.md"
+      ],
+      "scope": {
+        "tags": [
+          "demo"
+        ]
+      }
+    },
+    {
+      "name": "description",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/data-sources/mongodb.md"
+      ],
+      "scope": {
+        "tags": [
+          "description"
+        ]
+      }
+    },
+    {
+      "name": "disclaimer",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/offline-stores/athena.md"
+      ],
+      "scope": {
+        "tags": [
+          "disclaimer"
+        ]
+      }
+    },
+    {
+      "name": "documentation",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feature-servers/python-feature-server.md"
+      ],
+      "scope": {
+        "tags": [
+          "documentation"
+        ]
+      }
+    },
+    {
+      "name": "entities",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feast-cli-commands.md"
+      ],
+      "scope": {
+        "tags": [
+          "entities"
+        ]
+      }
+    },
+    {
+      "name": "example",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/beta-on-demand-feature-view.md"
+      ],
+      "scope": {
+        "tags": [
+          "example"
+        ]
+      }
+    },
+    {
+      "name": "examples",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/data-sources/mongodb.md"
+      ],
+      "scope": {
+        "tags": [
+          "examples"
+        ]
+      }
+    },
+    {
+      "name": "features",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/online-stores/mongodb.md"
+      ],
+      "scope": {
+        "tags": [
+          "features"
+        ]
+      }
+    },
+    {
+      "name": "field",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/getting-started/concepts/feature-view.md"
+      ],
+      "scope": {
+        "tags": [
+          "field"
+        ]
+      }
+    },
+    {
+      "name": "functionality",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/data-sources/overview.md"
+      ],
+      "scope": {
+        "tags": [
+          "functionality"
+        ]
+      }
+    },
+    {
+      "name": "indexing",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/online-stores/elasticsearch.md"
+      ],
+      "scope": {
+        "tags": [
+          "indexing"
+        ]
+      }
+    },
+    {
+      "name": "init",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feast-cli-commands.md"
+      ],
+      "scope": {
+        "tags": [
+          "init"
+        ]
+      }
+    },
+    {
+      "name": "installation",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/openlineage.md"
+      ],
+      "scope": {
+        "tags": [
+          "installation"
+        ]
+      }
+    },
+    {
+      "name": "integration",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/alpha-vector-database.md"
+      ],
+      "scope": {
+        "tags": [
+          "integration"
+        ]
+      }
+    },
+    {
+      "name": "limitation",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/offline-stores/snowflake.md"
+      ],
+      "scope": {
+        "tags": [
+          "limitation"
+        ]
+      }
+    },
+    {
+      "name": "limitations",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/offline-stores/ray.md"
+      ],
+      "scope": {
+        "tags": [
+          "limitations"
+        ]
+      }
+    },
+    {
+      "name": "materialize",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feast-cli-commands.md"
+      ],
+      "scope": {
+        "tags": [
+          "materialize"
+        ]
+      }
+    },
+    {
+      "name": "motivation",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/type-system.md"
+      ],
+      "scope": {
+        "tags": [
+          "motivation"
+        ]
+      }
+    },
+    {
+      "name": "options",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feature-repository/feature-store-yaml.md"
+      ],
+      "scope": {
+        "tags": [
+          "options"
+        ]
+      }
+    },
+    {
+      "name": "overview",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feature-servers/python-feature-server.md"
+      ],
+      "scope": {
+        "tags": [
+          "overview"
+        ]
+      }
+    },
+    {
+      "name": "permissions",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/online-stores/dynamodb.md"
+      ],
+      "scope": {
+        "tags": [
+          "permissions"
+        ]
+      }
+    },
+    {
+      "name": "pgvector",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/online-stores/postgres.md"
+      ],
+      "scope": {
+        "tags": [
+          "pgvector"
+        ]
+      }
+    },
+    {
+      "name": "preparations",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/dqm.md"
+      ],
+      "scope": {
+        "tags": [
+          "preparations"
+        ]
+      }
+    },
+    {
+      "name": "prerequisites",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/denormalized.md"
+      ],
+      "scope": {
+        "tags": [
+          "prerequisites"
+        ]
+      }
+    },
+    {
+      "name": "project",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/getting-started/concepts/project.md"
+      ],
+      "scope": {
+        "tags": [
+          "project"
+        ]
+      }
+    },
+    {
+      "name": "protobufs",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/codebase-structure.md"
+      ],
+      "scope": {
+        "tags": [
+          "protobufs"
+        ]
+      }
+    },
+    {
+      "name": "provider",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/getting-started/components/provider.md"
+      ],
+      "scope": {
+        "tags": [
+          "provider"
+        ]
+      }
+    },
+    {
+      "name": "reference",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feature-servers/go-feature-server.md"
+      ],
+      "scope": {
+        "tags": [
+          "reference"
+        ]
+      }
+    },
+    {
+      "name": "resources",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/online-stores/scylladb.md"
+      ],
+      "scope": {
+        "tags": [
+          "resources"
+        ]
+      }
+    },
+    {
+      "name": "summary",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/getting-started/concepts/tiling.md"
+      ],
+      "scope": {
+        "tags": [
+          "summary"
+        ]
+      }
+    },
+    {
+      "name": "teardown",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feast-cli-commands.md"
+      ],
+      "scope": {
+        "tags": [
+          "teardown"
+        ]
+      }
+    },
+    {
+      "name": "terminology",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/specs/offline_store_format.md"
+      ],
+      "scope": {
+        "tags": [
+          "terminology"
+        ]
+      }
+    },
+    {
+      "name": "troubleshooting",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/beta-on-demand-feature-view.md"
+      ],
+      "scope": {
+        "tags": [
+          "troubleshooting"
+        ]
+      }
+    },
+    {
+      "name": "usage",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/openlineage.md"
+      ],
+      "scope": {
+        "tags": [
+          "usage"
+        ]
+      }
+    },
+    {
+      "name": "version",
+      "status": "shipped",
+      "sourceDocs": [
+        "docs/reference/feast-cli-commands.md"
+      ],
+      "scope": {
+        "tags": [
+          "version"
+        ]
+      }
+    }
+  ],
+  "claims": [
+    {
+      "id": "4313f1c34bb629d64261e7432b54d55173f6efe2fc71f1ec1f6b09c53ca7ac36",
+      "topic": "auth",
+      "subject": "Kubernetes RBAC auth scheme",
+      "content": {
+        "scheme": "Bearer (Kubernetes service account token)",
+        "scope": "global"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/authz_manager.md",
+        "line": 141,
+        "quote": "### Kubernetes RBAC Authorization\nWith Kubernetes RBAC Authorization, the client uses the service account token as the authorizarion bearer token, and the\nserver fetches the associated roles from the Kubernetes RBAC resources. Feast supports advanced authorization by extracting user groups and namespaces from Kubernetes tokens, enabling fine-grained access control beyond simple role matching. This is achieved by leveraging Kubernetes Token Access Review, which allows Feast to determine the groups and namespaces associated with a user or service account.\n\nAn example of Kubernetes RBAC authorization configuration is the following: \n{% hint style=\"info\" %}\n**NOTE**: This configuration will only work if you deploy feast on Openshift or a Kubernetes platform.\n{% endhint %}\n```yaml\nproject: my-project\nauth:\n  type: kubernetes\n  user_token: <user_token> #Optional, else service account token Or env var is used for getting the token\n...\n```\n\nIn case the client cannot run on the same cluster as the servers, the client token can be injected using the `LOCAL_K8S_TOKEN` \nenvironment variable on the client side. The value must refer to the token of a service account created on the servers cluster\nand linked to the desired RBAC roles/groups/namespaces.\n\nMore details can be found in [Setting up kubernetes doc](../../reference/auth/kubernetes_auth_setup.md)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-07T22:55:26+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3ca7b4eacf0e2b454f09bd6acb64d421158ca5a71fc751d8e24715b76aa3c849",
+      "topic": "auth",
+      "subject": "OIDC auth scheme",
+      "content": {
+        "scheme": "Bearer JWT (OIDC)",
+        "scope": "global"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/authz_manager.md",
+        "line": 39,
+        "quote": "### OIDC Authorization\nWith OIDC authorization, the Feast client proxies retrieve the JWT token from an OIDC server (or [Identity Provider](https://openid.net/developers/how-connect-works/))\nand append it in every request to a Feast server, using an [Authorization Bearer Token](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#bearer).\n\nThe server, in turn, uses the same OIDC server to validate the token and extract user details — including username, roles, and groups — from the token itself.\n\nSome assumptions are made in the OIDC server configuration:\n* The OIDC token refers to a client with roles matching the RBAC roles of the configured `Permission`s (*)\n* The roles are exposed in the access token under `resource_access.<client_id>.roles`\n* The JWT token is expected to have a verified signature and not be expired. The Feast OIDC token parser logic validates for `verify_signature` and `verify_exp` so make sure that the given OIDC provider is configured to meet these requirements.\n* The `preferred_username` should be part of the JWT token claim.\n* For `GroupBasedPolicy` support, the `groups` claim should be present in the access token (requires a \"Group Membership\" protocol mapper in Keycloak).\n\n(*) Please note that **the role match is case-sensitive**, e.g. the name of the role in the OIDC server and in the `Permission` configuration\nmust be exactly the same.\n\nFor example, the access token for a client `app` of a user with `reader` role and membership in the `data-team` group should have the following claims:\n```json\n{\n  \"preferred_username\": \"alice\",\n  \"resource_access\": {\n    \"app\": {\n      \"roles\": [\n        \"reader\"\n      ]\n    }\n  },\n  \"groups\": [\n    \"data-team\"\n  ]\n}\n```\n\n#### Server-Side Configuration\n\nThe server requires `auth_discovery_url` and `client_id` to validate incoming JWT tokens via JWKS:\n```yaml\nproject: my-project\nauth:\n  type: oidc\n… (+62 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-07T22:55:26+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0ece62cbe1d725317473e9e14293160e261e92e0497c0faf236befa8fa776115",
+      "topic": "auth",
+      "subject": "no_auth scheme",
+      "content": {
+        "scheme": "none",
+        "scope": "global"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/authz_manager.md",
+        "line": 30,
+        "quote": "### No Authorization\nThis configuration applies the default `no_auth` authorization:\n```yaml\nproject: my-project\nauth:\n  type: no_auth\n...\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-07T22:55:26+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "fdaa0b3909ef58a9b644d515e8e3ed26571625f425bdb3716f5773196ededabe",
+      "topic": "data",
+      "subject": "Accessing the registry from clients / Option 2: specifying the registry in the project's `feature_store.yaml` file",
+      "content": {
+        "fields": {
+          "project": "feast_demo_aws",
+          "provider": "aws",
+          "registry": "s3://feast-test-s3-bucket/registry.pb",
+          "online_store": "null",
+          "type": "file"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/registry.md",
+        "line": 90,
+        "quote": "### Option 2: specifying the registry in the project's `feature_store.yaml` file\n\n```yaml\nproject: feast_demo_aws\nprovider: aws\nregistry: s3://feast-test-s3-bucket/registry.pb\nonline_store: null\noffline_store:\n  type: file\n```\n\nInstantiating a `FeatureStore` object can then point to this:\n\n```python\nstore = FeatureStore(repo_path=\".\")\n```\n\n{% hint style=\"info\" %}\nThe file-based feature registry is a [Protobuf representation](https://github.com/feast-dev/feast/blob/master/protos/feast/core/Registry.proto) of Feast metadata. This Protobuf file can be read programmatically from other programming languages, but no compatibility guarantees are made on the internal structure of the registry.\n{% endhint %}"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-14T10:41:09-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3bc2b679fd05f36a07036e8bcf8d89cbf272272160da6ba29d1a0c1774611145",
+      "topic": "data",
+      "subject": "Batch write mode",
+      "content": {
+        "fields": {
+          "project": "my_feature_repo",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "mysql",
+          "host": "DB_HOST",
+          "port": "DB_PORT",
+          "database": "DB_NAME",
+          "user": "DB_USERNAME",
+          "password": "DB_PASSWORD",
+          "batch_write": "true",
+          "batch_size": "100"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/mysql.md",
+        "line": 31,
+        "quote": "## Batch write mode\nBy default, the MySQL online store performs row-by-row insert and commit for each feature record. While this ensures per-record atomicity, it can lead to significant overhead on write operations — especially on distributed SQL databases (for example, TiDB, which is MySQL-compatible and uses a consensus protocol).\n\nTo improve writing performance, you can enable batch write mode by setting `batch_write` to `true` and `batch_size`, which executes multiple insert queries in batches and commits them together per batch instead of committing each record individually.\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n    type: mysql\n    host: DB_HOST\n    port: DB_PORT\n    database: DB_NAME\n    user: DB_USERNAME\n    password: DB_PASSWORD\n    batch_write: true\n    batch_size: 100\n```\n{% endcode %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-31T09:22:40+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ae7af431e58a0c9b180806280e7a3bbaedf15ff0122ac85c700f34b7857540b0",
+      "topic": "data",
+      "subject": "CLI Usage / Method 2: Configuration File",
+      "content": {
+        "fields": {
+          "project": "my-project",
+          "type": "kubernetes",
+          "user_token": "\"your-kubernetes-user-token-here\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/user_token_provisioning.md",
+        "line": 96,
+        "quote": "### Method 2: Configuration File\n\nCreate or update your `feature_store.yaml`:\n\n```yaml\nproject: my-project\nauth:\n  type: kubernetes\n  user_token: \"your-kubernetes-user-token-here\"\n```\n\nThen use CLI commands:\n\n```bash\nfeast apply\nfeast materialize\nfeast get-online-features \\\n  --features feature1,feature2 \\\n  --entity-rows '{\"entity_id\": \"123\"}'\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "75155ee3059191f2d2841ae72da1a37826ee008499c39493e8a210ba033871c5",
+      "topic": "data",
+      "subject": "Concepts",
+      "content": {
+        "fields": {
+          "create": "Create an instance",
+          "describe": "Access the instance state",
+          "update": "Update the instance state",
+          "delete": "Delete an instance",
+          "read": "Read both online and offline stores",
+          "read_online": "Read the online store",
+          "read_offline": "Read the offline store",
+          "write": "Write on any store",
+          "write_online": "Write to the online store",
+          "write_offline": "Write to the offline store",
+          "name": "The permission name",
+          "types": "The list of protected resource  types",
+          "name_patterns": "A list of regex patterns to match resource names",
+          "required_tags": "Dictionary of key-value pairs that must match the resource t",
+          "actions": "The actions authorized by this permission",
+          "policy": "The policy to be applied to validate a client request"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/permission.md",
+        "line": 16,
+        "quote": "## Concepts\n\nThe permission model is based on the following components:\n- A `resource` is a Feast object that we want to secure against unauthorized access.\n  - We assume that the resource has a `name` attribute and optional dictionary of associated key-value `tags`.\n- An `action` is a logical operation executed on the secured resource, like:\n  - `create`: Create an instance.\n  - `describe`: Access the instance state.\n  - `update`: Update the instance state.\n  - `delete`: Delete an instance.\n  - `read`:  Read both online and offline stores.\n  - `read_online`:  Read the online store.\n  - `read_offline`:  Read the offline store.\n  - `write`:  Write on any store.\n  - `write_online`:  Write to the online store.\n  - `write_offline`:  Write to the offline store.\n- A `policy` identifies the rule for enforcing authorization decisions on secured resources, based on the current user.\n  - A default implementation is provided for role-based policies, using the user roles to grant or deny access to the requested actions\n  on the secured resources.\n\nThe `Permission` class identifies a single permission configured on the feature store and is identified by these attributes:\n- `name`: The permission name.\n- `types`: The list of protected resource  types. Defaults to all managed types, e.g. the `ALL_RESOURCE_TYPES` alias. All sub-classes are included in the resource match.\n- `name_patterns`: A list of regex patterns to match resource names. If any regex matches, the `Permission` policy is applied. Defaults to `[]`, meaning no name filtering is applied.\n- `required_tags`: Dictionary of key-value pairs that must match the resource tags. Defaults to `None`, meaning that no tags filtering is applied.\n- `actions`: The actions authorized by this permission. Defaults to `ALL_VALUES`, an alias defined in the `action` module.\n- `policy`: The policy to be applied to validate a client request.\n\nTo simplify configuration, several constants are defined to streamline the permissions setup:\n- In module `feast.feast_object`:\n  - `ALL_RESOURCE_TYPES` is the list of all the `FeastObject` types.\n  - `ALL_FEATURE_VIEW_TYPES` is the list of all the feature view types, including those not inheriting from `FeatureView` type like \n  `OnDemandFeatureView`.\n- In module `feast.permissions.action`:\n  - `ALL_ACTIONS` is the list of all managed actions.\n  - `READ` includes all the read actions for online and offline store.\n  - `WRITE` includes all the write actions for online and offline store.\n  - `CRUD` includes all the state management actions to create, describe, update or delete a Feast resource.\n\nGiven the above definitions, the feature store can be configured with granular control over each resource, enabling partitioned access by \n… (+8 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8c5bf97d9a548fbd5625ce1b9268a427bbe8e2a75148ccb08ad276de58cc450f",
+      "topic": "data",
+      "subject": "Configuration / Execution Modes",
+      "content": {
+        "fields": {
+          "project": "my_project",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "ray",
+          "storage_path": "s3://my-bucket/feast-data",
+          "ray_address": "\"ray://my-cluster.example.com:10001\"",
+          "use_kuberay": "true",
+          "cluster_name": "\"feast-ray-cluster\"",
+          "namespace": "\"feast-system\"",
+          "auth_token": "\"${RAY_AUTH_TOKEN}\"",
+          "auth_server": "\"https://api.openshift.com:6443\"",
+          "skip_tls": "false",
+          "enable_ray_logging": "false"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 87,
+        "quote": "### Execution Modes\n\n#### Local Mode (Default)\n\nFor simple data I/O operations without distributed processing:\n\n```yaml\nproject: my_project\nregistry: data/registry.db\nprovider: local\noffline_store:\n    type: ray\n    storage_path: data/ray_storage        # Optional: Path for storing datasets\n```\n\n#### Remote Ray Cluster\n\nConnect to an existing Ray cluster:\n\n```yaml\noffline_store:\n    type: ray\n    storage_path: s3://my-bucket/feast-data\n    ray_address: \"ray://my-cluster.example.com:10001\"\n```\n\n#### KubeRay Cluster (Kubernetes)\n\nConnect to Ray clusters on Kubernetes using CodeFlare SDK:\n\n```yaml\noffline_store:\n    type: ray\n    storage_path: s3://my-bucket/feast-data\n    use_kuberay: true\n    kuberay_conf:\n        cluster_name: \"feast-ray-cluster\"\n        namespace: \"feast-system\"\n        auth_token: \"${RAY_AUTH_TOKEN}\"\n        auth_server: \"https://api.openshift.com:6443\"\n… (+13 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "546ef62d93dabe24d08b9fc4b6c2992a64ebcea9a8d76729b54ede66dad0b10e",
+      "topic": "data",
+      "subject": "Configuration / Key Parameters",
+      "content": {
+        "fields": {
+          "aggregations": "List of time-windowed aggregations to compute",
+          "column": "source column to aggregate",
+          "function": "aggregation function (`sum`, `avg`, `mean`, `min`, `max`, `c",
+          "time_window": "duration of the aggregation window",
+          "slide_interval": "hop/slide size (defaults to `time_window`)",
+          "timestamp_field": "Column name for timestamps (required when aggregations are s",
+          "enable_tiling": "Enable tiling optimization (default: `False`)",
+          "tiling_hop_size": "Time interval between tiles (default: 5 minutes)"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/tiling.md",
+        "line": 230,
+        "quote": "### Key Parameters\n\n- `aggregations`: List of time-windowed aggregations to compute. Each `Aggregation` accepts:\n  - `column`: source column to aggregate\n  - `function`: aggregation function (`sum`, `avg`, `mean`, `min`, `max`, `count`, `std`)\n  - `time_window`: duration of the aggregation window\n  - `slide_interval`: hop/slide size (defaults to `time_window`)\n  - `name` *(optional)*: output feature name. Defaults to `{function}_{column}` (e.g., `sum_amount`). Set this to use a custom name (e.g., `name=\"sum_amount_1h\"`).\n- `timestamp_field`: Column name for timestamps (required when aggregations are specified)\n- `enable_tiling`: Enable tiling optimization (default: `False`)\n  - Set to `True` for **streaming scenarios**\n- `tiling_hop_size`: Time interval between tiles (default: 5 minutes)\n  - Smaller = more granular tiles, potentially higher memory during processing window\n  - Larger = less granular tiles, potentially lower memory during processing window\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "1345bd91a8f1b625f602c46e8e477325aa66fdd6c286d798c98f27a556c5b191",
+      "topic": "data",
+      "subject": "Configuration / Local Development Configuration",
+      "content": {
+        "fields": {
+          "project": "my_local_project",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "ray.engine",
+          "storage_path": "./data/ray_storage",
+          "broadcast_join_threshold_mb": "25",
+          "max_parallelism_multiplier": "1",
+          "target_partition_size_mb": "16",
+          "enable_ray_logging": "false",
+          "num_cpus": "1",
+          "object_store_memory": "104857600",
+          "_memory": "524288000",
+          "max_workers": "2",
+          "enable_optimization": "false"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 177,
+        "quote": "### Local Development Configuration\n\nFor local development and testing:\n\n```yaml\nproject: my_local_project\nregistry: data/registry.db\nprovider: local\n\noffline_store:\n    type: ray\n    storage_path: ./data/ray_storage\n    # Conservative settings for local development\n    broadcast_join_threshold_mb: 25\n    max_parallelism_multiplier: 1\n    target_partition_size_mb: 16\n    enable_ray_logging: false\n    # Memory constraints to prevent OOM in test/development environments\n    ray_conf:\n        num_cpus: 1\n        object_store_memory: 104857600  # 100MB\n        _memory: 524288000              # 500MB\n\nbatch_engine:\n    type: ray.engine\n    max_workers: 2\n    enable_optimization: false\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "53e82e3486747af78bf60f4bb66084a2177e06da7771ce8abd3f232af30f43a8",
+      "topic": "data",
+      "subject": "Configuration / Production Configuration",
+      "content": {
+        "fields": {
+          "project": "my_production_project",
+          "registry": "s3://my-bucket/registry.db",
+          "provider": "local",
+          "type": "ray.engine",
+          "storage_path": "s3://my-production-bucket/feast-data",
+          "ray_address": "\"ray://production-head-node:10001\"",
+          "max_workers": "32",
+          "max_parallelism_multiplier": "4",
+          "enable_optimization": "true",
+          "broadcast_join_threshold_mb": "50",
+          "target_partition_size_mb": "128",
+          "window_size_for_joins": "\"30min\"",
+          "staging_location": "s3://my-production-bucket/staging"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 206,
+        "quote": "### Production Configuration\n\nFor production deployments with distributed Ray cluster:\n\n```yaml\nproject: my_production_project\nregistry: s3://my-bucket/registry.db\nprovider: local\n\noffline_store:\n    type: ray\n    storage_path: s3://my-production-bucket/feast-data\n    ray_address: \"ray://production-head-node:10001\"\n\nbatch_engine:\n    type: ray.engine\n    max_workers: 32\n    max_parallelism_multiplier: 4\n    enable_optimization: true\n    broadcast_join_threshold_mb: 50\n    target_partition_size_mb: 128\n    window_size_for_joins: \"30min\"\n    ray_address: \"ray://production-head-node:10001\"\n    staging_location: s3://my-production-bucket/staging\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d1b4ffc1777b04aa7831b6d7086c8d1810f7f19882a647d8c8b14242101a8221",
+      "topic": "data",
+      "subject": "Configuration / Ray Offline Store + Compute Engine",
+      "content": {
+        "fields": {
+          "project": "my_project",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "ray.engine",
+          "storage_path": "s3://my-bucket/feast-data",
+          "ray_address": "localhost:10001",
+          "max_workers": "8",
+          "max_parallelism_multiplier": "2",
+          "enable_optimization": "true",
+          "broadcast_join_threshold_mb": "100",
+          "target_partition_size_mb": "64",
+          "window_size_for_joins": "\"1H\"",
+          "enable_distributed_joins": "true",
+          "staging_location": "s3://my-bucket/staging"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 140,
+        "quote": "### Ray Offline Store + Compute Engine\n\nFor distributed feature processing with advanced capabilities:\n\n```yaml\nproject: my_project\nregistry: data/registry.db\nprovider: local\n\n# Ray offline store for data I/O operations\noffline_store:\n    type: ray\n    storage_path: s3://my-bucket/feast-data    # Optional: Path for storing datasets\n    ray_address: localhost:10001               # Optional: Ray cluster address\n\n# Ray compute engine for distributed feature processing\nbatch_engine:\n    type: ray.engine\n    \n    # Resource configuration\n    max_workers: 8                             # Maximum number of Ray workers\n    max_parallelism_multiplier: 2              # Parallelism as multiple of CPU cores\n    \n    # Performance optimization\n    enable_optimization: true                  # Enable performance optimizations\n    broadcast_join_threshold_mb: 100           # Broadcast join threshold (MB)\n    target_partition_size_mb: 64               # Target partition size (MB)\n    \n    # Distributed join configuration\n    window_size_for_joins: \"1H\"                # Time window for distributed joins\n    enable_distributed_joins: true            # Enable distributed joins\n    \n    # Ray cluster configuration (optional)\n    ray_address: localhost:10001               # Ray cluster address\n    staging_location: s3://my-bucket/staging   # Remote staging location\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "efc5c9ff1bab71db1e08364fa324bac0ad25c3420523c1a80d327d842054599a",
+      "topic": "data",
+      "subject": "Connection Pooling Configuration / Example with Connection Pooling",
+      "content": {
+        "fields": {
+          "project": "my-local-project",
+          "registry": "/remote/data/registry.db",
+          "provider": "local",
+          "type": "no_auth",
+          "path": "http://feast-feature-server:80",
+          "connection_pool_size": "50",
+          "connection_idle_timeout": "300",
+          "connection_retries": "3",
+          "entity_key_serialization_version": "3"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/remote.md",
+        "line": 40,
+        "quote": "### Example with Connection Pooling\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my-local-project\nregistry: /remote/data/registry.db\nprovider: local\nonline_store:\n  type: remote\n  path: http://feast-feature-server:80\n  \n  # Connection pooling configuration (optional)\n  connection_pool_size: 50        # Max connections in pool\n  connection_idle_timeout: 300    # Idle timeout in seconds (0 to disable)\n  connection_retries: 3           # Retry count with exponential backoff\n  \nentity_key_serialization_version: 3\nauth:\n  type: no_auth\n```\n{% endcode %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-26T10:23:00-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "e4d985d4825f81cb453d18e96be4675a2a6a016e01d3f34fb76a4c826f457f2d",
+      "topic": "data",
+      "subject": "Connection Pooling Configuration / Use Cases",
+      "content": {
+        "fields": {
+          "type": "remote",
+          "path": "http://feast-server:80",
+          "connection_pool_size": "10",
+          "connection_idle_timeout": "60",
+          "connection_retries": "5"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/remote.md",
+        "line": 62,
+        "quote": "### Use Cases\n\n**High-throughput workloads:**\n```yaml\nonline_store:\n  type: remote\n  path: http://feast-server:80\n  connection_pool_size: 100       # More connections for high concurrency\n  connection_idle_timeout: 600    # 10 minutes idle timeout\n  connection_retries: 5           # More retries for resilience\n```\n\n**Long-running services:**\n```yaml\nonline_store:\n  type: remote\n  path: http://feast-server:80\n  connection_idle_timeout: 0      # Never auto-close session\n```\n\n**Resource-constrained environments:**\n```yaml\nonline_store:\n  type: remote\n  path: http://feast-server:80\n  connection_pool_size: 10        # Fewer connections to reduce memory\n  connection_idle_timeout: 60     # 1 minute timeout\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-26T10:23:00-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f07fdb2cdc17ba5bc851835e4b9f4d3c556e88b72485749e1bd5d6510962182e",
+      "topic": "data",
+      "subject": "Custom Feast Facets / FeastFeatureViewFacet",
+      "content": {
+        "fields": {
+          "name": "Feature view name",
+          "ttl_seconds": "Time-to-live in seconds",
+          "entities": "List of entity names",
+          "features": "List of feature names",
+          "offline_enabled": "Store configuration",
+          "description": "Feature view description",
+          "tags": "Key-value tags"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 160,
+        "quote": "### FeastFeatureViewFacet\n\nCaptures metadata about feature views:\n- `name`: Feature view name\n- `ttl_seconds`: Time-to-live in seconds\n- `entities`: List of entity names\n- `features`: List of feature names\n- `online_enabled` / `offline_enabled`: Store configuration\n- `description`: Feature view description\n- `tags`: Key-value tags\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "dc0bf8103a4552f4caf595efc0ade03658877bce8f8a7480e18b1f7e1ae0f10c",
+      "topic": "data",
+      "subject": "Deploying as a service on Kubernetes",
+      "content": {
+        "fields": {
+          "apiVersion": "feast.dev/v1",
+          "kind": "FeatureStore",
+          "name": "sample-offline-server",
+          "feastProject": "my_project"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/offline-feature-server.md",
+        "line": 14,
+        "quote": "## Deploying as a service on Kubernetes\n\nSee [this](../../how-to-guides/running-feast-in-production.md#id-4.2.-deploy-feast-feature-servers-on-kubernetes) for an example on how to run Feast on Kubernetes using the Operator.\n\nThe Offline feature server can be deployed with a slight modification of the FeatureStore CR -\n```yaml\napiVersion: feast.dev/v1\nkind: FeatureStore\nmetadata:\n  name: sample-offline-server\nspec:\n  feastProject: my_project\n  services:\n    offlineStore:\n      server: {}\n```\n> _More advanced FeatureStore CR examples can be found in the feast-operator [samples directory](../../../infra/feast-operator/config/samples)._\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-13T18:01:23+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "63fa211ee9610705ea5517d76e15a2264ae7d4bae8b59efaf0f455febf938c6d",
+      "topic": "data",
+      "subject": "Description",
+      "content": {
+        "fields": {
+          "metadata": "* `event_ts` (ISO formatted timestamp)"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/couchbase.md",
+        "line": 5,
+        "quote": "## Description\nThe [Couchbase](https://www.couchbase.com/) online store provides support for materializing feature values into a Couchbase Operational cluster for serving online features in real-time.\n\n* Only the latest feature values are persisted\n* Features are stored in a document-oriented format\n\nThe data model for using Couchbase as an online store follows a document format:\n* Document ID: `{project}:{table_name}:{entity_key_hex}:{feature_name}`\n* Document Content:\n    * `metadata`:\n        * `event_ts` (ISO formatted timestamp)\n        * `created_ts` (ISO formatted timestamp)\n        * `feature_name` (String)\n    * `value` (Base64 encoded protobuf binary)\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-06-22T07:43:37-06:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "cd0d77210778b73992a57381801fd3e890750f7846ec8c4bd0dfe05d306b8f2a",
+      "topic": "data",
+      "subject": "Description / Authentication and User Configuration",
+      "content": {
+        "fields": {
+          "HADOOP_USER_NAME": "`KRB5CCNAME`"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/registries/hdfs.md",
+        "line": 13,
+        "quote": "### Authentication and User Configuration\n\nThe HDFS registry is using `pyarrow.fs.HadoopFileSystem` and **does not** support specifying HDFS users or Kerberos credentials directly in the `feature_store.yaml` configuration. It relies entirely on the Hadoop and system environment configuration available to the process running Feast.\n\nBy default, `pyarrow.fs.HadoopFileSystem` inherits authentication from the underlying Hadoop client libraries and environment variables, such as:\n\n- `HADOOP_USER_NAME`\n- `KRB5CCNAME`\n- `hadoop.security.authentication`\n- Any other relevant properties in `core-site.xml` and `hdfs-site.xml`\n\nFor more information, refer to:\n- [pyarrow.fs.HadoopFileSystem API Reference](https://arrow.apache.org/docs/python/generated/pyarrow.fs.HadoopFileSystem.html)\n- [Hadoop Security: Simple & Kerberos Authentication](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SecureMode.html)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-15T02:39:58+00:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "feea8f617f2af291c4d12a48fa5d2631fad35e25ae91f89bff4eb8b93c7b1ae8",
+      "topic": "data",
+      "subject": "Example / Example FeatureView",
+      "content": {
+        "fields": {
+          "name": "user_features",
+          "ttl": "null",
+          "dtype": "string",
+          "online": "true",
+          "path": "data/user_features.parquet",
+          "event_timestamp_column": "event_timestamp",
+          "created_timestamp_column": "created_timestamp",
+          "team": "bigtable"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/hybrid.md",
+        "line": 52,
+        "quote": "### Example FeatureView\n\n{% code title=\"feature_view\" %}\n```yaml\nname: user_features\nentities:\n  - name: user_id\n    join_keys: [\"user_id\"]\nttl: null\nschema:\n  - name: age\n    dtype: int64\n  - name: country\n    dtype: string\nonline: true\nsource:\n  path: data/user_features.parquet\n  event_timestamp_column: event_timestamp\n  created_timestamp_column: created_timestamp\ntags:\n  team: bigtable  # This tag determines which online store is used\n```\n{% endcode %}\n\nThe `team` tag in the FeatureView's `tags` field determines which online store backend is used for this FeatureView. In this example, all online operations for `user_features` will be routed to the Bigtable online store, as specified by the tag value and the `routing_tag` in your `feature_store.yaml`.\n\nThe HybridOnlineStore will route requests to the correct online store based on the value of the tag specified by `routing_tag`.\n\nThe full set of configuration options for each online store is available in their respective documentation:\n- [BigtableOnlineStoreConfig](https://rtd.feast.dev/en/latest/#feast.infra.online_stores.bigtable.BigtableOnlineStoreConfig)\n- [CassandraOnlineStoreConfig](https://rtd.feast.dev/en/master/#feast.infra.online_stores.cassandra_online_store.cassandra_online_store.CassandraOnlineStoreConfig)\n\nFor a full explanation of configuration options, please refer to the documentation for each online store backend you configure in the `online_stores` list.\n\nStorage specifications can be found at [docs/specs/online_store_format.md](../../specs/online_store_format.md).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-04T22:48:56-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "97b248a801809a48e21840887a8177127489d44961172e677976f18ea59160f3",
+      "topic": "data",
+      "subject": "Example / Pushing features to the online and offline stores",
+      "content": {
+        "fields": {
+          "type": "local",
+          "offline_push_batching_enabled": "true",
+          "offline_push_batching_batch_size": "1000",
+          "offline_push_batching_batch_interval_seconds": "10"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 199,
+        "quote": "### Pushing features to the online and offline stores\n\nThe Python feature server also exposes an endpoint for [push sources](../data-sources/push.md). This endpoint allows you to push data to the online and/or offline store.\n\nThe request definition for `PushMode` is a string parameter `to` where the options are: \\[`\"online\"`, `\"offline\"`, `\"online_and_offline\"`].\n\n**Note:** timestamps need to be strings, and might need to be timezone aware (matching the schema of the offline store)\n\n```\ncurl -X POST \"http://localhost:6566/push\" -d '{\n    \"push_source_name\": \"driver_stats_push_source\",\n    \"df\": {\n            \"driver_id\": [1001],\n            \"event_timestamp\": [\"2022-05-13 10:59:42+00:00\"],\n            \"created\": [\"2022-05-13 10:59:42\"],\n            \"conv_rate\": [1.0],\n            \"acc_rate\": [1.0],\n            \"avg_daily_trips\": [1000]\n    },\n    \"to\": \"online_and_offline\"\n  }' | jq\n```\n\nor equivalently from Python:\n\n```python\nimport json\nimport requests\nfrom datetime import datetime\n\nevent_dict = {\n    \"driver_id\": [1001],\n    \"event_timestamp\": [str(datetime(2021, 5, 13, 10, 59, 42))],\n    \"created\": [str(datetime(2021, 5, 13, 10, 59, 42))],\n    \"conv_rate\": [1.0],\n    \"acc_rate\": [1.0],\n    \"avg_daily_trips\": [1000],\n    \"string_feature\": \"test2\",\n}\npush_data = {\n… (+29 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f2c9ad13a89f9737d7f965651be6806bdb27129bfc38e24d3d6a7d6727dd2368",
+      "topic": "data",
+      "subject": "Example / Setting the Routing Tag in FeatureView",
+      "content": {
+        "fields": {
+          "team": "bigtable"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/hybrid.md",
+        "line": 41,
+        "quote": "### Setting the Routing Tag in FeatureView\n\nTo enable routing, add a tag to your FeatureView that matches the `routing_tag` specified in your `feature_store.yaml`. For example, if your `routing_tag` is `team`, add a `team` tag to your FeatureView:\n\n```yaml\ntags:\n  team: bigtable  # This tag determines which online store is used\n```\n\nThe value of this tag (e.g., `bigtable`) should match the type or identifier of the online store you want to use for this FeatureView. The HybridOnlineStore will route all online operations for this FeatureView to the corresponding backend.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-04T22:48:56-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3edcfb4cc143a8fd01db325fb076fde206a0fb4a60b7785d3e97cd5789e8f3ed",
+      "topic": "data",
+      "subject": "Examples / **Initialize Feast feature store and materialize the data to the online store**",
+      "content": {
+        "fields": {
+          "project": "local_rag",
+          "provider": "local",
+          "registry": "data/registry.db",
+          "type": "no_auth",
+          "path": "data/online_store.db",
+          "vector_enabled": "true",
+          "embedding_dim": "384",
+          "index_type": "\"IVF_FLAT\"",
+          "entity_key_serialization_version": "3"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-vector-database.md",
+        "line": 48,
+        "quote": "### **Initialize Feast feature store and materialize the data to the online store**\nUse the feature_store.yaml file to initialize the feature store. This will use the data as offline store, and Milvus as online store.\n\n```yaml\nproject: local_rag\nprovider: local\nregistry: data/registry.db\nonline_store:\n  type: milvus\n  path: data/online_store.db\n  vector_enabled: true\n  embedding_dim: 384\n  index_type: \"IVF_FLAT\"\n\n\noffline_store:\n  type: file\nentity_key_serialization_version: 3\n# By default, no_auth for authentication and authorization, other possible values kubernetes and oidc. Refer the documentation for more details.\nauth:\n    type: no_auth\n```\nRun the following command in terminal to apply the feature store configuration:\n\n```shell\nfeast apply\n```\n\nNote that when you run `feast apply` you are going to apply the following Feature View that we will use for retrieval later:  \n\n```python\ndocument_embeddings = FeatureView(\n    name=\"embedded_documents\",\n    entities=[item, author],\n    schema=[\n        Field(\n            name=\"vector\",\n            dtype=Array(Float32),\n            # Look how easy it is to enable RAG!\n            vector_index=True,\n… (+18 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-03-05T08:16:17-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "7f204150d6cf9367203300dfae0c551c4c4a9219591bb42d3c290fd35d088cb1",
+      "topic": "data",
+      "subject": "Examples / Advanced configuration with custom client options",
+      "content": {
+        "fields": {
+          "project": "my_feature_repo",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "mongodb",
+          "connection_string": "\"mongodb+srv://cluster.mongodb.net/\"",
+          "database_name": "feast_online_store",
+          "collection_suffix": "features",
+          "maxPoolSize": "50",
+          "minPoolSize": "10",
+          "serverSelectionTimeoutMS": "5000",
+          "connectTimeoutMS": "10000"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/mongodb.md",
+        "line": 73,
+        "quote": "### Advanced configuration with custom client options\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n  type: mongodb\n  connection_string: \"mongodb+srv://cluster.mongodb.net/\"\n  database_name: feast_online_store\n  collection_suffix: features\n  client_kwargs:\n    maxPoolSize: 50\n    minPoolSize: 10\n    serverSelectionTimeoutMS: 5000\n    connectTimeoutMS: 10000\n```\n{% endcode %}\n\nThe full set of configuration options is available in [MongoDBOnlineStoreConfig](https://rtd.feast.dev/en/latest/#feast.infra.online_stores.mongodb_online_store.mongodb.MongoDBOnlineStoreConfig).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T09:21:30+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "1d98eb2c1443b9cbde7ec1969fb490f28e9fe4e24c17fc5679bb90c879d3ed6a",
+      "topic": "data",
+      "subject": "Examples / Basic configuration with MongoDB Atlas",
+      "content": {
+        "fields": {
+          "project": "my_feature_repo",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "mongodb",
+          "connection_string": "\"mongodb+srv://username:password@cluster.mongodb.net/\"",
+          "database_name": "feast_online_store"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/mongodb.md",
+        "line": 27,
+        "quote": "### Basic configuration with MongoDB Atlas\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n  type: mongodb\n  connection_string: \"mongodb+srv://username:password@cluster.mongodb.net/\"  # pragma: allowlist secret\n  database_name: feast_online_store\n```\n{% endcode %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T09:21:30+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9084368c4c4c2948906c7198dc1f24155ee1f3939ecbd4d23397ceef9db486d2",
+      "topic": "data",
+      "subject": "Examples / MongoDB replica set configuration",
+      "content": {
+        "fields": {
+          "project": "my_feature_repo",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "mongodb",
+          "connection_string": "string",
+          "database_name": "feast_online_store",
+          "retryWrites": "true",
+          "w": "majority"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/mongodb.md",
+        "line": 56,
+        "quote": "### MongoDB replica set configuration\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n  type: mongodb\n  connection_string: \"mongodb://host1:27017,host2:27017,host3:27017/?replicaSet=myReplicaSet\"\n  database_name: feast_online_store\n  client_kwargs:\n    retryWrites: true\n    w: majority\n```\n{% endcode %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T09:21:30+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0a3387c84a76c4efcadcf2c008c7bbc2cce000d139dfb2574654d05bdddc9dd2",
+      "topic": "data",
+      "subject": "Examples / Self-hosted MongoDB with authentication",
+      "content": {
+        "fields": {
+          "project": "my_feature_repo",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "mongodb",
+          "connection_string": "\"mongodb://username:password@localhost:27017/\"",
+          "database_name": "feast_online_store",
+          "collection_suffix": "features"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/mongodb.md",
+        "line": 41,
+        "quote": "### Self-hosted MongoDB with authentication\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n  type: mongodb\n  connection_string: \"mongodb://username:password@localhost:27017/\"  # pragma: allowlist secret\n  database_name: feast_online_store\n  collection_suffix: features\n```\n{% endcode %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T09:21:30+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "084ea4cbcc559f24cebf959b75a8218b641c020f90af0f5cce6f3f6b5bd947dc",
+      "topic": "data",
+      "subject": "Feature views",
+      "content": {
+        "fields": {
+          "owner": "the email of the primary maintainer",
+          "org": "the organizational unit that owns the feature view (e"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-view.md",
+        "line": 3,
+        "quote": "## Feature views\n\n{% hint style=\"warning\" %}\n**Note**: Feature views do not work with non-timestamped data. A workaround is to insert dummy timestamps.\n{% endhint %}\n\nA **feature view** is defined as a *collection of features*. \n\n- In the online settings, this is a *stateful* collection of \nfeatures that are read when the `get_online_features` method is called. \n- In the offline setting, this is a *stateless* collection of features that are created when the `get_historical_features` \nmethod is called. \n\nA feature view is an object representing a logical group of time-series feature data as it is found in a [data source](data-ingestion.md). Depending on the kind of feature view, it may contain some lightweight (experimental) feature transformations (see [\\[Beta\\] On demand feature views](../../reference/beta-on-demand-feature-view.md)).\n\nFeature views consist of:\n\n* a [data source](data-ingestion.md)\n* zero or more [entities](entity.md)\n  * If the features are not related to a specific object, the feature view might not have entities; see [feature views without entities](feature-view.md#feature-views-without-entities) below.\n* a name to uniquely identify this feature view in the project.\n* (optional, but recommended) a schema specifying one or more [features](feature-view.md#field) (without this, Feast will infer the schema by reading from the data source)\n* (optional, but recommended) metadata (for example, description, or other free-form metadata via `tags`)\n* (optional) `owner`: the email of the primary maintainer\n* (optional) `org`: the organizational unit that owns the feature view (e.g. `\"ads\"`, `\"search\"`); useful for grouping feature views by team or product area\n* (optional) a TTL, which limits how far back Feast will look when generating historical datasets\n* (optional) `enable_validation=True`, which enables schema validation during materialization (see [Schema Validation](#schema-validation) below)\n\nFeature views allow Feast to model your existing feature data in a consistent way in both an offline (training) and online (serving) environment. Feature views generally contain features that are properties of a specific object, in which case that object is defined as an entity and included in the feature view.\n\n{% tabs %}\n{% tab title=\"driver_trips_feature_view.py\" %}\n```python\nfrom feast import BigQuerySource, Entity, FeatureView, Field\nfrom feast.types import Float32, Int64\n\ndriver = Entity(name=\"driver\", join_keys=[\"driver_id\"])\n\ndriver_stats_fv = FeatureView(\n    name=\"driver_activity\",\n… (+19 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-27T23:00:47-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9a2bcbf6a66d2047f6bff35f490e2eb81820f9572aa75965216850ea2dfc863a",
+      "topic": "data",
+      "subject": "Fields in feature\\_store.yaml / feature_server",
+      "content": {
+        "fields": {
+          "type": "local",
+          "enabled": "true",
+          "resource": "true",
+          "request": "true",
+          "online_features": "true",
+          "push": "true",
+          "materialization": "true",
+          "freshness": "true",
+          "offline_push_batching_enabled": "true",
+          "offline_push_batching_batch_size": "100",
+          "offline_push_batching_batch_interval_seconds": "5"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-store-yaml.md",
+        "line": 28,
+        "quote": "### feature_server\n\nThe `feature_server` block configures the Python Feature Server when it is used\nto serve online features and handle `/push` requests. This section is optional\nand only applies when running the Python feature server.\n\nAn example configuration:\n\n```yaml\nfeature_server:\n  type: local\n  metrics: # Prometheus metrics configuration. Also achievable via `feast serve --metrics`.\n    enabled: true             # Enable Prometheus metrics server on port 8000\n    resource: true            # CPU / memory gauges\n    request: true             # endpoint latency histograms & request counters\n    online_features: true     # online feature retrieval counters + store read & ODFV transform timing\n    push: true                # push request counters\n    materialization: true     # materialization counters & duration histograms\n    freshness: true           # per-feature-view freshness gauges\n  offline_push_batching_enabled: true # Enables batching of offline writes processed by /push. Online writes are unaffected.\n  offline_push_batching_batch_size: 100 # Maximum number of buffered rows before writing to the offline store.\n  offline_push_batching_batch_interval_seconds: 5 # Maximum time rows may remain buffered before a forced flush.\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-15T11:47:10+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "daebd19657455b9c45dc956cc476d6e41f10a6819178783878e2a35b8caefd16",
+      "topic": "data",
+      "subject": "Fields in feature\\_store.yaml / registry",
+      "content": {
+        "fields": {
+          "registry_type": "sql",
+          "path": "postgresql+psycopg://feast:feast@localhost:5432/feast",
+          "enabled": "true"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-store-yaml.md",
+        "line": 52,
+        "quote": "### registry\n\nThe `registry` field can be a simple path string or an object with additional\nconfiguration. When using the REST registry server, MCP support can be enabled:\n\n```yaml\nregistry:\n  registry_type: sql\n  path: postgresql+psycopg://feast:feast@localhost:5432/feast #pragma: allowlist secret\n  mcp:\n    enabled: true\n```\n\n| Field | Type | Default | Description |\n|-------|------|---------|-------------|\n| `registry_type` | string | `file` | Registry backend (`file`, `sql`, etc.) |\n| `path` | string | — | Connection string or file path |\n| `mcp.enabled` | bool | `false` | Enable MCP (Model Context Protocol) on the REST registry server |\n\nWhen `registry.mcp.enabled` is `true`, the REST registry server exposes registry\nmetadata (entities, feature views, feature services) as MCP tool endpoints for\nLLM agents. Requires `feast[mcp]` to be installed.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-15T11:47:10+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f7dd11f658585804ebfe536019b618dbce6d45e69b9bd65d930be573e00605fd",
+      "topic": "data",
+      "subject": "Functionality",
+      "content": {
+        "fields": {
+          "online_write_batch": "write feature values to the online store",
+          "online_read": "read feature values from the online store",
+          "update": "update infrastructure (e",
+          "teardown": "teardown infrastructure (e",
+          "plan": "generate a plan of infrastructure changes based on feature r"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/overview.md",
+        "line": 3,
+        "quote": "## Functionality\n\nHere are the methods exposed by the `OnlineStore` interface, along with the core functionality supported by the method:\n* `online_write_batch`: write feature values to the online store\n* `online_read`: read feature values from the online store\n* `update`: update infrastructure (e.g. tables) in the online store\n* `teardown`: teardown infrastructure (e.g. tables) in the online store\n* `plan`: generate a plan of infrastructure changes based on feature repo changes\n\nThere is also additional functionality not properly captured by these interface methods:\n* support for on-demand transforms\n* readable by Python SDK\n* readable by Java\n* readable by Go\n* support for entityless feature views\n* support for concurrent writing to the same key\n* support for ttl (time to live) at retrieval\n* support for deleting expired data\n\nFinally, there are multiple data models for storing the features in the online store. For example, features could be:\n* collocated by feature view\n* collocated by feature service\n* collocated by entity key\n\nSee this [issue](https://github.com/feast-dev/feast/issues/2254) for a discussion around the tradeoffs of each of these data models.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-01T05:09:50+04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "85ac9f4d81d1e6239b9a9404da38793732e743da41d69deef3351462063d529a",
+      "topic": "data",
+      "subject": "Getting started / Example (Astra DB)",
+      "content": {
+        "fields": {
+          "project": "my_feature_repo",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "cassandra",
+          "secure_bundle_path": "/path/to/secure/bundle.zip",
+          "keyspace": "KeyspaceName",
+          "username": "Client_ID",
+          "password": "Client_Secret",
+          "protocol_version": "4",
+          "local_dc": "'eu-central-1'",
+          "load_balancing_policy": "'TokenAwarePolicy(DCAwareRoundRobinPolicy)'",
+          "read_concurrency": "100",
+          "write_concurrency": "100"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/cassandra.md",
+        "line": 40,
+        "quote": "### Example (Astra DB)\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n    type: cassandra\n    secure_bundle_path: /path/to/secure/bundle.zip\n    keyspace: KeyspaceName\n    username: Client_ID\n    password: Client_Secret\n    protocol_version: 4                                                     # optional\n    load_balancing:                                                         # optional\n        local_dc: 'eu-central-1'                                            # optional\n        load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'  # optional\n    read_concurrency: 100                                                   # optional\n    write_concurrency: 100                                                  # optional\n```\n{% endcode %}\n\nThe full set of configuration options is available in [CassandraOnlineStoreConfig](https://rtd.feast.dev/en/master/#feast.infra.online_stores.cassandra_online_store.cassandra_online_store.CassandraOnlineStoreConfig).\nFor a full explanation of configuration options please look at file\n`sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/README.md`.\n\nStorage specifications can be found at `docs/specs/online_store_format.md`.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-07T14:14:00-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ddd6ae540290eb3ee6d8c8cf840b9d3dc493e347ed6accef0d6514d6f6cde905",
+      "topic": "data",
+      "subject": "Getting started / Example (Cassandra)",
+      "content": {
+        "fields": {
+          "project": "my_feature_repo",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "cassandra",
+          "keyspace": "KeyspaceName",
+          "port": "9042",
+          "username": "user",
+          "password": "secret",
+          "protocol_version": "5",
+          "local_dc": "'datacenter1'",
+          "load_balancing_policy": "'TokenAwarePolicy(DCAwareRoundRobinPolicy)'",
+          "read_concurrency": "100",
+          "write_concurrency": "100"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/cassandra.md",
+        "line": 14,
+        "quote": "### Example (Cassandra)\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n    type: cassandra\n    hosts:\n        - 192.168.1.1\n        - 192.168.1.2\n        - 192.168.1.3\n    keyspace: KeyspaceName\n    port: 9042                                                              # optional\n    username: user                                                          # optional\n    password: secret                                                        # optional\n    protocol_version: 5                                                     # optional\n    load_balancing:                                                         # optional\n        local_dc: 'datacenter1'                                             # optional\n        load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'  # optional\n    read_concurrency: 100                                                   # optional\n    write_concurrency: 100                                                  # optional\n```\n{% endcode %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-07T14:14:00-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f4391f9024e2175a3a98c583a68fe4321e1c4204e3caaa2e4b7cd6127bdaef5f",
+      "topic": "data",
+      "subject": "Getting started / Example (ScyllaDB Cloud)",
+      "content": {
+        "fields": {
+          "project": "scylla_feature_repo",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "cassandra",
+          "keyspace": "feast",
+          "username": "scylla",
+          "password": "password"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/scylladb.md",
+        "line": 38,
+        "quote": "### Example (ScyllaDB Cloud)\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: scylla_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n    type: cassandra\n    hosts:\n        - node-0.aws_us_east_1.xxxxxxxx.clusters.scylla.cloud\n        - node-1.aws_us_east_1.xxxxxxxx.clusters.scylla.cloud\n        - node-2.aws_us_east_1.xxxxxxxx.clusters.scylla.cloud\n    keyspace: feast\n    username: scylla\n    password: password\n```\n{% endcode %}\n\n\nThe full set of configuration options is available in [CassandraOnlineStoreConfig](https://rtd.feast.dev/en/master/#feast.infra.online_stores.cassandra_online_store.cassandra_online_store.CassandraOnlineStoreConfig).\nFor a full explanation of configuration options please look at file\n`sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/README.md`.\n\nStorage specifications can be found at `docs/specs/online_store_format.md`.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-07T14:14:00-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3043ef9502e3e652a82a1d56a17b48b0166b93a19f3593496b21ed5a4927e521",
+      "topic": "data",
+      "subject": "Getting started / Example (ScyllaDB)",
+      "content": {
+        "fields": {
+          "project": "scylla_feature_repo",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "cassandra",
+          "keyspace": "feast",
+          "username": "scylla",
+          "password": "password"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/scylladb.md",
+        "line": 21,
+        "quote": "### Example (ScyllaDB)\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: scylla_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n    type: cassandra\n    hosts:\n        - 172.17.0.2\n    keyspace: feast\n    username: scylla\n    password: password\n```\n{% endcode %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-07T14:14:00-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "1096671d9048d874ed746816a561ff322236e81fe8a9ec3e17f3abb7eac11628",
+      "topic": "data",
+      "subject": "How to configure Authentication and Authorization ? / Search API",
+      "content": {
+        "fields": {
+          "PopularTagsResponse": "**Response Example**:",
+          "FeatureViewInfo": "Contains feature view name and project",
+          "PopularTagInfo": "Contains tag information and associated feature views",
+          "PopularTagsMetadata": "Contains metadata about the response"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 1157,
+        "quote": "### Search API\n\n#### Search Resources\n- **Endpoint**: `GET /api/v1/search`\n- **Description**: Search across all Feast resources including entities, feature views, features, feature services, data sources, and saved datasets. Supports cross-project search, fuzzy matching, relevance scoring, and advanced filtering.\n- **Parameters**:\n  - `query` (required): Search query string. Searches in resource names, descriptions, and tags. Empty string returns all resources.\n  - `projects` (optional): List of project names to search in. If not specified, searches all projects\n  - `allow_cache` (optional, default: `true`): Whether to allow cached data\n  - `tags` (optional): Filter results by tags in key:value format (e.g., `tags=environment:production&tags=team:ml`)\n  - `page` (optional, default: `1`): Page number for pagination (starts from 1)\n  - `limit` (optional, default: `50`, max: `100`): Number of items per page\n  - `sort_by` (optional, default: `match_score`): Field to sort by (`match_score`, `name`, or `type`)\n  - `sort_order` (optional, default: `desc`): Sort order (\"asc\" or \"desc\")\n- **Search Algorithm**:\n  - **Exact name match**: Highest priority (score: 100)\n  - **Description match**: High priority (score: 80) \n  - **Feature name match**: Medium-high priority (score: 50)\n  - **Tag match**: Medium priority (score: 60)\n  - **Fuzzy name match**: Lower priority (score: 40, similarity threshold: 50%)\n- **Examples**:\n  ```bash\n  # Basic search across all projects\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/search?query=user\"\n  \n  # Search in specific projects\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/search?query=driver&projects=ride_sharing&projects=analytics\"\n  \n  # Search with tag filtering\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/search?query=features&tags=environment:production&tags=team:ml\"\n  \n  # Search with pagination and sorting\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/search?query=conv_rate&page=1&limit=10&sort_by=name&sort_order=asc\"\n  \n  # Empty query to list all resources with filtering\n  curl -H \"Authorization: Bearer <token>\" \\\n… (+182 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "886f9bc333996a26e05760dced20140e2e9b88e09809a40a2174ae45bef631ba",
+      "topic": "data",
+      "subject": "Integration Examples / With Cloud Storage",
+      "content": {
+        "fields": {
+          "type": "ray.engine",
+          "storage_path": "s3://my-bucket/feast-data",
+          "ray_address": "\"ray://ray-cluster:10001\"",
+          "broadcast_join_threshold_mb": "50"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 459,
+        "quote": "### With Cloud Storage\n\n```yaml\n# Use Ray compute engine with cloud storage\noffline_store:\n    type: ray\n    storage_path: s3://my-bucket/feast-data\nbatch_engine:\n    type: ray.engine\n    ray_address: \"ray://ray-cluster:10001\"\n    broadcast_join_threshold_mb: 50\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "94abff637939450ccdbdf5a9a32a5a83396e9d3c48c83873f77ce071a4ca4e34",
+      "topic": "data",
+      "subject": "Integration Examples / With Spark Offline Store",
+      "content": {
+        "fields": {
+          "type": "ray.engine",
+          "max_workers": "8",
+          "enable_optimization": "true"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 444,
+        "quote": "### With Spark Offline Store\n\n```yaml\n# Use Ray compute engine with Spark offline store\noffline_store:\n    type: spark\n    spark_conf:\n        spark.executor.memory: \"4g\"\n        spark.executor.cores: \"2\"\nbatch_engine:\n    type: ray.engine\n    max_workers: 8\n    enable_optimization: true\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "dbbfa83fb0c56f63951622bf452c132999e7f2532415f37bab47c1934787995f",
+      "topic": "data",
+      "subject": "Kubernetes / Feast Operator",
+      "content": {
+        "fields": {
+          "metrics": "true"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 487,
+        "quote": "### Kubernetes / Feast Operator\n\nSet `metrics: true` in your FeatureStore CR:\n\n```yaml\nspec:\n  services:\n    onlineStore:\n      server:\n        metrics: true\n```\n\nThe operator automatically exposes port 8000 and creates the corresponding\nService port so Prometheus can discover it.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9a028ba5433b9de71fbcd8cc345be61fbaaba4994fcdc0944248f031b0803c65",
+      "topic": "data",
+      "subject": "Kubernetes auth configuration",
+      "content": {
+        "fields": {
+          "type": "\"kubernetes\"",
+          "user_token": "string (optional, else service account token used)"
+        },
+        "validation": {
+          "type": "must be \"kubernetes\"",
+          "deployment": "only works on Kubernetes/OpenShift"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/authz_manager.md",
+        "line": 141,
+        "quote": "### Kubernetes RBAC Authorization\nWith Kubernetes RBAC Authorization, the client uses the service account token as the authorizarion bearer token, and the\nserver fetches the associated roles from the Kubernetes RBAC resources. Feast supports advanced authorization by extracting user groups and namespaces from Kubernetes tokens, enabling fine-grained access control beyond simple role matching. This is achieved by leveraging Kubernetes Token Access Review, which allows Feast to determine the groups and namespaces associated with a user or service account.\n\nAn example of Kubernetes RBAC authorization configuration is the following: \n{% hint style=\"info\" %}\n**NOTE**: This configuration will only work if you deploy feast on Openshift or a Kubernetes platform.\n{% endhint %}\n```yaml\nproject: my-project\nauth:\n  type: kubernetes\n  user_token: <user_token> #Optional, else service account token Or env var is used for getting the token\n...\n```\n\nIn case the client cannot run on the same cluster as the servers, the client token can be injected using the `LOCAL_K8S_TOKEN` \nenvironment variable on the client side. The value must refer to the token of a service account created on the servers cluster\nand linked to the desired RBAC roles/groups/namespaces.\n\nMore details can be found in [Setting up kubernetes doc](../../reference/auth/kubernetes_auth_setup.md)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-07T22:55:26+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "be08cc47a588c4c8930fad8ae474a0734ace5e7bd3f56afb18ad4f11ce5bce81",
+      "topic": "data",
+      "subject": "Monitoring",
+      "content": {
+        "fields": {
+          "feast_feature_server_memory_usage": "Memory utilization of the feature server",
+          "feast_feature_server_cpu_usage": "CPU usage statistics",
+          "feast_feature_server_request_latency_seconds": "Request latency with feature count dimensions",
+          "feast_feature_server_online_store_read_duration_seconds": "Online store read phase duration",
+          "feast_feature_server_transformation_duration_seconds": "ODFV read-path transformation duration (per ODFV, requires `",
+          "feast_feature_server_write_transformation_duration_seconds": "ODFV write-path transformation duration (per ODFV, requires "
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/open-telemetry.md",
+        "line": 141,
+        "quote": "## Monitoring\n\nOnce configured, you can monitor various metrics including:\n\n- `feast_feature_server_memory_usage`: Memory utilization of the feature server\n- `feast_feature_server_cpu_usage`: CPU usage statistics\n- `feast_feature_server_request_latency_seconds`: Request latency with feature count dimensions\n- `feast_feature_server_online_store_read_duration_seconds`: Online store read phase duration\n- `feast_feature_server_transformation_duration_seconds`: ODFV read-path transformation duration (per ODFV, requires `track_metrics=True`)\n- `feast_feature_server_write_transformation_duration_seconds`: ODFV write-path transformation duration (per ODFV, requires `track_metrics=True`)\n- Additional custom metrics based on your configuration\n\nFor the full list of metrics, see the [Python Feature Server reference](../../reference/feature-servers/python-feature-server.md#available-metrics).\n\nThese metrics can be visualized using Prometheus and other compatible monitoring tools.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-24T10:11:58-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b5be1c6ec1b3890f266a8cebc3ab0f53371d3820d5502e63f6b2e67944b2a169",
+      "topic": "data",
+      "subject": "OIDC client configuration",
+      "content": {
+        "fields": {
+          "type": "\"oidc\"",
+          "token": "string (static JWT)",
+          "token_env_var": "string (env var name containing JWT)",
+          "client_id": "string",
+          "client_secret": "string",
+          "username": "string",
+          "password": "string",
+          "auth_discovery_url": "string"
+        },
+        "validation": {
+          "token_resolution_order": "INTRA_COMMUNICATION_BASE64 > token > token_env_var > client_secret > FEAST_OIDC_TOKEN > k8s service account"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/authz_manager.md",
+        "line": 88,
+        "quote": "### OIDC Authorization\nWith OIDC authorization, the Feast client proxies retrieve the JWT token from an OIDC server (or [Identity Provider](https://openid.net/developers/how-connect-works/))\nand append it in every request to a Feast server, using an [Authorization Bearer Token](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#bearer).\n\nThe server, in turn, uses the same OIDC server to validate the token and extract user details — including username, roles, and groups — from the token itself.\n\nSome assumptions are made in the OIDC server configuration:\n* The OIDC token refers to a client with roles matching the RBAC roles of the configured `Permission`s (*)\n* The roles are exposed in the access token under `resource_access.<client_id>.roles`\n* The JWT token is expected to have a verified signature and not be expired. The Feast OIDC token parser logic validates for `verify_signature` and `verify_exp` so make sure that the given OIDC provider is configured to meet these requirements.\n* The `preferred_username` should be part of the JWT token claim.\n* For `GroupBasedPolicy` support, the `groups` claim should be present in the access token (requires a \"Group Membership\" protocol mapper in Keycloak).\n\n(*) Please note that **the role match is case-sensitive**, e.g. the name of the role in the OIDC server and in the `Permission` configuration\nmust be exactly the same.\n\nFor example, the access token for a client `app` of a user with `reader` role and membership in the `data-team` group should have the following claims:\n```json\n{\n  \"preferred_username\": \"alice\",\n  \"resource_access\": {\n    \"app\": {\n      \"roles\": [\n        \"reader\"\n      ]\n    }\n  },\n  \"groups\": [\n    \"data-team\"\n  ]\n}\n```\n\n#### Server-Side Configuration\n\nThe server requires `auth_discovery_url` and `client_id` to validate incoming JWT tokens via JWKS:\n```yaml\nproject: my-project\nauth:\n  type: oidc\n… (+62 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-07T22:55:26+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "df221c95e63719d8e019585a6a9554af179e3bffd842f8980145c80194141429",
+      "topic": "data",
+      "subject": "OIDC server configuration",
+      "content": {
+        "fields": {
+          "type": "\"oidc\"",
+          "client_id": "string",
+          "auth_discovery_url": "string",
+          "verify_ssl": "boolean (default true)"
+        },
+        "validation": {
+          "type": "must be \"oidc\"",
+          "client_id": "required for JWKS validation",
+          "auth_discovery_url": "required for JWKS validation"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/authz_manager.md",
+        "line": 66,
+        "quote": "### OIDC Authorization\nWith OIDC authorization, the Feast client proxies retrieve the JWT token from an OIDC server (or [Identity Provider](https://openid.net/developers/how-connect-works/))\nand append it in every request to a Feast server, using an [Authorization Bearer Token](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#bearer).\n\nThe server, in turn, uses the same OIDC server to validate the token and extract user details — including username, roles, and groups — from the token itself.\n\nSome assumptions are made in the OIDC server configuration:\n* The OIDC token refers to a client with roles matching the RBAC roles of the configured `Permission`s (*)\n* The roles are exposed in the access token under `resource_access.<client_id>.roles`\n* The JWT token is expected to have a verified signature and not be expired. The Feast OIDC token parser logic validates for `verify_signature` and `verify_exp` so make sure that the given OIDC provider is configured to meet these requirements.\n* The `preferred_username` should be part of the JWT token claim.\n* For `GroupBasedPolicy` support, the `groups` claim should be present in the access token (requires a \"Group Membership\" protocol mapper in Keycloak).\n\n(*) Please note that **the role match is case-sensitive**, e.g. the name of the role in the OIDC server and in the `Permission` configuration\nmust be exactly the same.\n\nFor example, the access token for a client `app` of a user with `reader` role and membership in the `data-team` group should have the following claims:\n```json\n{\n  \"preferred_username\": \"alice\",\n  \"resource_access\": {\n    \"app\": {\n      \"roles\": [\n        \"reader\"\n      ]\n    }\n  },\n  \"groups\": [\n    \"data-team\"\n  ]\n}\n```\n\n#### Server-Side Configuration\n\nThe server requires `auth_discovery_url` and `client_id` to validate incoming JWT tokens via JWKS:\n```yaml\nproject: my-project\nauth:\n  type: oidc\n… (+62 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-07T22:55:26+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "81633a6e187fef6741304331279993cde9852a643d782734c1fa005d06a49eeb",
+      "topic": "data",
+      "subject": "Performance Optimization / Manual Tuning",
+      "content": {
+        "fields": {
+          "type": "ray.engine",
+          "broadcast_join_threshold_mb": "200",
+          "max_parallelism_multiplier": "1",
+          "target_partition_size_mb": "512",
+          "window_size_for_joins": "\"2H\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 327,
+        "quote": "### Manual Tuning\n\nFor specific workloads, you can fine-tune performance:\n\n```yaml\nbatch_engine:\n    type: ray.engine\n    # Fine-tuning for high-throughput scenarios\n    broadcast_join_threshold_mb: 200      # Larger broadcast threshold\n    max_parallelism_multiplier: 1        # Conservative parallelism\n    target_partition_size_mb: 512        # Larger partitions\n    window_size_for_joins: \"2H\"          # Larger time windows\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "6124745a3597c08357fda9b206c4691dc8c82363f1be28336c0974700b47e6c5",
+      "topic": "data",
+      "subject": "Performance characteristics / Write path: `skip_dedup` for bulk loads",
+      "content": {
+        "fields": {
+          "type": "redis",
+          "connection_string": "\"localhost:6379\"",
+          "skip_dedup": "true"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/redis.md",
+        "line": 115,
+        "quote": "### Write path: `skip_dedup` for bulk loads\n\nBy default, `online_write_batch()` checks existing timestamps before writing (to avoid overwriting newer data with older data). This requires two pipeline round trips per batch: one to read existing timestamps, one to write new values.\n\nFor initial bulk loads or append-only pipelines where out-of-order writes are not a concern, set `skip_dedup: true` to write in a **single pipeline round trip**:\n\n```yaml\nonline_store:\n  type: redis\n  connection_string: \"localhost:6379\"\n  skip_dedup: true\n```\n\n{% hint style=\"warning\" %}\nWith `skip_dedup: true`, writes always overwrite existing data regardless of timestamp order. Under concurrent writers, an older record can overwrite a newer one. Use only for controlled bulk loads or pipelines that guarantee ordered delivery.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:27:21+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "787d92a145e2769ea24e94135f4317770b10c9641e407ecbc8c064f26364266f",
+      "topic": "data",
+      "subject": "Prometheus Metrics / Audit logging",
+      "content": {
+        "fields": {
+          "type": "local",
+          "enabled": "true",
+          "audit_logging": "true"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 414,
+        "quote": "### Audit logging\n\nFeast can emit structured JSON audit log entries for every online and offline\nfeature retrieval. These are written via the standard `feast.audit` Python\nlogger, so you can route them to a dedicated file, SIEM, or log aggregator\nindependently of application logs.\n\nAudit logging is **disabled by default**. Enable it in `feature_store.yaml`:\n\n```yaml\nfeature_server:\n  type: local\n  metrics:\n    enabled: true\n    audit_logging: true\n```\n\n**Online audit log** (emitted per `/get-online-features` call):\n\n```json\n{\n  \"event\": \"online_feature_request\",\n  \"timestamp\": \"2026-05-11T08:30:00.123456+00:00\",\n  \"requestor_id\": \"user@example.com\",\n  \"entity_keys\": [\"driver_id\"],\n  \"entity_count\": 3,\n  \"feature_views\": [\"driver_hourly_stats\"],\n  \"feature_count\": 3,\n  \"status\": \"success\",\n  \"latency_ms\": 12.34\n}\n```\n\n**Offline audit log** (emitted per `RetrievalJob.to_arrow()` call):\n\n```json\n{\n  \"event\": \"offline_feature_retrieval\",\n  \"timestamp\": \"2026-05-11T08:31:00.456789+00:00\",\n  \"method\": \"to_arrow\",\n… (+24 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2c21b282b5d6ddd9d8460e1e6235f6b256ca9d14d330298719abe223e18b0637",
+      "topic": "data",
+      "subject": "Prometheus Metrics / Enabling metrics",
+      "content": {
+        "fields": {
+          "type": "local",
+          "enabled": "true"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 320,
+        "quote": "### Enabling metrics\n\n**Option 1 — CLI flag** (useful for one-off runs):\n\n```bash\nfeast serve --metrics\n```\n\n**Option 2 — `feature_store.yaml`** (recommended for production):\n\n```yaml\nfeature_server:\n  type: local\n  metrics:\n    enabled: true\n```\n\nEither option is sufficient. When both are set, metrics are enabled.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c367cdff38818df7c18ef308c3217c6ba5cc584562615471c9424dccd37ee1d7",
+      "topic": "data",
+      "subject": "Prometheus Metrics / Per-category control",
+      "content": {
+        "fields": {
+          "type": "local",
+          "enabled": "true",
+          "resource": "true",
+          "request": "false",
+          "online_features": "true",
+          "push": "true",
+          "materialization": "true",
+          "freshness": "true",
+          "offline_features": "true",
+          "audit_logging": "false"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 339,
+        "quote": "### Per-category control\n\nBy default, enabling metrics turns on **all** categories. You can selectively\ndisable individual categories within the same `metrics` block:\n\n```yaml\nfeature_server:\n  type: local\n  metrics:\n    enabled: true\n    resource: true          # CPU / memory gauges\n    request: false          # disable endpoint latency & request counters\n    online_features: true   # online feature retrieval counters\n    push: true              # push request counters\n    materialization: true   # materialization counters & duration\n    freshness: true         # feature freshness gauges\n    offline_features: true  # offline store retrieval counters & latency\n    audit_logging: false    # structured JSON audit logs (see below)\n```\n\nAny category set to `false` will emit no metrics and start no background\nthreads (e.g., setting `freshness: false` prevents the registry polling\nthread from starting). All categories default to `true` except\n`audit_logging`, which defaults to `false`.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "6b58e02e897c67a5c9dba65f6051511e8e6b8297ec606c56d08c50d9a363de7c",
+      "topic": "data",
+      "subject": "Quick Reference / Configuration Templates",
+      "content": {
+        "fields": {
+          "type": "ray.engine",
+          "storage_path": "s3://my-bucket/feast-data",
+          "broadcast_join_threshold_mb": "100",
+          "max_parallelism_multiplier": "1",
+          "target_partition_size_mb": "16",
+          "enable_ray_logging": "false",
+          "max_workers": "8",
+          "enable_optimization": "true"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 619,
+        "quote": "### Configuration Templates\n\n**Basic Ray Offline Store** (local development):\n```yaml\noffline_store:\n    type: ray\n    storage_path: ./data/ray_storage\n    # Conservative settings for local development\n    broadcast_join_threshold_mb: 25\n    max_parallelism_multiplier: 1\n    target_partition_size_mb: 16\n    enable_ray_logging: false\n```\n\n**Ray Offline Store + Compute Engine** (distributed processing):\n```yaml\noffline_store:\n    type: ray\n    storage_path: s3://my-bucket/feast-data\n    \nbatch_engine:\n    type: ray.engine\n    max_workers: 8\n    enable_optimization: true\n    broadcast_join_threshold_mb: 100\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c34bebd34513d967f730dee9507d4e6447e128ff0df844a34f4db76d02f82c68",
+      "topic": "data",
+      "subject": "REST API Endpoints / Relationships and Pagination",
+      "content": {
+        "fields": {
+          "entity": "Feast entities",
+          "dataSource": "Data sources",
+          "featureView": "Feature views (including regular, on-demand, and stream)",
+          "feature": "Features (including features from on-demand feature views)",
+          "featureService": "Feature services",
+          "permission": "Permissions",
+          "savedDataset": "Saved datasets"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 936,
+        "quote": "### Relationships and Pagination\n\nThe REST API has been enhanced with comprehensive support for relationships and pagination across all endpoints.\n\n#### Relationships\n\nRelationships show how different Feast objects connect to each other, providing insight into dependencies and data lineage. When the `include_relationships` parameter is set to `true`, the API returns both direct and indirect relationships.\n\n**Supported Object Types:**\n- `entity` - Feast entities\n- `dataSource` - Data sources\n- `featureView` - Feature views (including regular, on-demand, and stream)\n- `feature` - Features (including features from on-demand feature views)\n- `featureService` - Feature services\n- `permission` - Permissions\n- `savedDataset` - Saved datasets\n\n**Common Relationship Patterns:**\n- Feature Views → Data Sources (feature views depend on data sources)\n- Feature Views → Entities (feature views use entities as join keys)\n- Feature Services → Feature Views (feature services consume feature views)\n- Features → Feature Views (features belong to feature views, including on-demand feature views)\n- Features → Feature Services (features are consumed by feature services)\n- Entities → Data Sources (entities connect to data sources through feature views)\n- Entities → Feature Services (entities connect to feature services through feature views)\n\n#### Pagination\n\nAll list endpoints support pagination to improve performance and manageability of large datasets:\n\n- **`page`** - Page number (starts from 1)\n- **`limit`** - Number of items per page (maximum 100)\n- **`sort_by`** - Field to sort by\n- **`sort_order`** - Sort order: \"asc\" (ascending) or \"desc\" (descending)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8ea94ab5e96aef5fe61af3cd754b5958013a961bcb63d6382bfa9357c6d660b4",
+      "topic": "data",
+      "subject": "Redshift Serverless",
+      "content": {
+        "fields": {
+          "project": "my_feature_repo",
+          "registry": "data/registry.db",
+          "provider": "aws",
+          "type": "redshift",
+          "region": "us-west-2",
+          "workgroup": "feast-workgroup",
+          "database": "feast-database",
+          "s3_staging_location": "s3://feast-bucket/redshift",
+          "iam_role": "arn:aws:iam::123456789012:role/redshift_s3_access_role"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/redshift.md",
+        "line": 160,
+        "quote": "## Redshift Serverless\n\nIn order to use [AWS Redshift Serverless](https://aws.amazon.com/redshift/redshift-serverless/), specify a workgroup instead of a cluster_id and user.\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_feature_repo\nregistry: data/registry.db\nprovider: aws\noffline_store:\n  type: redshift\n  region: us-west-2\n  workgroup: feast-workgroup\n  database: feast-database\n  s3_staging_location: s3://feast-bucket/redshift\n  iam_role: arn:aws:iam::123456789012:role/redshift_s3_access_role\n```\n{% endcode %}\n\nPlease note that the IAM policies above will need the [redshift-serverless](https://aws.permissions.cloud/iam/redshift-serverless) version, rather than the standard [redshift](https://aws.permissions.cloud/iam/redshift)."
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-05-07T07:44:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2c1fce95c8106e49a61ea9c16573d20c9aa4eafd06d6cee1122cd9028c3352f2",
+      "topic": "data",
+      "subject": "Registry Server Configuration: Recent Visit Logging",
+      "content": {
+        "fields": {
+          "type": "local",
+          "limit": "100"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 1379,
+        "quote": "## Registry Server Configuration: Recent Visit Logging\n\nThe registry server supports configuration of recent visit logging via the `feature_server` section in `feature_store.yaml`.\n\n**Example:**\n```yaml\nfeature_server:\n  type: local\n  recent_visit_logging:\n    limit: 100  # Number of recent visits to store per user\n    log_patterns:\n      - \".*/entities/(?!all$)[^/]+$\"\n      - \".*/data_sources/(?!all$)[^/]+$\"\n      - \".*/feature_views/(?!all$)[^/]+$\"\n      - \".*/features/(?!all$)[^/]+$\"\n      - \".*/feature_services/(?!all$)[^/]+$\"\n      - \".*/saved_datasets/(?!all$)[^/]+$\"\n      - \".*/custom_api/.*\"\n```\n\n**Configuration Options:**\n- **recent_visit_logging.limit**: Maximum number of recent visits to store per user (default: 100).\n- **recent_visit_logging.log_patterns**: List of regex patterns for API paths to log as recent visits.\n\n**Default Log Patterns:**\n- `.*/entities/(?!all$)[^/]+$` - Individual entity endpoints\n- `.*/data_sources/(?!all$)[^/]+$` - Individual data source endpoints  \n- `.*/feature_views/(?!all$)[^/]+$` - Individual feature view endpoints\n- `.*/features/(?!all$)[^/]+$` - Individual feature endpoints\n- `.*/feature_services/(?!all$)[^/]+$` - Individual feature service endpoints\n- `.*/saved_datasets/(?!all$)[^/]+$` - Individual saved dataset endpoints\n\n**Behavior:**\n- Only requests matching one of the `log_patterns` will be tracked\n- Only the most recent `limit` visits per user are stored\n- Metrics endpoints (`/metrics/*`) are automatically excluded from logging to prevent circular references\n- Visit data is stored per user and per project in the registry metadata\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8a5774794b896c55891e709a6098f79ff6eb72627713fb86db964e55ab222a8d",
+      "topic": "data",
+      "subject": "Resource Management and Testing / Environment-Specific Recommendations",
+      "content": {
+        "fields": {
+          "type": "ray",
+          "broadcast_join_threshold_mb": "200",
+          "max_parallelism_multiplier": "4",
+          "target_partition_size_mb": "16",
+          "ray_address": "\"ray://cluster-head:10001\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 322,
+        "quote": "### Environment-Specific Recommendations\n\n#### Local Development\n```yaml\n# feature_store.yaml\noffline_store:\n    type: ray\n    broadcast_join_threshold_mb: 25\n    max_parallelism_multiplier: 1\n    target_partition_size_mb: 16\n```\n\n#### Production Clusters\n```yaml\n# feature_store.yaml  \noffline_store:\n    type: ray\n    ray_address: \"ray://cluster-head:10001\"\n    broadcast_join_threshold_mb: 200\n    max_parallelism_multiplier: 4\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "85350ed6bbf1fa68821ac957aa2f9270cbf7261dbb9ac7d4ab3d13c743deb960",
+      "topic": "data",
+      "subject": "Resource Management and Testing / Resource Configuration",
+      "content": {
+        "fields": {
+          "type": "ray",
+          "storage_path": "s3://my-bucket/feast-data",
+          "broadcast_join_threshold_mb": "100",
+          "max_parallelism_multiplier": "2",
+          "target_partition_size_mb": "64",
+          "enable_ray_logging": "true",
+          "num_cpus": "1",
+          "object_store_memory": "104857600",
+          "_memory": "524288000",
+          "ray_address": "\"ray://production-cluster:10001\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 277,
+        "quote": "### Resource Configuration\n\nFor custom resource control, configure limits in your `feature_store.yaml`:\n\n#### Conservative Settings (Local Development/Testing)\n\n```yaml\noffline_store:\n    type: ray\n    storage_path: ./data/ray_storage\n    # Resource optimization settings\n    broadcast_join_threshold_mb: 25        # Smaller datasets for broadcast joins\n    max_parallelism_multiplier: 1          # Reduced parallelism  \n    target_partition_size_mb: 16           # Smaller partition sizes\n    enable_ray_logging: false              # Disable verbose logging\n    # Memory constraints to prevent OOM in test environments\n    ray_conf:\n        num_cpus: 1\n        object_store_memory: 104857600      # 100MB\n        _memory: 524288000                  # 500MB\n```\n\n#### Production Settings\n\n```yaml\noffline_store:\n    type: ray\n    storage_path: s3://my-bucket/feast-data\n    ray_address: \"ray://production-cluster:10001\"\n    # Optimized for production workloads\n    broadcast_join_threshold_mb: 100\n    max_parallelism_multiplier: 2\n    target_partition_size_mb: 64\n    enable_ray_logging: true\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ee5d5412dc06431d2f71832b0e2fdf1215981ff1e4f8bf0ccfe078c296754bb4",
+      "topic": "data",
+      "subject": "SDK Configuration (Python) / Method 3: Configuration File",
+      "content": {
+        "fields": {
+          "project": "my-project",
+          "type": "kubernetes",
+          "user_token": "\"your-kubernetes-user-token-here\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/user_token_provisioning.md",
+        "line": 54,
+        "quote": "### Method 3: Configuration File\n\nCreate or update your `feature_store.yaml`:\n\n```yaml\nproject: my-project\nauth:\n  type: kubernetes\n  user_token: \"your-kubernetes-user-token-here\"\n```\nFeature Store will read the token from config YAML\n```python\nfs = FeatureStore(\"path/to/feature_repo\")\n```\n\n**Note**: The `KubernetesAuthConfig` class is configured to allow extra fields, so the `user_token` field will be properly recognized when loaded from YAML files.\n\nThen use in Python:\n\n```python\nfrom feast import FeatureStore\n\n# FeatureStore will read auth config from feature_store.yaml\nfs = FeatureStore(\"path/to/feature_repo\")\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "acad31645144375829e26419a654fcff49558d91746a7585d0333f81fed4a851",
+      "topic": "data",
+      "subject": "Setup and Configuration / 3. Configure OpenTelemetry Collector",
+      "content": {
+        "fields": {
+          "enabled": "true",
+          "endpoint": "\"otel-collector.default.svc.cluster.local:4317\"",
+          "api-key": "\"your-api-key\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/open-telemetry.md",
+        "line": 54,
+        "quote": "### 3. Configure OpenTelemetry Collector\nAdd the OpenTelemetry Collector configuration under the metrics section in your values.yaml file:\n\n```yaml\nmetrics:\n  enabled: true\n  otelCollector:\n    endpoint: \"otel-collector.default.svc.cluster.local:4317\"  # sample\n    headers:\n      api-key: \"your-api-key\"\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-24T10:11:58-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "79fef2d1ced2ce63c20d0efede052a5cc3885bda5db68b50d58e9088574807d2",
+      "topic": "data",
+      "subject": "Setup and Configuration / 4. Add Instrumentation Configuration",
+      "content": {
+        "fields": {
+          "value": "\"true\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/open-telemetry.md",
+        "line": 66,
+        "quote": "### 4. Add Instrumentation Configuration\nAdd the following annotations and environment variables to your deployment.yaml:\n\n```yaml\ntemplate:\n  metadata:\n    annotations:\n      instrumentation.opentelemetry.io/inject-python: \"true\"\n```\n\n```yaml\n- name: OTEL_EXPORTER_OTLP_ENDPOINT\n  value: http://{{ .Values.service.name }}-collector.{{ .Release.namespace }}.svc.cluster.local:{{ .Values.metrics.endpoint.port}}\n- name: OTEL_EXPORTER_OTLP_INSECURE\n  value: \"true\"\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-24T10:11:58-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "fa5366b64dc4099fd463cb3db17c05c8413d14f074c4c181e08c6a782382eb76",
+      "topic": "data",
+      "subject": "Setup and Configuration / 5. Add Metric Checks",
+      "content": {
+        "fields": {
+          "apiVersion": "opentelemetry.io/v1alpha1",
+          "kind": "Instrumentation",
+          "name": "feast-instrumentation",
+          "endpoint": "string",
+          "value": "\"true\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/open-telemetry.md",
+        "line": 83,
+        "quote": "### 5. Add Metric Checks\nAdd metric checks to all manifests and deployment files:\n\n```yaml\n{{ if .Values.metrics.enabled }}\napiVersion: opentelemetry.io/v1alpha1\nkind: Instrumentation\nmetadata:\n  name: feast-instrumentation\nspec:\n  exporter:\n    endpoint: http://{{ .Values.service.name }}-collector.{{ .Release.Namespace }}.svc.cluster.local:4318\n  env:\n  propagators:\n    - tracecontext\n    - baggage\n  python:\n    env:\n      - name: OTEL_METRICS_EXPORTER\n        value: console,otlp_proto_http\n      - name: OTEL_LOGS_EXPORTER\n        value: otlp_proto_http\n      - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED\n        value: \"true\"\n{{end}}\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-24T10:11:58-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4e89543c7294ec1a1d12621cfba9825d1aea7b1767424d7e056eec8471d62e06",
+      "topic": "data",
+      "subject": "Synapse offline store (contrib) / Example",
+      "content": {
+        "fields": {
+          "registry_store_type": "AzureRegistryStore",
+          "path": "${REGISTRY_PATH}",
+          "project": "production",
+          "provider": "azure",
+          "type": "mssql",
+          "connection_string": "${SQL_CONN}"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/mssql.md",
+        "line": 17,
+        "quote": "## Example\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nregistry:\n  registry_store_type: AzureRegistryStore\n  path: ${REGISTRY_PATH} # Environment Variable\nproject: production\nprovider: azure\nonline_store:\n    type: redis\n    connection_string: ${REDIS_CONN} # Environment Variable\noffline_store:\n    type: mssql\n    connection_string: ${SQL_CONN}  # Environment Variable\n```\n{% endcode %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-09-26T10:00:57-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a82109bc840e97590fc89f553573f774df35a6966d7bf760452712d48a891af4",
+      "topic": "data",
+      "subject": "TTL configuration",
+      "content": {
+        "fields": {
+          "type": "redis",
+          "key_ttl_seconds": "604800",
+          "connection_string": "\"localhost:6379\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/redis.md",
+        "line": 68,
+        "quote": "## TTL configuration\n\nThe Redis online store supports two complementary TTL mechanisms:\n\n### Key-level TTL (`key_ttl_seconds`)\n\nSets a Redis `EXPIRE` on the entire entity hash key. When the TTL elapses, Redis automatically deletes all feature values for that entity across **all** feature views that share the same key. Use this to bound memory usage and automatically evict stale entity data.\n\n```yaml\nonline_store:\n  type: redis\n  key_ttl_seconds: 604800   # 7 days\n  connection_string: \"localhost:6379\"\n```\n\n{% hint style=\"warning\" %}\nBecause all feature views for the same entity share one Redis hash key, `key_ttl_seconds` uses the **entity** as the expiry unit, not the feature view. Writing any feature view for an entity resets the TTL for the whole hash. This means a frequently written feature view can keep a stale, infrequently written feature view alive beyond its intended TTL.\n{% endhint %}\n\n{% hint style=\"info\" %}\n`FeatureView.ttl` defines the **offline retrieval window** (how far back in time point-in-time joins look in the offline store). It does **not** filter online store reads. To control online data expiry, use `key_ttl_seconds`.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:27:21+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b98b35d8ca23f2e5aa301529d336cdf87546238c3cd365e5f4a252a49460e5a0",
+      "topic": "data",
+      "subject": "The feature\\_store.yaml configuration file",
+      "content": {
+        "fields": {
+          "project": "my_feature_repo_1",
+          "registry": "data/metadata.db",
+          "provider": "local",
+          "path": "data/online_store.db"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-repository.md",
+        "line": 46,
+        "quote": "## The feature\\_store.yaml configuration file\n\nThe configuration for a feature store is stored in a file named `feature_store.yaml` , which must be located at the root of a feature repository. An example `feature_store.yaml` file is shown below:\n\n{% code title=\"feature\\_store.yaml\" %}\n```yaml\nproject: my_feature_repo_1\nregistry: data/metadata.db\nprovider: local\nonline_store:\n    path: data/online_store.db\n```\n{% endcode %}\n\nThe `feature_store.yaml` file configures how the feature store should run. See [feature\\_store.yaml](feature-store-yaml.md) for more details.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-08-05T15:51:41-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c505d473eb9c1a115471620c08c5d09d8767db8609e651095be8ad06fe01539f",
+      "topic": "data",
+      "subject": "Transport Types / File Transport",
+      "content": {
+        "fields": {
+          "enabled": "true",
+          "transport_type": "file",
+          "log_file_path": "openlineage_events.json"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 135,
+        "quote": "### File Transport\n\n```yaml\nopenlineage:\n  enabled: true\n  transport_type: file\n  additional_config:\n    log_file_path: openlineage_events.json\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9f90c273dd5d343fd58a2100af8470412cc92f17cddc1c6008410a930db417f5",
+      "topic": "data",
+      "subject": "Transport Types / HTTP Transport (Recommended for Production)",
+      "content": {
+        "fields": {
+          "enabled": "true",
+          "transport_type": "http",
+          "transport_url": "http://marquez:5000",
+          "transport_endpoint": "api/v1/lineage",
+          "api_key": "your-api-key"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 124,
+        "quote": "### HTTP Transport (Recommended for Production)\n\n```yaml\nopenlineage:\n  enabled: true\n  transport_type: http\n  transport_url: http://marquez:5000\n  transport_endpoint: api/v1/lineage\n  api_key: your-api-key  # Optional\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2ff08272cf36f46f2d4a81eeea6e8c7b9e292d877f02c6dc60d3653a1ce61214",
+      "topic": "data",
+      "subject": "Transport Types / Kafka Transport",
+      "content": {
+        "fields": {
+          "enabled": "true",
+          "transport_type": "kafka",
+          "bootstrap_servers": "localhost:9092",
+          "topic": "openlineage.events"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 145,
+        "quote": "### Kafka Transport\n\n```yaml\nopenlineage:\n  enabled: true\n  transport_type: kafka\n  additional_config:\n    bootstrap_servers: localhost:9092\n    topic: openlineage.events\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a63d02f4c7488cc31b84292efb0f361365ecd4810231f720fe8d0abb3fda34e8",
+      "topic": "data",
+      "subject": "Usage",
+      "content": {
+        "fields": {
+          "enabled": "true",
+          "endpoint": "\"otel-collector.default.svc.cluster.local:4317\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/open-telemetry.md",
+        "line": 125,
+        "quote": "## Usage\n\nTo enable OpenTelemetry monitoring in your Feast deployment:\n\n1. Set `metrics.enabled=true` in your Helm values\n2. Configure the OpenTelemetry Collector endpoint\n3. Deploy with proper annotations and environment variables\n\nExample configuration:\n```yaml\nmetrics:\n  enabled: true\n  otelCollector:\n    endpoint: \"otel-collector.default.svc.cluster.local:4317\"\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-24T10:11:58-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "345344bebe768ceecf6c04e1e539a04e24542c2040cefc1b1f2564eb2d9957a8",
+      "topic": "data",
+      "subject": "Usage Examples / Advanced Configuration",
+      "content": {
+        "fields": {
+          "type": "ray.engine",
+          "max_workers": "16",
+          "max_parallelism_multiplier": "4",
+          "enable_optimization": "true",
+          "broadcast_join_threshold_mb": "50",
+          "target_partition_size_mb": "128",
+          "window_size_for_joins": "\"30min\"",
+          "ray_address": "\"ray://head-node:10001\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 178,
+        "quote": "### Advanced Configuration\n\n```yaml\n# Production-ready configuration\nbatch_engine:\n    type: ray.engine\n    # Resource configuration\n    max_workers: 16\n    max_parallelism_multiplier: 4\n    \n    # Performance optimization\n    enable_optimization: true\n    broadcast_join_threshold_mb: 50\n    target_partition_size_mb: 128\n    \n    # Distributed join configuration\n    window_size_for_joins: \"30min\"\n    \n    # Ray cluster configuration\n    ray_address: \"ray://head-node:10001\"\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "bde1437d65ad4827c4bc72dab161234c43c0da11eedd69b80d31e3ee38948979",
+      "topic": "data",
+      "subject": "Usage Examples / Complete Example Configuration",
+      "content": {
+        "fields": {
+          "project": "my_feast_project",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "ray.engine",
+          "storage_path": "s3://my-bucket/feast-data",
+          "ray_address": "localhost:10001",
+          "max_workers": "8",
+          "max_parallelism_multiplier": "2",
+          "enable_optimization": "true",
+          "broadcast_join_threshold_mb": "100",
+          "target_partition_size_mb": "64",
+          "window_size_for_joins": "\"1H\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 200,
+        "quote": "### Complete Example Configuration\n\nHere's a complete example configuration showing how to use Ray offline store with Ray compute engine:\n\n```yaml\n# Complete example configuration for Ray offline store + Ray compute engine\n# This shows how to use both components together for distributed processing\n\nproject: my_feast_project\nregistry: data/registry.db\nprovider: local\n\n# Ray offline store configuration\n# Handles data I/O operations (reading/writing data)\noffline_store:\n    type: ray\n    storage_path: s3://my-bucket/feast-data    # Optional: Path for storing datasets\n    ray_address: localhost:10001               # Optional: Ray cluster address\n\n# Ray compute engine configuration  \n# Handles complex feature computation and distributed processing\nbatch_engine:\n    type: ray.engine\n    \n    # Resource configuration\n    max_workers: 8                             # Maximum number of Ray workers\n    max_parallelism_multiplier: 2              # Parallelism as multiple of CPU cores\n    \n    # Performance optimization\n    enable_optimization: true                  # Enable performance optimizations\n    broadcast_join_threshold_mb: 100           # Broadcast join threshold (MB)\n    target_partition_size_mb: 64               # Target partition size (MB)\n    \n    # Distributed join configuration\n    window_size_for_joins: \"1H\"                # Time window for distributed joins\n    \n    # Ray cluster configuration (inherits from offline_store if not specified)\n    ray_address: localhost:10001               # Ray cluster address\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "332f0b73ef29ca45531e5e31135b3b92c4c24b072eac7c710aae7e9ddf392037",
+      "topic": "data",
+      "subject": "Usage Examples / Using Ray Cluster",
+      "content": {
+        "fields": {
+          "type": "ray",
+          "ray_address": "localhost:10001",
+          "storage_path": "s3://my-bucket/feast-data",
+          "use_kuberay": "true",
+          "cluster_name": "\"feast-ray-cluster\"",
+          "namespace": "\"feast-system\"",
+          "auth_token": "\"${RAY_AUTH_TOKEN}\"",
+          "auth_server": "\"https://api.openshift.com:6443\"",
+          "skip_tls": "false",
+          "enable_ray_logging": "false"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 477,
+        "quote": "### Using Ray Cluster\n\n#### Standard Ray Cluster\n\nTo use Ray in cluster mode for distributed data access:\n\n1. Start a Ray cluster:\n```bash\nray start --head --port=10001\n```\n\n2. Configure your `feature_store.yaml`:\n```yaml\noffline_store:\n    type: ray\n    ray_address: localhost:10001\n    storage_path: s3://my-bucket/features\n```\n\n3. For multiple worker nodes:\n```bash\n# On worker nodes\nray start --address='head-node-ip:10001'\n```\n\n#### KubeRay Cluster (Kubernetes)\n\nTo use Feast with Ray clusters on Kubernetes via CodeFlare SDK:\n\n**Prerequisites:**\n- KubeRay cluster deployed on Kubernetes\n- CodeFlare SDK installed: `pip install codeflare-sdk`\n- Access credentials for the Kubernetes cluster\n\n**Configuration:**\n\n1. Using configuration file:\n```yaml\noffline_store:\n    type: ray\n… (+32 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "81663dc7d740b41b7b17491678e6ff7a43057cc1f96b4a8e117d6b3ca161b539",
+      "topic": "data",
+      "subject": "Vector Search / Configuration",
+      "content": {
+        "fields": {
+          "project": "my_project",
+          "provider": "local",
+          "type": "mongodb",
+          "connection_string": "mongodb+srv://<user>:<pass>@cluster.mongodb.net",
+          "vector_enabled": "true",
+          "similarity": "cosine",
+          "vector_index_wait_timeout": "60",
+          "vector_index_wait_poll_interval": "1.0"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/mongodb.md",
+        "line": 33,
+        "quote": "### Configuration\n\nEnable vector search in your `feature_store.yaml`:\n\n```yaml\nproject: my_project\nprovider: local\nonline_store:\n  type: mongodb\n  connection_string: mongodb+srv://<user>:<pass>@cluster.mongodb.net  # pragma: allowlist secret\n  vector_enabled: true\n  similarity: cosine  # cosine | euclidean | dotProduct\n  vector_index_wait_timeout: 60  # seconds to wait for index to become queryable\n  vector_index_wait_poll_interval: 1.0  # seconds between polls\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9ae5db4535da431b960071ee0b98d81af10c9802ecdcc75e103859158a55e1d6",
+      "topic": "data",
+      "subject": "Worker Resource Scheduling / Full example — KubeRay with GPU + all common options",
+      "content": {
+        "fields": {
+          "type": "ray.engine",
+          "use_kuberay": "true",
+          "cluster_name": "\"feast-gpu-cluster\"",
+          "namespace": "\"feast-system\"",
+          "auth_token": "\"${RAY_AUTH_TOKEN}\"",
+          "auth_server": "\"https://api.openshift.com:6443\"",
+          "num_gpus": "1",
+          "gpu_batch_format": "numpy",
+          "num_cpus": "4",
+          "memory": "8589934592",
+          "accelerator_type": "\"A100\"",
+          "max_retries": "5",
+          "CUDA_VISIBLE_DEVICES": "\"0\""
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 404,
+        "quote": "### Full example — KubeRay with GPU + all common options\n\n```yaml\nbatch_engine:\n    type: ray.engine\n    use_kuberay: true\n    kuberay_conf:\n        cluster_name: \"feast-gpu-cluster\"\n        namespace: \"feast-system\"\n        auth_token: \"${RAY_AUTH_TOKEN}\"\n        auth_server: \"https://api.openshift.com:6443\"\n    num_gpus: 1\n    gpu_batch_format: numpy\n    worker_task_options:\n        num_cpus: 4\n        memory: 8589934592        # 8 GB\n        accelerator_type: \"A100\"  # pin to A100 nodes on mixed GPU pool\n        max_retries: 5\n        runtime_env:\n            pip:\n                - cudf-cu12==24.10.0\n                - torch==2.4.0\n            env_vars:\n                CUDA_VISIBLE_DEVICES: \"0\"\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8f73aa88a1032bc22079a19c8719431ae445fef665ac8b0cd9186328493f9265",
+      "topic": "data",
+      "subject": "Worker Resource Scheduling / GPU support",
+      "content": {
+        "fields": {
+          "type": "ray.engine",
+          "num_gpus": "1",
+          "gpu_batch_format": "numpy"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 382,
+        "quote": "### GPU support\n\n`num_gpus` is the only first-class GPU field because it also drives `gpu_batch_format` selection inside Feast. Set it directly rather than inside `worker_task_options`:\n\n```yaml\nbatch_engine:\n    type: ray.engine\n    num_gpus: 1               # GPUs per task (fractional values like 0.5 supported)\n    gpu_batch_format: numpy   # numpy/pyarrow for GPU-native libs (cuDF, PyTorch)\n```\n\nWhen `num_gpus` is set your transformation UDF runs on a GPU worker:\n\n```python\nimport cudf  # RAPIDS cuDF – GPU-accelerated DataFrame library\n\ndef gpu_transform(batch):\n    gpu_df = cudf.from_pandas(batch)\n    gpu_df[\"score\"] = gpu_df[\"raw_value\"] * 2.0\n    return gpu_df.to_pandas()\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "6a145cd593c62b6c7abc6151099eeaf0e8fff298f775b34cf830eaa6d901a9d0",
+      "topic": "data",
+      "subject": "`materialization` configuration / `online_write_batch_size`",
+      "content": {
+        "fields": {
+          "online_write_batch_size": "10000"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-repository/feature-store-yaml.md",
+        "line": 52,
+        "quote": "### `online_write_batch_size`\n\n| Field | Type | Default | Supported engines |\n| --- | --- | --- | --- |\n| `online_write_batch_size` | `int` (positive) | `null` | local, spark, ray |\n\nControls how many rows are converted to protobuf and written to the online store per batch during materialization.\n\n**Default behaviour (`null`):** All rows fetched from the offline store are converted to protobuf in a single in-memory operation before writing. This is fast but can exhaust memory for large datasets — every row must be held as a Python proto object simultaneously.\n\n**With `online_write_batch_size` set:** The Arrow table returned by the offline store is split into chunks of at most `online_write_batch_size` rows. Each chunk is converted and written independently, keeping peak memory proportional to the batch size rather than the full dataset size.\n\n```yaml\n# Recommended for datasets > a few million rows or memory-constrained workers\nmaterialization:\n  online_write_batch_size: 10000\n```\n\n**Choosing a value:**\n\n| Dataset size | Worker memory | Recommended batch size |\n| --- | --- | --- |\n| < 1 M rows | Any | `null` (default — single batch is fine) |\n| 1–10 M rows | ≥ 4 GB | `50000` |\n| 10–100 M rows | ≥ 8 GB | `10000` |\n| > 100 M rows | Any | `5000`–`10000` |\n\nA smaller batch size reduces peak memory at the cost of more `online_write_batch` calls to the online store. For Redis, each call is a pipelined batch, so the overhead is low. For stores with higher per-call latency (e.g. DynamoDB), prefer larger batch sizes.\n\n{% hint style=\"info\" %}\n`online_write_batch_size` is applied **per feature view** within a single materialization job. If you materialize five feature views in parallel, peak memory is `5 × batch_size × bytes_per_row`.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:27:21+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "40f2ef2409a21ca25f7345a0d69c4dabe7adf77875de4f6e3fe03e251fa554d2",
+      "topic": "data",
+      "subject": "batch_engine configuration",
+      "content": {
+        "fields": {
+          "type": "string (e.g. spark.engine, local.engine)",
+          "config": "object (engine-specific configuration)"
+        },
+        "validation": {
+          "location": "feature_store.yaml under batch_engine key"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/compute-engine.md",
+        "line": 31,
+        "quote": "### Batch Engine\nBatch Engine Config can be configured in the `feature_store.yaml` file, and it serves as the default configuration for all materialization and historical retrieval tasks. The `batch_engine` config in BatchFeatureView. E.g\n```yaml\nbatch_engine:\n    type: spark.engine\n    config:\n        spark_master: \"local[*]\"\n        spark_app_name: \"Feast Batch Engine\"\n        spark_conf:\n            spark.sql.shuffle.partitions: 100\n            spark.executor.memory: \"4g\"\n\n```\nin BatchFeatureView.\n```python\nfrom feast import BatchFeatureView\n\nfv = BatchFeatureView(\n    batch_engine={\n        \"spark_conf\": {\n            \"spark.sql.shuffle.partitions\": 200,\n            \"spark.executor.memory\": \"8g\"\n        },\n    }\n)\n```\nThen, when you materialize the feature view, it will use the batch_engine configuration specified in the feature view, which has shuffle partitions set to 200 and executor memory set to 8g.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-29T14:42:40-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9a18f00e5fe54efa5e4e85f1c44a45f297baa56f5ec3c836d4198fbbcde7cdbd",
+      "topic": "data",
+      "subject": "compute engine types",
+      "content": {
+        "fields": {
+          "LocalComputeEngine": "Arrow + Pandas/Polars/Dask, lightweight",
+          "SparkComputeEngine": "Apache Spark, large-scale",
+          "LambdaComputeEngine": "AWS Lambda",
+          "RayComputeEngine": "Ray distributed",
+          "SnowflakeComputeEngine": "Snowflake"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/compute-engine.md",
+        "line": 19,
+        "quote": "### Supported Compute Engines\n```markdown\n| Compute Engine         | Description                                                                                      | Supported  | Link |\n|-------------------------|-------------------------------------------------------------------------------------------------|------------|------|\n| LocalComputeEngine      | Runs on Arrow + Pandas/Polars/Dask etc., designed for light weight transformation.              | ✅         |      |\n| SparkComputeEngine      | Runs on Apache Spark, designed for large-scale distributed feature generation.                  | ✅         |      |\n| SnowflakeComputeEngine  | Runs on Snowflake, designed for scalable feature generation using Snowflake SQL.                | ✅         |      |\n| LambdaComputeEngine     | Runs on AWS Lambda, designed for serverless feature generation.                                 | ✅         |      |\n| FlinkComputeEngine      | Runs on Apache Flink, designed for stream processing and real-time feature generation.          | ❌         |      |\n| RayComputeEngine        | Runs on Ray, designed for distributed feature generation and machine learning workloads.        | ✅         |      |\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-29T14:42:40-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "81ed676581729a883302b7559e12f72a94ebcca49b07a535b0763e1b443f1c17",
+      "topic": "data",
+      "subject": "stream_engine configuration",
+      "content": {
+        "fields": {
+          "type": "string (e.g. spark.engine)",
+          "config": "object (engine-specific configuration)"
+        },
+        "validation": {
+          "location": "feature_store.yaml under stream_engine key"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/compute-engine.md",
+        "line": 59,
+        "quote": "### Stream Engine\nStream Engine Config can be configured in the `feature_store.yaml` file, and it serves as the default configuration for all stream materialization and historical retrieval tasks. The `stream_engine` config in FeatureView. E.g\n```yaml\nstream_engine:\n    type: spark.engine\n    config:\n        spark_master: \"local[*]\"\n        spark_app_name: \"Feast Stream Engine\"\n        spark_conf:\n            spark.sql.shuffle.partitions: 100\n            spark.executor.memory: \"4g\"\n```\n```python\nfrom feast import StreamFeatureView\nfv = StreamFeatureView(\n    stream_engine={\n        \"spark_conf\": {\n            \"spark.sql.shuffle.partitions\": 200,\n            \"spark.executor.memory\": \"8g\"\n        },\n    }\n)\n```\nThen, when you materialize the feature view, it will use the stream_engine configuration specified in the feature view, which has shuffle partitions set to 200 and executor memory set to 8g.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-29T14:42:40-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "855a7182e30e230ece8145d59d250520214f9713ca8272ff8d8a81f4f2d863f8",
+      "topic": "overview",
+      "subject": "**Permissions**",
+      "content": {
+        "summary": "## **Permissions** | **Command**                 | Component               | Permissions"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/providers/google-cloud-platform.md",
+        "line": 21,
+        "quote": "## **Permissions**\n\n| **Command**                 | Component               | Permissions                                                                                                                                                                                                                    | Recommended Role          |\n| --------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------- |\n| **Apply**                   | BigQuery (source)       | <p>bigquery.jobs.create</p><p>bigquery.readsessions.create</p><p>bigquery.readsessions.getData</p>                                                                                                                             | roles/bigquery.user       |\n| **Apply**                   | Datastore (destination) | <p>datastore.entities.allocateIds</p><p>datastore.entities.create</p><p>datastore.entities.delete</p><p>datastore.entities.get</p><p>datastore.entities.list</p><p>datastore.entities.update</p>                               | roles/datastore.owner     |\n| **Materialize**             | BigQuery (source)       | bigquery.jobs.create                                                                                                                                                                                                           | roles/bigquery.user       |\n| **Materialize**             | Datastore (destination) | <p>datastore.entities.allocateIds</p><p>datastore.entities.create</p><p>datastore.entities.delete</p><p>datastore.entities.get</p><p>datastore.entities.list</p><p>datastore.entities.update</p><p>datastore.databases.get</p> | roles/datastore.owner     |\n| **Get Online Features**     | Datastore               | datastore.entities.get                                                                                                                                                                                                         | roles/datastore.user      |\n| **Get Historical Features** | BigQuery (source)       | <p>bigquery.datasets.get</p><p>bigquery.tables.get</p><p>bigquery.tables.create</p><p>bigquery.tables.updateData</p><p>bigquery.tables.update</p><p>bigquery.tables.delete</p><p>bigquery.tables.getData</p>                   | roles/bigquery.dataEditor |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-09-26T10:00:57-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "265930964d1f18c5d20544f83c5cfb4f27bb98657cf916abffcb06dc4e62eb9a",
+      "topic": "overview",
+      "subject": "Accessing the registry from clients / Option 1: programmatically specifying the registry",
+      "content": {
+        "summary": "### Option 1: programmatically specifying the registry"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/registry.md",
+        "line": 77,
+        "quote": "### Option 1: programmatically specifying the registry\n\n```python\nrepo_config = RepoConfig(\n    registry=RegistryConfig(path=\"gs://feast-test-gcs-bucket/registry.pb\"),\n    project=\"feast_demo_gcp\",\n    provider=\"gcp\",\n    offline_store=\"file\",  # Could also be the OfflineStoreConfig e.g. FileOfflineStoreConfig\n    online_store=\"null\",  # Could also be the OnlineStoreConfig e.g. RedisOnlineStoreConfig\n)\nstore = FeatureStore(config=repo_config)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-14T10:41:09-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "897394e9aa9801007938856ddf9588a00825c9ff9119b4af9a104a2fd4f78b3c",
+      "topic": "overview",
+      "subject": "Aggregation Categories / Algebraic Aggregations",
+      "content": {
+        "summary": "### Algebraic Aggregations These can be merged by applying the same aggregation function to tiles: | Aggregation | Stored Value | Merge Strategy | Storage | |-------------|--------------|----------------|---------| | `sum` | sum | `sum(tile_sums)` | 1 column | | `count` | count | `sum(tile_counts)`"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/tiling.md",
+        "line": 74,
+        "quote": "### Algebraic Aggregations\n\nThese can be merged by applying the same aggregation function to tiles:\n\n| Aggregation | Stored Value | Merge Strategy | Storage |\n|-------------|--------------|----------------|---------|\n| `sum` | sum | `sum(tile_sums)` | 1 column |\n| `count` | count | `sum(tile_counts)` | 1 column |\n| `max` | max | `max(tile_maxes)` | 1 column |\n| `min` | min | `min(tile_mins)` | 1 column |\n\n**No IRs needed** - the final value is the IR!\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "463980edcc79613cfdaf7138e48e918565634fb2de96b0f24df34df7da36a612",
+      "topic": "overview",
+      "subject": "Aggregation Categories / Holistic Aggregations",
+      "content": {
+        "summary": "### Holistic Aggregations These require storing multiple intermediate values: #### Average (`avg`, `mean`) **Stored IRs**: `sum`, `count`   **Final computation**: `avg = sum / count`   **Merge strategy**: Sum the sums and counts, then divide **Storage**: 3 columns (final + 2 IRs) --- #### Standard D"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/tiling.md",
+        "line": 89,
+        "quote": "### Holistic Aggregations\n\nThese require storing multiple intermediate values:\n\n#### Average (`avg`, `mean`)\n\n**Stored IRs**: `sum`, `count`  \n**Final computation**: `avg = sum / count`  \n**Merge strategy**: Sum the sums and counts, then divide\n\n**Storage**: 3 columns (final + 2 IRs)\n\n---\n\n#### Standard Deviation (`std`, `stddev`)\n\n**Stored IRs**: `count`, `sum`, `sum_of_squares`  \n**Final computation**: \n```python\nvariance = (sum_sq - sum²/count) / (count - δ)\nstd = sqrt(variance)\n# δ = 1 for sample, 0 for population\n```\n\n**Merge strategy**: Sum all three IRs, then apply formula\n\n**Storage**: 4 columns (final + 3 IRs)\n\n---\n\n#### Variance (`var`, `variance`)\n\n**Stored IRs**: `count`, `sum`, `sum_of_squares`  \n**Final computation**: Same as std but without `sqrt()`\n\n**Storage**: 4 columns (final + 3 IRs)\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a54168f0ec42e11d3cd7fc7574022bad1416dae3e8c82faba418aab9df2fdd5c",
+      "topic": "overview",
+      "subject": "Aggregations / Usage",
+      "content": {
+        "summary": "### Usage Aggregated columns are automatically named using the pattern `{function}_{column}` (e.g., `sum_trips`, `mean_rating`)."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/beta-on-demand-feature-view.md",
+        "line": 48,
+        "quote": "### Usage\n\n```python\nfrom feast import Aggregation\nfrom datetime import timedelta\n\n@on_demand_feature_view(\n    sources=[driver_hourly_stats_view],\n    schema=[\n        Field(name=\"total_trips\", dtype=Int64),\n        Field(name=\"avg_rating\", dtype=Float64),\n    ],\n    aggregations=[\n        Aggregation(column=\"trips\", function=\"sum\"),\n        Aggregation(column=\"rating\", function=\"mean\"),\n    ],\n)\ndef driver_aggregated_stats(inputs):\n    # No transformation function needed when using aggregations\n    pass\n```\n\nAggregated columns are automatically named using the pattern `{function}_{column}` (e.g., `sum_trips`, `mean_rating`).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-22T17:08:58-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f66591dd5212c265a06cad87b9ce02466abde565ecb5d3e3a435250ee5d79315",
+      "topic": "overview",
+      "subject": "Aggregations / Using `input_schema` with Aggregations",
+      "content": {
+        "summary": "### Using `input_schema` with Aggregations When the input data is not already stored as a feature view, use `input_schema` instead of `sources` to describe the fields that will be passed at request ti"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/beta-on-demand-feature-view.md",
+        "line": 72,
+        "quote": "### Using `input_schema` with Aggregations\n\nWhen the input data is not already stored as a feature view, use `input_schema` instead of `sources` to describe the fields that will be passed at request time. Feast will create an internal `RequestSource` automatically.\n\n```python\nfrom datetime import timedelta\nfrom feast import Field, on_demand_feature_view\nfrom feast.aggregation import Aggregation\nfrom feast.types import Float64, Int64\n\n@on_demand_feature_view(\n    input_schema=[\n        Field(name=\"txn_amount\", dtype=Float64),\n    ],\n    schema=[\n        Field(name=\"txn_count\", dtype=Int64),\n        Field(name=\"total_txn_amount\", dtype=Float64),\n        Field(name=\"avg_txn_amount\", dtype=Float64),\n    ],\n    aggregations=[\n        Aggregation(column=\"txn_amount\", function=\"count\", name=\"txn_count\",\n                    time_window=timedelta(days=30)),\n        Aggregation(column=\"txn_amount\", function=\"sum\", name=\"total_txn_amount\",\n                    time_window=timedelta(days=30)),\n        Aggregation(column=\"txn_amount\", function=\"mean\", name=\"avg_txn_amount\",\n                    time_window=timedelta(days=30)),\n    ],\n    entities=[user],\n)\ndef user_transaction_stats(inputs):\n    # Aggregations replace the transformation function — no body needed.\n    pass\n```\n\n`input_schema` also accepts fields that are not aggregation columns — for example, thresholds, currency codes, or other contextual values passed at request time that your UDF needs but that are not stored as features.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-22T17:08:58-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "bb1ab85d6d909216c19eed9ed7c98d04a454d00cc1bf663d96553a41f17dcbde",
+      "topic": "overview",
+      "subject": "Appendix A. Value proto format.",
+      "content": {
+        "summary": "##### Appendix A. Value proto format."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/online_store_format.md",
+        "line": 200,
+        "quote": "##### Appendix A. Value proto format.\n\n```protobuf\nmessage ValueType {\n  enum Enum {\n    INVALID = 0;\n    BYTES = 1;\n    STRING = 2;\n    INT32 = 3;\n    INT64 = 4;\n    DOUBLE = 5;\n    FLOAT = 6;\n    BOOL = 7;\n    UNIX_TIMESTAMP = 8;\n    BYTES_LIST = 11;\n    STRING_LIST = 12;\n    INT32_LIST = 13;\n    INT64_LIST = 14;\n    DOUBLE_LIST = 15;\n    FLOAT_LIST = 16;\n    BOOL_LIST = 17;\n    UNIX_TIMESTAMP_LIST = 18;\n  }\n}\n\nmessage Value {\n  // ValueType is referenced by the metadata types, FeatureInfo and EntityInfo.\n  // The enum values do not have to match the oneof val field ids, but they should.\n  oneof val {\n    bytes bytes_val = 1;\n    string string_val = 2;\n    int32 int32_val = 3;\n    int64 int64_val = 4;\n    double double_val = 5;\n    float float_val = 6;\n    bool bool_val = 7;\n    int64 unix_timestamp_val = 8;\n    BytesList bytes_list_val = 11;\n    StringList string_list_val = 12;\n    Int32List int32_list_val = 13;\n… (+38 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-10-05T11:10:11-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "018df1ddad957f2965cc39307a45b748fd5ebb05d583eeb4b3bae167cd33a59a",
+      "topic": "overview",
+      "subject": "Apply",
+      "content": {
+        "summary": "## Apply Creates or updates a feature store deployment **Options:** * `--skip-source-validation`: Skip validation of data sources (don't check if tables exist) * `--skip-feature-view-validation`: Skip"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 48,
+        "quote": "## Apply\n\nCreates or updates a feature store deployment\n\n```bash\nfeast apply\n```\n\n**Options:**\n* `--skip-source-validation`: Skip validation of data sources (don't check if tables exist)\n* `--skip-feature-view-validation`: Skip validation of feature views. Use with caution as this skips important checks\n\n```bash\n# Skip only data source validation\nfeast apply --skip-source-validation\n\n# Skip only feature view validation\nfeast apply --skip-feature-view-validation\n\n# Skip both validations\nfeast apply --skip-source-validation --skip-feature-view-validation\n```\n\n**What does Feast apply do?**\n\n1. Feast will scan Python files in your feature repository and find all Feast object definitions, such as feature views, entities, and data sources.\n2. Feast will validate your feature definitions (e.g. for uniqueness of features). This validation can be skipped using the `--skip-feature-view-validation` flag if the type/validation system is being overly strict.\n3. Feast will sync the metadata about Feast objects to the registry. If a registry does not exist, then it will be instantiated. The standard registry is a simple protobuf binary file that is stored on disk \\(locally or in an object store\\).\n4. Feast CLI will create all necessary feature store infrastructure. The exact infrastructure that is deployed or configured depends on the `provider` configuration that you have set in `feature_store.yaml`. For example, setting `local` as your provider will result in a `sqlite` online store being created. \n\n{% hint style=\"info\" %}\nThe `--skip-feature-view-validation` flag is particularly useful for On-Demand Feature Views (ODFVs) with complex transformations that may fail validation. However, use it with caution and please report any validation issues to the Feast team on GitHub.\n{% endhint %}\n\n{% hint style=\"warning\" %}\n`feast apply` \\(when configured to use cloud provider like `gcp` or `aws`\\) will create cloud infrastructure. This may incur costs.\n{% endhint %}\n\n{% hint style=\"info\" %}\n**Important:** `feast apply` only registers or updates objects found in your Python files. It does **not** delete objects that you've removed from your code. To delete objects from the registry, you must use the `feast delete` command or explicit delete methods in the Python SDK. See the [Delete command](#delete) below and the [Registry documentation](../getting-started/components/registry.md#deleting-objects-from-the-registry) for details.\n… (+2 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "apply",
+      "source": "extracted"
+    },
+    {
+      "id": "adf7127d814769dba283318800f34127d76e124931075ae5ed0715b340b8ae91",
+      "topic": "overview",
+      "subject": "Astra DB Online Store Format / Cassandra Online Store Format",
+      "content": {
+        "summary": "### Cassandra Online Store Format Each project (denoted by its name, called \"feature store name\" elsewhere) may contain an arbitrary number of `FeatureView`s: these correspond each to a specific table"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/online_store_format.md",
+        "line": 133,
+        "quote": "### Cassandra Online Store Format\n\nEach project (denoted by its name, called \"feature store name\" elsewhere) may contain an\narbitrary number of `FeatureView`s: these correspond each to a specific table, and\nall tables for a project are to be contained in a single keyspace. The keyspace should\nhave been created by the Feast user preliminarly and is to be specified in the feature store\nconfiguration `yaml`.\n\nThe table for a project `project` and feature view `FeatureView` will have name\n`project_FeatureView` (e.g. `feature_repo_driver_hourly_stats`).\n\nAll tables have the same structure. Cassandra is schemaful and the columns are strongly typed.\nIn the following table schema (which also serves as Chebotko diagram) the Python\nand Cassandra data types are both specified:\n\n|Table:         |`<project>`_`<FeatureView>`  |  | _(Python type)_      |\n|---------------|-----------------------------|--|----------------------|\n|`entity_key`   |`TEXT`                       |K | `str`                |\n|`feature_name` |`TEXT`                       |C↑| `str`                |\n|`value`        |`BLOB`                       |  | `bytes`              |\n|`event_ts`     |`TIMESTAMP`                  |  | `datetime.datetime`  |\n|`created_ts`   |`TIMESTAMP`                  |  | `datetime.datetime`  |\n\nEach row in the table represents a single value for a feature in a feature view,\nthus associated to a specific entity. The choice of partitioning ensures that,\nwithin a given feature view (i.e. a single table), for a given entity any number\nof features can be retrieved with a single, best-practice-respecting query\n(which is what happens in the `online_read` method implementation).\n\n\nThe `entity_key` column is computed as `serialize_entity_key(entityKey).hex()`,\nwhere `entityKey` is of type `feast.protos.feast.types.EntityKey_pb2.EntityKey`.\n\nThe value of `feature_name` is the plain-text name of the feature as defined\nin the corresponding `FeatureView`.\n\nFor `value`, the bytes from `[protoValue].SerializeToString()`\nare used, where `protoValue` is of type `feast.protos.feast.types.Value_pb2.Value`.\n\nColumn `event_ts` stores the timestamp the feature value refers to, as passed\n… (+6 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-10-05T11:10:11-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "940e058d74982442210940c2ef717847f5aef9dca48725b6c36a9b77b85bb84f",
+      "topic": "overview",
+      "subject": "Astra DB Online Store Format / Example entry",
+      "content": {
+        "summary": "### Example entry For a project `feature_repo` and feature view named `driver_hourly_stats`, a typical row in table `feature_repo_driver_hourly_stats` might look like: |Column         |content        "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/online_store_format.md",
+        "line": 179,
+        "quote": "### Example entry\n\nFor a project `feature_repo` and feature view named `driver_hourly_stats`,\na typical row in table `feature_repo_driver_hourly_stats` might look like:\n\n|Column         |content                                              | notes                                                             |\n|---------------|-----------------------------------------------------|-------------------------------------------------------------------|\n|`entity_key`   |`020000006472697665725f69640400000004000000ea030000` | from `\"driver_id = 1002\"`                                         |\n|`feature_name` |`conv_rate`                                          |                                                                   |\n|`value`        |`0x35f5696d3f`                                       | from `float_val: 0.9273980259895325`, i.e. `(b'5\\xf5im?').hex()`  |\n|`event_ts`     |`2022-07-07 09:00:00.000000+0000`                    | from `datetime.datetime(2022, 7, 7, 9, 0)`                        |\n|`created_ts`   |`null`                                               | not explicitly written to avoid unnecessary tombstones            |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-10-05T11:10:11-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "390546c47a094d4c7f65f628187e2d7e70335888eb4ac24c7ddc0e734d2c0a08",
+      "topic": "overview",
+      "subject": "Astra DB Online Store Format / Known Issues",
+      "content": {
+        "summary": "### Known Issues If a `FeatureView` ever gets _re-defined_ in a schema-breaking way, the implementation is not able to rearrange the schema of the underlying table accordingly (neither dropping all da"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/online_store_format.md",
+        "line": 192,
+        "quote": "### Known Issues\n\nIf a `FeatureView` ever gets _re-defined_ in a schema-breaking way, the implementation is not able to rearrange the\nschema of the underlying table accordingly (neither dropping all data nor, even less so, keeping it somehow).\nThis should never occur, lest one encounters all sorts of data-retrieval issues anywhere in Feast usage.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-10-05T11:10:11-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f1aae606ba8cc3da02f65d5e6232f4fe28414d2593d9fd7b8834ca37e05da894",
+      "topic": "overview",
+      "subject": "Astra DB Online Store Format / Overview",
+      "content": {
+        "summary": "### Overview Apache Cassandra™ is a table-oriented NoSQL distributed database. Astra DB is a managed database-as-a-service built on Cassandra, and will be assimilated to the former in what follows. In Cassandra, tables are grouped in _keyspaces_ (groups of related tables). Each table is comprised of"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/online_store_format.md",
+        "line": 120,
+        "quote": "### Overview\n\nApache Cassandra™ is a table-oriented NoSQL distributed database. Astra DB is a managed database-as-a-service\nbuilt on Cassandra, and will be assimilated to the former in what follows.\n\nIn Cassandra, tables are grouped in _keyspaces_ (groups of related tables). Each table is comprised of\n_rows_, each containing data for a given set of _columns_. Moreover, rows are grouped in _partitions_ according\nto a _partition key_ (a portion of the uniqueness-defining _primary key_ set of columns), so that all rows\nwith the same values for the partition key are guaranteed to be stored on the same Cassandra nodes, next to each other,\nwhich guarantees fast retrieval times.\n\nThis architecture makes Cassandra a good fit for an online feature store in Feast.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-10-05T11:10:11-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c7c9fcff18754bc408a864b525b5d8016f3e30933b941b65da612997e503be78",
+      "topic": "overview",
+      "subject": "Async Support",
+      "content": {
+        "summary": "## Async Support The MongoDB online store provides native async support using PyMongo 4.13+'s stable `AsyncMongoClient`. This enables: * **High concurrency**: Handle thousands of concurrent feature requests without thread pool limitations * **True async I/O**: Non-blocking operations for better perf"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/mongodb.md",
+        "line": 140,
+        "quote": "## Async Support\n\nThe MongoDB online store provides native async support using PyMongo 4.13+'s stable `AsyncMongoClient`. This enables:\n\n* **High concurrency**: Handle thousands of concurrent feature requests without thread pool limitations\n* **True async I/O**: Non-blocking operations for better performance in async applications\n* **10-20x performance improvement**: For concurrent workloads compared to sequential sync operations\n\nBoth sync and async methods are fully supported:\n* `online_read` / `online_read_async`\n* `online_write_batch` / `online_write_batch_async`\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T09:21:30+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "e5f9ebff9f473d1060f4e3453cfd052760181513a3203cba4e9281a87aa9958c",
+      "topic": "overview",
+      "subject": "Authorization configuration",
+      "content": {
+        "summary": "## Authorization configuration In order to leverage the permission functionality, the `auth` section is needed in the `feature_store.yaml` configuration. Currently, Feast supports OIDC and Kubernetes "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/permission.md",
+        "line": 113,
+        "quote": "## Authorization configuration\nIn order to leverage the permission functionality, the `auth` section is needed in the `feature_store.yaml` configuration.\nCurrently, Feast supports OIDC and Kubernetes RBAC authorization protocols.\n\nThe default configuration, if you don't specify the `auth` configuration section, is `no_auth`, indicating that no permission\nenforcement is applied.\n\nThe `auth` section includes a `type` field specifying the actual authorization protocol, and protocol-specific fields that\nare specified in [Authorization Manager](../components/authz_manager.md).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "002986d391a4c253d5532465808838e778776ffbb8b873692bdbe4366ce98e5d",
+      "topic": "overview",
+      "subject": "Backend Type Mapping for Complex Types",
+      "content": {
+        "summary": "### Backend Type Mapping for Complex Types Map, JSON, and Struct types are supported across all major Feast backends: | Backend | Native Type | Feast Type | |---------|-------------|------------| | Po"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feast-types.md",
+        "line": 25,
+        "quote": "### Backend Type Mapping for Complex Types\n\nMap, JSON, and Struct types are supported across all major Feast backends:\n\n| Backend | Native Type | Feast Type |\n|---------|-------------|------------|\n| PostgreSQL | `jsonb` | `Map`, `Json`, `Struct` |\n| PostgreSQL | `jsonb[]` | `Array(Map)` |\n| Snowflake | `VARIANT`, `OBJECT` | `Map` |\n| Snowflake | `JSON` | `Json` |\n| Redshift | `SUPER` | `Map` |\n| Redshift | `json` | `Json` |\n| BigQuery | `JSON` | `Json` |\n| BigQuery | `STRUCT`, `RECORD` | `Struct` |\n| Spark | `map<string,string>` | `Map` |\n| Spark | `array<map<string,string>>` | `Array(Map)` |\n| Spark | `struct<...>` | `Struct` |\n| Spark | `array<struct<...>>` | `Array(Struct(...))` |\n| MSSQL | `nvarchar(max)` | `Map`, `Json`, `Struct` |\n| DynamoDB | Proto bytes | `Map`, `Json`, `Struct`, `ScalarMap` |\n| Redis | Proto bytes | `Map`, `Json`, `Struct`, `ScalarMap` |\n| Milvus | `VARCHAR` (serialized) | `Map`, `Json`, `Struct` |\n\n**Note**: When the backend native type is ambiguous (e.g., `jsonb` could be `Map`, `Json`, or `Struct`), the **schema-declared Feast type takes precedence**. The backend-to-Feast type mappings above are only used for schema inference when no explicit type is provided.\n\n**Note**: Feast currently does *not* support a null type in its type system."
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "50788d018501302bedc3bdc650385924fd1b77fc989a143fe646d0cee69a6820",
+      "topic": "overview",
+      "subject": "Batch data ingestion / Batch data schema inference",
+      "content": {
+        "summary": "### Batch data schema inference If the `schema` parameter is not specified when defining a data source, Feast attempts to infer the schema of the data source during `feast apply`. The way it does this"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/data-ingestion.md",
+        "line": 90,
+        "quote": "### Batch data schema inference\n\nIf the `schema` parameter is not specified when defining a data source, Feast attempts to infer the schema of the data source during `feast apply`.\nThe way it does this depends on the implementation of the offline store. For the offline stores that ship with Feast out of the box this inference is performed by inspecting the schema of the table in the cloud data warehouse,\nor if a query is provided to the source, by running the query with a `LIMIT` clause and inspecting the result.\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-09-24T17:10:05+01:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "1df80cce4060f98bb901908b420891055ca9272e9bd53659e80a540482f1a75e",
+      "topic": "overview",
+      "subject": "Batch data ingestion / How to run this in the CLI",
+      "content": {
+        "summary": "#### How to run this in the CLI **With timestamps:** **Simple materialization (for data without event timestamps):**"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/data-ingestion.md",
+        "line": 65,
+        "quote": "#### How to run this in the CLI\n\n**With timestamps:**\n```bash\nCURRENT_TIME=$(date -u +\"%Y-%m-%dT%H:%M:%S\")\nfeast materialize-incremental $CURRENT_TIME\n```\n\n**Simple materialization (for data without event timestamps):**\n```bash\nfeast materialize --disable-event-timestamp\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-09-24T17:10:05+01:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "126bf97fbf283f213563a75016399892adf13f06cc22325cb8be080a227cedb1",
+      "topic": "overview",
+      "subject": "Batch data ingestion / How to run this on Airflow",
+      "content": {
+        "summary": "#### How to run this on Airflow </details>"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/data-ingestion.md",
+        "line": 78,
+        "quote": "#### How to run this on Airflow\n\n```python\n# Use BashOperator\nmaterialize_bash = BashOperator(\n    task_id='materialize',\n    bash_command=f'feast materialize-incremental {datetime.datetime.now().replace(microsecond=0).isoformat()}',\n)\n```\n\n</details>\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-09-24T17:10:05+01:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "722ea88158455f7438ff2f9d1a107a20c2a78d4eab6900dd3e5b1d6b0b771f3f",
+      "topic": "overview",
+      "subject": "Benefits of Table Formats / Flexibility",
+      "content": {
+        "summary": "### Flexibility - **Schema evolution**: Add, remove, or modify columns without rewriting data - **Time travel**: Access historical data states for auditing or debugging - **Incremental processing**: P"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 282,
+        "quote": "### Flexibility\n- **Schema evolution**: Add, remove, or modify columns without rewriting data\n- **Time travel**: Access historical data states for auditing or debugging\n- **Incremental processing**: Process only changed data efficiently\n- **Multiple readers/writers**: Concurrent access without conflicts\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9339707a984158c1ef7771bbe60f4fe6adec5d459224a1e68fd5f4603031a2ff",
+      "topic": "overview",
+      "subject": "Benefits of Table Formats / Performance",
+      "content": {
+        "summary": "### Performance - **Data skipping**: Read only relevant files based on metadata - **Partition pruning**: Skip entire partitions based on predicates - **Compaction**: Merge small files for better performance - **Columnar pruning**: Read only necessary columns - **Indexing**: Advanced indexing for fas"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 275,
+        "quote": "### Performance\n- **Data skipping**: Read only relevant files based on metadata\n- **Partition pruning**: Skip entire partitions based on predicates\n- **Compaction**: Merge small files for better performance\n- **Columnar pruning**: Read only necessary columns\n- **Indexing**: Advanced indexing for fast lookups\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "bc3e94ba1a2a77194330b1bcb8ce1880cc960e8dfd0713ba7906369012bbe112",
+      "topic": "overview",
+      "subject": "Benefits of Table Formats / Reliability",
+      "content": {
+        "summary": "### Reliability - **ACID transactions**: Ensure data consistency across concurrent operations - **Automatic retries**: Handle transient failures gracefully - **Schema validation**: Prevent incompatibl"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 269,
+        "quote": "### Reliability\n- **ACID transactions**: Ensure data consistency across concurrent operations\n- **Automatic retries**: Handle transient failures gracefully\n- **Schema validation**: Prevent incompatible schema changes\n- **Data quality**: Constraints and validation rules\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "5f1fae55ecea672bef19e7714eb08b95cc5c47247fd5cc9fd2e68c6236887919",
+      "topic": "overview",
+      "subject": "Best Practices",
+      "content": {
+        "summary": "## Best Practices 1. **Principle of Least Privilege**: Grant only the minimum required permissions 2. **Group Organization**: Organize users into logical groups based on their responsibilities 3. **Na"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/kubernetes_auth_setup.md",
+        "line": 170,
+        "quote": "## Best Practices\n\n1. **Principle of Least Privilege**: Grant only the minimum required permissions\n2. **Group Organization**: Organize users into logical groups based on their responsibilities\n3. **Namespace Isolation**: Use namespaces to isolate different environments or teams\n4. **Regular Audits**: Periodically review and audit permissions\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "90f56eaec6fe641d25f2bb2eb6ef6ade30a888ddb1deb88c2efa5dbfc87b1873",
+      "topic": "overview",
+      "subject": "Best Practices / 1. Choose Appropriate Partitioning",
+      "content": {
+        "summary": "### 1. Choose Appropriate Partitioning"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 301,
+        "quote": "### 1. Choose Appropriate Partitioning\n```python\n# Iceberg - hidden partitioning\niceberg_format.set_property(\"partition-spec\", \"days(event_timestamp)\")\n\n# Delta - explicit partitioning in data source\n# Hudi - configure via properties\nhudi_format.set_property(\"hoodie.datasource.write.partitionpath.field\", \"date\")\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ea7921cffe85364dd89071340daa0ebd29ace212f361b9053d2ceec1ecf628a1",
+      "topic": "overview",
+      "subject": "Best Practices / 2. Enable Optimization Features",
+      "content": {
+        "summary": "### 2. Enable Optimization Features"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 311,
+        "quote": "### 2. Enable Optimization Features\n```python\n# Delta auto-optimize\ndelta_format.set_property(\"delta.autoOptimize.optimizeWrite\", \"true\")\ndelta_format.set_property(\"delta.autoOptimize.autoCompact\", \"true\")\n\n# Hudi compaction\nhudi_format.set_property(\"hoodie.compact.inline\", \"true\")\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "986501085f2be9fff210912d1f0d195f9c98ff08c2caf3fe3aa6c181133c2d8f",
+      "topic": "overview",
+      "subject": "Best Practices / 4. Monitor Metadata Size",
+      "content": {
+        "summary": "### 4. Monitor Metadata Size - Table formats maintain metadata for all operations - Monitor metadata size and clean up old versions - Configure retention policies based on your needs"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 329,
+        "quote": "### 4. Monitor Metadata Size\n- Table formats maintain metadata for all operations\n- Monitor metadata size and clean up old versions\n- Configure retention policies based on your needs\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "5896078f67b95e602ea7d97e42d2e3a42d5cdccb6fc5284534aea1fef86ee59a",
+      "topic": "overview",
+      "subject": "CLI / Performance Best Practices",
+      "content": {
+        "summary": "### Performance Best Practices **Worker Configuration:** - For production: Use `--workers -1` to auto-calculate optimal worker count (2 × CPU cores + 1) - For development: Use default single worker (`"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 34,
+        "quote": "### Performance Best Practices\n\n**Worker Configuration:**\n- For production: Use `--workers -1` to auto-calculate optimal worker count (2 × CPU cores + 1)\n- For development: Use default single worker (`--workers 1`)\n- Monitor CPU and memory usage to tune worker count manually if needed\n\n**Registry TTL:**\n- Production: Use `--registry_ttl_sec 60` or higher to reduce refresh overhead\n- Development: Use lower values (5-10s) for faster iteration when schemas change frequently\n- Balance between performance (higher TTL) and freshness (lower TTL)\n\n**Connection Tuning:**\n- Increase `--worker-connections` for high-concurrency workloads\n- Use `--max-requests` to prevent memory leaks in long-running deployments\n- Adjust `--keep-alive-timeout` based on client connection patterns\n\n**Container Deployments:**\n- Set appropriate CPU/memory limits in Kubernetes to match worker configuration\n- Use HTTP health checks instead of TCP for better application-level monitoring\n- Consider horizontal pod autoscaling based on request latency metrics\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "e586f7006c7a1591c89bfa905a7dec07f15f26b97b8390a5fdb500df915c0cd7",
+      "topic": "overview",
+      "subject": "CLI / Performance Configuration",
+      "content": {
+        "summary": "### Performance Configuration For production deployments, the feature server supports several performance optimization options: Key performance options: - `--workers, -w`: Number of worker processes. "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 11,
+        "quote": "### Performance Configuration\n\nFor production deployments, the feature server supports several performance optimization options:\n\n```bash\n# Basic usage\nfeast serve\n\n# Production configuration with multiple workers\nfeast serve --workers -1 --worker-connections 1000 --registry_ttl_sec 60\n\n# Manual worker configuration\nfeast serve --workers 8 --worker-connections 2000 --max-requests 1000\n```\n\nKey performance options:\n- `--workers, -w`: Number of worker processes. Use `-1` to auto-calculate based on CPU cores (recommended for production)\n- `--worker-connections`: Maximum simultaneous clients per worker process (default: 1000)\n- `--max-requests`: Maximum requests before worker restart, prevents memory leaks (default: 1000)\n- `--max-requests-jitter`: Jitter to prevent thundering herd on worker restart (default: 50)\n- `--registry_ttl_sec, -r`: Registry refresh interval in seconds. Higher values reduce overhead but increase staleness (default: 60)\n- `--keep-alive-timeout`: Keep-alive connection timeout in seconds (default: 30)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0077e2d236168dcbd072c1cfbc17945cd880adaec88a84e639f28f8de60784ba",
+      "topic": "overview",
+      "subject": "CLI Commands",
+      "content": {
+        "summary": "## CLI Commands There are new CLI commands to manage on demand feature views: feast on-demand-feature-views list: Lists all registered on demand feature views after feast apply is run. feast on-demand-feature-views describe [NAME]: Describes the definition of an on demand feature view."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/beta-on-demand-feature-view.md",
+        "line": 342,
+        "quote": "## CLI Commands\nThere are new CLI commands to manage on demand feature views:\n\nfeast on-demand-feature-views list: Lists all registered on demand feature views after feast apply is run.\nfeast on-demand-feature-views describe [NAME]: Describes the definition of an on demand feature view.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-22T17:08:58-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4bace7653fe2bfc241ee0bcd51a6ec06797e388b00c419ea8858b3951fd592a9",
+      "topic": "overview",
+      "subject": "CLI Usage / Method 1: Environment Variable",
+      "content": {
+        "summary": "### Method 1: Environment Variable"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/user_token_provisioning.md",
+        "line": 82,
+        "quote": "### Method 1: Environment Variable\n\n```bash\n# Set the token as environment variable\nexport LOCAL_K8S_TOKEN=\"your-kubernetes-user-token-here\"\n\n# Use Feast CLI commands\nfeast apply\nfeast materialize\nfeast get-online-features \\\n  --features feature1,feature2 \\\n  --entity-rows '{\"entity_id\": \"123\"}'\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "249701bd533fd9439e08d2a0f301c2bd15f2353d98cad4e7c9dd3cc16c2a6b14",
+      "topic": "overview",
+      "subject": "Choosing the Right Table Format",
+      "content": {
+        "summary": "## Choosing the Right Table Format | Use Case | Recommended Format | Why | |----------|-------------------|-----| | Large-scale analytics with frequent schema changes | **Iceberg** | Best schema evolu"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 288,
+        "quote": "## Choosing the Right Table Format\n\n| Use Case | Recommended Format | Why |\n|----------|-------------------|-----|\n| Large-scale analytics with frequent schema changes | **Iceberg** | Best schema evolution, hidden partitioning, mature ecosystem |\n| Streaming + batch workloads | **Delta Lake** | Unified architecture, strong integration with Spark, good docs |\n| CDC and upsert-heavy workloads | **Hudi** | Efficient record-level updates, incremental queries |\n| Read-heavy analytics | **Iceberg or Delta** | Excellent query performance |\n| Write-heavy transactional | **Hudi (MOR)** | Optimized for fast writes |\n| Multi-engine support | **Iceberg** | Widest engine support (Spark, Flink, Trino, etc.) |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "232507a0c738ee06ec6e93b481c24f77069982d41093551f08b1292efa6dbeb7",
+      "topic": "overview",
+      "subject": "Client Example",
+      "content": {
+        "summary": "## Client Example The complete example can be find under remote-offline-store-example"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/remote-offline-store.md",
+        "line": 22,
+        "quote": "## Client Example\n\nThe complete example can be find under [remote-offline-store-example](../../../examples/remote-offline-store)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-08-21T10:22:49-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "359099db412274191eb4d8d00d7d1b7bc996ac19c2e7aabc03e71939d5de4884",
+      "topic": "overview",
+      "subject": "Complete Feature View Example / Decimal Type Usage Examples",
+      "content": {
+        "summary": "### Decimal Type Usage Examples The `Decimal` type stores arbitrary-precision decimal numbers using Python's `decimal.Decimal`. Values are stored as strings in the proto to preserve full precision — n"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 328,
+        "quote": "### Decimal Type Usage Examples\n\nThe `Decimal` type stores arbitrary-precision decimal numbers using Python's `decimal.Decimal`.\nValues are stored as strings in the proto to preserve full precision — no floating-point rounding occurs.\n\n```python\nimport decimal\n\n# Scalar decimal — e.g., a financial price\nprice = decimal.Decimal(\"19.99\")\n\n# High-precision value — all digits preserved\ntax_rate = decimal.Decimal(\"0.08750000000000000000\")\n\n# Decimal values are returned as decimal.Decimal objects from get_online_features()\nresponse = store.get_online_features(\n    features=[\"product_features:price\"],\n    entity_rows=[{\"product_id\": 42}],\n)\nresult = response.to_dict()\n# result[\"price\"][0] is a decimal.Decimal object\n\n# Decimal lists — e.g., a history of prices\nhistorical_prices = [\n    decimal.Decimal(\"18.50\"),\n    decimal.Decimal(\"19.00\"),\n    decimal.Decimal(\"19.99\"),\n]\n\n# Decimal sets — unique price points seen\nunique_prices = {decimal.Decimal(\"9.99\"), decimal.Decimal(\"19.99\"), decimal.Decimal(\"29.99\")}\n```\n\n{% hint style=\"warning\" %}\n`Decimal` is **not** inferred from any backend schema. You must declare it explicitly in your feature view schema. The pandas dtype for `Decimal` columns is `object` (holding `decimal.Decimal` instances), not a numeric dtype.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4d2245f3ee8ac83ce645615e1b98f5d37b16c6ee938490719bed75d1644632c5",
+      "topic": "overview",
+      "subject": "Complete Feature View Example / JSON Type Usage Examples",
+      "content": {
+        "summary": "### JSON Type Usage Examples Feast's `Json` type stores values as JSON strings at the proto level. You can pass either a pre-serialized JSON string or a Python dict/list — Feast will call `json.dumps("
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 458,
+        "quote": "### JSON Type Usage Examples\n\nFeast's `Json` type stores values as JSON strings at the proto level. You can pass either a\npre-serialized JSON string or a Python dict/list — Feast will call `json.dumps()` automatically\nwhen the value is not already a string:\n\n```python\nimport json\n\n# Option 1: pass a Python dict — Feast calls json.dumps() internally during proto conversion\nraw_event = {\"type\": \"click\", \"target\": \"button_1\", \"metadata\": {\"page\": \"home\"}}\n\n# Option 2: pass an already-serialized JSON string — Feast validates it via json.loads()\nraw_event = '{\"type\": \"click\", \"target\": \"button_1\", \"metadata\": {\"page\": \"home\"}}'\n\n# When building a DataFrame for store.push(), values must be strings since\n# Pandas/PyArrow columns expect uniform types:\nimport pandas as pd\nevent_df = pd.DataFrame({\n    \"user_id\": [\"user_1\"],\n    \"event_timestamp\": [datetime.now()],\n    \"raw_event\": [json.dumps({\"type\": \"click\", \"target\": \"button_1\"})],\n})\nstore.push(\"event_push_source\", event_df)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f5bad47b97b7acadaf7eae2b661f1157b7e2f7df03cfe47955486d5caf73764b",
+      "topic": "overview",
+      "subject": "Complete Feature View Example / Map Type Usage Examples",
+      "content": {
+        "summary": "### Map Type Usage Examples Maps can store complex nested data structures:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 387,
+        "quote": "### Map Type Usage Examples\n\nMaps can store complex nested data structures:\n\n```python\n# Simple map (string keys)\nuser_preferences = {\n    \"theme\": \"dark\",\n    \"language\": \"en\",\n    \"notifications_enabled\": True,\n    \"font_size\": 14\n}\n\n# Nested map\nmetadata = {\n    \"profile\": {\n        \"bio\": \"Software engineer\",\n        \"location\": \"San Francisco\"\n    },\n    \"stats\": {\n        \"followers\": 1000,\n        \"posts\": 250\n    }\n}\n\n# List of maps\nactivity_log = [\n    {\"action\": \"login\", \"timestamp\": \"2024-01-01T10:00:00\", \"ip\": \"192.168.1.1\"},\n    {\"action\": \"purchase\", \"timestamp\": \"2024-01-01T11:30:00\", \"amount\": 99.99},\n    {\"action\": \"logout\", \"timestamp\": \"2024-01-01T12:00:00\"}\n]\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ddaab6677424d1d88f2eee61fd372ecc2b0e417dc8a086a05209c18d4d17c8b5",
+      "topic": "overview",
+      "subject": "Complete Feature View Example / Nested Collection Type Usage Examples",
+      "content": {
+        "summary": "### Nested Collection Type Usage Examples **Limitation:** Empty inner collections round-trip as `None`:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 365,
+        "quote": "### Nested Collection Type Usage Examples\n\n```python\n# List of lists — e.g., weekly score history per user\nweekly_scores = [[85.0, 90.5, 78.0], [92.0, 88.5], [95.0, 91.0, 87.5]]\n\n# List of sets — e.g., unique tags assigned per category\nunique_tags_per_category = [[\"python\", \"ml\"], [\"rust\", \"systems\"], [\"python\", \"web\"]]\n\n# 3-level nesting — e.g., multi-dimensional matrices\nField(name=\"tensor\", dtype=Array(Array(Array(Float64))))\n\n# Mixed nesting\nField(name=\"grouped_tags\", dtype=Array(Set(Array(String))))\n```\n\n**Limitation:** Empty inner collections round-trip as `None`:\n```python\n# Input:  [[1, 2], [], [3]]\n# Output: [[1, 2], None, [3]]  (empty [] becomes None after write-read cycle)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "170c70e74748c8a3f7494b6a1e4a2ef98136d31c23aa8c165861bd061f2d96e6",
+      "topic": "overview",
+      "subject": "Complete Feature View Example / ScalarMap Type Usage Examples",
+      "content": {
+        "summary": "### ScalarMap Type Usage Examples `ScalarMap` supports non-string keys. Feast infers it automatically when the first dict key is not a string: {% hint style=\"warning\" %} `ScalarMap` must be **explicit"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 420,
+        "quote": "### ScalarMap Type Usage Examples\n\n`ScalarMap` supports non-string keys. Feast infers it automatically when the first dict key is not a string:\n\n```python\nimport uuid\nimport decimal\n\n# Integer keys — e.g., category ID → item count\nevent_counts = {1001: 5, 1002: 12, 1003: 0}\n\n# UUID keys — e.g., session ID → score\nimport uuid\nsession_scores = {\n    uuid.UUID(\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\"): 0.95,\n    uuid.UUID(\"a8098c1a-f86e-11da-bd1a-00112444be1e\"): 0.87,\n}\n\n# Decimal keys — e.g., price bucket → product name\nprice_tier = {\n    decimal.Decimal(\"9.99\"): \"budget\",\n    decimal.Decimal(\"49.99\"): \"standard\",\n    decimal.Decimal(\"99.99\"): \"premium\",\n}\n\n# Type inference: Feast automatically picks SCALAR_MAP when the key is non-string\nfrom feast.type_map import python_type_to_feast_value_type\nfrom feast.value_type import ValueType\n\npython_type_to_feast_value_type({1: \"a\"})         # → ValueType.SCALAR_MAP\npython_type_to_feast_value_type({\"a\": 1})          # → ValueType.MAP\npython_type_to_feast_value_type({})                # → ValueType.MAP (empty dict defaults to MAP)\n```\n\n{% hint style=\"warning\" %}\n`ScalarMap` must be **explicitly declared** in your feature view schema — it is never inferred from backend type schemas. It is best suited for online serving via stores that use proto byte serialization (e.g., Redis, DynamoDB, SQLite). Materialization paths that use PyArrow (e.g., BigQuery, Snowflake, Redshift, Spark) do not have native `ScalarMap` support.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "71f4cf1919198a3fdd4313aafc69a7ff80b1f359b61895181669ed51f5f6a5d4",
+      "topic": "overview",
+      "subject": "Complete Feature View Example / Set Type Usage Examples",
+      "content": {
+        "summary": "### Set Type Usage Examples Sets store unique values and automatically remove duplicates:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 282,
+        "quote": "### Set Type Usage Examples\n\nSets store unique values and automatically remove duplicates:\n\n```python\n# Simple set\nvisited_pages = {\"home\", \"products\", \"checkout\", \"products\"}  # \"products\" appears twice\n# Feast will store this as: {\"home\", \"products\", \"checkout\"}\n\n# Integer set\nunique_categories = {1, 2, 3, 2, 1}  # duplicates will be removed\n# Feast will store this as: {1, 2, 3}\n\n# Converting a list with duplicates to a set\ntag_list = [100, 200, 300, 100, 200]\ntag_ids = set(tag_list)  # {100, 200, 300}\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c46a0b8ab045c1952fbcf3c199fb9bdaf2a96d22f5875ef029312bb2fc909608",
+      "topic": "overview",
+      "subject": "Complete Feature View Example / UUID Type Usage Examples",
+      "content": {
+        "summary": "### UUID Type Usage Examples UUID types store universally unique identifiers natively, with support for both random UUIDs and time-based UUIDs:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 300,
+        "quote": "### UUID Type Usage Examples\n\nUUID types store universally unique identifiers natively, with support for both random UUIDs and time-based UUIDs:\n\n```python\nimport uuid\n\n# Random UUID (version 4) — use Uuid type\nsession_id = uuid.uuid4()  # e.g., UUID('a8098c1a-f86e-11da-bd1a-00112444be1e')\n\n# Time-based UUID (version 1) — use TimeUuid type\nevent_id = uuid.uuid1()  # e.g., UUID('6ba7b810-9dad-11d1-80b4-00c04fd430c8')\n\n# UUID values are returned as uuid.UUID objects from get_online_features()\nresponse = store.get_online_features(\n    features=[\"user_features:session_id\"],\n    entity_rows=[{\"user_id\": 1}],\n)\nresult = response.to_dict()\n# result[\"session_id\"][0] is a uuid.UUID object\n\n# UUID lists\nrelated_sessions = [uuid.uuid4(), uuid.uuid4(), uuid.uuid4()]\n\n# UUID sets (unique values)\nunique_devices = {uuid.uuid4(), uuid.uuid4()}\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "32e2594838cc9dcaabc3cd7f6b14e994d83e13d1cd3d8d0423090b30703b97e5",
+      "topic": "overview",
+      "subject": "Compute Engine DAG execution",
+      "content": {
+        "summary": "Compute engine builds execution plans as DAGs (FeatureBuilder), supporting Transformation, Aggregation, Join, and Filter operations from FeatureView definitions."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/compute-engine.md",
+        "line": 84,
+        "quote": "### API\n\nThe compute engine builds the execution plan in a DAG format named FeatureBuilder. It derives feature generation from\nFeature View definitions including:\n\n```\n1. Transformation (via Transformation API)\n2. Aggregation (via Aggregation API)\n3. Join (join with entity datasets, customized JOIN or join with another Feature View)\n4. Filter (Point in time filter, ttl filter, filter by custom expression)\n...\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-29T14:42:40-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c59aacf20ac2ee3406df33bacb8cee8e38511eb69a625377db4263c1e8d5d822",
+      "topic": "overview",
+      "subject": "Concepts / Dataset",
+      "content": {
+        "summary": "### Dataset A dataset is a collection of rows that is produced by a historical retrieval from Feast in order to train a model. A dataset is produced by a join from one or more feature views onto an en"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-retrieval.md",
+        "line": 183,
+        "quote": "### Dataset\n\nA dataset is a collection of rows that is produced by a historical retrieval from Feast in order to train a model. A dataset is produced by a join from one or more feature views onto an entity dataframe. Therefore, a dataset may consist of features from multiple feature views.\n\n**Dataset vs Feature View:** Feature views contain the schema of data and a reference to where data can be found (through its data source). Datasets are the actual data manifestation of querying those data sources.\n\n**Dataset vs Data Source:** Datasets are the output of historical retrieval, whereas data sources are the inputs. One or more data sources can be used in the creation of a dataset.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-02T19:16:42+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "694d5f072070654a87e2dc64b0eae77f6f0ca9517a289940f7d34977ecb1455a",
+      "topic": "overview",
+      "subject": "Concepts / Event timestamp",
+      "content": {
+        "summary": "### Event timestamp The timestamp on which an event occurred, as found in a feature view's data source. The event timestamp describes the event time at which a feature was observed or generated. Event"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-retrieval.md",
+        "line": 137,
+        "quote": "### Event timestamp\n\nThe timestamp on which an event occurred, as found in a feature view's data source. The event timestamp describes the event time at which a feature was observed or generated.\n\nEvent timestamps are used during point-in-time joins to ensure that the latest feature values are joined from feature views onto entity rows. Event timestamps are also used to ensure that old feature values aren't served to models during online serving.\n\n#### Why `event_timestamp` is required in the entity dataframe\n\nWhen calling `get_historical_features()`, the `entity_df` must include an `event_timestamp` column. This timestamp acts as the **upper bound (inclusive)** for which feature values are allowed to be retrieved for each entity row. Feast performs a point-in-time join (also called a \"last known good value\" temporal join): for each entity row, it retrieves the latest feature values with a timestamp **at or before** the entity row's `event_timestamp`.\n\nThis ensures **point-in-time correctness**, which is critical to prevent **data leakage** during model training. Without this constraint, features generated *after* the prediction time could leak into training data—effectively letting the model \"see the future\"—leading to inflated offline metrics that do not translate to real-world performance.\n\nFor example, if you want to predict whether a driver will be rated well on April 12 at 10:00 AM, the entity dataframe row should have `event_timestamp = datetime(2021, 4, 12, 10, 0, 0)`. Feast will then only join feature values observed on or before that time, excluding any data generated after 10:00 AM.\n\n#### Retrieving features without an entity dataframe\n\nWhile the entity dataframe is the standard way to retrieve historical features, Feast also supports **entity-less historical feature retrieval** by datetime range. This is useful when:\n\n- You are training **time-series or population-level models** and don't have a pre-defined list of entity IDs.\n- You want **all features in a time window** for exploratory analysis or batch training on full history.\n- Constructing an entity dataframe upfront is unnecessarily complex or expensive.\n\nInstead of passing `entity_df`, you specify a time window with `start_date` and/or `end_date`:\n\n```python\nfrom datetime import datetime\n\ntraining_df = store.get_historical_features(\n    features=[\n        \"driver_hourly_stats:conv_rate\",\n        \"driver_hourly_stats:acc_rate\",\n        \"driver_hourly_stats:avg_daily_trips\",\n    ],\n    start_date=datetime(2025, 7, 1),\n    end_date=datetime(2025, 7, 2),\n).to_df()\n```\n\nIf `start_date` is omitted, it defaults to `end_date` minus the feature view TTL. If `end_date` is omitted, it defaults to the current time. Point-in-time correctness is still preserved.\n\n… (+6 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-02T19:16:42+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d9b992b5c7fedbe1213e82f04bbdeff53f660e7a1dbdd91641ce98a61b0dd5be",
+      "topic": "overview",
+      "subject": "Concepts / Feature References",
+      "content": {
+        "summary": "### Feature References This mechanism of retrieving features is only recommended as you're experimenting. Once you want to launch experiments or serve models, feature services are recommended. Feature"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-retrieval.md",
+        "line": 102,
+        "quote": "### Feature References\n\nThis mechanism of retrieving features is only recommended as you're experimenting. Once you want to launch experiments or serve models, feature services are recommended.\n\nFeature references uniquely identify feature values in Feast. The structure of a feature reference in string form is as follows: `<feature_view>[@version]:<feature>`\n\nThe `@version` part is optional. When omitted, the latest (active) version is used. You can specify a version like `@v2` to read from a specific historical version snapshot.\n\nFeature references are used for the retrieval of features from Feast:\n\n```python\nonline_features = fs.get_online_features(\n    features=[\n        'driver_locations:lon',                # latest version (default)\n        'drivers_activity:trips_today',        # latest version (default)\n        'drivers_activity@v2:trips_today',     # specific version\n        'drivers_activity@latest:trips_today', # explicit latest\n    ],\n    entity_rows=[\n        # {join_key: entity_value}\n        {'driver': 'driver_1001'}\n    ]\n)\n```\n\n{% hint style=\"info\" %}\nVersion-qualified reads (`@v<N>`) require `enable_online_feature_view_versioning: true` in your registry config and are currently supported only on the SQLite online store. See the [feature view versioning docs](feature-view.md#version-qualified-feature-references) for details.\n{% endhint %}\n\nIt is possible to retrieve features from multiple feature views with a single request, and Feast is able to join features from multiple tables in order to build a training dataset. However, it is not possible to reference (or retrieve) features from multiple projects at the same time.\n\n{% hint style=\"info\" %}\nNote, if you're using [Feature views without entities](feature-view.md#feature-views-without-entities), then those features can be added here without additional entity values in the `entity_rows` parameter.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-02T19:16:42+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "815e52084c7898081dcd22499e56e1cd64fb38f368b540af7dafdbf7f72a2f1c",
+      "topic": "overview",
+      "subject": "Concepts / Feature Services",
+      "content": {
+        "summary": "### Feature Services A feature service is an object that represents a logical group of features from one or more feature views. Feature Services allows features from within a feature view to be used as needed by an ML model. Users can expect to create one feature service per model version, allowing"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-retrieval.md",
+        "line": 25,
+        "quote": "### Feature Services\n\nA feature service is an object that represents a logical group of features from one or more [feature views](feature-view.md#feature-view). Feature Services allows features from within a feature view to be used as needed by an ML model. Users can expect to create one feature service per model version, allowing for tracking of the features used by models.\n\n{% tabs %}\n{% tab title=\"driver_trips_feature_service.py\" %}\n```python\nfrom driver_ratings_feature_view import driver_ratings_fv\nfrom driver_trips_feature_view import driver_stats_fv\n\ndriver_stats_fs = FeatureService(\n    name=\"driver_activity\",\n    features=[driver_stats_fv, driver_ratings_fv[[\"lifetime_rating\"]]]\n)\n```\n{% endtab %}\n{% endtabs %}\n\nFeature services are used during\n\n* The generation of training datasets when querying feature views in order to find historical feature values. A single training dataset may consist of features from multiple feature views.\n* Retrieval of features for batch scoring from the offline store (e.g. with an entity dataframe where all timestamps are `now()`)\n* Retrieval of features from the online store for online inference (with smaller batch sizes). The features retrieved from the online store may also belong to multiple feature views.\n\n{% hint style=\"info\" %}\nApplying a feature service does not result in an actual service being deployed.\n{% endhint %}\n\nFeature services enable referencing all or some features from a feature view.\n\n#### Pre-computed feature vectors (`precompute_online`)\n\nFor latency-critical online serving, you can enable **pre-computed feature vectors** on a feature service. When `precompute_online=True`, Feast stores all of the service's features for each entity as a single serialized blob in the online store. At read time, this reduces the number of store reads from O(N feature views) to O(1), regardless of how many feature views the service spans.\n\n```python\n# A feature service with pre-computed vectors enabled\nlow_latency_service = FeatureService(\n    name=\"low_latency_inference\",\n    features=[driver_stats_fv, vehicle_stats_fv, route_features_fv],\n    precompute_online=True,\n… (+37 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-02T19:16:42+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "954c998a94e560e1d94baaa72e67861061090708b9c967d8039ad455f68b8eba",
+      "topic": "overview",
+      "subject": "Configuration / Client Configuration",
+      "content": {
+        "summary": "### Client Configuration For external users (not service accounts), you can provide a user token in the configuration: Refer examples of providing the token are described in doc [User Token Provisioni"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/kubernetes_auth_setup.md",
+        "line": 80,
+        "quote": "### Client Configuration\n\nFor external users (not service accounts), you can provide a user token in the configuration:\n\nRefer examples of providing the token are described in doc [User Token Provisioning](./user_token_provisioning.md)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "028eedb1cdac4081d52ccd96ac58b8cb0953e98a40e2cf1b54a3236fb5cbeae2",
+      "topic": "overview",
+      "subject": "Configuration / Compute Engine Requirements",
+      "content": {
+        "summary": "### Compute Engine Requirements - **Spark Compute Engine**: Fully supported for streaming and batch - **Ray Compute Engine**: Fully supported for streaming and batch - **Local Compute Engine**: Does NOT support time-windowed aggregations ---"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/tiling.md",
+        "line": 245,
+        "quote": "### Compute Engine Requirements\n\n- **Spark Compute Engine**: Fully supported for streaming and batch\n- **Ray Compute Engine**: Fully supported for streaming and batch\n- **Local Compute Engine**: Does NOT support time-windowed aggregations\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "816ca34af9425adbb056772bb90ab09ad63fdb9a295548a0d4418e3daa42ba5c",
+      "topic": "overview",
+      "subject": "Configuration / Configuration options",
+      "content": {
+        "summary": "### Configuration options | Option | Type | Default | Description | |--------|------|---------|-------------| | `enabled` | bool | `false` | Master switch for the entire integration | | `tracking_uri`"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 56,
+        "quote": "### Configuration options\n\n| Option | Type | Default | Description |\n|--------|------|---------|-------------|\n| `enabled` | bool | `false` | Master switch for the entire integration |\n| `tracking_uri` | string | *(none)* | MLflow tracking server URI. Falls back to `MLFLOW_TRACKING_URI` env var, then MLflow default (`./mlruns`) |\n| `auto_log` | bool | `true` | Automatically log feature metadata on every retrieval when an active MLflow run exists |\n| `auto_log_entity_df` | bool | `false` | Save the entity DataFrame as `entity_df.parquet` artifact on historical retrieval |\n| `entity_df_max_rows` | int | `100000` | Skip entity DataFrame artifact upload for DataFrames exceeding this limit |\n| `log_operations` | bool | `false` | Log `feast apply` and `feast materialize` to a separate MLflow experiment |\n| `ops_experiment_suffix` | string | `\"-feast-ops\"` | Suffix appended to project name for the operations experiment |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b22d24cfc878a0997f2a14274af3fa7aa3460d0286337f4762fb44c00a44c092",
+      "topic": "overview",
+      "subject": "Configuration / Mode Detection Precedence",
+      "content": {
+        "summary": "### Mode Detection Precedence The Ray compute engine automatically detects the execution mode: 1. **Environment Variables** → KubeRay mode (if `FEAST_RAY_USE_KUBERAY=true`) 2. **Config `kuberay_conf`*"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 95,
+        "quote": "### Mode Detection Precedence\n\nThe Ray compute engine automatically detects the execution mode:\n\n1. **Environment Variables** → KubeRay mode (if `FEAST_RAY_USE_KUBERAY=true`)\n2. **Config `kuberay_conf`** → KubeRay mode\n3. **Config `ray_address`** → Remote mode\n4. **Default** → Local mode\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "5372c31ea91f4b46f9736d1fb6ddb5fe26f309d0430343ef65c61344e0ad86b0",
+      "topic": "overview",
+      "subject": "Configuration / Performance Tuning",
+      "content": {
+        "summary": "### Performance Tuning **Parallel Batch Reads**: When reading features for many entities, DynamoDB's BatchGetItem is limited to 100 items per request. For 500 entities, this requires 5 batch requests."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/dynamodb.md",
+        "line": 55,
+        "quote": "### Performance Tuning\n\n**Parallel Batch Reads**: When reading features for many entities, DynamoDB's BatchGetItem is limited to 100 items per request. For 500 entities, this requires 5 batch requests. The `max_read_workers` option controls how many of these batches execute in parallel:\n\n- **Sequential (old behavior)**: 5 batches × 10ms = 50ms total\n- **Parallel (with `max_read_workers: 10`)**: 5 batches in parallel ≈ 10ms total\n\nFor high-throughput workloads with large entity counts, increase `max_read_workers` (up to 20-30) based on your DynamoDB capacity and network conditions.\n\n**Batch Size**: Increase `batch_size` up to 100 to reduce the number of API calls. However, larger batches may hit DynamoDB's 16MB response limit for tables with large feature values.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-25T08:53:08-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ce97c7cef7452e84a22cc1e8f9b7a4f10f4dca80add0ddfd5fa407bc2aa9b540",
+      "topic": "overview",
+      "subject": "Configuration / Recommended: StreamFeatureView (Streaming Scenarios)",
+      "content": {
+        "summary": "### Recommended: StreamFeatureView (Streaming Scenarios) Tiling provides **maximum benefit for streaming scenarios** with frequent updates: **When to Enable:** - Streaming data sources (Kafka, Kinesis, PushSource) - Frequent updates (every few minutes) - Real-time feature serving - High-throughput e"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/tiling.md",
+        "line": 188,
+        "quote": "### Recommended: StreamFeatureView (Streaming Scenarios)\n\nTiling provides **maximum benefit for streaming scenarios** with frequent updates:\n\n```python\nfrom feast import StreamFeatureView, Aggregation\nfrom feast.data_source import PushSource, KafkaSource\nfrom datetime import timedelta\n\n# Example with Kafka streaming source\ncustomer_features = StreamFeatureView(\n    name=\"customer_transaction_features\",\n    entities=[customer],\n    source=KafkaSource(\n        name=\"transactions_stream\",\n        kafka_bootstrap_servers=\"localhost:9092\",\n        topic=\"transactions\",\n        timestamp_field=\"event_timestamp\",\n        batch_source=file_source,  # For historical data\n    ),\n    aggregations=[\n        Aggregation(column=\"amount\", function=\"sum\", time_window=timedelta(hours=1), name=\"sum_amount_1h\"),\n        Aggregation(column=\"amount\", function=\"avg\", time_window=timedelta(hours=1), name=\"avg_amount_1h\"),\n        Aggregation(column=\"amount\", function=\"std\", time_window=timedelta(hours=1), name=\"std_amount_1h\"),\n    ],\n    timestamp_field=\"event_timestamp\",\n    online=True,\n    \n    # Tiling configuration\n    enable_tiling=True,  # speedup for streaming!\n    tiling_hop_size=timedelta(minutes=5),  # Update frequency\n)\n```\n\n**When to Enable:**\n- Streaming data sources (Kafka, Kinesis, PushSource)\n- Frequent updates (every few minutes)\n- Real-time feature serving\n- High-throughput event processing\n\n… (+2 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "fbcd13dc835362e69afde389a9f4311410f65ef68fc11a738297e33b17e0589b",
+      "topic": "overview",
+      "subject": "Configuration / Server Configuration",
+      "content": {
+        "summary": "### Server Configuration The server automatically extracts groups, namespaces and roles when using Kubernetes authentication. No additional configuration is required beyond the existing Kubernetes aut"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/kubernetes_auth_setup.md",
+        "line": 76,
+        "quote": "### Server Configuration\n\nThe server automatically extracts groups, namespaces and roles when using Kubernetes authentication. No additional configuration is required beyond the existing Kubernetes auth setup.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0d622c47e6868d16d6201e659e638a17a6d1919de92d5e37a650871f09ce19b3",
+      "topic": "overview",
+      "subject": "Configuration / Tracking URI resolution",
+      "content": {
+        "summary": "### Tracking URI resolution The tracking URI is resolved in this order: 1. `tracking_uri` field in `feature_store.yaml` 2. `MLFLOW_TRACKING_URI` environment variable 3. MLflow's default (`./mlruns` lo"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 68,
+        "quote": "### Tracking URI resolution\n\nThe tracking URI is resolved in this order:\n\n1. `tracking_uri` field in `feature_store.yaml`\n2. `MLFLOW_TRACKING_URI` environment variable\n3. MLflow's default (`./mlruns` local directory)\n\nThis means you can omit `tracking_uri` from the YAML and set `MLFLOW_TRACKING_URI` in your environment instead, or it would be pulled from `./mlruns` automatically when both are not set.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "60d60cf774336796ab2adac711dbfd732b1e5090dbe7bd2f01565a602ad83b11",
+      "topic": "overview",
+      "subject": "Configuration Priority",
+      "content": {
+        "summary": "## Configuration Priority The system checks for tokens in this order: 1. **Intra-communication**: `INTRA_COMMUNICATION_BASE64` (for service-to-service) 2. **Direct configuration**: `user_token` in `Ku"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/user_token_provisioning.md",
+        "line": 252,
+        "quote": "## Configuration Priority\n\nThe system checks for tokens in this order:\n\n1. **Intra-communication**: `INTRA_COMMUNICATION_BASE64` (for service-to-service)\n2. **Direct configuration**: `user_token` in `KubernetesAuthConfig` or in `feature_store.yaml`\n3. **Service account token**: `/var/run/secrets/kubernetes.io/serviceaccount/token` (for pods)\n4. **Environment variable**: `LOCAL_K8S_TOKEN`\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "cec72bd0ea5c1a550d8db458906aef48d459bb6cfd6f08a8559ff10aeb2c09a4",
+      "topic": "overview",
+      "subject": "Configuration of `feature_store.yaml`",
+      "content": {
+        "summary": "## Configuration of `feature_store.yaml` The current Go feature server needs a Python based feature Transformation service support. Please refer to the following code as an example: At the same time, "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/go-feature-server.md",
+        "line": 6,
+        "quote": "## Configuration of `feature_store.yaml`\nThe current Go feature server needs a Python based feature Transformation service support. Please refer to the following code as an example:\n```\n# -*- coding: utf-8 -*-\nfrom feast.feature_store import FeatureStore\n\n\ndef main():\n    # Init the Feature Store\n    store = FeatureStore(repo_path=\"./feature_repo/\")\n\n    # Start the feature transformation server\n    # default port is 6569\n    store.serve_transformations(6569)\n\nif __name__ == \"__main__\":\n    main()\n```\nAt the same time, we need to configure the `feature_store.yaml` as following:\n\n```\n...\nentity_key_serialization_version: 3\nfeature_server:\n    type: local\n    transformation_service_endpoint: \"localhost:6569\"\n...\n```"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-27T15:46:59-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3b598060c388f86bcf21847dea3816a025a0a10b591b14062865dbc737ff89ad",
+      "topic": "overview",
+      "subject": "Configuration reference",
+      "content": {
+        "summary": "## Configuration reference | Parameter | Default | Description | | --- | --- | --- | | `type` | `redis` | Online store type selector | | `redis_type` | `redis` | Connection type: `redis`, `redis_clust"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/redis.md",
+        "line": 136,
+        "quote": "## Configuration reference\n\n| Parameter | Default | Description |\n| --- | --- | --- |\n| `type` | `redis` | Online store type selector |\n| `redis_type` | `redis` | Connection type: `redis`, `redis_cluster`, or `redis_sentinel` |\n| `connection_string` | `localhost:6379` | Host:port and optional parameters. For cluster: `redis1:6379,redis2:6379,ssl=true,password=...` |\n| `sentinel_master` | `mymaster` | Sentinel master name (only used when `redis_type: redis_sentinel`) |\n| `key_ttl_seconds` | `null` | Redis `EXPIRE` TTL in seconds applied to the entity hash key after each write. Expires all feature views for that entity together. |\n| `full_scan_for_deletion` | `true` | When `true`, deleting or renaming a feature view scans Redis to remove its hash fields. Set `false` to skip deletion scans (faster `feast apply`, but leaves orphaned data). |\n| `skip_dedup` | `false` | When `true`, skips the existing-timestamp read before each write, halving write round trips. Suitable for initial bulk loads; may cause older values to overwrite newer ones under concurrent writers. |\n\nThe full set of configuration options is available in [RedisOnlineStoreConfig](https://rtd.feast.dev/en/latest/#feast.infra.online_stores.redis.RedisOnlineStoreConfig).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:27:21+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "228357ab69bb9b2d8afbf2c781e0f4b419ab27047393f114d27c89b9f077235f",
+      "topic": "overview",
+      "subject": "Connecting an MCP client",
+      "content": {
+        "summary": "## Connecting an MCP client Use your MCP client’s “HTTP” configuration and point it to the Feature Server base URL. For example, if your Feature Server runs at `http://localhost:6566`, use: - `http://"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/mcp-feature-server.md",
+        "line": 42,
+        "quote": "## Connecting an MCP client\n\nUse your MCP client’s “HTTP” configuration and point it to the Feature Server base URL. For example, if your Feature Server runs at `http://localhost:6566`, use:\n\n- `http://localhost:6566/mcp`\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-05T21:30:15+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2bd2ceb27b81002a063cc57ba9a6c7ae7dc0c0c1cdc80fce3b7c150dfa00f0e2",
+      "topic": "overview",
+      "subject": "Connection Pooling Configuration / Configuration Options",
+      "content": {
+        "summary": "### Configuration Options | Option | Type | Default | Description | |--------|------|---------|-------------| | `connection_pool_size` | int | 50 | Maximum number of connections to keep in the pool. I"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/remote.md",
+        "line": 32,
+        "quote": "### Configuration Options\n\n| Option | Type | Default | Description |\n|--------|------|---------|-------------|\n| `connection_pool_size` | int | 50 | Maximum number of connections to keep in the pool. Increase for high-concurrency workloads. |\n| `connection_idle_timeout` | int | 300 | Maximum time in seconds a session can be idle before being closed. Set to `0` to disable idle timeout. |\n| `connection_retries` | int | 3 | Number of retries for failed requests with exponential backoff. |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-26T10:23:00-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "01a71275f6fdeafb7c4e241de6cbc8eee8343a025781f1af044c342bcd43d087",
+      "topic": "overview",
+      "subject": "Connection Pooling Configuration / Performance Benefits",
+      "content": {
+        "summary": "### Performance Benefits Connection pooling provides significant latency improvements: - **Without pooling**: Each request requires a new TCP connection (~10-50ms) and TLS handshake (~30-100ms) - **With pooling**: Subsequent requests reuse existing connections, eliminating connection overhead This i"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/remote.md",
+        "line": 91,
+        "quote": "### Performance Benefits\n\nConnection pooling provides significant latency improvements:\n\n- **Without pooling**: Each request requires a new TCP connection (~10-50ms) and TLS handshake (~30-100ms)\n- **With pooling**: Subsequent requests reuse existing connections, eliminating connection overhead\n\nThis is especially beneficial for:\n- High-frequency feature retrieval in real-time inference pipelines\n- Batch processing with many sequential `get_online_features()` calls\n- Services with authentication enabled (reduces token refresh overhead)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-26T10:23:00-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "5e30c57c9d9d90322177048aaaf227583b3f60234733c4951c08f3a1a4b818a8",
+      "topic": "overview",
+      "subject": "Connection Pooling Configuration / Session Cleanup",
+      "content": {
+        "summary": "### Session Cleanup The HTTP session is automatically managed with idle timeout, but you can also explicitly close it when your application is shutting down or when you want to release resources. ####"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/remote.md",
+        "line": 103,
+        "quote": "### Session Cleanup\n\nThe HTTP session is automatically managed with idle timeout, but you can also explicitly close it when your application is shutting down or when you want to release resources.\n\n#### Using FeatureStore context manager (recommended)\n\nThe recommended way to ensure proper cleanup is to use the `FeatureStore` as a context manager:\n\n```python\nfrom feast import FeatureStore\n\n# Session is automatically closed when exiting the context\nwith FeatureStore(repo_path=\".\") as store:\n    features = store.get_online_features(\n        features=[\"driver_hourly_stats:conv_rate\"],\n        entity_rows=[{\"driver_id\": 1001}]\n    )\n```\n\n#### Explicit cleanup\n\nYou can also explicitly close the session by calling `close()` on the `FeatureStore`:\n\n```python\nfrom feast import FeatureStore\n\nstore = FeatureStore(repo_path=\".\")\ntry:\n    features = store.get_online_features(\n        features=[\"driver_hourly_stats:conv_rate\"],\n        entity_rows=[{\"driver_id\": 1001}]\n    )\nfinally:\n    store.close()  # Closes HTTP session and releases resources\n```\n\n#### Direct session management\n\nFor advanced use cases, you can directly manage the HTTP session via `HttpSessionManager`:\n\n… (+7 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-26T10:23:00-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8e9ddea859b200d7191a0079918818766daad54cdac2cf58f1e83199cc6d33ba",
+      "topic": "overview",
+      "subject": "Container Deployment",
+      "content": {
+        "summary": "## Container Deployment Static artifacts work with containerized deployments. Include your artifacts in the container image: The server will automatically load static artifacts during container startup."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-static-artifacts.md",
+        "line": 191,
+        "quote": "## Container Deployment\n\nStatic artifacts work with containerized deployments. Include your artifacts in the container image:\n\n```dockerfile\nFROM python:3.11-slim\n\n# Install dependencies\nCOPY requirements.txt .\nRUN pip install -r requirements.txt\n\n# Copy feature repository including static_artifacts.py\nCOPY feature_repo/ /app/feature_repo/\n\nWORKDIR /app/feature_repo\n\n# Start feature server\nCMD [\"feast\", \"serve\", \"--host\", \"0.0.0.0\"]\n```\n\nThe server will automatically load static artifacts during container startup.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-22T20:04:28-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f328eb831688094b2d873bdf141cf32c62494b47b0ae0ff533d54fde44b023fa",
+      "topic": "overview",
+      "subject": "Contributing",
+      "content": {
+        "summary": "## Contributing This is an alpha feature and we welcome contributions! Areas for improvement: - Configurable artifact file locations - Asynchronous artifact loading - Built-in artifact versioning - Pe"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-static-artifacts.md",
+        "line": 305,
+        "quote": "## Contributing\n\nThis is an alpha feature and we welcome contributions! Areas for improvement:\n- Configurable artifact file locations\n- Asynchronous artifact loading\n- Built-in artifact versioning\n- Performance monitoring and metrics\n- Integration with model registries\n\nPlease report issues and contribute improvements via the [Feast GitHub repository](https://github.com/feast-dev/feast)."
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-22T20:04:28-05:00"
+      },
+      "module": "contributing",
+      "source": "extracted"
+    },
+    {
+      "id": "e423d5b52ad44bfed184999b5833d84ab4619bc3023cc9e4efadf186324b9952",
+      "topic": "overview",
+      "subject": "Create Your Streaming Pipeline",
+      "content": {
+        "summary": "## Create Your Streaming Pipeline In `stream_job.py`, define your streaming computations:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/denormalized.md",
+        "line": 79,
+        "quote": "## Create Your Streaming Pipeline\n\nIn `stream_job.py`, define your streaming computations:\n\n```python\nfrom denormalized import Context, FeastDataStream\nfrom denormalized.datafusion import col, functions as f\nfrom feast import FeatureStore\n\nsample_event = {\n    \"occurred_at_ms\": 100,\n    \"sensor_name\": \"foo\",\n    \"reading\": 0.0,\n}\n\n# Create a stream from your Kafka topic\nds = FeastDataStream(Context().from_topic(\"temperature\", json.dumps(sample_event), \"localhost:9092\", \"occurred_at_ms\"))\n\n# Define your feature computations\nds = ds.window(\n    [col(\"sensor_name\")],  # Group by sensor\n    [\n        f.count(col(\"reading\")).alias(\"count\"),\n        f.min(col(\"reading\")).alias(\"min\"),\n        f.max(col(\"reading\")).alias(\"max\"),\n        f.avg(col(\"reading\")).alias(\"average\"),\n    ],\n    1000,  # Window size in ms\n    None   # Slide interval (None = tumbling window)\n)\n\nfeature_store = FeatureStore(repo_path=\"feature_repo/\")\n\n# This single line connects Denormalized to Feast!\nds.write_feast_feature(feature_store, \"push_sensor_statistics\")\n```\n\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-13T20:58:32+00:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "14c2dfc8e0b3e4a0542f41308715c53a08e1aa5002ea9dd5260480f8089a3c97",
+      "topic": "overview",
+      "subject": "Creating a saved dataset from historical retrieval",
+      "content": {
+        "summary": "### Creating a saved dataset from historical retrieval To create a saved dataset from historical features for later retrieval or analysis, a user needs to call `get_historical_features` method first a"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/dataset.md",
+        "line": 13,
+        "quote": "### Creating a saved dataset from historical retrieval\n\nTo create a saved dataset from historical features for later retrieval or analysis, a user needs to call `get_historical_features` method first and then pass the returned retrieval job to `create_saved_dataset` method. `create_saved_dataset` will trigger the provided retrieval job (by calling `.persist()` on it) to store the data using the specified `storage` behind the scenes. Storage type must be the same as the globally configured offline store (e.g it's impossible to persist data to a different offline source). `create_saved_dataset` will also create a `SavedDataset` object with all of the related metadata and will write this object to the registry.\n\n```python\nfrom feast import FeatureStore\nfrom feast.infra.offline_stores.bigquery_source import SavedDatasetBigQueryStorage\n\nstore = FeatureStore()\n\nhistorical_job = store.get_historical_features(\n    features=[\"driver:avg_trip\"],\n    entity_df=...,\n)\n\ndataset = store.create_saved_dataset(\n    from_=historical_job,\n    name='my_training_dataset',\n    storage=SavedDatasetBigQueryStorage(table_ref='<gcp-project>.<gcp-dataset>.my_training_dataset'),\n    tags={'author': 'oleksii'}\n)\n\ndataset.to_df()\n```\n\nSaved dataset can be retrieved later using the `get_saved_dataset` method in the feature store:\n\n```python\ndataset = store.get_saved_dataset('my_training_dataset')\ndataset.to_df()\n```\n\n***\n\nCheck out our [tutorial on validating historical features](../../tutorials/validating-historical-features.md) to see how this concept can be applied in a real-world use case.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-13T05:46:29-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "628f4ac40166c46bbcc48bb1388242a531bb07d459ac3bbdb67e5164c412bfc7",
+      "topic": "overview",
+      "subject": "Custom Feast Facets / FeastFeatureServiceFacet",
+      "content": {
+        "summary": "### FeastFeatureServiceFacet Captures metadata about feature services: - `name`: Feature service name - `feature_views`: List of feature view names - `feature_count`: Total number of features - `descr"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 171,
+        "quote": "### FeastFeatureServiceFacet\n\nCaptures metadata about feature services:\n- `name`: Feature service name\n- `feature_views`: List of feature view names\n- `feature_count`: Total number of features\n- `description`: Feature service description\n- `tags`: Key-value tags\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "695c45e7e585b9164dfdcaed6eba62ca7a099194db7b83b89b1087a8ac9b1e97",
+      "topic": "overview",
+      "subject": "Custom Feast Facets / FeastMaterializationFacet",
+      "content": {
+        "summary": "### FeastMaterializationFacet Captures materialization run metadata: - `feature_views`: Feature views being materialized - `start_date` / `end_date`: Materialization window - `rows_written`: Number of"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 180,
+        "quote": "### FeastMaterializationFacet\n\nCaptures materialization run metadata:\n- `feature_views`: Feature views being materialized\n- `start_date` / `end_date`: Materialization window\n- `rows_written`: Number of rows written\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ca50cf123ac316133429bb17396924166c835673a0a8750d48d4ea8fa5d8047c",
+      "topic": "overview",
+      "subject": "DAG Node Types / RayAggregationNode",
+      "content": {
+        "summary": "### RayAggregationNode Handles feature aggregations: - Windowed aggregations - Grouped aggregations - Custom aggregation functions"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 265,
+        "quote": "### RayAggregationNode\n\nHandles feature aggregations:\n- Windowed aggregations\n- Grouped aggregations\n- Custom aggregation functions\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "15b524e0649c1c556f323be5442ebb0a9dc20bf6c59307b89856578f1d65d7e3",
+      "topic": "overview",
+      "subject": "DAG Node Types / RayFilterNode",
+      "content": {
+        "summary": "### RayFilterNode Applies filters and time-based constraints: - TTL-based filtering - Timestamp range filtering - Custom predicate filtering"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 258,
+        "quote": "### RayFilterNode\n\nApplies filters and time-based constraints:\n- TTL-based filtering\n- Timestamp range filtering\n- Custom predicate filtering\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "624c89ebb7881611f0f44ff9d55560d9ffa96d05aa0ecc62df48cb9834a2834e",
+      "topic": "overview",
+      "subject": "DAG Node Types / RayJoinNode",
+      "content": {
+        "summary": "### RayJoinNode Performs distributed joins: - **Broadcast Join**: For small datasets (<100MB) - **Distributed Join**: For large datasets with time-based windowing - **Automatic Strategy Selection**: Based on dataset size and cluster resources"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 251,
+        "quote": "### RayJoinNode\n\nPerforms distributed joins:\n- **Broadcast Join**: For small datasets (<100MB)\n- **Distributed Join**: For large datasets with time-based windowing\n- **Automatic Strategy Selection**: Based on dataset size and cluster resources\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a29948ac6f028390ceb968498c84b029f132e238f552cfe796e604707d8a37c4",
+      "topic": "overview",
+      "subject": "DAG Node Types / RayReadNode",
+      "content": {
+        "summary": "### RayReadNode Reads data from Ray-compatible sources: - Supports Parquet, CSV, and other formats - Handles partitioning and schema inference - Applies field mappings and filters"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 244,
+        "quote": "### RayReadNode\n\nReads data from Ray-compatible sources:\n- Supports Parquet, CSV, and other formats\n- Handles partitioning and schema inference\n- Applies field mappings and filters\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "04df099c75e8a4df545e5e9d900383297f373cc1acc2a52cf2d9497ab6b20e12",
+      "topic": "overview",
+      "subject": "DAG Node Types / RayTransformationNode",
+      "content": {
+        "summary": "### RayTransformationNode Applies feature transformations: - Row-level transformations - Column-level transformations - Custom transformation functions"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 272,
+        "quote": "### RayTransformationNode\n\nApplies feature transformations:\n- Row-level transformations\n- Column-level transformations\n- Custom transformation functions\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "dda001cecbafde2aa33573425d7ca40644c51f074bdb546d5a7a6d12410c08d9",
+      "topic": "overview",
+      "subject": "DAG Node Types / RayWriteNode",
+      "content": {
+        "summary": "### RayWriteNode Writes results to various targets: - Online stores - Offline stores - Temporary storage"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 279,
+        "quote": "### RayWriteNode\n\nWrites results to various targets:\n- Online stores\n- Offline stores\n- Temporary storage\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a1a5831fb4d96dc52e47bd4d51a63a9fb3862eb67ec309fd15d8d450a57d9cf7",
+      "topic": "overview",
+      "subject": "Data Model",
+      "content": {
+        "summary": "## Data Model The offline store uses a single shared collection (by default `feature_history`) that stores append-only historical feature rows for all feature views. Each document represents one observation of one entity for one FeatureView at a specific event timestamp: Key properties: * **Append-o"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/mongodb.md",
+        "line": 34,
+        "quote": "## Data Model\n\nThe offline store uses a single shared collection (by default `feature_history`) that stores append-only historical feature rows for all feature views. Each document represents one observation of one entity for one FeatureView at a specific event timestamp:\n\n```json\n{\n  \"entity_id\": \"Binary(...)\",\n  \"feature_view\": \"driver_stats\",\n  \"event_timestamp\": \"ISODate(2024-01-15T12:00:00Z)\",\n  \"created_at\": \"ISODate(2024-01-15T12:01:00Z)\",\n  \"features\": {\n    \"conv_rate\": 0.72,\n    \"acc_rate\": 0.91,\n    \"avg_daily_trips\": 14\n  }\n}\n```\n\nKey properties:\n\n* **Append-only**: Historical data is treated as immutable; corrections are written as new rows with newer `created_at` timestamps rather than in-place updates.\n* **Time-series friendly**: `event_timestamp` represents when the feature value was observed; `created_at` is used as a tie-breaker when multiple observations share the same event timestamp.\n* **Feature grouping by FeatureView**: `feature_view` identifies which FeatureView the row belongs to, so a single collection can host multiple FVs.\n\nA single compound index supports all major query patterns:\n\n```\n(entity_id ASC, feature_view ASC, event_timestamp DESC, created_at DESC)\n```\n\nThis index enables efficient range scans over entities and feature views, while ensuring that the most recent observation per `(entity_id, feature_view)` is seen first during aggregation. The index is created lazily on first use and cached per connection string.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8d985e2a798d32f857898c4463b6f8f477c18b7d9eaf38271f5662ac9f246658",
+      "topic": "overview",
+      "subject": "Data Model / Example Document Schema",
+      "content": {
+        "summary": "### Example Document Schema The example shows a single entity. It contains 3 features from 2 feature views: \"rating\" and \"trips_last7d\" from Feature View \"driver_stats\", and \"surge_multiplier\" from \"p"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/mongodb.md",
+        "line": 99,
+        "quote": "### Example Document Schema\n\nThe example shows a single entity. It contains 3 features from 2 feature views: \"rating\" and \"trips_last7d\" from Feature\nView \"driver_stats\", and \"surge_multiplier\" from \"pricing\" view. \nEach feature view has its own event timestamp. \nThe \"created_timestamp\" marks when the entity was materialized.\n\n```javascript\n{\n  \"_id\": \"<serialized_entity_key>\",  // Binary entity key (bytes)\n  \"features\": {\n    \"driver_stats\": {\n      \"rating\": 4.91,\n      \"trips_last_7d\": 132\n    },\n    \"pricing\": {\n      \"surge_multiplier\": 1.2\n    }\n  },\n  \"event_timestamps\": {\n    \"driver_stats\": ISODate(\"2026-01-20T12:00:00Z\"),\n    \"pricing\": ISODate(\"2026-01-21T08:30:00Z\")\n  },\n  \"created_timestamp\": ISODate(\"2026-01-21T12:00:05Z\")\n}\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T09:21:30+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8aa8baaa51fd750e95dd339205c07e712979ab3ca90eef1a50f246904c7508ee",
+      "topic": "overview",
+      "subject": "Data Model / Indexes",
+      "content": {
+        "summary": "### Indexes The online store automatically creates the following index: * Primary key index on `_id` (automatic in MongoDB), set to the serialized entity key. No additional indexes are required for th"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/mongodb.md",
+        "line": 133,
+        "quote": "### Indexes\n\nThe online store automatically creates the following index:\n* Primary key index on `_id` (automatic in MongoDB), set to the serialized entity key.\n\nNo additional indexes are required for the online store operations.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T09:21:30+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "6fd1cc9a3e12afd186694fa7027c4decb83b192429cfc4f311130e93c9725083",
+      "topic": "overview",
+      "subject": "Data Model / Key Design Decisions",
+      "content": {
+        "summary": "### Key Design Decisions * **`_id` field**: Uses the serialized entity key (bytes) as the primary key for efficient lookups * **Nested features**: Features are organized by feature view name, allowing"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/mongodb.md",
+        "line": 126,
+        "quote": "### Key Design Decisions\n\n* **`_id` field**: Uses the serialized entity key (bytes) as the primary key for efficient lookups\n* **Nested features**: Features are organized by feature view name, allowing multiple feature views per entity\n* **Event timestamps**: Stored per feature view to track when each feature set was last updated\n* **Created timestamp**: Global timestamp for the entire document\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T09:21:30+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "670d2209a52a1b3455cfdec58f8eb52db6f23b8d61846ff7df3b4c36fd5e7a4d",
+      "topic": "overview",
+      "subject": "Data Source Support",
+      "content": {
+        "summary": "## Data Source Support Currently, table formats are supported with: - Spark data source - Full support for Iceberg, Delta, and Hudi Future support planned for: - BigQuery (Iceberg) - Snowflake (Iceberg) - Other data sources"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 341,
+        "quote": "## Data Source Support\n\nCurrently, table formats are supported with:\n- [Spark data source](spark.md) - Full support for Iceberg, Delta, and Hudi\n\nFuture support planned for:\n- BigQuery (Iceberg)\n- Snowflake (Iceberg)\n- Other data sources\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "54622d21c35e697c6bc30387af1d18961fddd36503df51722ed95ed119af15a9",
+      "topic": "overview",
+      "subject": "Data Sources",
+      "content": {
+        "summary": "## Data Sources [`RaySource`](../data-sources/ray.md) is the recommended data source for the Ray offline store. It is a pure-metadata descriptor that tells Feast how to load a Ray Dataset from any sou"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 570,
+        "quote": "## Data Sources\n\n[`RaySource`](../data-sources/ray.md) is the recommended data source for the\nRay offline store. It is a pure-metadata descriptor that tells Feast how to\nload a Ray Dataset from any source Ray Data supports — Parquet, CSV, JSON,\nHuggingFace datasets, MongoDB, binary files, images, TFRecords, WebDataset,\nSQL, and more.\n\n```python\nfrom feast.infra.offline_stores.contrib.ray_offline_store.ray_source import RaySource\n\n# Load directly from the HuggingFace Hub \ncheque_source = RaySource(\n    name=\"cheque_images_hf\",\n    reader_type=\"huggingface\",\n    reader_options={\n        \"dataset_name\": \"cheques_sample_data\",\n        \"split\": \"train\",\n    },\n    timestamp_field=\"event_timestamp\",\n)\n```\n\nSee the [RaySource reference](../data-sources/ray.md) for a full list of\n`reader_type` values and configuration options.\n\n> **Note:** `FileSource` (Parquet) remains supported for backward compatibility\n> but `RaySource(reader_type=\"parquet\")` is preferred for new projects.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ea0cad74cc2d346efa2e10b15e2a376bd75bf25f9ccfeb672a42924f8c0e1789",
+      "topic": "overview",
+      "subject": "Data ingestion",
+      "content": {
+        "summary": "### Data ingestion For _offline use cases_ that only rely on batch data, Feast does not need to ingest data and can query your existing data (leveraging a compute engine, whether it be a data warehouse or (experimental) Spark / Trino). Feast can help manage **pushing** streaming features to a batch"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/overview.md",
+        "line": 8,
+        "quote": "### Data ingestion\n\nFor _offline use cases_ that only rely on batch data, Feast does not need to ingest data and can query your existing data (leveraging a compute engine, whether it be a data warehouse or (experimental) Spark / Trino). Feast can help manage **pushing** streaming features to a batch source to make features available for training.\n\nFor _online use cases_, Feast supports **ingesting** features from batch sources to make them available online (through a process called **materialization**), and **pushing** streaming features to make them available both offline / online. We explore this more in the next concept page ([Data ingestion](data-ingestion.md))\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-10-21T12:24:29-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0b94b0e66bab0dcc80d204c3ecc2c6574760732e378557c1041e18276b0e15cc",
+      "topic": "overview",
+      "subject": "Data source",
+      "content": {
+        "summary": "## Data source A data source in Feast refers to raw underlying data that users own (e.g. in a table in BigQuery). Feast does not manage any of the raw underlying data but instead, is in charge of loading this data and performing different operations on the data to retrieve or serve features. Feast u"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/data-ingestion.md",
+        "line": 3,
+        "quote": "## Data source\n\nA data source in Feast refers to raw underlying data that users own (e.g. in a table in BigQuery). Feast does not manage any of the raw underlying data but instead, is in charge of loading this data and performing different operations on the data to retrieve or serve features.\n\nFeast uses a time-series data model to represent data. This data model is used to interpret feature data in data sources in order to build training datasets or materialize features into an online store.\n\nBelow is an example data source with a single entity column (`driver`) and two feature columns (`trips_today`, and `rating`).\n\n![Ride-hailing data source](<../../.gitbook/assets/image (16).png>)\n\nFeast supports primarily **time-stamped** tabular data as data sources. There are many kinds of possible data sources:\n\n* **Batch data sources:** ideally, these live in data warehouses (BigQuery, Snowflake, Redshift), but can be in data lakes (S3, GCS, etc). Feast supports ingesting and querying data across both.\n* **Stream data sources**: Feast does **not** have native streaming integrations. It does however facilitate making streaming features available in different environments. There are two kinds of sources:\n  * **Push sources** allow users to push features into Feast, and make it available for training / batch scoring (\"offline\"), for realtime feature serving (\"online\") or both.\n  * **\\[Alpha] Stream sources** allow users to register metadata from Kafka or Kinesis sources. The onus is on the user to ingest from these sources, though Feast provides some limited helper methods to ingest directly from Kafka / Kinesis topics.\n* **(Experimental) Request data sources:** This is data that is only available at request time (e.g. from a user action that needs an immediate model prediction response). This is primarily relevant as an input into [**on-demand feature views**](../../../docs/reference/beta-on-demand-feature-view.md), which allow light-weight feature engineering and combining features across sources.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-09-24T17:10:05+01:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c8d19de397540db2e97fb2e249d8f244422b343007696602fe94a455907f849e",
+      "topic": "overview",
+      "subject": "Dataset profile",
+      "content": {
+        "summary": "### Dataset profile Currently, Feast supports only [Great Expectation's](https://greatexpectations.io/) [ExpectationSuite](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/dqm.md",
+        "line": 30,
+        "quote": "### Dataset profile\nCurrently, Feast supports only [Great Expectation's](https://greatexpectations.io/) [ExpectationSuite](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/core/expectation_suite/index.html#great_expectations.core.expectation_suite.ExpectationSuite)\nas dataset's profile. Hence, the user needs to define a function (profiler) that would receive a dataset and return an [ExpectationSuite](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/core/expectation_suite/index.html#great_expectations.core.expectation_suite.ExpectationSuite).\n\nGreat Expectations supports automatic profiling as well as manually specifying expectations:\n```python\nfrom great_expectations.dataset import Dataset\nfrom great_expectations.core.expectation_suite import ExpectationSuite\n\nfrom feast.dqm.profilers.ge_profiler import ge_profiler\n\n@ge_profiler\ndef automatic_profiler(dataset: Dataset) -> ExpectationSuite:\n    from great_expectations.profile.user_configurable_profiler import UserConfigurableProfiler\n\n    return UserConfigurableProfiler(\n        profile_dataset=dataset,\n        ignored_columns=['conv_rate'],\n        value_set_threshold='few'\n    ).build_suite()\n```\nHowever, from our experience capabilities of automatic profiler are quite limited. So we would recommend crafting your own expectations:\n```python\n@ge_profiler\ndef manual_profiler(dataset: Dataset) -> ExpectationSuite:\n    dataset.expect_column_max_to_be_between(\"column\", 1, 2)\n    return dataset.get_expectation_suite()\n```\n\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-02-02T07:01:43-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "abae0eeec5403f9de0170eeb6154ded3858575e4cd6f1b0b712eb253724516b1",
+      "topic": "overview",
+      "subject": "Declarative Feature Definitions",
+      "content": {
+        "summary": "## Declarative Feature Definitions When using the CLI to apply changes (via `feast apply`), the CLI determines the state of the feature repo from the source files and updates the registry state to reflect the definitions in the feature repo files. This means that new feature views are added to the r"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-repo.md",
+        "line": 16,
+        "quote": "## Declarative Feature Definitions\n\nWhen using the CLI to apply changes (via `feast apply`), the CLI determines the state of the feature repo from the source files and updates the registry state to reflect the definitions in the feature repo files.\nThis means that new feature views are added to the registry, existing feature views are updated as necessary, and Feast objects removed from the source files are deleted from the registry.\n\nFor more details, see the [Feature repository](../../reference/feature-repository/) reference.\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-08-10T13:47:53-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "83de6c64b76fd736ca1549f6405027bbed375efe5c79d69269b30b214435e44e",
+      "topic": "overview",
+      "subject": "Define Your Features",
+      "content": {
+        "summary": "## Define Your Features In `feature_repo/sensor_data.py`, define your feature view and entity:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/denormalized.md",
+        "line": 49,
+        "quote": "## Define Your Features\n\nIn `feature_repo/sensor_data.py`, define your feature view and entity:\n\n```python\nfrom feast import Entity, FeatureView, PushSource, Field\nfrom feast.types import Float64, String\n\n# Define your entity\nsensor = Entity(\n    name=\"sensor\",\n    join_keys=[\"sensor_name\"],\n)\n\n# Create a push source for real-time features\nsource = PushSource(\n    name=\"push_sensor_statistics\",\n    batch_source=your_batch_source  # Define your batch source\n)\n\n# Define your feature view\nstats_view = FeatureView(\n    name=\"sensor_statistics\",\n    entities=[sensor],\n    schema=ds.get_feast_schema(),  # Denormalized handles this for you!\n    source=source,\n    online=True,\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-13T20:58:32+00:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "43d92b7a4a12d4a2ea7fb05395114a45f9c360655ae68c0363e1fb79c9f24495",
+      "topic": "overview",
+      "subject": "Definition examples",
+      "content": {
+        "summary": "## Definition examples This permission definition grants access to the resource state and the ability to read all of the stores for any feature view or feature service to all users with the role `supe"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/permission.md",
+        "line": 64,
+        "quote": "## Definition examples\nThis permission definition grants access to the resource state and the ability to read all of the stores for any feature view or\nfeature service to all users with the role `super-reader`:\n```py\nPermission(\n    name=\"feature-reader\",\n    types=[FeatureView, FeatureService],\n    policy=RoleBasedPolicy(roles=[\"super-reader\"]),\n    actions=[AuthzedAction.DESCRIBE, *READ],\n)\n```\n\nThis example grants permission to write on all the data sources with `risk_level` tag set to `high` only to users with role `admin` or `data_team`:\n```py\nPermission(\n    name=\"ds-writer\",\n    types=[DataSource],\n    required_tags={\"risk_level\": \"high\"},\n    policy=RoleBasedPolicy(roles=[\"admin\", \"data_team\"]),\n    actions=[AuthzedAction.WRITE],\n)\n```\n\n{% hint style=\"info\" %}\n**Note**: When using multiple roles in a role-based policy, the user must be granted at least one of the specified roles.\n{% endhint %}\n\n\nThe following permission grants authorization to read the offline store of all the feature views including `risky` in the name, to users with role `trusted`:\n\n```py\nPermission(\n    name=\"reader\",\n    types=[FeatureView],\n    name_patterns=\".*risky.*\", # Accepts both `str` or `list[str]` types\n    policy=RoleBasedPolicy(roles=[\"trusted\"]),\n    actions=[AuthzedAction.READ_OFFLINE],\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "300d1d59cd2705aba776abae1a010bf6eed67ef116b2760e4786df838a3d2555",
+      "topic": "overview",
+      "subject": "Delete",
+      "content": {
+        "summary": "## Delete Delete a Feast object from the registry by its name. **What does feast delete do?** The `feast delete` command removes a Feast object (such as a feature view, entity, data source, feature se"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 112,
+        "quote": "## Delete\n\nDelete a Feast object from the registry by its name.\n\n```bash\nfeast delete <OBJECT_NAME>\n```\n\n**What does feast delete do?**\n\nThe `feast delete` command removes a Feast object (such as a feature view, entity, data source, feature service, etc.) from the registry. The command will:\n\n1. Search for the object by name across all object types (entities, feature views, feature services, data sources, saved datasets, validation references, etc.)\n2. Delete the first matching object found\n3. Remove any associated infrastructure\n\n**Example:**\n\n```bash\n# Delete a feature view named \"driver_hourly_stats\"\nfeast delete driver_hourly_stats\n\n# Delete an entity named \"driver\"\nfeast delete driver\n```\n\n{% hint style=\"warning\" %}\nThe delete operation is permanent and will remove the object from the registry. Make sure you want to delete the object before running this command.\n{% endhint %}\n\n{% hint style=\"info\" %}\nIf multiple objects have the same name across different types, `feast delete` will delete the first one it finds. For programmatic deletion with more control, use the Python SDK methods like `store.delete_feature_view()`, `store.delete_feature_service()`, etc.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "delete",
+      "source": "extracted"
+    },
+    {
+      "id": "e7e3b734375a523efa6544f7e6bcd3c962a7d9e05236c8ad60d4caa9d89a09b4",
+      "topic": "overview",
+      "subject": "Deleting objects from the registry / Using the CLI",
+      "content": {
+        "summary": "### Using the CLI The simplest way to delete objects is using the `feast delete` command: See the [CLI documentation](../../reference/feast-cli-commands.md#delete) for more details."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/registry.md",
+        "line": 20,
+        "quote": "### Using the CLI\n\nThe simplest way to delete objects is using the `feast delete` command:\n\n```bash\n# Delete any Feast object by name\nfeast delete my_feature_view\nfeast delete my_entity\nfeast delete my_feature_service\n```\n\nSee the [CLI documentation](../../reference/feast-cli-commands.md#delete) for more details.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-14T10:41:09-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4854ec06383c6fe43d3d0495a7abd70a03108fc7825352e2a39d3176b8cc35ec",
+      "topic": "overview",
+      "subject": "Deleting objects from the registry / Using the Python SDK",
+      "content": {
+        "summary": "### Using the Python SDK To delete objects programmatically, use the explicit delete methods provided by the `FeatureStore` class: #### Deleting feature views #### Deleting feature services #### Delet"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/registry.md",
+        "line": 33,
+        "quote": "### Using the Python SDK\n\nTo delete objects programmatically, use the explicit delete methods provided by the `FeatureStore` class:\n\n#### Deleting feature views\n```python\nfrom feast import FeatureStore\n\nstore = FeatureStore(repo_path=\".\")\nstore.delete_feature_view(\"my_feature_view\")\n```\n\n#### Deleting feature services\n```python\nstore.delete_feature_service(\"my_feature_service\")\n```\n\n#### Deleting entities, data sources, and other objects\n\nFor entities, data sources, and other registry objects, you can use the registry methods directly:\n\n```python\n# Delete an entity\nstore._registry.delete_entity(\"my_entity\", project=store.project)\n\n# Delete a data source\nstore._registry.delete_data_source(\"my_data_source\", project=store.project)\n\n# Delete a saved dataset\nstore._registry.delete_saved_dataset(\"my_saved_dataset\", project=store.project)\n\n# Delete a validation reference\nstore._registry.delete_validation_reference(\"my_validation_reference\", project=store.project)\n```\n\n{% hint style=\"info\" %}\nWhen using `feast apply` via the CLI, you can also use the `objects_to_delete` parameter with `partial=False` to delete objects as part of the apply operation. However, this is less common and typically used in automated deployment scenarios.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-14T10:41:09-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "7cafbe2780ad2331ed48e87acec50a62f4222cb67fa97d2383eca111835113f4",
+      "topic": "overview",
+      "subject": "Demo",
+      "content": {
+        "summary": "## Demo Please check the Reference[2] for a local demo of Go feature server. If you want to see a real world example of applying Go feature server in Production, please check Reference[1]."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/go-feature-server.md",
+        "line": 49,
+        "quote": "## Demo\nPlease check the Reference[2] for a local demo of Go feature server. If you want to see a real world example of applying Go feature server in Production, please check Reference[1].\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-27T15:46:59-04:00"
+      },
+      "module": "demo",
+      "source": "extracted"
+    },
+    {
+      "id": "a5fd1cf5549da50ab2c82d47d96370a947a074c857c2311935a457ce6bc249ff",
+      "topic": "overview",
+      "subject": "Demo Notebooks",
+      "content": {
+        "summary": "## Demo Notebooks Generate tailored demo Jupyter notebooks for each Feast project found in the current directory. The command searches for `feature_store.yaml` in the current directory and every file inside the `feast-config/` directory. Each file is treated as a separate project config, and noteboo"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 146,
+        "quote": "## Demo Notebooks\n\nGenerate tailored demo Jupyter notebooks for each Feast project found in the current directory.\n\n```bash\nfeast demo-notebooks\n```\n\nThe command searches for `feature_store.yaml` in the current directory and every file inside the `feast-config/` directory. Each file is treated as a separate project config, and notebooks are created under `./feast-demo-notebooks/<project>/`.\n\nThe generated notebooks adapt to your project configuration (online/offline store types, authentication, vector search) and cover:\n\n* **Feature store overview** — explore registered entities, feature views, and services.\n* **Historical feature retrieval** — build training datasets with point-in-time correct joins.\n* **Online feature serving** — materialize features and retrieve them at low latency.\n\n**Options:**\n\n* `-o, --output-dir` — Directory where the notebooks are written. Default: `./feast-demo-notebooks`.\n* `--overwrite` — Overwrite existing notebooks if the output directory already exists.\n\n```bash\nfeast demo-notebooks -o ./my-notebooks --overwrite\n```\n\nYou can also use the `--chdir` global option to point at a different feature repository:\n\n```bash\nfeast -c /path/to/feature_repo demo-notebooks\n```\n\nThe same functionality is available via the Python SDK:\n\n```python\nfrom feast import copy_demo_notebooks\n\ncopy_demo_notebooks(output_dir=\"./feast-demo-notebooks\", repo_path=\".\")\n```\n\nFor more details see the [Demo Notebooks tutorial](../tutorials/demo-notebooks.md).\n… (+1 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "21230f411d78531653f05ce5ddeced1f4020f810269cae4b6131f75db5884093",
+      "topic": "overview",
+      "subject": "Deploying as a service",
+      "content": {
+        "summary": "## Deploying as a service See this for an example on how to run Feast on Kubernetes using the Operator."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 56,
+        "quote": "## Deploying as a service\n\nSee [this](../../how-to-guides/running-feast-in-production.md#id-4.2.-deploy-feast-feature-servers-on-kubernetes) for an example on how to run Feast on Kubernetes using the Operator.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9bbbdf3470eb2453aa2006e30a02ffcc48515358dd1f8aea1523e63d38d3b5b8",
+      "topic": "overview",
+      "subject": "Description / Pre-requisites",
+      "content": {
+        "summary": "### Pre-requisites The HDFS registry requires Hadoop 3.3+ to be installed and the `HADOOP_HOME` environment variable set."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/registries/hdfs.md",
+        "line": 9,
+        "quote": "### Pre-requisites\n\nThe HDFS registry requires Hadoop 3.3+ to be installed and the `HADOOP_HOME` environment variable set.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-15T02:39:58+00:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b0bb36830476ff473a6d1fc689b28917da89b90b253fa85ac8aa8b9d4fa058f0",
+      "topic": "overview",
+      "subject": "Documentation",
+      "content": {
+        "summary": "## Documentation For comprehensive documentation, examples, and best practices, see the Alpha Static Artifacts Loading reference guide. The PyTorch NLP template provides a complete working example."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 588,
+        "quote": "## Documentation\n\nFor comprehensive documentation, examples, and best practices, see the [Alpha Static Artifacts Loading](../alpha-static-artifacts.md) reference guide.\n\nThe [PyTorch NLP template](https://github.com/feast-dev/feast/tree/main/sdk/python/feast/templates/pytorch_nlp) provides a complete working example.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "documentation",
+      "source": "extracted"
+    },
+    {
+      "id": "add61589dfe3635b7d3f1c90c3979050737ebc7fc9440f2cc3cef4aeb15408b8",
+      "topic": "overview",
+      "subject": "Endpoints Overview",
+      "content": {
+        "summary": "## Endpoints Overview | Endpoint                     | Description                                                             | |------------------------------|-------------------------------------------------------------------------| | `/get-online-features`       | Retrieves feature values for sp"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/feature-server.md",
+        "line": 32,
+        "quote": "## Endpoints Overview\n\n| Endpoint                     | Description                                                             |\n|------------------------------|-------------------------------------------------------------------------|\n| `/get-online-features`       | Retrieves feature values for specified entities and feature references. |\n| `/push`                      | Pushes feature data to the online and/or offline store.                 |\n| `/materialize`               | Materializes features within a specific time range to the online store. |\n| `/materialize-incremental`   | Incrementally materializes features up to the current timestamp.        |\n| `/retrieve-online-documents` | Supports Vector Similarity Search for RAG (Alpha end-ponit)             |\n| `/docs`                      | API Contract for available endpoints                                    | \n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-02-06T13:59:44-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2cf7bfd8e0fed2ddf6be0bf79f3403b29176ff72e89efe6e6ee7ae47bec5514a",
+      "topic": "overview",
+      "subject": "Entities",
+      "content": {
+        "summary": "## Entities List all registered entities"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 187,
+        "quote": "## Entities\n\nList all registered entities\n\n```text\nfeast entities list\n\nOptions:\n  --tags TEXT  Filter by tags (e.g. --tags 'key:value' --tags 'key:value,\n               key:value, ...'). Items return when ALL tags match.\n```\n\n```text\nNAME       DESCRIPTION    TYPE\ndriver_id  driver id      ValueType.INT64\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "entities",
+      "source": "extracted"
+    },
+    {
+      "id": "963d375dd4b18828451a13eb5e168f00afcb0daba774d06b38433503f7dee3d0",
+      "topic": "overview",
+      "subject": "Entity aliasing",
+      "content": {
+        "summary": "## Entity aliasing \"Entity aliases\" can be specified to join `entity_dataframe` columns that do not match the column names in the source table of a FeatureView. This could be used if a user has no con"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-view.md",
+        "line": 90,
+        "quote": "## Entity aliasing\n\n\"Entity aliases\" can be specified to join `entity_dataframe` columns that do not match the column names in the source table of a FeatureView.\n\nThis could be used if a user has no control over these column names or if there are multiple entities are a subclass of a more general entity. For example, \"spammer\" and \"reporter\" could be aliases of a \"user\" entity, and \"origin\" and \"destination\" could be aliases of a \"location\" entity as shown below.\n\nIt is suggested that you dynamically specify the new FeatureView name using `.with_name` and `join_key_map` override using `.with_join_key_map` instead of needing to register each new copy.\n\n{% tabs %}\n{% tab title=\"location_stats_feature_view.py\" %}\n```python\nfrom feast import BigQuerySource, Entity, FeatureView, Field\nfrom feast.types import Int32, Int64\n\nlocation = Entity(name=\"location\", join_keys=[\"location_id\"])\n\nlocation_stats_fv= FeatureView(\n    name=\"location_stats\",\n    entities=[location],\n    schema=[\n        Field(name=\"temperature\", dtype=Int32),\n        Field(name=\"location_id\", dtype=Int64),\n    ],\n    source=BigQuerySource(\n        table=\"feast-oss.demo_data.location_stats\"\n    ),\n)\n```\n{% endtab %}\n\n{% tab title=\"temperatures_feature_service.py\" %}\n```python\nfrom location_stats_feature_view import location_stats_fv\n\ntemperatures_fs = FeatureService(\n    name=\"temperatures\",\n    features=[\n        location_stats_fv\n            .with_name(\"origin_stats\")\n            .with_join_key_map(\n… (+13 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-27T23:00:47-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "bdfb0bedcb3cd50457254fa462ca0d5c9fa2887ef813674fbde0deaa741b3c01",
+      "topic": "overview",
+      "subject": "Error Handling",
+      "content": {
+        "summary": "## Error Handling Static artifacts loading includes graceful error handling: - **Missing file**: Server starts normally without static artifacts - **Loading errors**: Warnings are logged, feature view"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-static-artifacts.md",
+        "line": 227,
+        "quote": "## Error Handling\n\nStatic artifacts loading includes graceful error handling:\n- **Missing file**: Server starts normally without static artifacts\n- **Loading errors**: Warnings are logged, feature views should implement fallback logic\n- **Partial failures**: Successfully loaded artifacts remain available\n\nAlways implement fallback behavior in your feature transformations:\n\n```python\n@on_demand_feature_view(...)\ndef robust_prediction(inputs: pd.DataFrame) -> pd.DataFrame:\n    global _sentiment_model\n\n    results = []\n    for text in inputs[\"input_text\"]:\n        if _sentiment_model is not None:\n            # Use pre-loaded model\n            predictions = _sentiment_model(text)\n            sentiment = max(predictions, key=lambda x: x[\"score\"])[\"label\"]\n        else:\n            # Fallback when artifacts aren't available\n            sentiment = \"neutral\"\n\n        results.append({\"predicted_sentiment\": sentiment})\n\n    return pd.DataFrame(results)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-22T20:04:28-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9542eb40668c92442bea5ca1d1750c7556eb1d074dd4c6a643de096e6c209892",
+      "topic": "overview",
+      "subject": "Example (Spark Streaming)",
+      "content": {
+        "summary": "## Example (Spark Streaming) The default option to write features from a stream is to add the Python SDK into your existing PySpark pipeline. This can also be used under the hood by a contrib stream p"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/push.md",
+        "line": 66,
+        "quote": "## Example (Spark Streaming)\n\nThe default option to write features from a stream is to add the Python SDK into your existing PySpark pipeline.\n\n```python\nfrom feast import FeatureStore\n\nstore = FeatureStore(...)\n\nspark = SparkSession.builder.getOrCreate()\n\nstreamingDF = spark.readStream.format(...).load()\n\ndef feast_writer(spark_df):\n    pandas_df = spark_df.to_pandas()\n    store.push(\"driver_hourly_stats\", pandas_df)\n\nstreamingDF.writeStream.foreachBatch(feast_writer).start()\n```\n\nThis can also be used under the hood by a contrib stream processor (see [Tutorial: Building streaming features](../../tutorials/building-streaming-features.md))\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-06-17T12:53:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "433a2681e51b51799854d92be2f5201d8854c66ca05c384420a44fad97335dba",
+      "topic": "overview",
+      "subject": "Example (basic) / Defining a push source",
+      "content": {
+        "summary": "### Defining a push source Note that the push schema needs to also include the entity."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/push.md",
+        "line": 27,
+        "quote": "### Defining a push source\n\nNote that the push schema needs to also include the entity.\n\n```python\nfrom feast import Entity, PushSource, ValueType, BigQuerySource, FeatureView, Feature, Field\nfrom feast.types import Int64\n\npush_source = PushSource(\n    name=\"push_source\",\n    batch_source=BigQuerySource(table=\"test.test\"),\n)\n\nuser = Entity(name=\"user\", join_keys=[\"user_id\"])\n\nfv = FeatureView(\n    name=\"feature view\",\n    entities=[user],\n    schema=[Field(name=\"life_time_value\", dtype=Int64)],\n    source=push_source,\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-06-17T12:53:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "18992798a6c9ca6807bec1a0e1b04bbf8b875d3d51270f32630891e5c605f206",
+      "topic": "overview",
+      "subject": "Example (basic) / Pushing data",
+      "content": {
+        "summary": "### Pushing data Note that the `to` parameter is optional and defaults to online but we can specify these options: `PushMode.ONLINE`, `PushMode.OFFLINE`, or `PushMode.ONLINE_AND_OFFLINE`. See also [Py"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/push.md",
+        "line": 50,
+        "quote": "### Pushing data\n\nNote that the `to` parameter is optional and defaults to online but we can specify these options: `PushMode.ONLINE`, `PushMode.OFFLINE`, or `PushMode.ONLINE_AND_OFFLINE`.\n\n```python\nfrom feast import FeatureStore\nimport pandas as pd\nfrom feast.data_source import PushMode\n\nfs = FeatureStore(...)\nfeature_data_frame = pd.DataFrame()\nfs.push(\"push_source_name\", feature_data_frame, to=PushMode.ONLINE_AND_OFFLINE)\n```\n\nSee also [Python feature server](../feature-servers/python-feature-server.md) for instructions on how to push data to a deployed feature server.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-06-17T12:53:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "6013ef6cf438c8c289d46977fec9619257e00b2d17c9daa490e57f39536169bc",
+      "topic": "overview",
+      "subject": "Example / Defining a Kafka source",
+      "content": {
+        "summary": "### Defining a Kafka source Note that the Kafka source has a batch source."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/kafka.md",
+        "line": 21,
+        "quote": "### Defining a Kafka source\nNote that the Kafka source has a batch source.\n```python\nfrom datetime import timedelta\n\nfrom feast import Field, FileSource, KafkaSource, stream_feature_view\nfrom feast.data_format import JsonFormat\nfrom feast.types import Float32\n\ndriver_stats_batch_source = FileSource(\n    name=\"driver_stats_source\",\n    path=\"data/driver_stats.parquet\",\n    timestamp_field=\"event_timestamp\",\n)\n\ndriver_stats_stream_source = KafkaSource(\n    name=\"driver_stats_stream\",\n    kafka_bootstrap_servers=\"localhost:9092\",\n    topic=\"drivers\",\n    timestamp_field=\"event_timestamp\",\n    batch_source=driver_stats_batch_source,\n    message_format=JsonFormat(\n        schema_json=\"driver_id integer, event_timestamp timestamp, conv_rate double, acc_rate double, created timestamp\"\n    ),\n    watermark_delay_threshold=timedelta(minutes=5),\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-06-23T13:33:01-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "5a1d34c0b04295965cadbb902f05af78b5113463917d8b816c7f3620cc057b69",
+      "topic": "overview",
+      "subject": "Example / Defining a Kinesis source",
+      "content": {
+        "summary": "### Defining a Kinesis source Note that the Kinesis source has a batch source."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/kinesis.md",
+        "line": 21,
+        "quote": "### Defining a Kinesis source\nNote that the Kinesis source has a batch source.\n```python\nfrom datetime import timedelta\n\nfrom feast import Field, FileSource, KinesisSource, stream_feature_view\nfrom feast.data_format import JsonFormat\nfrom feast.types import Float32\n\ndriver_stats_batch_source = FileSource(\n    name=\"driver_stats_source\",\n    path=\"data/driver_stats.parquet\",\n    timestamp_field=\"event_timestamp\",\n)\n\ndriver_stats_stream_source = KinesisSource(\n    name=\"driver_stats_stream\",\n    stream_name=\"drivers\",\n    timestamp_field=\"event_timestamp\",\n    batch_source=driver_stats_batch_source,\n    record_format=JsonFormat(\n        schema_json=\"driver_id integer, event_timestamp timestamp, conv_rate double, acc_rate double, created timestamp\"\n    ),\n    watermark_delay_threshold=timedelta(minutes=5),\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-06-23T13:33:01-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "7597d1eda6f03d1e46c5c4549699b114808b1f4cead214d027d455c5a633b27f",
+      "topic": "overview",
+      "subject": "Example / Initializing a feature server",
+      "content": {
+        "summary": "### Initializing a feature server Here's an example of how to start the Python feature server with a local feature repo:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 62,
+        "quote": "### Initializing a feature server\n\nHere's an example of how to start the Python feature server with a local feature repo:\n\n```bash\n$ feast init feature_repo\nCreating a new Feast repository in /home/tsotne/feast/feature_repo.\n\n$ cd feature_repo\n\n$ feast apply\nCreated entity driver\nCreated feature view driver_hourly_stats\nCreated feature service driver_activity\n\nCreated sqlite table feature_repo_driver_hourly_stats\n\n$ feast materialize-incremental $(date +%Y-%m-%d)\nMaterializing 1 feature views to 2021-09-09 17:00:00-07:00 into the sqlite online store.\n\ndriver_hourly_stats from 2021-09-09 16:51:08-07:00 to 2021-09-09 17:00:00-07:00:\n100%|████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 295.24it/s]\n\n$ feast serve\n09/10/2021 10:42:11 AM INFO:Started server process [8889]\nINFO:     Waiting for application startup.\n09/10/2021 10:42:11 AM INFO:Waiting for application startup.\nINFO:     Application startup complete.\n09/10/2021 10:42:11 AM INFO:Application startup complete.\nINFO:     Uvicorn running on http://127.0.0.1:6566 (Press CTRL+C to quit)\n09/10/2021 10:42:11 AM INFO:Uvicorn running on http://127.0.0.1:6566 (Press CTRL+C to quit)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "af3678fbaeb1fb2a69077e4950f695e70bfe0e6e85357588ceccb2c75efb1beb",
+      "topic": "overview",
+      "subject": "Example / Materializing features",
+      "content": {
+        "summary": "### Materializing features The Python feature server also exposes an endpoint for materializing features from the offline store to the online store. **Standard materialization with timestamps:** **Mat"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 268,
+        "quote": "### Materializing features\n\nThe Python feature server also exposes an endpoint for materializing features from the offline store to the online store.\n\n**Standard materialization with timestamps:**\n```bash\ncurl -X POST \"http://localhost:6566/materialize\" -d '{\n    \"start_ts\": \"2021-01-01T00:00:00\",\n    \"end_ts\": \"2021-01-02T00:00:00\",\n    \"feature_views\": [\"driver_hourly_stats\"]\n}' | jq\n```\n\n**Materialize all data without event timestamps:**\n```bash\ncurl -X POST \"http://localhost:6566/materialize\" -d '{\n    \"feature_views\": [\"driver_hourly_stats\"],\n    \"disable_event_timestamp\": true\n}' | jq\n```\n\nWhen `disable_event_timestamp` is set to `true`, the `start_ts` and `end_ts` parameters are not required, and all available data is materialized using the current datetime as the event timestamp. This is useful when your source data lacks proper event timestamp columns.\n\nOr from Python:\n```python\nimport json\nimport requests\n\n# Standard materialization\nmaterialize_data = {\n    \"start_ts\": \"2021-01-01T00:00:00\",\n    \"end_ts\": \"2021-01-02T00:00:00\",\n    \"feature_views\": [\"driver_hourly_stats\"]\n}\n\n# Materialize without event timestamps\nmaterialize_data_no_timestamps = {\n    \"feature_views\": [\"driver_hourly_stats\"],\n    \"disable_event_timestamp\": True\n}\n… (+6 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f61e40034a0d358ed67ab33f7212e2c6604f2e4341e0862fd23a90ff7a004806",
+      "topic": "overview",
+      "subject": "Example / Retrieving features",
+      "content": {
+        "summary": "### Retrieving features After the server starts, we can execute cURL commands from another terminal tab: It's also possible to specify a feature service name instead of the list of features:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 95,
+        "quote": "### Retrieving features\n\nAfter the server starts, we can execute cURL commands from another terminal tab:\n\n```bash\n$  curl -X POST \\\n  \"http://localhost:6566/get-online-features\" \\\n  -d '{\n    \"features\": [\n      \"driver_hourly_stats:conv_rate\",\n      \"driver_hourly_stats:acc_rate\",\n      \"driver_hourly_stats:avg_daily_trips\"\n    ],\n    \"entities\": {\n      \"driver_id\": [1001, 1002, 1003]\n    }\n  }' | jq\n{\n  \"metadata\": {\n    \"feature_names\": [\n      \"driver_id\",\n      \"conv_rate\",\n      \"avg_daily_trips\",\n      \"acc_rate\"\n    ]\n  },\n  \"results\": [\n    {\n      \"values\": [\n        1001,\n        0.7037263512611389,\n        308,\n        0.8724706768989563\n      ],\n      \"statuses\": [\n        \"PRESENT\",\n        \"PRESENT\",\n        \"PRESENT\",\n        \"PRESENT\"\n      ],\n… (+64 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "bad1250a1159e8873968bf4751ed6c461332856dc357954e44ad614b6b88466c",
+      "topic": "overview",
+      "subject": "Example / Using the Kafka source in a stream feature view",
+      "content": {
+        "summary": "### Using the Kafka source in a stream feature view The Kafka source can be used in a stream feature view."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/kafka.md",
+        "line": 49,
+        "quote": "### Using the Kafka source in a stream feature view\nThe Kafka source can be used in a stream feature view.\n```python\n@stream_feature_view(\n    entities=[driver],\n    ttl=timedelta(seconds=8640000000),\n    mode=\"spark\",\n    schema=[\n        Field(name=\"conv_percentage\", dtype=Float32),\n        Field(name=\"acc_percentage\", dtype=Float32),\n    ],\n    timestamp_field=\"event_timestamp\",\n    online=True,\n    source=driver_stats_stream_source,\n)\ndef driver_hourly_stats_stream(df: DataFrame):\n    from pyspark.sql.functions import col\n\n    return (\n        df.withColumn(\"conv_percentage\", col(\"conv_rate\") * 100.0)\n        .withColumn(\"acc_percentage\", col(\"acc_rate\") * 100.0)\n        .drop(\"conv_rate\", \"acc_rate\")\n    )\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-06-23T13:33:01-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "86568eb4a617785b2288f65cee95f12676d2bc11df0eea280c2c4df543a9e7ff",
+      "topic": "overview",
+      "subject": "Example / Using the Kinesis source in a stream feature view",
+      "content": {
+        "summary": "### Using the Kinesis source in a stream feature view The Kinesis source can be used in a stream feature view."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/kinesis.md",
+        "line": 48,
+        "quote": "### Using the Kinesis source in a stream feature view\nThe Kinesis source can be used in a stream feature view.\n```python\n@stream_feature_view(\n    entities=[driver],\n    ttl=timedelta(seconds=8640000000),\n    mode=\"spark\",\n    schema=[\n        Field(name=\"conv_percentage\", dtype=Float32),\n        Field(name=\"acc_percentage\", dtype=Float32),\n    ],\n    timestamp_field=\"event_timestamp\",\n    online=True,\n    source=driver_stats_stream_source,\n)\ndef driver_hourly_stats_stream(df: DataFrame):\n    from pyspark.sql.functions import col\n\n    return (\n        df.withColumn(\"conv_percentage\", col(\"conv_rate\") * 100.0)\n        .withColumn(\"acc_percentage\", col(\"acc_rate\") * 100.0)\n        .drop(\"conv_rate\", \"acc_rate\")\n    )\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-06-23T13:33:01-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "86b6ee6d12699781f50826dde71b7077405e7789cfcd17f264d5d291146fe474",
+      "topic": "overview",
+      "subject": "Example 1: Basic Model Loading",
+      "content": {
+        "summary": "## Example 1: Basic Model Loading Create a `static_artifacts.py` file in your feature repository: Use the pre-loaded model in your on-demand feature view:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-static-artifacts.md",
+        "line": 33,
+        "quote": "## Example 1: Basic Model Loading\n\nCreate a `static_artifacts.py` file in your feature repository:\n\n```python\n# static_artifacts.py\nfrom fastapi import FastAPI\nfrom transformers import pipeline\n\ndef load_sentiment_model():\n    \"\"\"Load sentiment analysis model.\"\"\"\n    return pipeline(\n        \"sentiment-analysis\",\n        model=\"cardiffnlp/twitter-roberta-base-sentiment-latest\",\n        device=\"cpu\"\n    )\n\ndef load_artifacts(app: FastAPI):\n    \"\"\"Load static artifacts into app.state.\"\"\"\n    app.state.sentiment_model = load_sentiment_model()\n\n    # Update global references for access from feature views\n    import example_repo\n    example_repo._sentiment_model = app.state.sentiment_model\n```\n\nUse the pre-loaded model in your on-demand feature view:\n\n```python\n# example_repo.py\nimport pandas as pd\nfrom feast.on_demand_feature_view import on_demand_feature_view\nfrom feast import Field\nfrom feast.types import String, Float32\n\n# Global reference for static artifacts\n_sentiment_model = None\n\n@on_demand_feature_view(\n    sources=[text_input_request],\n… (+22 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-22T20:04:28-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "eefe1dd8efba39668078aa4a77e3387054deaeb575e4bb106227ca85f85bc1fa",
+      "topic": "overview",
+      "subject": "Example 2: Multiple Artifacts with Lookup Tables",
+      "content": {
+        "summary": "## Example 2: Multiple Artifacts with Lookup Tables Load multiple types of artifacts: Use multiple artifacts in feature transformations:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-static-artifacts.md",
+        "line": 95,
+        "quote": "## Example 2: Multiple Artifacts with Lookup Tables\n\nLoad multiple types of artifacts:\n\n```python\n# static_artifacts.py\nfrom fastapi import FastAPI\nfrom transformers import pipeline\nimport json\nfrom pathlib import Path\n\ndef load_sentiment_model():\n    \"\"\"Load sentiment analysis model.\"\"\"\n    return pipeline(\"sentiment-analysis\", model=\"distilbert-base-uncased-finetuned-sst-2-english\")\n\ndef load_lookup_tables():\n    \"\"\"Load static lookup tables.\"\"\"\n    return {\n        \"sentiment_labels\": {\"NEGATIVE\": \"negative\", \"POSITIVE\": \"positive\"},\n        \"domain_categories\": {\"twitter.com\": \"social\", \"news.com\": \"news\", \"github.com\": \"tech\"},\n        \"priority_users\": {\"user_123\", \"user_456\", \"user_789\"}\n    }\n\ndef load_config():\n    \"\"\"Load application configuration.\"\"\"\n    return {\n        \"model_threshold\": 0.7,\n        \"max_text_length\": 512,\n        \"default_sentiment\": \"neutral\"\n    }\n\ndef load_artifacts(app: FastAPI):\n    \"\"\"Load all static artifacts.\"\"\"\n    app.state.sentiment_model = load_sentiment_model()\n    app.state.lookup_tables = load_lookup_tables()\n    app.state.config = load_config()\n\n    # Update global references\n    import example_repo\n    example_repo._sentiment_model = app.state.sentiment_model\n… (+56 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-22T20:04:28-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "79fc076862b743ba123f48b2d0f5d7f6fdfb591ddb0b6407dd0c4ce23a2ac283",
+      "topic": "overview",
+      "subject": "Example Usage: Concurrent materialization",
+      "content": {
+        "summary": "## Example Usage: Concurrent materialization The SQL Registry should be used when materializing feature views concurrently to ensure correctness of data in the registry. This can be achieved by simply"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/registries/sql.md",
+        "line": 88,
+        "quote": "## Example Usage: Concurrent materialization\nThe SQL Registry should be used when materializing feature views concurrently to ensure correctness of data in the registry. This can be achieved by simply running feast materialize or feature_store.materialize multiple times using a correctly configured feature_store.yaml. This will make each materialization process talk to the registry database concurrently, and ensure the metadata updates are serialized.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-03-10T13:35:40-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "73cde619d9a66440b5af2a0f8d0c2f1d8f6914d37bd642171769ea2dbd89d493",
+      "topic": "overview",
+      "subject": "Example in Python",
+      "content": {
+        "summary": "## Example in Python {% code title=\"feature_store.py\" %} {% endcode %}"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/spark.md",
+        "line": 37,
+        "quote": "## Example in Python\n\n{% code title=\"feature_store.py\" %}\n```python\nfrom feast import FeatureStore, RepoConfig\nfrom feast.repo_config import RegistryConfig\nfrom feast.infra.online_stores.dynamodb import DynamoDBOnlineStoreConfig\nfrom feast.infra.offline_stores.contrib.spark_offline_store.spark import SparkOfflineStoreConfig\n\nrepo_config = RepoConfig(\n    registry=\"s3://[YOUR_BUCKET]/feast-registry.db\",\n    project=\"feast_repo\",\n    provider=\"aws\",\n    offline_store=SparkOfflineStoreConfig(\n      spark_conf={\n        \"spark.ui.enabled\": \"false\",\n        \"spark.eventLog.enabled\": \"false\",\n        \"spark.sql.catalogImplementation\": \"hive\",\n        \"spark.sql.parser.quotedRegexColumnNames\": \"true\",\n        \"spark.sql.session.timeZone\": \"UTC\"\n      }\n    ),\n    batch_engine={\n      \"type\": \"spark.engine\",\n      \"partitions\": 10\n    },\n    online_store=DynamoDBOnlineStoreConfig(region=\"us-west-1\"),\n    entity_key_serialization_version=3\n)\n\nstore = FeatureStore(config=repo_config)\n```\n{% endcode %}"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-07-18T21:43:37-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "dd028f1e2e9978d4efccc075b3b561f5f51c753daeaf37cc1a2b4a2d649f4cad",
+      "topic": "overview",
+      "subject": "Examples / **Generate the Response**",
+      "content": {
+        "summary": "### **Generate the Response**  Let's assume we have a base prompt and a function that formats the retrieved documents called `format_documents` that we  can then use to generate the response with Open"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-vector-database.md",
+        "line": 167,
+        "quote": "### **Generate the Response** \nLet's assume we have a base prompt and a function that formats the retrieved documents called `format_documents` that we \ncan then use to generate the response with OpenAI's chat completion API.\n```python \nFULL_PROMPT = format_documents(rag_context_data, BASE_PROMPT)\n\nfrom openai import OpenAI\n\nclient = OpenAI(\n    api_key=os.environ.get(\"OPENAI_API_KEY\"),\n)\nresponse = client.chat.completions.create(\n    model=\"gpt-4o-mini\",\n    messages=[\n        {\"role\": \"system\", \"content\": FULL_PROMPT},\n        {\"role\": \"user\", \"content\": question}\n    ],\n)\n\n# And this will print the content. Look at the examples/rag/milvus-quickstart.ipynb for an end-to-end example.\nprint('\\n'.join([c.message.content for c in response.choices]))\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-03-05T08:16:17-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "6cf23045b8ed511b449acc714d22f06642b735ecaa49f6ab564a4d4e26d5624f",
+      "topic": "overview",
+      "subject": "Examples / **Prepare a query embedding**",
+      "content": {
+        "summary": "### **Prepare a query embedding** During inference (e.g., during when a user submits a chat message) we need to embed the input text. This can be thought of as a feature transformation of the input da"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-vector-database.md",
+        "line": 106,
+        "quote": "### **Prepare a query embedding**\nDuring inference (e.g., during when a user submits a chat message) we need to embed the input text. This can be thought of as a feature transformation of the input data. In this example, we'll do this with a small Sentence Transformer from Hugging Face.\n\n```python\nimport torch\nimport torch.nn.functional as F\nfrom feast import FeatureStore\nfrom pymilvus import MilvusClient, DataType, FieldSchema\nfrom transformers import AutoTokenizer, AutoModel\nfrom example_repo import city_embeddings_feature_view, item\n\nTOKENIZER = \"sentence-transformers/all-MiniLM-L6-v2\"\nMODEL = \"sentence-transformers/all-MiniLM-L6-v2\"\n\ndef mean_pooling(model_output, attention_mask):\n    token_embeddings = model_output[\n        0\n    ]  # First element of model_output contains all token embeddings\n    input_mask_expanded = (\n        attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()\n    )\n    return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(\n        input_mask_expanded.sum(1), min=1e-9\n    )\n\ndef run_model(sentences, tokenizer, model):\n    encoded_input = tokenizer(\n        sentences, padding=True, truncation=True, return_tensors=\"pt\"\n    )\n    # Compute token embeddings\n    with torch.no_grad():\n        model_output = model(**encoded_input)\n\n    sentence_embeddings = mean_pooling(model_output, encoded_input[\"attention_mask\"])\n    sentence_embeddings = F.normalize(sentence_embeddings, p=2, dim=1)\n    return sentence_embeddings\n\nquestion = \"Which city has the largest population in New York?\"\n\ntokenizer = AutoTokenizer.from_pretrained(TOKENIZER)\n… (+4 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-03-05T08:16:17-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2c026178b427098c1284cd5ceb9bb61d911b1cae3d4afc25cb3f1115df4fccea",
+      "topic": "overview",
+      "subject": "Examples / **Prepare offline embedding dataset**",
+      "content": {
+        "summary": "### **Prepare offline embedding dataset** Run the following commands to prepare the embedding dataset: The output will be stored in `data/city_wikipedia_summaries.csv.`"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-vector-database.md",
+        "line": 40,
+        "quote": "### **Prepare offline embedding dataset**\nRun the following commands to prepare the embedding dataset:\n```shell\npython pull_states.py\npython batch_score_documents.py\n```\nThe output will be stored in `data/city_wikipedia_summaries.csv.`\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-03-05T08:16:17-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "15a95353c32aa5eb8d9d086ca8d247f57bd66958ea8c859049de48340a6605e9",
+      "topic": "overview",
+      "subject": "Examples / **Retrieve the top K similar documents**",
+      "content": {
+        "summary": "### **Retrieve the top K similar documents** First create a feature store instance, and use the `retrieve_online_documents_v2` API to retrieve the top 5 similar documents to the specified query."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-vector-database.md",
+        "line": 150,
+        "quote": "### **Retrieve the top K similar documents**\nFirst create a feature store instance, and use the `retrieve_online_documents_v2` API to retrieve the top 5 similar documents to the specified query.\n\n```python\ncontext_data = store.retrieve_online_documents_v2(\n    features=[\n        \"city_embeddings:vector\",\n        \"city_embeddings:item_id\",\n        \"city_embeddings:state\",\n        \"city_embeddings:sentence_chunks\",\n        \"city_embeddings:wiki_summary\",\n    ],\n    query=query_embedding,\n    top_k=3,\n    distance_metric='COSINE',\n).to_df()\n```"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-03-05T08:16:17-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c708722b9bcbe0f05c6423f2d952beb8b66e1c7912bbd0d75b10db22a7448a1f",
+      "topic": "overview",
+      "subject": "Examples / Basic Examples",
+      "content": {
+        "summary": "### Basic Examples Using a table reference from SparkSession (for example, either in-memory or a Hive Metastore): Using a query: Using a file reference:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/spark.md",
+        "line": 16,
+        "quote": "### Basic Examples\n\nUsing a table reference from SparkSession (for example, either in-memory or a Hive Metastore):\n\n```python\nfrom feast.infra.offline_stores.contrib.spark_offline_store.spark_source import (\n    SparkSource,\n)\n\nmy_spark_source = SparkSource(\n    table=\"FEATURE_TABLE\",\n)\n```\n\nUsing a query:\n\n```python\nfrom feast.infra.offline_stores.contrib.spark_offline_store.spark_source import (\n    SparkSource,\n)\n\nmy_spark_source = SparkSource(\n    query=\"SELECT timestamp as ts, created, f1, f2 \"\n          \"FROM spark_table\",\n)\n```\n\nUsing a file reference:\n\n```python\nfrom feast.infra.offline_stores.contrib.spark_offline_store.spark_source import (\n    SparkSource,\n)\n\nmy_spark_source = SparkSource(\n    path=f\"{CURRENT_DIR}/data/driver_hourly_stats\",\n    file_format=\"parquet\",\n    timestamp_field=\"event_timestamp\",\n    created_timestamp_column=\"created\",\n)\n… (+2 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "bc9534fc64f187781f8d88fdbe7939a19325103b86c9f20510de553c689eb803",
+      "topic": "overview",
+      "subject": "Examples / Configuration and Installation",
+      "content": {
+        "summary": "### Configuration and Installation We offer [Milvus](https://milvus.io/), [PGVector](https://github.com/pgvector/pgvector), [SQLite](https://github.com/asg017/sqlite-vec), [Elasticsearch](https://www."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-vector-database.md",
+        "line": 190,
+        "quote": "### Configuration and Installation\n\nWe offer [Milvus](https://milvus.io/), [PGVector](https://github.com/pgvector/pgvector), [SQLite](https://github.com/asg017/sqlite-vec), [Elasticsearch](https://www.elastic.co) and [Qdrant](https://qdrant.tech/) as Online Store options for Vector Databases.\n\nMilvus offers a convenient local implementation for vector similarity search. To use Milvus, you can install the Feast package with the Milvus extra.\n\n#### Installation with Milvus\n\n```bash\npip install feast[milvus]\n```\n#### Installation with Elasticsearch\n\n```bash\npip install feast[elasticsearch]\n```\n\n#### Installation with Qdrant\n\n```bash\npip install feast[qdrant]\n```\n#### Installation with SQLite\n\nIf you are using `pyenv` to manage your Python versions, you can install the SQLite extension with the following command:\n```bash\nPYTHON_CONFIGURE_OPTS=\"--enable-loadable-sqlite-extensions\" \\\n    LDFLAGS=\"-L/opt/homebrew/opt/sqlite/lib\" \\\n    CPPFLAGS=\"-I/opt/homebrew/opt/sqlite/include\" \\\n    pyenv install 3.10.14\n```\n\nAnd you can the Feast install package via:\n```bash\npip install feast[sqlite_vec]\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-03-05T08:16:17-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "62c5b54d6e94777ef88494e54a8e96036cde9a2f78c9f8e0456f7d7c8ed6e21d",
+      "topic": "overview",
+      "subject": "Examples / Table Format Examples",
+      "content": {
+        "summary": "### Table Format Examples SparkSource supports advanced table formats for modern data lakehouse architectures. For detailed documentation, configuration options, and best practices, see the **[Table F"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/spark.md",
+        "line": 58,
+        "quote": "### Table Format Examples\n\nSparkSource supports advanced table formats for modern data lakehouse architectures. For detailed documentation, configuration options, and best practices, see the **[Table Formats guide](table-formats.md)**.\n\n#### Apache Iceberg\n\n```python\nfrom feast.infra.offline_stores.contrib.spark_offline_store.spark_source import SparkSource\nfrom feast.table_format import IcebergFormat\n\niceberg_format = IcebergFormat(\n    catalog=\"my_catalog\",\n    namespace=\"my_database\"\n)\n\nmy_spark_source = SparkSource(\n    name=\"user_features\",\n    path=\"my_catalog.my_database.user_table\",\n    table_format=iceberg_format,\n    timestamp_field=\"event_timestamp\"\n)\n```\n\n#### Delta Lake\n\n```python\nfrom feast.infra.offline_stores.contrib.spark_offline_store.spark_source import SparkSource\nfrom feast.table_format import DeltaFormat\n\ndelta_format = DeltaFormat()\n\nmy_spark_source = SparkSource(\n    name=\"transaction_features\",\n    path=\"s3://my-bucket/delta-tables/transactions\",\n    table_format=delta_format,\n    timestamp_field=\"transaction_timestamp\"\n)\n```\n\n#### Apache Hudi\n… (+21 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a74c919e4f1eb5c7e8396e99bae2d8426be9a380a3deee2cd706fd8797c445ba",
+      "topic": "overview",
+      "subject": "Feast UI integration",
+      "content": {
+        "summary": "## Feast UI integration The Feast UI server exposes three API endpoints that aggregate data from MLflow: | Endpoint | Description | |----------|-------------| | `/api/mlflow-runs` | All Feast-tagged M"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 329,
+        "quote": "## Feast UI integration\n\nThe Feast UI server exposes three API endpoints that aggregate data from MLflow:\n\n| Endpoint | Description |\n|----------|-------------|\n| `/api/mlflow-runs` | All Feast-tagged MLflow runs with linked registered models |\n| `/api/mlflow-feature-usage` | Per-feature-view usage stats (run count, last used, associated models) |\n| `/api/mlflow-feature-models` | Reverse index of feature refs to registered models |\n\nThe feature view detail page in the Feast UI displays:\n- **MLflow Training Runs** count and **Last Used** date in the header stats\n- An **MLflow Usage** panel showing training run count, relative last-used time, and a table of registered models that depend on the feature view\n\nStart the Feast UI with:\n\n```bash\nfeast ui --host 127.0.0.1 --port 8888\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "62df30dcf1bae6c1a7312ae098bf32a2c2d3131cd1e8522320a882c3b7d23a86",
+      "topic": "overview",
+      "subject": "Feast project structure",
+      "content": {
+        "summary": "### Feast project structure The top-level namespace within Feast is a **project**. Users define one or more [feature views](feature-view.md) within a project. Each feature view contains one or more [f"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/overview.md",
+        "line": 3,
+        "quote": "### Feast project structure\n\nThe top-level namespace within Feast is a **project**. Users define one or more [feature views](feature-view.md) within a project. Each feature view contains one or more [features](feature-view.md#feature). These features typically relate to one or more [entities](entity.md). A feature view must always have a [data source](data-ingestion.md), which in turn is used during the generation of training [datasets](feature-retrieval.md#dataset) and when materializing feature values into the online store.\nYou can read more about Feast projects in the [project page](project.md).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-10-21T12:24:29-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c07bd7320b1b72b6cc531debb44e912bb98758b533c1a894f51474d5b313ada6",
+      "topic": "overview",
+      "subject": "Feast to OpenLineage Mapping",
+      "content": {
+        "summary": "## Feast to OpenLineage Mapping | Feast Concept | OpenLineage Concept | |---------------|---------------------| | DataSource | InputDataset | | FeatureView | OutputDataset (of feature views job) / Inp"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 209,
+        "quote": "## Feast to OpenLineage Mapping\n\n| Feast Concept | OpenLineage Concept |\n|---------------|---------------------|\n| DataSource | InputDataset |\n| FeatureView | OutputDataset (of feature views job) / InputDataset (of feature service job) |\n| Feature | Schema field |\n| Entity | InputDataset |\n| FeatureService | OutputDataset |\n| Materialization | RunEvent (START/COMPLETE/FAIL) |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0553069b34477e54ede75d665c4b5ac3d83440ce78f4e6dfc852bf049deb154c",
+      "topic": "overview",
+      "subject": "Feature definitions",
+      "content": {
+        "summary": "## Feature definitions A feature repository can also contain one or more Python files that contain feature definitions. An example feature definition file is shown below: {% code title=\"driver\\_featur"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-repository.md",
+        "line": 84,
+        "quote": "## Feature definitions\n\nA feature repository can also contain one or more Python files that contain feature definitions. An example feature definition file is shown below:\n\n{% code title=\"driver\\_features.py\" %}\n```python\nfrom datetime import timedelta\n\nfrom feast import BigQuerySource, Entity, Feature, FeatureView, Field\nfrom feast.types import Float32, Int64, String\n\ndriver_locations_source = BigQuerySource(\n    table=\"rh_prod.ride_hailing_co.drivers\",\n    timestamp_field=\"event_timestamp\",\n    created_timestamp_column=\"created_timestamp\",\n)\n\ndriver = Entity(\n    name=\"driver\",\n    description=\"driver id\",\n)\n\ndriver_locations = FeatureView(\n    name=\"driver_locations\",\n    entities=[driver],\n    ttl=timedelta(days=1),\n    schema=[\n        Field(name=\"lat\", dtype=Float32),\n        Field(name=\"lon\", dtype=String),\n        Field(name=\"driver\", dtype=Int64),\n    ],\n    source=driver_locations_source,\n)\n```\n{% endcode %}\n\nTo declare new feature definitions, just add code to the feature repository, either in existing files or in a new file. For more information on how to define features, see [Feature Views](../getting-started/concepts/feature-view.md).\n\n### Next steps\n\n… (+4 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-08-05T15:51:41-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3e6a3ac1f0b6dc0f01961bc04f4e7f06441f657a00a9fd19993ece33f39a4511",
+      "topic": "overview",
+      "subject": "Feature inferencing",
+      "content": {
+        "summary": "## Feature inferencing If the `schema` parameter is not specified in the creation of the feature view, Feast will infer the features during `feast apply` by creating a `Field` for each column in the u"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-view.md",
+        "line": 86,
+        "quote": "## Feature inferencing\n\nIf the `schema` parameter is not specified in the creation of the feature view, Feast will infer the features during `feast apply` by creating a `Field` for each column in the underlying data source except the columns corresponding to the entities of the feature view or the columns corresponding to the timestamp columns of the feature view's data source. The names and value types of the inferred features will use the names and data types of the columns from which the features were inferred.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-27T23:00:47-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "e06cb5d29419b854b1c6a6efc53c7ba795b9d70730996867bfd0c3d2884f3771",
+      "topic": "overview",
+      "subject": "Feature registration and retrieval",
+      "content": {
+        "summary": "### Feature registration and retrieval Features are _registered_ as code in a version controlled repository, and tie to data sources + model versions via the concepts of **entities, feature views,** a"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/overview.md",
+        "line": 14,
+        "quote": "### Feature registration and retrieval\n\nFeatures are _registered_ as code in a version controlled repository, and tie to data sources + model versions via the concepts of **entities, feature views,** and **feature services.** We explore these concepts more in the upcoming concept pages. These features are then _stored_ in a **registry**, which can be accessed across users and services. The features can then be _retrieved_ via SDK API methods or via a deployed **feature server** which exposes endpoints to query for online features (to power real time models).\n\n\n\nFeast supports several patterns of feature retrieval.\n\n|                         Use case                         |                                                Example                                                 |            API            |\n| :------------------------------------------------------: | :----------------------------------------------------------------------------------------------------: | :-----------------------: |\n|                 Training data generation                 | Fetching user and item features for (user, item) pairs when training a production recommendation model | `get_historical_features` |\n|     Offline feature retrieval for batch predictions      |                          Predicting user churn for all users on a daily basis                          | `get_historical_features` |\n| Online feature retrieval for real-time model predictions |  Fetching pre-computed features to predict whether a real-time credit card transaction is fraudulent   |   `get_online_features`   |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-10-21T12:24:29-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8d41d1c51a7b7a8230ce817b4b2547978bc67ca4527424ccb14202bb13d32906",
+      "topic": "overview",
+      "subject": "Feature repository",
+      "content": {
+        "summary": "## Feature repository Feast users use Feast to manage two important sets of configuration: * Configuration about how to run Feast on your infrastructure * Feature definitions With Feast, the above con"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-repo.md",
+        "line": 3,
+        "quote": "## Feature repository\nFeast users use Feast to manage two important sets of configuration:\n\n* Configuration about how to run Feast on your infrastructure\n* Feature definitions\n\nWith Feast, the above configuration can be written declaratively and stored as code in a central location. This central location is called a feature repository. The feature repository is the declarative source of truth for what the desired state of a feature store should be.\n\nA feature repository is the collection of python files that define entities, feature views and data sources. Feature Repos also have a `feature_store.yaml` file at their root. \n\nUsers can collaborate by making and reviewing changes to Feast object definitions (feature views, entities, etc.) in the feature repo.\nBut, these objects must be applied, either through API, or the CLI, for them to be available by downstream Feast actions (such as materialization, or retrieving online features). Internally, Feast only looks at the registry when performing these actions, and not at the feature repo directly.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-08-10T13:47:53-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f91f4bd247ac17341d7b7ab7dc653a77965d854f617d83205c9da83808cb5063",
+      "topic": "overview",
+      "subject": "Feature views",
+      "content": {
+        "summary": "## Feature views List all registered feature views List version history for a feature view"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 204,
+        "quote": "## Feature views\n\nList all registered feature views\n\n```text\nfeast feature-views list\n\nOptions:\n  --tags TEXT  Filter by tags (e.g. --tags 'key:value' --tags 'key:value,\n               key:value, ...'). Items return when ALL tags match.\n```\n\n```text\nNAME                 ENTITIES    TYPE\ndriver_hourly_stats  {'driver'}  FeatureView\n```\n\nList version history for a feature view\n\n```text\nfeast feature-views list-versions FEATURE_VIEW_NAME\n```\n\n```text\nVERSION  TYPE          CREATED              VERSION_ID\nv0       feature_view  2024-01-15 10:30:00  a1b2c3d4-...\nv1       feature_view  2024-01-16 14:22:00  e5f6g7h8-...\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "683b1676cb1936e89cf41bc3138997c4aef93ca2c69ebbbc8c9600fc3dd83045",
+      "topic": "overview",
+      "subject": "Feature views without entities",
+      "content": {
+        "summary": "## Feature views without entities If a feature view contains features that are not related to a specific entity, the feature view can be defined without entities (only timestamps are needed for this f"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-view.md",
+        "line": 62,
+        "quote": "## Feature views without entities\n\nIf a feature view contains features that are not related to a specific entity, the feature view can be defined without entities (only timestamps are needed for this feature view).\n\n{% tabs %}\n{% tab title=\"global_stats.py\" %}\n```python\nfrom feast import BigQuerySource, FeatureView, Field\nfrom feast.types import Int64\n\nglobal_stats_fv = FeatureView(\n    name=\"global_stats\",\n    entities=[],\n    schema=[\n        Field(name=\"total_trips_today_by_all_drivers\", dtype=Int64),\n    ],\n    source=BigQuerySource(\n        table=\"feast-oss.demo_data.global_stats\"\n    )\n)\n```\n{% endtab %}\n{% endtabs %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-27T23:00:47-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b2e40d09e852520b229c1e9e5f180ffce20db310b7a9e9fdc9590f4ba4091317",
+      "topic": "overview",
+      "subject": "Features",
+      "content": {
+        "summary": "## Features * Supports both synchronous and asynchronous operations for high-performance feature retrieval * Native async support uses PyMongo's `AsyncMongoClient` (no Motor dependency required) * Fle"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/mongodb.md",
+        "line": 7,
+        "quote": "## Features\n\n* Supports both synchronous and asynchronous operations for high-performance feature retrieval\n* Native async support uses PyMongo's `AsyncMongoClient` (no Motor dependency required)\n* Flexible connection options supporting MongoDB Atlas, self-hosted MongoDB, and MongoDB replica sets\n* Automatic index creation for optimized query performance\n* Entity key collocation for efficient feature retrieval\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T09:21:30+05:30"
+      },
+      "module": "features",
+      "source": "extracted"
+    },
+    {
+      "id": "604b24edc21a8f6fffdf5489769a8cb923bc138148b03adfa950535c5cb391af",
+      "topic": "overview",
+      "subject": "Field",
+      "content": {
+        "summary": "## Field A field or feature is an individual measurable property. It is typically a property observed on a specific entity, but does not have to be associated with an entity. For example, a feature of"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-view.md",
+        "line": 143,
+        "quote": "## Field\n\nA field or feature is an individual measurable property. It is typically a property observed on a specific entity, but does not have to be associated with an entity. For example, a feature of a `customer` entity could be the number of transactions they have made on an average month, while a feature that is not observed on a specific entity could be the total number of posts made by all users in the last month. Supported types for fields in Feast can be found in `sdk/python/feast/types.py`.\n\nFields are defined as part of feature views. Since Feast does not transform data, a field is essentially a schema that only contains a name and a type:\n\n```python\nfrom feast import Field\nfrom feast.types import Float32\n\ntrips_today = Field(\n    name=\"trips_today\",\n    dtype=Float32\n)\n```\n\nTogether with [data sources](data-ingestion.md), they indicate to Feast where to find your feature values, e.g., in a specific parquet file or BigQuery table. Feature definitions are also used when reading features from the feature store, using [feature references](feature-retrieval.md#feature-references).\n\nFeature names must be unique within a [feature view](feature-view.md#feature-view).\n\nEach field can have additional metadata associated with it, specified as key-value [tags](https://rtd.feast.dev/en/master/feast.html#feast.field.Field).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-27T23:00:47-07:00"
+      },
+      "module": "field",
+      "source": "extracted"
+    },
+    {
+      "id": "8536729180b9bcde1c2760aa0f23ef431a3e62417a295ece00317f75b77211ea",
+      "topic": "overview",
+      "subject": "Full Details",
+      "content": {
+        "summary": "## Full Details\r \r For the complete design, concurrency semantics, and feature service interactions, see the Feature View Versioning RFC."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-feature-view-versioning.md",
+        "line": 207,
+        "quote": "## Full Details\r\n\r\nFor the complete design, concurrency semantics, and feature service interactions, see the [Feature View Versioning RFC](../adr/feature-view-versioning.md).\r\n\r"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:26:28+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a69221dafc7ea7b610659d9f545e927e3a50c4df7165910a1808729ea430f22e",
+      "topic": "overview",
+      "subject": "Global Options",
+      "content": {
+        "summary": "## Global Options The Feast CLI provides one global top-level option that can be used with other commands **chdir \\(-c, --chdir\\)** This command allows users to run Feast CLI commands in a different folder from the current working directory."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 36,
+        "quote": "## Global Options\n\nThe Feast CLI provides one global top-level option that can be used with other commands\n\n**chdir \\(-c, --chdir\\)**\n\nThis command allows users to run Feast CLI commands in a different folder from the current working directory.\n\n```text\nfeast -c path/to/my/feature/repo apply\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "22fbf2901d6896fb7f31d368f51076e47aded557a4b44032b2812bed3a7bb6f9",
+      "topic": "overview",
+      "subject": "Go feature server",
+      "content": {
+        "summary": "## Go feature server The `go/` directory contains the Go feature server. Most of the files here have logic to help with reading features from the online store. Within `go/`, the `internal/feast/` dire"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/codebase-structure.md",
+        "line": 111,
+        "quote": "## Go feature server\n\nThe `go/` directory contains the Go feature server.\nMost of the files here have logic to help with reading features from the online store.\nWithin `go/`, the `internal/feast/` directory contains most of the core logic:\n* `onlineserving/` covers the core serving logic.\n* `model/` contains the implementations of the Feast objects (entity, feature view, etc.).\n  * For example, `entity.go` is the Go equivalent of `entity.py`. It contains a very simple Go implementation of the entity object.\n* `registry/` covers the registry.\n  * Currently only the file-based registry supported (the sql-based registry is unsupported). Additionally, the file-based registry only supports a file-based registry store, not the GCS or S3 registry stores.\n* `onlinestore/` covers the online stores (currently only Redis and SQLite are supported).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-07-18T21:43:37-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "70653e8523b98deb1a509dbcc8c2d7fe80bb79ee67ecc941fb6a5974f2d8a9da",
+      "topic": "overview",
+      "subject": "Google Bigtable Online Store Format",
+      "content": {
+        "summary": "## Google Bigtable Online Store Format Bigtable storage model consists of massively scalable tables, with each row keyed by a \"row key\". The rows in a table are stored lexicographically sorted by this row key. We use the following structure to store feature data in Bigtable: * All feature data for a"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/online_store_format.md",
+        "line": 95,
+        "quote": "## Google Bigtable Online Store Format\n\n[Bigtable storage model](https://cloud.google.com/bigtable/docs/overview#storage-model)\nconsists of massively scalable tables, with each row keyed by a \"row key\". The rows in a\ntable are stored lexicographically sorted by this row key.\n\nWe use the following structure to store feature data in Bigtable:\n\n* All feature data for an entity or a specific group of entities is stored in the same\n  table. The table name is derived by concatenating the lexicographically sorted names\n  of entities.\n* This implementation only uses one column family per table, named `features`.\n* Each row key is created by concatenating a hash derived from the specific entity keys\n  and the name of the feature view. Each row only stores feature values for a specific\n  feature view. This arrangement also means that feature values for a given group of\n  entities are colocated.\n* The columns used in each row are named after the features in the feature view.\n  Bigtable is perfectly content being sparsely populated.\n* By default, we store 1 historical value of each feature value. This can be configured\n  using the `max_versions` setting in `BigtableOnlineStoreConfig`. This implementation\n  of the online store does not have the ability to revert any given value to its old\n  self. To use the historical version, you'll have to use custom code.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-10-05T11:10:11-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "46ef541389abf6dcbafaca0f10320656402e2f1108fec5e507d91d94e053e588",
+      "topic": "overview",
+      "subject": "Google Datastore Online Store Format",
+      "content": {
+        "summary": "## Google Datastore Online Store Format [Datastore data model](https://cloud.google.com/datastore/docs/concepts/entities) is a collection of documents called Entities (not to be confused with Feast En"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/online_store_format.md",
+        "line": 62,
+        "quote": "## Google Datastore Online Store Format\n\n[Datastore data model](https://cloud.google.com/datastore/docs/concepts/entities) is a collection of documents called Entities (not to be confused with Feast Entities). Documents can be organized in a hierarchy using Kinds.\n\nWe use the following structure to store feature data in Datastore:\n* There is a Datastore Entity for each Feast Project, with Kind `Project`.\n* Under that Datastore Entity, there is a Datastore Entity for each Feast Feature Table or View, with Kind `Table`. That contains one additional field, `created_ts` that contains the timestamp when this Datastore Entity was created.\n* Under that Datastore Entity, there is a Datastore Entity for each Feast Entity Key with Kind `Row`. That contains the following fields:\n\t * `key` contains entity key as serialized `feast.types.EntityKey` proto\n\t * `values` contains feature name to value map, values serialized as `feast.types.Value` proto\n   * `event_ts` contains event timestamp (in the datastore timestamp format)\n   * `created_ts` contains write timestamp (in the datastore timestamp format).\n\nThe id for the `Row` Datastore Entity is computed by hashing entity key using murmurhash3_128 algorithm as follows:\n\n1. Hash entity names, sorted in alphanumeric order, by serializing them to bytes using the Value Serialization steps below.\n2. Hash the entity values in the same order as corresponding entity names, by serializing them to bytes using the Value Serialization steps below.\n\nValue Serialization:\n* Store the type of the value (ValueType enum) as little-endian uint32.\n* Store the byte length of the serialized value as little-endian uint32.\n* Store the serialized value as bytes:\n  - binary values are serialized as is\n  - string values serialized as utf8 string\n  - int64 and int32 hashed as little-endian byte representation (8 and 4 bytes respectively)\n  - bool hashed as 0 or 1 byte.\n\nOther types of entity keys are not supported in this version of the specification, when using Cloud Firestore.\n\n**Example:**\n\n![Datastore Online Example](datastore_online_example.png)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-10-05T11:10:11-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "be5c30b6ecd30890adf7d262669fc28a3ac66456c374276f346d98637c1a5822",
+      "topic": "overview",
+      "subject": "How Tiling Works / 1. Continuous Tile Updates",
+      "content": {
+        "summary": "### 1. Continuous Tile Updates **Why It's Fast:** - **Without tiling:** Scan entire 1-hour window (1000+ events) every 5 minutes - **With tiling:** Only process 5 minutes of new events, reuse previous"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/tiling.md",
+        "line": 132,
+        "quote": "### 1. Continuous Tile Updates\n\n```\nStream Events → Partition by Hop Intervals → Compute IRs → Store Windowed Aggregations\n  |                  |                            |              |\n  |                  |                            |              └─> Online Store (Redis, etc.)\n  |                  |                            └─> avg_sum, avg_count, std_sum_sq, etc.\n  |                  └─> 5-min hops: [00:00-00:05], [00:05-00:10], ...\n  └─> customer_id=1: [txn1, txn2, txn3, ...]\n\nEvery 5 minutes:\n- New events arrive\n- Only 1 new tile computed (5 min of data)\n- 11 previous tiles reused (in memory during streaming session)\n- Final aggregation = merge 12 tiles (1 new + 11 reused)\n```\n\n**Why It's Fast:**\n- **Without tiling:** Scan entire 1-hour window (1000+ events) every 5 minutes\n- **With tiling:** Only process 5 minutes of new events, reuse previous tiles\n- **Speedup:** Faster for streaming updates!\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "95c5711a20ed9f4d02f139262adee7174a052d34695da4ee1736e17934b1836c",
+      "topic": "overview",
+      "subject": "How Tiling Works / 2. Streaming Update Efficiency",
+      "content": {
+        "summary": "### 2. Streaming Update Efficiency | Update | Without Tiling | With Tiling | Tile Reuse | |--------|---------------|-------------|------------| | T=00:00 | Compute 1hr | Compute 12 tiles | 0% reuse (i"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/tiling.md",
+        "line": 156,
+        "quote": "### 2. Streaming Update Efficiency\n\n| Update | Without Tiling | With Tiling | Tile Reuse |\n|--------|---------------|-------------|------------|\n| T=00:00 | Compute 1hr | Compute 12 tiles | 0% reuse (initial) |\n| T=00:05 | Compute 1hr (1000+ events) | Compute 1 tile + reuse 11 | 92% reuse |\n| T=00:10 | Compute 1hr (1000+ events) | Compute 1 tile + reuse 11 | 92% reuse |\n| T=00:15 | Compute 1hr (1000+ events) | Compute 1 tile + reuse 11 | 92% reuse |\n\n**Key Benefit:** Tiles stay in memory during the streaming session, enabling massive reuse.\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4de6dca5108aa14429f5f8d0e1b29a8bcb686d62c8efd61855b8830e66a2c054",
+      "topic": "overview",
+      "subject": "How to configure Authentication and Authorization",
+      "content": {
+        "summary": "## How to configure Authentication and Authorization Please refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorizati"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/remote-offline-store.md",
+        "line": 30,
+        "quote": "[docs/reference/offline-stores/remote-offline-store.md:30] ## How to configure Authentication and Authorization\nPlease refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization.\n\n---\n[docs/reference/registry/registry-permissions.md:44] ## How to configure Authentication and Authorization\nPlease refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization.\n\n---\n[docs/reference/registries/remote.md:27] ## How to configure Authentication and Authorization\nPlease refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization.\n\n---\n[docs/reference/online-stores/remote.md:150] ## How to configure Authentication and Authorization\nPlease refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization.\n\n",
+        "additionalSources": [
+          {
+            "file": "docs/reference/registry/registry-permissions.md",
+            "line": 44,
+            "quote": "## How to configure Authentication and Authorization\nPlease refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization.\n"
+          },
+          {
+            "file": "docs/reference/registries/remote.md",
+            "line": 27,
+            "quote": "## How to configure Authentication and Authorization\nPlease refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization.\n"
+          },
+          {
+            "file": "docs/reference/online-stores/remote.md",
+            "line": 150,
+            "quote": "## How to configure Authentication and Authorization\nPlease refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization.\n\n"
+          }
+        ]
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-08-21T10:22:49-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "77203c5f72a586d2dc3b2e704f543fc86ad40fb06ae26e6d34ff271115780860",
+      "topic": "overview",
+      "subject": "How to configure Authentication and Authorization ?",
+      "content": {
+        "summary": "## How to configure Authentication and Authorization ? Please refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authoriza"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/offline-feature-server.md",
+        "line": 58,
+        "quote": "[docs/reference/feature-servers/offline-feature-server.md:58] ## How to configure Authentication and Authorization ?\n\nPlease refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization.\n---\n[docs/reference/feature-servers/python-feature-server.md:607] ## How to configure Authentication and Authorization ?\n\nPlease refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization.",
+        "additionalSources": [
+          {
+            "file": "docs/reference/feature-servers/python-feature-server.md",
+            "line": 607,
+            "quote": "## How to configure Authentication and Authorization ?\n\nPlease refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization."
+          }
+        ]
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-13T18:01:23+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "db6d61340924b74e0027148bed386a32158d07e14cccb4b9c92b7325d7ba50eb",
+      "topic": "overview",
+      "subject": "How to configure Authentication and Authorization ? / Metrics",
+      "content": {
+        "summary": "### Metrics #### Get Resource Counts - **Endpoint**: `GET /api/v1/metrics/resource_counts` - **Description**: Retrieve counts of registry objects (entities, data sources, feature views, etc.) for a pr"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 1010,
+        "quote": "### Metrics\n\n#### Get Resource Counts\n- **Endpoint**: `GET /api/v1/metrics/resource_counts`\n- **Description**: Retrieve counts of registry objects (entities, data sources, feature views, etc.) for a project or across all projects.\n- **Parameters**:\n  - `project` (optional): Project name to filter resource counts (if not provided, returns counts for all projects)\n- **Examples**:\n  ```bash\n  # Get counts for specific project\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/metrics/resource_counts?project=my_project\"\n  \n  # Get counts for all projects\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/metrics/resource_counts\"\n  ```\n- **Response Example** (single project):\n  ```json\n  {\n    \"project\": \"my_project\",\n    \"counts\": {\n      \"entities\": 5,\n      \"dataSources\": 3,\n      \"savedDatasets\": 2,\n      \"features\": 12,\n      \"featureViews\": 4,\n      \"featureServices\": 2\n    }\n  }\n  ```\n- **Response Example** (all projects):\n  ```json\n  {\n    \"total\": {\n      \"entities\": 15,\n      \"dataSources\": 8,\n      \"savedDatasets\": 5,\n      \"features\": 35,\n      \"featureViews\": 12,\n… (+107 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3f90716d53ed51b86a32cc2daf696c048a3cfa560ebd094bc690103fe0b809cb",
+      "topic": "overview",
+      "subject": "Indexing",
+      "content": {
+        "summary": "## Indexing Currently, the indexing mapping in the ElasticSearch online store is configured as: {% code title=\"indexing_mapping\" %} {% endcode %} And the online_read API mapping is configured as: {% c"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/elasticsearch.md",
+        "line": 77,
+        "quote": "## Indexing\nCurrently, the indexing mapping in the ElasticSearch online store is configured as:\n\n{% code title=\"indexing_mapping\" %}\n```json\n{\n    \"dynamic_templates\": [\n        {\n            \"feature_objects\": {\n                \"match_mapping_type\": \"object\",\n                \"match\": \"*\",\n                \"mapping\": {\n                    \"type\": \"object\",\n                    \"properties\": {\n                        \"feature_value\": {\"type\": \"binary\"},\n                        \"value_text\": {\"type\": \"text\"},\n                        \"vector_value\": {\n                            \"type\": \"dense_vector\",\n                            \"dims\": vector_field_length,\n                            \"index\": True,\n                            \"similarity\": config.online_store.similarity,\n                        },\n                    },\n                },\n            }\n        }\n    ],\n    \"properties\": {\n        \"entity_key\": {\"type\": \"keyword\"},\n        \"timestamp\": {\"type\": \"date\"},\n        \"created_ts\": {\"type\": \"date\"},\n    },\n}\n```\n{% endcode %}\nAnd the online_read API mapping is configured as:\n\n{% code title=\"online_read_mapping\" %}\n```json\n\"query\": {\n… (+23 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-04-25T12:07:08-04:00"
+      },
+      "module": "indexing",
+      "source": "extracted"
+    },
+    {
+      "id": "814f232ac505cd24eb980df12bc165edea649285c03c9bda3cab2884b400f9f4",
+      "topic": "overview",
+      "subject": "Init",
+      "content": {
+        "summary": "## Init Creates a new feature repository It's also possible to use other templates or to set the name of the new project"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 233,
+        "quote": "## Init\n\nCreates a new feature repository\n\n```text\nfeast init my_repo_name\n```\n\n```text\nCreating a new Feast repository in /projects/my_repo_name.\n```\n\n```text\n.\n├── data\n│   └── driver_stats.parquet\n├── example.py\n└── feature_store.yaml\n```\n\nIt's also possible to use other templates\n\n```text\nfeast init -t gcp my_feature_repo\n```\n\nor to set the name of the new project\n\n```text\nfeast init -t gcp my_feature_repo\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "init",
+      "source": "extracted"
+    },
+    {
+      "id": "78de5e1054f17df376e07127ab127f2a65beec151758610b58abbc38922a5414",
+      "topic": "overview",
+      "subject": "Integration",
+      "content": {
+        "summary": "## Integration Below are supported vector databases and implemented features: | Vector Database | Retrieval | Indexing | V2 Support* | Online Read | |-----------------|-----------|----------|---------"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-vector-database.md",
+        "line": 7,
+        "quote": "## Integration\nBelow are supported vector databases and implemented features:\n\n| Vector Database | Retrieval | Indexing | V2 Support* | Online Read |\n|-----------------|-----------|----------|-------------|-------------|\n| Pgvector        | [x]       | [ ]      | []          | []          |\n| Elasticsearch   | [x]       | [x]      | []          | []          |\n| Milvus          | [x]       | [x]      | [x]         | [x]         |\n| Faiss           | [ ]       | [ ]      | []          | []          |\n| SQLite          | [x]       | [ ]      | [x]         | [x]         |\n| Qdrant          | [x]       | [x]      | []          | []          |\n\n*Note: V2 Support means the SDK supports retrieval of features along with vector embeddings from vector similarity search.\n\nNote: SQLite is in limited access and only working on Python 3.10. It will be updated as [sqlite_vec](https://github.com/asg017/sqlite-vec/) progresses.\n\n{% hint style=\"danger\" %}\nWe will be deprecating the `retrieve_online_documents` method in the SDK in the future. \nWe recommend using the `retrieve_online_documents_v2` method instead, which offers easier vector index configuration \ndirectly in the Feature View and the ability to retrieve standard features alongside your vector embeddings for richer context injection. \n\nLong term we will collapse the two methods into one, but for now, we recommend using the `retrieve_online_documents_v2` method.\nBeyond that, we will then have `retrieve_online_documents` and `retrieve_online_documents_v2` simply point to `get_online_features` for \nbackwards compatibility and the adopt industry standard naming conventions.\n{% endhint %}\n\n**Note**: Milvus and SQLite implement the v2 `retrieve_online_documents_v2` method in the SDK. This will be the longer-term solution so that Data Scientists can easily enable vector similarity search by just flipping a flag.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-03-05T08:16:17-05:00"
+      },
+      "module": "integration",
+      "source": "extracted"
+    },
+    {
+      "id": "1b59936a3c83464fac82c05d1eda4679ba95c480588aaae076812f9ca2f79e69",
+      "topic": "overview",
+      "subject": "Integration Examples / With Feature Transformations",
+      "content": {
+        "summary": "### With Feature Transformations #### On-Demand Transformations #### Ray Native Transformations For distributed transformations that leverage Ray's dataset and parallel processing capabilities, use `m"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 472,
+        "quote": "### With Feature Transformations\n\n#### On-Demand Transformations\n\n```python\nfrom feast import FeatureView, Field\nfrom feast.types import Float64\nfrom feast.on_demand_feature_view import on_demand_feature_view\n\n@on_demand_feature_view(\n    sources=[\"driver_stats\"],\n    schema=[Field(name=\"trips_per_hour\", dtype=Float64)]\n)\ndef trips_per_hour(features_df):\n    features_df[\"trips_per_hour\"] = features_df[\"avg_daily_trips\"] / 24\n    return features_df\n\n# Ray compute engine handles transformations efficiently\nfeatures = store.get_historical_features(\n    entity_df=entity_df,\n    features=[\"trips_per_hour:trips_per_hour\"]\n)\n```\n\n#### Ray Native Transformations\n\nFor distributed transformations that leverage Ray's dataset and parallel processing capabilities, use `mode=\"ray\"` in your `BatchFeatureView`:\n\n```python\n# Feature view with Ray transformation mode\ndocument_embeddings_view = BatchFeatureView(\n    name=\"document_embeddings\",\n    entities=[document],\n    mode=\"ray\",  # Enable Ray native transformation\n    ttl=timedelta(days=365),\n    schema=[\n        Field(name=\"document_id\", dtype=String),\n        Field(name=\"embedding\", dtype=Array(Float32), vector_index=True),\n        Field(name=\"movie_name\", dtype=String),\n        Field(name=\"movie_director\", dtype=String),\n… (+8 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "dbe99b5eb65e186dbef36ab2b53e680ecd8eba211b1e6a1945fa2f2a2fec6b15",
+      "topic": "overview",
+      "subject": "Integration with Ray Compute Engine",
+      "content": {
+        "summary": "## Integration with Ray Compute Engine For complex feature processing operations, use the Ray offline store in combination with the [Ray Compute Engine](../compute-engine/ray.md). See the **Ray Offlin"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 610,
+        "quote": "## Integration with Ray Compute Engine\n\nFor complex feature processing operations, use the Ray offline store in combination with the [Ray Compute Engine](../compute-engine/ray.md). See the **Ray Offline Store + Compute Engine** configuration example in the [Configuration](#configuration) section above for a complete setup.\n\n\nFor more advanced troubleshooting, refer to the [Ray documentation](https://docs.ray.io/en/latest/data/getting-started.html).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "67c84b2a0b3bea322a1ba545d87fad3e44efcece44aeb27d2a1b48c2e6f4e2af",
+      "topic": "overview",
+      "subject": "Java SDK",
+      "content": {
+        "summary": "## Java SDK The `java/` directory contains the Java serving component. See [here](https://github.com/feast-dev/feast/blob/master/java/CONTRIBUTING.md) for more details on how the repo is structured."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/codebase-structure.md",
+        "line": 106,
+        "quote": "## Java SDK\n\nThe `java/` directory contains the Java serving component.\nSee [here](https://github.com/feast-dev/feast/blob/master/java/CONTRIBUTING.md) for more details on how the repo is structured.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-07-18T21:43:37-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d791861dd22eb7a34019e5dcd53f44e025996fdf87c7dff29d5859e05ece7a02",
+      "topic": "overview",
+      "subject": "Join Strategies / Broadcast Join",
+      "content": {
+        "summary": "### Broadcast Join Used for small feature datasets: - Automatically selected when feature data < 100MB - Features are cached in Ray's object store - Entities are distributed across cluster - Each worker gets a copy of feature data"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 290,
+        "quote": "### Broadcast Join\n\nUsed for small feature datasets:\n- Automatically selected when feature data < 100MB\n- Features are cached in Ray's object store\n- Entities are distributed across cluster\n- Each worker gets a copy of feature data\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0536fd01d3c1761240898dc85689c3f18faaa74c94a416f8e04e52144bf222cd",
+      "topic": "overview",
+      "subject": "Join Strategies / Distributed Windowed Join",
+      "content": {
+        "summary": "### Distributed Windowed Join Used for large feature datasets: - Automatically selected when feature data > 100MB - Data is partitioned by time windows - Point-in-time joins within each window - Results are combined across windows"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 298,
+        "quote": "### Distributed Windowed Join\n\nUsed for large feature datasets:\n- Automatically selected when feature data > 100MB\n- Data is partitioned by time windows\n- Point-in-time joins within each window\n- Results are combined across windows\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b42b77e64f014ff13dfdfb45b4f973f7fef2ff107e52574622466581f80847ba",
+      "topic": "overview",
+      "subject": "Key Capabilities",
+      "content": {
+        "summary": "### Key Capabilities - **Real-time Feature Generation**: Supports defining features that are continuously updated from a streaming source. - **Transformations**: Apply transformation logic (e.g., `feature_transformation` or `udf`) to raw data source. - **Aggregations**: Define time-windowed aggregat"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/stream-feature-view.md",
+        "line": 9,
+        "quote": "### Key Capabilities\n- **Real-time Feature Generation**: Supports defining features that are continuously updated from a streaming source.\n\n- **Transformations**: Apply transformation logic (e.g., `feature_transformation` or `udf`) to raw data source.\n\n- **Aggregations**: Define time-windowed aggregations (e.g., `sum`, `avg`) over event-timestamped data.\n\n- **⚡ Tiling with Intermediate Representations**: Enable efficient pre-aggregation with correct merging semantics for holistic aggregations like `avg` and `std`. This provides faster queries while maintaining mathematical accuracy. [Learn more about tiling](tiling.md) \n\n- **Feature resolution & execution**: Automatically resolves and executes dependent views during materialization or retrieval.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-27T21:39:01-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c89462c567fa23dabcb508ab99da01756d2b010b97afe2379628871c5f4a7452",
+      "topic": "overview",
+      "subject": "Key Optimizations",
+      "content": {
+        "summary": "## Key Optimizations * **Scoring vs. training paths**: When each entity appears only once in `entity_df` (scoring/inference — one feature lookup per entity), server-side `$group $first` efficiently re"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/mongodb.md",
+        "line": 66,
+        "quote": "## Key Optimizations\n\n* **Scoring vs. training paths**: When each entity appears only once in `entity_df` (scoring/inference — one feature lookup per entity), server-side `$group $first` efficiently returns the single latest value per entity. When the same entity appears at multiple timestamps (training — building a dataset with many historical snapshots per entity), the store retrieves all candidate rows and uses `pd.merge_asof` to select the correct point-in-time value for each request timestamp.\n* **Two-level chunking**: `CHUNK_SIZE` (50,000 rows) controls the size of intermediate DataFrames in memory; `MONGO_BATCH_SIZE` (10,000 entity IDs) limits the query size sent to MongoDB.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "eb24c0b5dad8cf57dec42455ce48ce7f6cd7857e977398b3c77a15559a7beb06",
+      "topic": "overview",
+      "subject": "Known Limitations",
+      "content": {
+        "summary": "## Known Limitations\r \r - **Online store coverage** — Version-qualified reads (`@v<N>`) are SQLite-only today. Other online stores are follow-up work.\r - **Offline store versioning** — Versioned historical retrieval is not yet supported.\r - **Version deletion** — There is no mechanism to prune old v"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-feature-view-versioning.md",
+        "line": 223,
+        "quote": "## Known Limitations\r\n\r\n- **Online store coverage** — Version-qualified reads (`@v<N>`) are SQLite-only today. Other online stores are follow-up work.\r\n- **Offline store versioning** — Versioned historical retrieval is not yet supported.\r\n- **Version deletion** — There is no mechanism to prune old versions from the registry.\r\n- **Cross-version joins** — Joining features from different versions of the same feature view in `get_historical_features` is not supported.\r\n- **Feature services** — Feature services always resolve to the active (promoted) version. `--no-promote` versions are not served until promoted.\r\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:26:28+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "134c9b2225733da148d05c12e818ac3c7ed3bd7f1b357159764e9414b66e724f",
+      "topic": "overview",
+      "subject": "Limitation",
+      "content": {
+        "summary": "## Limitation Please be aware that here is a restriction/limitation for using SQL query string in Feast with Snowflake. Try to avoid the usage of single quote in SQL query string. For example, the fol"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/snowflake.md",
+        "line": 38,
+        "quote": "## Limitation\nPlease be aware that here is a restriction/limitation for using SQL query string in Feast with Snowflake. Try to avoid the usage of single quote in SQL query string. For example, the following query string will fail:\n```\nSELECT\n    some_column\nFROM\n    some_table\nWHERE\n    other_column = 'value'\n```\nThat 'value' will fail in Snowflake. Instead, please use pairs of dollar signs like `$$value$$` as [mentioned in Snowflake document](https://docs.snowflake.com/en/sql-reference/data-types-text#label-dollar-quoted-string-constants).  \n\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-06-13T06:26:51-05:00"
+      },
+      "module": "limitation",
+      "source": "extracted"
+    },
+    {
+      "id": "c416ce4a4ff3259c4e40420ffbbc8bb96616e7b8331e13f0270444b1092393ed",
+      "topic": "overview",
+      "subject": "Lineage Graph Structure",
+      "content": {
+        "summary": "## Lineage Graph Structure When you run `feast apply`, Feast creates a lineage graph that matches the Feast UI: **Jobs created:** - `feast_feature_views_{project}`: Shows DataSources + Entities → Feat"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 100,
+        "quote": "## Lineage Graph Structure\n\nWhen you run `feast apply`, Feast creates a lineage graph that matches the Feast UI:\n\n```\nDataSources ──┐\n              ├──→ feast_feature_views_{project} ──→ FeatureViews\nEntities ─────┘                                          │\n                                                         │\n                                                         ▼\n                                     feature_service_{name} ──→ FeatureService\n```\n\n**Jobs created:**\n- `feast_feature_views_{project}`: Shows DataSources + Entities → FeatureViews\n- `feature_service_{name}`: Shows specific FeatureViews → FeatureService (one per service)\n\n**Datasets include:**\n- Schema with feature names, types, descriptions, and tags\n- Feast-specific facets with metadata (TTL, entities, owner, etc.)\n- Documentation facets with descriptions\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "7132bff08a57549d1b1a7cd2cfde8bea49313c7b838fbb7d3e1773b30102dc21",
+      "topic": "overview",
+      "subject": "Lineage Visualization",
+      "content": {
+        "summary": "## Lineage Visualization Use [Marquez](https://marquezproject.ai/) to visualize your Feast lineage: Then access the Marquez UI at http://localhost:3000 to see your feature lineage."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 187,
+        "quote": "## Lineage Visualization\n\nUse [Marquez](https://marquezproject.ai/) to visualize your Feast lineage:\n\n```bash\n# Start Marquez\ndocker run -p 5000:5000 -p 3000:3000 marquezproject/marquez\n\n# Configure Feast to emit to Marquez (in feature_store.yaml)\n# openlineage:\n#   enabled: true\n#   transport_type: http\n#   transport_url: http://localhost:5000\n```\n\nThen access the Marquez UI at http://localhost:3000 to see your feature lineage.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "29f651490f5c8a8f48bdd0ef0a54ae9d4a39006a1d1845dd5d8fe8b51fd30206",
+      "topic": "overview",
+      "subject": "Listing Version History",
+      "content": {
+        "summary": "## Listing Version History\r \r Use the CLI to inspect version history:\r \r \r \r \r \r Or programmatically via the Python SDK:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-feature-view-versioning.md",
+        "line": 136,
+        "quote": "## Listing Version History\r\n\r\nUse the CLI to inspect version history:\r\n\r\n```bash\r\nfeast feature-views list-versions driver_stats\r\n```\r\n\r\n```text\r\nVERSION  TYPE          CREATED              VERSION_ID\r\nv0       feature_view  2024-01-15 10:30:00  a1b2c3d4-...\r\nv1       feature_view  2024-01-16 14:22:00  e5f6g7h8-...\r\nv2       feature_view  2024-01-20 09:15:00  i9j0k1l2-...\r\n```\r\n\r\nOr programmatically via the Python SDK:\r\n\r\n```python\r\nstore = FeatureStore(repo_path=\".\")\r\nversions = store.list_feature_view_versions(\"driver_stats\")\r\nfor v in versions:\r\n    print(f\"{v['version']} created at {v['created_timestamp']}\")\r\n```\r\n\r"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:26:28+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4e3c4bb873098169929f44694634749c6aaa43f659bba00f3b109ca602e662ff",
+      "topic": "overview",
+      "subject": "Materialize",
+      "content": {
+        "summary": "## Materialize Load data from feature views into the online store. **With timestamps:** **Without timestamps (uses current datetime):** Load data for specific feature views: The `--disable-event-times"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 265,
+        "quote": "## Materialize\n\nLoad data from feature views into the online store.\n\n**With timestamps:**\n```bash\nfeast materialize 2020-01-01T00:00:00 2022-01-01T00:00:00\n```\n\n**Without timestamps (uses current datetime):**\n```bash\nfeast materialize --disable-event-timestamp\n```\n\nLoad data for specific feature views:\n\n```text\nfeast materialize -v driver_hourly_stats 2020-01-01T00:00:00 2022-01-01T00:00:00\n```\n\n```text\nfeast materialize --disable-event-timestamp -v driver_hourly_stats\n```\n\nThe `--disable-event-timestamp` flag is useful when your source data lacks event timestamp columns, allowing you to materialize all available data using the current datetime as the event timestamp.\n\n```text\nMaterializing 1 feature views from 2020-01-01 to 2022-01-01\n\ndriver_hourly_stats:\n100%|██████████████████████████| 5/5 [00:00<00:00, 5949.37it/s]\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "materialize",
+      "source": "extracted"
+    },
+    {
+      "id": "74212b11ceee589b713981137dac7ef0ca48b1c566787f1874bb761c3e756f25",
+      "topic": "overview",
+      "subject": "Materialize incremental",
+      "content": {
+        "summary": "## Materialize incremental Load data from feature views into the online store, beginning from either the previous `materialize` or `materialize-incremental` end date, or the beginning of time."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 298,
+        "quote": "## Materialize incremental\n\nLoad data from feature views into the online store, beginning from either the previous `materialize` or `materialize-incremental` end date, or the beginning of time.\n\n```text\nfeast materialize-incremental 2022-01-01T00:00:00\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b02920f8bb8f25118ccde385fb1af56836cdf14a29009b4133b93b9615e6ea7d",
+      "topic": "overview",
+      "subject": "Migration Guide",
+      "content": {
+        "summary": "## Migration Guide ### From Role-Based to Group/Namespace-Based 1. **Identify User Groups**: Determine which groups your users belong to 2. **Map Namespaces**: Identify which namespaces users should h"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/kubernetes_auth_setup.md",
+        "line": 159,
+        "quote": "## Migration Guide\n\n### From Role-Based to Group/Namespace-Based\n\n1. **Identify User Groups**: Determine which groups your users belong to\n2. **Map Namespaces**: Identify which namespaces users should have access to\n3. **Create New Policies**: Define group-based and namespace-based policies\n4. **Test Gradually**: Start with read-only permissions and gradually expand\n5. **Monitor**: Watch logs to ensure proper authentication and authorization\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ee0f4a34c1c3af97d4396e47c02aef82fe5b306e4e60ce080940890b54417f83",
+      "topic": "overview",
+      "subject": "Namespace Behavior",
+      "content": {
+        "summary": "## Namespace Behavior - If `namespace` is set to `\"feast\"` (default): Uses project name as namespace (e.g., `my_project`) - If `namespace` is set to a custom value: Uses `{namespace}/{project}` (e.g., `custom/my_project`)"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 204,
+        "quote": "## Namespace Behavior\n\n- If `namespace` is set to `\"feast\"` (default): Uses project name as namespace (e.g., `my_project`)\n- If `namespace` is set to a custom value: Uses `{namespace}/{project}` (e.g., `custom/my_project`)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3bfc5aee407bd4e0fb6edcd2b83d81c120a08fbf9494976dd6c351975bb559b8",
+      "topic": "overview",
+      "subject": "Naming Restrictions",
+      "content": {
+        "summary": "## Naming Restrictions\r \r Feature references use a structured format: `feature_view_name@v<N>:feature_name`. To avoid\r ambiguity, the following characters are reserved and must not appear in feature v"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-feature-view-versioning.md",
+        "line": 211,
+        "quote": "## Naming Restrictions\r\n\r\nFeature references use a structured format: `feature_view_name@v<N>:feature_name`. To avoid\r\nambiguity, the following characters are reserved and must not appear in feature view or feature names:\r\n\r\n- **`@`** — Reserved as the version delimiter (e.g., `driver_stats@v2:trips_today`). `feast apply`\r\n  will reject feature views with `@` in their name. If you have existing feature views with `@` in\r\n  their names, they will continue to work for unversioned reads, but we recommend renaming them to\r\n  avoid ambiguity with the `@v<N>` syntax.\r\n- **`:`** — Reserved as the separator between feature view name and feature name in fully qualified\r\n  feature references (e.g., `driver_stats:trips_today`).\r\n\r"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:26:28+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "00c5815cd07b764f77184641eb09facdafa29c300889c4256b55b36ae4cb4f85",
+      "topic": "overview",
+      "subject": "Need Help?",
+      "content": {
+        "summary": "## Need Help? - Email us at hello@denormalized.io - Check out more examples on our [GitHub](https://github.com/probably-nothing-labs/denormalized/tree/main/py-denormalized/python/examples)"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/denormalized.md",
+        "line": 118,
+        "quote": "## Need Help?\n\n- Email us at hello@denormalized.io\n- Check out more examples on our [GitHub](https://github.com/probably-nothing-labs/denormalized/tree/main/py-denormalized/python/examples)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-13T20:58:32+00:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "88219bfedc02dc4553262c389123e1878ada38b6cd2e5414dbb25f99e6d15874",
+      "topic": "overview",
+      "subject": "OTEL based Observability",
+      "content": {
+        "summary": "## OTEL based Observability The Go feature server support [OTEL](https://opentelemetry.io/) based Observabilities. To enable it, we need to set the global env `ENABLE_OTEL_TRACING` to `\"true\"` (as a s"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/go-feature-server.md",
+        "line": 41,
+        "quote": "## OTEL based Observability\nThe Go feature server support [OTEL](https://opentelemetry.io/) based Observabilities.\nTo enable it, we need to set the global env `ENABLE_OTEL_TRACING` to `\"true\"` (as a string type!) in the container or your local OS.\n```\nexport ENABLE_OTEL_TRACING='true'\n```\nThere are example OTEL infra setup under the `/go/infra/docker/otel` folder.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-27T15:46:59-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ac8a9ad08ce37851838f960a98719a5dc06323bb6c297fc879813a6d51bd3198",
+      "topic": "overview",
+      "subject": "Offline store",
+      "content": {
+        "summary": "# Offline store An offline store is an interface for working with historical time-series feature values that are stored in [data sources](../../getting-started/concepts/data-ingestion.md). The `Offlin"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/offline-store.md",
+        "line": 1,
+        "quote": "# Offline store\n\nAn offline store is an interface for working with historical time-series feature values that are stored in [data sources](../../getting-started/concepts/data-ingestion.md).\nThe `OfflineStore` interface has several different implementations, such as the `BigQueryOfflineStore`, each of which is backed by a different storage and compute engine.\nFor more details on which offline stores are supported, please see [Offline Stores](../../reference/offline-stores/).\n\nOffline stores are primarily used for two reasons:\n1. Building training datasets from time-series features.\n2. Materializing \\(loading\\) features into an online store to serve those features at low-latency in a production setting.\n\nOffline stores are configured through the [feature\\_store.yaml](../../reference/feature-repository/feature-store-yaml.md).\nWhen building training datasets or materializing features into an online store, Feast will use the configured offline store with your configured data sources to execute the necessary data operations.\n\nOnly a single offline store can be used at a time.\nMoreover, offline stores are not compatible with all data sources; for example, the `BigQuery` offline store cannot be used to query a file-based data source.\n\nPlease see [Push Source](../../reference/data-sources/push.md) for more details on how to push features directly to the offline store in your feature store.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-02-13T07:44:36-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3b2d787a86209b62eb30b82939e94bc5c0113cd6a229b0962058c859326f9771",
+      "topic": "overview",
+      "subject": "Online Store Support",
+      "content": {
+        "summary": "## Online Store Support\r \r {% hint style=\"info\" %}\r **Currently, version-qualified online reads (`@v<N>`) are only supported with the SQLite online store.** Support for additional online stores (Redis"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-feature-view-versioning.md",
+        "line": 197,
+        "quote": "## Online Store Support\r\n\r\n{% hint style=\"info\" %}\r\n**Currently, version-qualified online reads (`@v<N>`) are only supported with the SQLite online store.** Support for additional online stores (Redis, DynamoDB, Bigtable, Postgres, etc.) will be added based on community priority.\r\n\r\nIf you need versioned online reads for a specific online store, please [open a GitHub issue](https://github.com/feast-dev/feast/issues/new) describing your use case and which store you need. This helps us prioritize development.\r\n{% endhint %}\r\n\r\nVersion history tracking in the registry (listing versions, pinning, `--no-promote`) works with **all** registry backends (file, SQL, Snowflake).\r\n\r"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:26:28+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b2d182471cfa9aa95f2fd1036b23aa4ada0d3ce5196281d9abfc367cf2f1e837",
+      "topic": "overview",
+      "subject": "Online store",
+      "content": {
+        "summary": "# Online store\r \r Feast uses online stores to serve features at low latency.\r Feature values are loaded from data sources into the online store through _materialization_, which can be triggered throug"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/online-store.md",
+        "line": 1,
+        "quote": "# Online store\r\n\r\nFeast uses online stores to serve features at low latency.\r\nFeature values are loaded from data sources into the online store through _materialization_, which can be triggered through the `materialize` command (either with specific timestamps or using `--disable-event-timestamp` to materialize all data with current timestamps).\r\n\r\nThe storage schema of features within the online store mirrors that of the original data source.\r\nOne key difference is that for each [entity key](../concepts/entity.md), only the latest feature values are stored.\r\nNo historical values are stored.\r\n\r\nHere is an example batch data source:\r\n\r\n![](../../.gitbook/assets/image%20%286%29.png)\r\n\r\nOnce the above data source is materialized into Feast (using `feast materialize` with timestamps or `feast materialize --disable-event-timestamp`), the feature values will be stored as follows:\r\n\r\n![](../../.gitbook/assets/image%20%285%29.png)\r\n\r\nFeatures can also be written directly to the online store via [push sources](../../reference/data-sources/push.md) ."
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-09-24T17:10:05+01:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "317328e6db1d56cf0a97aa80100dfeb593aeac82b106711d5754371063a6076b",
+      "topic": "overview",
+      "subject": "Options",
+      "content": {
+        "summary": "## Options The following top-level configuration options exist in the `feature_store.yaml` file. * **provider**  — Configures the environment in which Feast will deploy and operate. * **registry** — C"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-repository/feature-store-yaml.md",
+        "line": 18,
+        "quote": "## Options\n\nThe following top-level configuration options exist in the `feature_store.yaml` file.\n\n* **provider**  — Configures the environment in which Feast will deploy and operate.\n* **registry** — Configures the location of the feature registry.\n* **online_store** — Configures the online store.\n* **offline_store** — Configures the offline store.\n* **project** — Defines a namespace for the entire feature store. Can be used to isolate multiple deployments in a single installation of Feast. Should only contain letters, numbers, and underscores.\n* **engine** - Configures the batch materialization engine.\n* **materialization** - Configures materialization behavior (write batching, feature pull strategy). See below.\n\nPlease see the [RepoConfig](https://rtd.feast.dev/en/latest/#feast.repo_config.RepoConfig) API reference for the full list of configuration options.\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:27:21+05:30"
+      },
+      "module": "options",
+      "source": "extracted"
+    },
+    {
+      "id": "db8bdc41e6aa12fb744c6906c0665ac8e115b163ebefea459d313798ce216b07",
+      "topic": "overview",
+      "subject": "PGVector",
+      "content": {
+        "summary": "## PGVector The Postgres online store supports the use of [PGVector](https://github.com/pgvector/pgvector) for storing feature values. To enable PGVector, set `vector_enabled: true` in the online stor"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/postgres.md",
+        "line": 65,
+        "quote": "## PGVector\nThe Postgres online store supports the use of [PGVector](https://github.com/pgvector/pgvector) for storing feature values.\nTo enable PGVector, set `vector_enabled: true` in the online store configuration. \n\nThe `vector_length` parameter can be used to specify the length of the vector in the Field.\n\nPlease make sure to follow the instructions in the repository, which, as the time of this writing, requires you to \nrun `CREATE EXTENSION vector;` in the database.\n\n\nThen you can use `retrieve_online_documents` to retrieve the top k closest vectors to a query vector. \nFor the Retrieval Augmented  Generation (RAG) use-case, you have to embed the query prior to passing the query vector.\n\n{% code title=\"python\" %}\n```python\nfrom feast import FeatureStore\nfrom feast.infra.online_stores.postgres_online_store import retrieve_online_documents\n\nfeature_store = FeatureStore(repo_path=\".\")\n\nquery_vector = [0.1, 0.2, 0.3, 0.4, 0.5]\ntop_k = 5\n\nfeature_values = retrieve_online_documents(\n    feature_store=feature_store,\n    feature_view_name=\"document_fv:embedding_float\",\n    query_vector=query_vector,\n    top_k=top_k,\n)\n```\n{% endcode %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-17T21:33:19+05:30"
+      },
+      "module": "pgvector",
+      "source": "extracted"
+    },
+    {
+      "id": "c59118fadf82dc18b8eaf5987a416f65cc076e71b2b6da99f1fe3edc2055a368",
+      "topic": "overview",
+      "subject": "Performance Considerations",
+      "content": {
+        "summary": "## Performance Considerations - **Startup time**: Artifacts are loaded during server initialization, which may increase startup time - **Memory usage**: All artifacts remain in memory for the server's lifetime - **Concurrency**: Artifacts are shared across all request threads - **Container resources"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-static-artifacts.md",
+        "line": 284,
+        "quote": "## Performance Considerations\n\n- **Startup time**: Artifacts are loaded during server initialization, which may increase startup time\n- **Memory usage**: All artifacts remain in memory for the server's lifetime\n- **Concurrency**: Artifacts are shared across all request threads\n- **Container resources**: Ensure sufficient memory allocation for your artifacts\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-22T20:04:28-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0f6c36bc89ad16578a35c246e7869ca70d7a1a185b30faf3217336a0eddc3c14",
+      "topic": "overview",
+      "subject": "Performance Optimization / Automatic Optimization",
+      "content": {
+        "summary": "### Automatic Optimization The Ray compute engine includes several automatic optimizations: 1. **Partition Optimization**: Automatically determines optimal partition sizes 2. **Join Strategy Selection**: Chooses between broadcast and distributed joins 3. **Resource Allocation**: Scales workers based"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 318,
+        "quote": "### Automatic Optimization\n\nThe Ray compute engine includes several automatic optimizations:\n\n1. **Partition Optimization**: Automatically determines optimal partition sizes\n2. **Join Strategy Selection**: Chooses between broadcast and distributed joins\n3. **Resource Allocation**: Scales workers based on available resources\n4. **Memory Management**: Handles out-of-core processing for large datasets\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3857ccaeeaadf5d22966d5e8dcf3f6e2dfe7dc63493e9ce26f5df392c63f21ae",
+      "topic": "overview",
+      "subject": "Performance Optimization / Monitoring and Metrics",
+      "content": {
+        "summary": "### Monitoring and Metrics Monitor Ray compute engine performance:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 341,
+        "quote": "### Monitoring and Metrics\n\nMonitor Ray compute engine performance:\n\n```python\nimport ray\n\n# Check cluster resources\nresources = ray.cluster_resources()\nprint(f\"Available CPUs: {resources.get('CPU', 0)}\")\nprint(f\"Available GPUs: {resources.get('GPU', 0)}\")\nprint(f\"Available memory: {resources.get('memory', 0) / 1e9:.2f} GB\")\n\n# Monitor job progress\njob = store.get_historical_features(...)\n# Ray compute engine provides built-in progress tracking\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "66e2dd3df6293ff2640781cc69407151ac14feffa7892db8c0f836c13c570b62",
+      "topic": "overview",
+      "subject": "Performance characteristics / Async write support",
+      "content": {
+        "summary": "### Async write support The Redis online store implements `online_write_batch_async()` using the async Redis client. This enables non-blocking batch writes in async serving frameworks. `skip_dedup` is also respected in the async path."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/redis.md",
+        "line": 132,
+        "quote": "### Async write support\n\nThe Redis online store implements `online_write_batch_async()` using the async Redis client. This enables non-blocking batch writes in async serving frameworks. `skip_dedup` is also respected in the async path.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:27:21+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d535916aaa4d5df40d2acee1600addc1ff7b5bb4fb46eb4a94a7cfabb978827e",
+      "topic": "overview",
+      "subject": "Performance characteristics / Batched multi-feature-view reads",
+      "content": {
+        "summary": "### Batched multi-feature-view reads Unlike most online stores, the Redis implementation overrides `get_online_features()` to issue a **single pipeline execution** for all feature views in the request"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/redis.md",
+        "line": 93,
+        "quote": "### Batched multi-feature-view reads\n\nUnlike most online stores, the Redis implementation overrides `get_online_features()` to issue a **single pipeline execution** for all feature views in the request. Because all feature views for the same entity live in the same Redis hash, all `HMGET` commands across every feature view are batched into one `pipeline.execute()` call.\n\n| Feature views in request | Redis round trips (before) | Redis round trips (after) |\n| :---: | :---: | :---: |\n| 1 | 1 | 1 |\n| 5 | 5 | 1 |\n| 10 | 10 | 1 |\n| 20 | 20 | 1 |\n\nBenchmark results against Redis 8.6.2 (localhost, 50 entities, 3 features/FV, 300 rounds):\n\n| Feature views | Master (per-FV pipeline) | Improved (batched pipeline) | Speedup |\n| :---: | ---: | ---: | :---: |\n| 1 | 1.57 ms | 1.32 ms | 1.19× |\n| 5 | 7.27 ms | 5.63 ms | 1.29× |\n| 10 | 15.64 ms | 10.65 ms | 1.47× |\n| 20 | 36.33 ms | 21.21 ms | **1.71×** |\n\nThe speedup grows with the number of feature views and is most pronounced in production environments with non-trivial network RTT to Redis.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:27:21+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8a2f58a0a2cddbce8c78ecf18df0eac73f86614d26df01affd5d1491b2ffc9af",
+      "topic": "overview",
+      "subject": "Permission granting order",
+      "content": {
+        "summary": "## Permission granting order When mixing and matching policies in permissions script, the permission granting order is as follows: 1. The first matching policy wins in the list of policies and the per"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/permission.md",
+        "line": 104,
+        "quote": "## Permission granting order\n\nWhen mixing and matching policies in permissions script, the permission granting order is as follows:\n\n1. The first matching policy wins in the list of policies and the permission is granted based on the matching policy rules and rest policies are ignored.\n2. If any policy matches from the list of policies, the permission is granted based on the matching policy rules and rest policies are ignored\n3. If no policy matches, the permission is denied\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "fc38236a8c03f3dec86577f3c78cbf50b8ab1ed39b3f6d19c574b016ab34439e",
+      "topic": "overview",
+      "subject": "Permissions / Describe a permission",
+      "content": {
+        "summary": "### Describe a permission Describes the provided permission"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 352,
+        "quote": "### Describe a permission\nDescribes the provided permission\n\n```text\nfeast permissions describe permission-name\nname: permission-name\ntypes:\n- FEATURE_VIEW\nnamePattern: transformed_conv_rate\nrequiredTags:\n  required1: required-value1\n  required2: required-value2\nactions:\n- DESCRIBE\npolicy:\n  roleBasedPolicy:\n    roles:\n    - reader\ntags:\n  key1: value1\n  key2: value2\n\n```"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "e1365c83dea885c8a6d6365106dd04145eb8171bb01f25b4dd1bbd906d58e972",
+      "topic": "overview",
+      "subject": "Permissions / List of the configured roles",
+      "content": {
+        "summary": "### List of the configured roles List all the configured roles `verbose` option describes the resources and actions permitted to each managed role:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 418,
+        "quote": "### List of the configured roles\nList all the configured roles\n\n```text\nfeast permissions list-roles\n\nOptions:\n  --verbose Print the resources and actions permitted to each configured\n            role\n```\n\n```text\nROLE NAME\nadmin\nreader\nwriter\n```\n\n`verbose` option describes the resources and actions permitted to each managed role: \n\n```text\nfeast permissions list-roles -v\n```\n\n```text            \nROLE NAME          RESOURCE NAME               RESOURCE TYPE    PERMITTED ACTIONS\nadmin              driver_hourly_stats_source  FileSource       CREATE\n                                                                DELETE\n                                                                QUERY_OFFLINE\n                                                                QUERY_ONLINE\n                                                                DESCRIBE\n                                                                UPDATE\nadmin              vals_to_add                 RequestSource    CREATE\n                                                                DELETE\n                                                                QUERY_OFFLINE\n                                                                QUERY_ONLINE\n                                                                DESCRIBE\n                                                                UPDATE\nadmin              driver_stats_push_source    PushSource       CREATE\n                                                                DELETE\n… (+28 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c79fcfde738c73f7c5ae4ac579ddf4786b4cd64086ff220400da9fc6dfe2e777",
+      "topic": "overview",
+      "subject": "Permissions / List permissions",
+      "content": {
+        "summary": "### List permissions List all registered permission `verbose` option describes the resources matching each configured permission:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 308,
+        "quote": "### List permissions\nList all registered permission\n\n```text\nfeast permissions list\n\nOptions:\n  --tags TEXT    Filter by tags (e.g. --tags 'key:value' --tags 'key:value,\n                 key:value, ...'). Items return when ALL tags match.\n  -v, --verbose  Print the resources matching each configured permission\n```\n\n```text\n+-----------------------+-------------+-----------------------+-----------+----------------+-------------------------+\n| NAME                  | TYPES       | NAME_PATTERNS         | ACTIONS   | ROLES          | REQUIRED_TAGS           |\n+=======================+=============+=======================+===========+================+================+========+\n| reader_permission1234 | FeatureView | transformed_conv_rate | DESCRIBE  | reader         | -                       |\n|                       |             | driver_hourly_stats   | DESCRIBE  | reader         | -                       |\n+-----------------------+-------------+-----------------------+-----------+----------------+-------------------------+\n| writer_permission1234 | FeatureView | transformed_conv_rate | CREATE    | writer         | -                       |\n+-----------------------+-------------+-----------------------+-----------+----------------+-------------------------+\n| special               | FeatureView | special.*             | DESCRIBE  | admin          | test-key2 : test-value2 |\n|                       |             |                       | UPDATE    | special-reader | test-key : test-value   |\n+-----------------------+-------------+-----------------------+-----------+----------------+-------------------------+\n```\n\n`verbose` option describes the resources matching each configured permission: \n\n```text\nfeast permissions list -v\n```\n\n```text\nPermissions:\n\npermissions\n├── reader_permission1234 ['reader']\n│   └── FeatureView: none\n└── writer_permission1234 ['writer']\n    ├── FeatureView: none\n… (+4 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "499c926064e93f3c641082982f01e829bb7a4233059b7a125000712359a80438",
+      "topic": "overview",
+      "subject": "Permissions / Permission check",
+      "content": {
+        "summary": "### Permission check The `permissions check` command is used to identify resources that lack the appropriate permissions based on their type, name, or tags. This command is particularly useful for adm"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 375,
+        "quote": "### Permission check\nThe `permissions check` command is used to identify resources that lack the appropriate permissions based on their type, name, or tags.\n\nThis command is particularly useful for administrators when roles, actions, or permissions have been modified or newly configured. By running this command, administrators can easily verify which resources and actions are not protected by any permission configuration, ensuring that proper security measures are in place.\n\n```text\n> feast permissions check\n\n\nThe following resources are not secured by any permission configuration:\nNAME                         TYPE\ndriver                       Entity\ndriver_hourly_stats_fresh    FeatureView\nThe following actions are not secured by any permission configuration (Note: this might not be a security concern, depending on the used APIs):\nNAME                         TYPE                 UNSECURED ACTIONS\ndriver                       Entity               CREATE\n                                                  DESCRIBE\n                                                  UPDATE\n                                                  DELETE\n                                                  READ_ONLINE\n                                                  READ_OFFLINE\n                                                  WRITE_ONLINE\n                                                  WRITE_OFFLINE\ndriver_hourly_stats_fresh    FeatureView          CREATE\n                                                  DESCRIBE\n                                                  UPDATE\n                                                  DELETE\n                                                  READ_ONLINE\n                                                  READ_OFFLINE\n                                                  WRITE_ONLINE\n                                                  WRITE_OFFLINE\n\nBased on the above results, the administrator can reassess the permissions configuration and make any necessary adjustments to meet their security requirements.\n\nIf no resources are accessible publicly, the permissions check command will return the following response:\n> feast permissions check\nThe following resources are not secured by any permission configuration:\nNAME    TYPE\nThe following actions are not secured by any permission configuration (Note: this might not be a security concern, depending on the used APIs):\nNAME    TYPE    UNSECURED ACTIONS\n… (+3 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4e0c449cc94b02147d92e0887a9654f1cd38d750f5e0ce009666043eda19c8bd",
+      "topic": "overview",
+      "subject": "Pinning to a Specific Version",
+      "content": {
+        "summary": "## Pinning to a Specific Version\r \r You can pin a feature view to a specific historical version by setting the `version` parameter. When pinned, `feast apply` replaces the active feature view with the"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-feature-view-versioning.md",
+        "line": 56,
+        "quote": "## Pinning to a Specific Version\r\n\r\nYou can pin a feature view to a specific historical version by setting the `version` parameter. When pinned, `feast apply` replaces the active feature view with the snapshot from that version. This is useful for reverting to a known-good definition.\r\n\r\n```python\r\nfrom feast import FeatureView\r\n\r\n# Default behavior: always use the latest version (auto-increments on changes)\r\ndriver_stats = FeatureView(\r\n    name=\"driver_stats\",\r\n    entities=[driver],\r\n    schema=[...],\r\n    source=my_source,\r\n)\r\n\r\n# Pin to a specific version (reverts the active definition to v2's snapshot)\r\ndriver_stats = FeatureView(\r\n    name=\"driver_stats\",\r\n    entities=[driver],\r\n    schema=[...],\r\n    source=my_source,\r\n    version=\"v2\",  # also accepts \"version2\"\r\n)\r\n```\r\n\r\nWhen pinning, the feature view definition (schema, source, transformations, etc.) must match the currently active definition. If you've also modified the definition alongside the pin, `feast apply` will raise a `FeatureViewPinConflict` error. To apply changes, use `version=\"latest\"`. To revert, only change the `version` parameter.\r\n\r\nThe snapshot's content replaces the active feature view. Version history is not modified by a pin; the existing v0, v1, v2, etc. snapshots remain intact.\r\n\r\nAfter reverting with a pin, you can go back to normal auto-incrementing behavior by removing the `version` parameter (or setting it to `\"latest\"`) and running `feast apply` again. If the restored definition differs from the pinned snapshot, a new version will be created.\r\n\r\n### Version string formats\r\n\r\n| Format | Meaning |\r\n|--------|---------|\r\n| `\"latest\"` (or omitted) | Always use the latest version (auto-increments on changes) |\r\n| `\"v0\"`, `\"v1\"`, `\"v2\"`, ... | Pin to a specific version number |\r\n| `\"version0\"`, `\"version1\"`, ... | Equivalent long form (case-insensitive) |\r\n\r"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:26:28+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f85ce825e8242b928e355de8af814de9131e08e0d452c6aee6ee0d430b42e5c6",
+      "topic": "overview",
+      "subject": "Point-in-time joins",
+      "content": {
+        "summary": "# Point-in-time joins Feature values in Feast are modeled as time-series records. Below is an example of a driver feature view with two feature columns \\(`trips_today`, and `earnings_today`\\): ![](../"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/point-in-time-joins.md",
+        "line": 1,
+        "quote": "# Point-in-time joins\n\nFeature values in Feast are modeled as time-series records. Below is an example of a driver feature view with two feature columns \\(`trips_today`, and `earnings_today`\\):\n\n![](../../.gitbook/assets/image%20%2836%29.png)\n\nThe above table can be registered with Feast through the following feature view:\n\n```python\nfrom feast import Entity, FeatureView, Field, FileSource\nfrom feast.types import Float32, Int64\nfrom datetime import timedelta\n\ndriver = Entity(name=\"driver\", join_keys=[\"driver_id\"])\n\ndriver_stats_fv = FeatureView(\n    name=\"driver_hourly_stats\",\n    entities=[driver],\n    schema=[\n        Field(name=\"trips_today\", dtype=Int64),\n        Field(name=\"earnings_today\", dtype=Float32),\n    ],\n    ttl=timedelta(hours=2),\n    source=FileSource(\n        path=\"driver_hourly_stats.parquet\"\n    )\n)\n```\n\nFeast is able to join features from one or more feature views onto an entity dataframe in a point-in-time correct way. This means Feast is able to reproduce the state of features at a specific point in the past.\n\nGiven the following entity dataframe, imagine a user would like to join the above `driver_hourly_stats` feature view onto it, while preserving the `trip_success` column:\n\n![Entity dataframe containing timestamps, driver ids, and the target variable](../../.gitbook/assets/image%20%2823%29.png)\n\nThe timestamps within the entity dataframe above are the events at which we want to reproduce the state of the world \\(i.e., what the feature values were at those specific points in time\\). In order to do a point-in-time join, a user would load the entity dataframe and run historical retrieval:\n\n```python\n# Read in entity dataframe\nentity_df = pd.read_csv(\"entity_df.csv\")\n… (+25 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-08-22T15:01:58-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "80671b1a3feef6dd9d6fbd802a7b066e2bc51fa8459c8c98984d41aba9961723",
+      "topic": "overview",
+      "subject": "Policy Types / GroupBasedPolicy",
+      "content": {
+        "summary": "### GroupBasedPolicy Grants access based on user group membership. #### NamespaceBasedPolicy Grants access based on user namespace association. #### CombinedGroupNamespacePolicy Grants access only whe"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/kubernetes_auth_setup.md",
+        "line": 44,
+        "quote": "### GroupBasedPolicy\nGrants access based on user group membership.\n\n```python\nfrom feast.permissions.policy import GroupBasedPolicy\n\npolicy = GroupBasedPolicy(groups=[\"data-team\", \"ml-engineers\"])\n```\n\n#### NamespaceBasedPolicy\nGrants access based on user namespace association.\n\n```python\nfrom feast.permissions.policy import NamespaceBasedPolicy\n\npolicy = NamespaceBasedPolicy(namespaces=[\"production\", \"staging\"])\n```\n\n#### CombinedGroupNamespacePolicy\nGrants access only when user is added into either permitted groups OR namespaces.\n\n```python\nfrom feast.permissions.policy import CombinedGroupNamespacePolicy\n\npolicy = CombinedGroupNamespacePolicy(\n    groups=[\"data-team\"],\n    namespaces=[\"production\"]\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2f50087e4caa81b53f454815749da6c754582a0b190a5749937618b7d08b5ebe",
+      "topic": "overview",
+      "subject": "Policy Types / RoleBasedPolicy",
+      "content": {
+        "summary": "### RoleBasedPolicy Grants access based on user role membership."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/kubernetes_auth_setup.md",
+        "line": 35,
+        "quote": "### RoleBasedPolicy\nGrants access based on user role membership.\n\n```python\nfrom feast.permissions.policy import RoleBasedPolicy\n\npolicy = RoleBasedPolicy(roles=[\"data-team\", \"ml-engineers\"])\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4a12519c503a255d6c92744f614dd3fb87ce8c3c2c44923ade27418db88f7994",
+      "topic": "overview",
+      "subject": "Preparations",
+      "content": {
+        "summary": "### Preparations Feast with Great Expectations support can be installed via"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/dqm.md",
+        "line": 24,
+        "quote": "### Preparations\nFeast with Great Expectations support can be installed via\n```shell\npip install 'feast[ge]'\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-02-02T07:01:43-08:00"
+      },
+      "module": "preparations",
+      "source": "extracted"
+    },
+    {
+      "id": "4a3af295eae7e99c4e085fe7b7f4a1c7f136f92741fe5baa3c196c9c02e9db51",
+      "topic": "overview",
+      "subject": "Prerequisites",
+      "content": {
+        "summary": "## Prerequisites - Python 3.12+ - Kafka cluster (local or remote) OR docker installed For a full working demo, check out the [feast-example](https://github.com/probably-nothing-labs/feast-example) rep"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/denormalized.md",
+        "line": 7,
+        "quote": "## Prerequisites\n\n- Python 3.12+\n- Kafka cluster (local or remote) OR docker installed\n\nFor a full working demo, check out the [feast-example](https://github.com/probably-nothing-labs/feast-example) repo.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-13T20:58:32+00:00"
+      },
+      "module": "prerequisites",
+      "source": "extracted"
+    },
+    {
+      "id": "80e2d005666d13287f4454791ce22fd4f61247652beb7694764f228bd6295b9d",
+      "topic": "overview",
+      "subject": "Programmatic SDK Usage",
+      "content": {
+        "summary": "## Programmatic SDK Usage ### Token from Kubernetes Config"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/user_token_provisioning.md",
+        "line": 217,
+        "quote": "## Programmatic SDK Usage\n\n### Token from Kubernetes Config\n\n```python\nfrom feast import FeatureStore\nfrom feast.permissions.auth_model import KubernetesAuthConfig\nfrom kubernetes import client, config\n\n# Load kubeconfig and get token\nconfig.load_kube_config()\nv1 = client.CoreV1Api()\n\n# Get token from Kubernetes API or secure storage\ndef get_token_from_k8s():\n    # Example: Get token from secret\n    secret = v1.read_namespaced_secret(\n        name=\"user-token\",\n        namespace=\"default\"\n    )\n    return secret.data[\"token\"].decode(\"utf-8\")\n\nuser_token = get_token_from_k8s()\n\nauth_config = KubernetesAuthConfig(\n    type=\"kubernetes\",\n    user_token=user_token\n)\n\nfs = FeatureStore(\n    repo_path=\"path/to/feature_repo\",\n    auth_config=auth_config\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8873db249a02368b3af18a1e5e85f9a63a1fee7354a988efbf699e7e3dbf4c49",
+      "topic": "overview",
+      "subject": "Project",
+      "content": {
+        "summary": "# Project Projects provide complete isolation of feature stores at the infrastructure level. This is accomplished through resource namespacing, e.g., prefixing table names with the associated project."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/project.md",
+        "line": 1,
+        "quote": "# Project\n\nProjects provide complete isolation of feature stores at the infrastructure level. This is accomplished through resource namespacing, e.g., prefixing table names with the associated project. Each project should be considered a completely separate universe of entities and features. It is not possible to retrieve features from multiple projects in a single request. We recommend having a single feature store and a single project per environment (`dev`, `staging`, `prod`).\n\n![](<../../.gitbook/assets/image (7).png>)\n\nUsers define one or more [feature views](feature-view.md) within a project. Each feature view contains one or more [features](feature-view.md#field). These features typically relate to one or more [entities](entity.md). A feature view must always have a [data source](data-ingestion.md), which in turn is used during the generation of training [datasets](feature-retrieval.md#dataset) and when materializing feature values into the online store.\n\nThe concept of a \"project\" provide the following benefits:\n\n**Logical Grouping**: Projects group related features together, making it easier to manage and track them.\n\n**Feature Definitions**: Within a project, you can define features, including their metadata, types, and sources. This helps standardize how features are created and consumed.\n\n**Isolation**: Projects provide a way to isolate different environments, such as development, testing, and production, ensuring that changes in one project do not affect others.\n\n**Collaboration**: By organizing features within projects, teams can collaborate more effectively, with clear boundaries around the features they are responsible for.\n\n**Access Control**: Projects can implement permissions, allowing different users or teams to access only the features relevant to their work."
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-10-21T12:24:29-04:00"
+      },
+      "module": "project",
+      "source": "extracted"
+    },
+    {
+      "id": "7fff9738094edecf9bdc1586a6b6eb893d564cc8855fc620582518076d64902a",
+      "topic": "overview",
+      "subject": "Project Structure",
+      "content": {
+        "summary": "## Project Structure Your project should look something like this: 3. Run a test Kafka instance in docker `docker run --rm -p 9092:9092 emgeee/kafka_emit_measurements:latest` This will spin up a docke"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/denormalized.md",
+        "line": 30,
+        "quote": "## Project Structure\n\nYour project should look something like this:\n```\nmy-feature-project/\n├── feature_repo/\n│   ├── feature_store.yaml\n│   └── sensor_data.py        # Feature definitions\n├── stream_job.py             # Denormalized pipeline\n└── main.py                   # Pipeline runner\n```\n\n3. Run a test Kafka instance in docker\n\n`docker run --rm -p 9092:9092 emgeee/kafka_emit_measurements:latest`\n\nThis will spin up a docker container that runs a kafka instance and run a simple script to emit fake data to two topics.\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-13T20:58:32+00:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "df4eaba2eeafa19347c9504e5e1b496fbf63bbd829e5c2251de84916d37f6005",
+      "topic": "overview",
+      "subject": "Prometheus Metrics / Available metrics",
+      "content": {
+        "summary": "### Available metrics | Metric | Type | Labels | Category | Description | |--------|------|--------|----------|-------------| | `feast_feature_server_cpu_usage` | Gauge | — | `resource` | Process CPU "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 364,
+        "quote": "### Available metrics\n\n| Metric | Type | Labels | Category | Description |\n|--------|------|--------|----------|-------------|\n| `feast_feature_server_cpu_usage` | Gauge | — | `resource` | Process CPU usage % |\n| `feast_feature_server_memory_usage` | Gauge | — | `resource` | Process memory usage % |\n| `feast_feature_server_request_total` | Counter | `endpoint`, `status` | `request` | Total requests per endpoint |\n| `feast_feature_server_request_latency_seconds` | Histogram | `endpoint`, `feature_count`, `feature_view_count` | `request` | Request latency with p50/p95/p99 support |\n| `feast_online_features_request_total` | Counter | — | `online_features` | Total online feature retrieval requests |\n| `feast_online_features_entity_count` | Histogram | — | `online_features` | Entity rows per online feature request |\n| `feast_feature_server_online_store_read_duration_seconds` | Histogram | — | `online_features` | Online store read phase duration (sync and async) |\n| `feast_feature_server_transformation_duration_seconds` | Histogram | `odfv_name`, `mode` | `online_features` | ODFV read-path transformation duration (requires `track_metrics=True` on the ODFV) |\n| `feast_feature_server_write_transformation_duration_seconds` | Histogram | `odfv_name`, `mode` | `online_features` | ODFV write-path transformation duration (requires `track_metrics=True` on the ODFV) |\n| `feast_push_request_total` | Counter | `push_source`, `mode` | `push` | Push requests by source and mode |\n| `feast_materialization_result_total` | Counter | `feature_view`, `status` | `materialization` | Materialization runs (success/failure) |\n| `feast_materialization_duration_seconds` | Histogram | `feature_view` | `materialization` | Materialization duration per feature view |\n| `feast_feature_freshness_seconds` | Gauge | `feature_view`, `project` | `freshness` | Seconds since last materialization |\n| `feast_offline_store_request_total` | Counter | `method`, `status` | `offline_features` | Total offline store retrieval requests |\n| `feast_offline_store_request_latency_seconds` | Histogram | `method` | `offline_features` | Latency of offline store retrieval operations |\n| `feast_offline_store_row_count` | Histogram | `method` | `offline_features` | Rows returned by offline store retrieval |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "e1378967fd11b79a5493afedb3e28485995623ef59a02b27aee2ed390ae84418",
+      "topic": "overview",
+      "subject": "Prometheus Metrics / Multi-worker and multi-replica (HPA) support",
+      "content": {
+        "summary": "### Multi-worker and multi-replica (HPA) support Feast uses Prometheus **multiprocess mode** so that metrics are correct regardless of the number of Gunicorn workers or Kubernetes replicas. **How it w"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 502,
+        "quote": "### Multi-worker and multi-replica (HPA) support\n\nFeast uses Prometheus **multiprocess mode** so that metrics are correct\nregardless of the number of Gunicorn workers or Kubernetes replicas.\n\n**How it works:**\n\n* Each Gunicorn worker writes metric values to shared files in a\n  temporary directory (`PROMETHEUS_MULTIPROCESS_DIR`).  Feast creates\n  this directory automatically; you can override it by setting the\n  environment variable yourself.\n* The metrics HTTP server on port 8000 aggregates all workers'\n  metric files using `MultiProcessCollector`, so a single scrape\n  returns accurate totals.\n* Gunicorn hooks clean up dead-worker files automatically\n  (`child_exit` → `mark_process_dead`).\n* CPU and memory gauges use `multiprocess_mode=liveall` — Prometheus\n  shows per-worker values distinguished by a `pid` label.\n* Feature freshness gauges use `multiprocess_mode=max` — Prometheus\n  shows the worst-case staleness (all workers compute the same value).\n* Counters and histograms (request counts, latency, materialization)\n  are automatically summed across workers.\n\n**Multiple replicas (HPA):** Each pod runs its own metrics endpoint.\nPrometheus adds an `instance` label per pod, so there is no\nduplication.  Use `sum(rate(...))` or `histogram_quantile(...)` across\ninstances as usual.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b2a4073dc495870229741c83caf77cb4206466597bb31546cf564d87c7b53823",
+      "topic": "overview",
+      "subject": "Prometheus Metrics / Per-ODFV transformation metrics",
+      "content": {
+        "summary": "### Per-ODFV transformation metrics The `transformation_duration_seconds` and `write_transformation_duration_seconds` metrics are gated behind **two** conditions — both must be true for any instrument"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 385,
+        "quote": "### Per-ODFV transformation metrics\n\nThe `transformation_duration_seconds` and `write_transformation_duration_seconds`\nmetrics are gated behind **two** conditions — both must be true for any\ninstrumentation to run:\n\n1. **Server-level**: the `online_features` category must be enabled in the\n   metrics configuration.\n2. **ODFV-level**: the `OnDemandFeatureView` must have `track_metrics=True`.\n\nThis defaults to `False`, so no ODFV incurs timing overhead unless explicitly\nopted in:\n\n```python\nfrom feast.on_demand_feature_view import on_demand_feature_view\n\n@on_demand_feature_view(\n    sources=[my_feature_view, my_request_source],\n    schema=[Field(name=\"output\", dtype=Float64)],\n    track_metrics=True,   # opt in to transformation timing\n)\ndef my_transform(inputs: pd.DataFrame) -> pd.DataFrame:\n    ...\n```\n\nThe `odfv_name` label lets you filter or group by individual ODFV,\nand the `mode` label (`python`, `pandas`, `substrait`) lets you compare\ntransformation engines.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "e00bfd98731c0c53396ebd8fc214e5f5da81393595e76cf6bfa8f510bba7ded7",
+      "topic": "overview",
+      "subject": "Proto serialisation",
+      "content": {
+        "summary": "## Proto serialisation `RaySource` is fully serialisable to Feast's protobuf registry format. The `reader_type`, `path`, and `reader_options` dict are all persisted and can be round-tripped via `to_pr"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/ray.md",
+        "line": 211,
+        "quote": "## Proto serialisation\n\n`RaySource` is fully serialisable to Feast's protobuf registry format. The\n`reader_type`, `path`, and `reader_options` dict are all persisted and can be\nround-tripped via `to_proto()` / `from_proto()`.\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "89585a16bb17fe398367904f31f93922faedf6caf01a3d0abeef7df3c8b3088d",
+      "topic": "overview",
+      "subject": "Protobufs",
+      "content": {
+        "summary": "## Protobufs Feast uses [protobuf](https://github.com/protocolbuffers/protobuf) to store serialized versions of the core Feast objects. The protobuf definitions are stored in `protos/feast`. The [regi"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/codebase-structure.md",
+        "line": 123,
+        "quote": "## Protobufs\n\nFeast uses [protobuf](https://github.com/protocolbuffers/protobuf) to store serialized versions of the core Feast objects.\nThe protobuf definitions are stored in `protos/feast`.\n\nThe [registry](../getting-started/concepts/registry.md) consists of the serialized representations of the Feast objects.\n\nTypically, changes being made to the Feast objects require changes to their corresponding protobuf representations. \nThe usual best practices for making changes to protobufs should be followed ensure backwards and forwards compatibility.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-07-18T21:43:37-04:00"
+      },
+      "module": "protobufs",
+      "source": "extracted"
+    },
+    {
+      "id": "017ba8ed0cefd7cb183b3085dfff56e7c7fccab5497ec3292db7f1b8f8b71a2b",
+      "topic": "overview",
+      "subject": "Provider",
+      "content": {
+        "summary": "# Provider A provider is an implementation of a feature store using specific feature store components (e.g. offline store, online store) targeting a specific environment (e.g. GCP stack). Providers orchestrate various components (offline store, online store, infrastructure, compute) inside an enviro"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/provider.md",
+        "line": 1,
+        "quote": "# Provider\n\nA provider is an implementation of a feature store using specific feature store components (e.g. offline store, online store) targeting a specific environment (e.g. GCP stack).\n\nProviders orchestrate various components (offline store, online store, infrastructure, compute) inside an environment. For example, the `gcp` provider supports [BigQuery](https://cloud.google.com/bigquery) as an offline store and [Datastore](https://cloud.google.com/datastore) as an online store, ensuring that these components can work together seamlessly. Feast has three built-in providers (`local`, `gcp`, and `aws`) with default configurations that make it easy for users to start a feature store in a specific environment. These default configurations can be overridden easily. For instance, you can use the `gcp` provider but use Redis as the online store instead of Datastore.\n\nIf the built-in providers are not sufficient, you can create your own custom provider. Please see [this guide](../../how-to-guides/customizing-feast/creating-a-custom-provider.md) for more details.\n\nPlease see [feature\\_store.yaml](../../reference/feature-repository/feature-store-yaml.md#overview) for configuring providers.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-08-14T14:17:31-04:00"
+      },
+      "module": "provider",
+      "source": "extracted"
+    },
+    {
+      "id": "a8068d75dae8756f560929eb272a75e5a994a39d476f82f21d1457e780c96a33",
+      "topic": "overview",
+      "subject": "Providers / **GCP**",
+      "content": {
+        "summary": "### **GCP** When using the GCP provider: * Feast can read data from **BigQuery data sources.** * Feast performs historical feature retrieval \\(point-in-time joins\\) in **BigQuery.** * Feast performs o"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-store-yaml.md",
+        "line": 87,
+        "quote": "### **GCP**\n\nWhen using the GCP provider:\n\n* Feast can read data from **BigQuery data sources.**\n* Feast performs historical feature retrieval \\(point-in-time joins\\) in **BigQuery.**\n* Feast performs online feature serving from **Google Cloud Datastore.**\n\n**Permissions**\n\n<table>\n  <thead>\n    <tr>\n      <th style=\"text-align:left\"><b>Command</b>\n      </th>\n      <th style=\"text-align:left\">Component</th>\n      <th style=\"text-align:left\">Permissions</th>\n      <th style=\"text-align:left\">Recommended Role</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td style=\"text-align:left\"><b>Apply</b>\n      </td>\n      <td style=\"text-align:left\">BigQuery (source)</td>\n      <td style=\"text-align:left\">\n        <p>bigquery.jobs.create</p>\n        <p>bigquery.readsessions.create</p>\n        <p>bigquery.readsessions.getData</p>\n      </td>\n      <td style=\"text-align:left\">roles/bigquery.user</td>\n    </tr>\n    <tr>\n      <td style=\"text-align:left\"><b>Apply</b>\n      </td>\n      <td style=\"text-align:left\">Datastore (destination)</td>\n      <td style=\"text-align:left\">\n        <p>datastore.entities.allocateIds</p>\n        <p>datastore.entities.create</p>\n        <p>datastore.entities.delete</p>\n… (+54 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-15T11:47:10+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "98f5eec231aa330bcc88664f7a32f62e44a6a47c99c0b445479592a51cddfd2f",
+      "topic": "overview",
+      "subject": "Providers / Local",
+      "content": {
+        "summary": "### Local When using the local provider: * Feast can read from **local Parquet data sources.** * Feast performs historical feature retrieval \\(point-in-time joins\\) using **pandas.** * Feast performs online feature serving from a **SQLite database.**"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-store-yaml.md",
+        "line": 79,
+        "quote": "### Local\n\nWhen using the local provider:\n\n* Feast can read from **local Parquet data sources.**\n* Feast performs historical feature retrieval \\(point-in-time joins\\) using **pandas.**\n* Feast performs online feature serving from a **SQLite database.**\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-15T11:47:10+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "aeaf17763becf9a7b7344baca067efebbc5be8d9bcaef2408ee2277272ee6859",
+      "topic": "overview",
+      "subject": "Python SDK / Example flow: `feast apply`",
+      "content": {
+        "summary": "### Example flow: `feast apply` Let's walk through how `feast apply` works by tracking its execution across the codebase.     1. All CLI commands are in `cli.py`.     Most of these commands are backed"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/codebase-structure.md",
+        "line": 63,
+        "quote": "### Example flow: `feast apply`\n\nLet's walk through how `feast apply` works by tracking its execution across the codebase.\n   \n1. All CLI commands are in `cli.py`.\n    Most of these commands are backed by methods in `repo_operations.py`.\n    The `feast apply` command triggers `apply_total_command`, which then calls `apply_total` in `repo_operations.py`.\n2. With a `FeatureStore` object (from `feature_store.py`) that is initialized based on the `feature_store.yaml` in the current working directory, `apply_total` first parses the feature repo with `parse_repo` and then calls either `FeatureStore.apply` or `FeatureStore._apply_diffs` to apply those changes to the feature store.\n3. Let's examine `FeatureStore.apply`.\n    It splits the objects based on class (e.g. `Entity`, `FeatureView`, etc.) and then calls the appropriate registry method to apply or delete the object.\n    For example, it might call `self._registry.apply_entity` to apply an entity.\n    If the default file-based registry is used, this logic can be found in `infra/registry/registry.py`.\n4. Then the feature store must update its cloud infrastructure (e.g. online store tables) to match the new feature repo, so it calls `Provider.update_infra`, which can be found in `infra/provider.py`.\n5. Assuming the provider is a built-in provider (e.g. one of the local, GCP, or AWS providers), it will call `PassthroughProvider.update_infra` in `infra/passthrough_provider.py`.\n6. This delegates to the online store and batch materialization engine.\n    For example, if the feature store is configured to use the Redis online store then the `update` method from `infra/online_stores/redis.py` will be called.\n    And if the local materialization engine is configured then the `update` method from `infra/materialization/local_engine.py` will be called.\n\nAt this point, the `feast apply` command is complete.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-07-18T21:43:37-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "7001528abe8ec81a55b24a2979881c9c37de1e896f144674e855b5da98f24acb",
+      "topic": "overview",
+      "subject": "Python SDK / Example flow: `feast materialize`",
+      "content": {
+        "summary": "### Example flow: `feast materialize` Let's walk through how `feast materialize` works by tracking its execution across the codebase. 1. The `feast materialize` command triggers `materialize_command` "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/codebase-structure.md",
+        "line": 83,
+        "quote": "### Example flow: `feast materialize`\n\nLet's walk through how `feast materialize` works by tracking its execution across the codebase.\n\n1. The `feast materialize` command triggers `materialize_command` in `cli.py`, which then calls `FeatureStore.materialize` from `feature_store.py`.\n2. This then calls `Provider.materialize_single_feature_view`, which can be found in `infra/provider.py`.\n3. As with `feast apply`, the provider is most likely backed by the passthrough provider, in which case `PassthroughProvider.materialize_single_feature_view` will be called.\n4. This delegates to the underlying batch materialization engine.\n    Assuming that the local engine has been configured, `LocalMaterializationEngine.materialize` from `infra/materialization/local_engine.py` will be called.\n5. Since materialization involves reading features from the offline store and writing them to the online store, the local engine will delegate to both the offline store and online store.\n    Specifically, it will call `OfflineStore.pull_latest_from_table_or_query` and `OnlineStore.online_write_batch`.\n    These two calls will be routed to the offline store and online store that have been configured.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-07-18T21:43:37-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4a2afa7e8b3983352cf7fc0fd5eca7fac5ea6a4e0f55e24832b70a0678ff6009",
+      "topic": "overview",
+      "subject": "Python SDK / Example flow: `get_historical_features`",
+      "content": {
+        "summary": "### Example flow: `get_historical_features` Let's walk through how `get_historical_features` works by tracking its execution across the codebase. 1. We start with `FeatureStore.get_historical_features"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/codebase-structure.md",
+        "line": 96,
+        "quote": "### Example flow: `get_historical_features`\n\nLet's walk through how `get_historical_features` works by tracking its execution across the codebase.\n\n1. We start with `FeatureStore.get_historical_features` in `feature_store.py`.\n    This method does some internal preparation, and then delegates the actual execution to the underlying provider by calling `Provider.get_historical_features`, which can be found in `infra/provider.py`.\n2. As with `feast apply`, the provider is most likely backed by the passthrough provider, in which case `PassthroughProvider.get_historical_features` will be called.\n3. That call simply delegates to `OfflineStore.get_historical_features`.\n    So if the feature store is configured to use Snowflake as the offline store, `SnowflakeOfflineStore.get_historical_features` will be executed.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-07-18T21:43:37-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f7cf044200e0f408aa252a165a16487689dbc5611c01fec070e8775af77d964e",
+      "topic": "overview",
+      "subject": "Quick Example",
+      "content": {
+        "summary": "## Quick Example Create a `static_artifacts.py` file in your feature repository: Access pre-loaded artifacts in your on-demand feature views:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 558,
+        "quote": "## Quick Example\n\nCreate a `static_artifacts.py` file in your feature repository:\n\n```python\n# static_artifacts.py\nfrom fastapi import FastAPI\nfrom transformers import pipeline\n\ndef load_artifacts(app: FastAPI):\n    \"\"\"Load static artifacts into app.state.\"\"\"\n    app.state.sentiment_model = pipeline(\"sentiment-analysis\", model=\"distilbert-base-uncased-finetuned-sst-2-english\")\n\n    # Update global references for access from feature views\n    import example_repo\n    example_repo._sentiment_model = app.state.sentiment_model\n```\n\nAccess pre-loaded artifacts in your on-demand feature views:\n\n```python\n# example_repo.py\n_sentiment_model = None\n\n@on_demand_feature_view(...)\ndef sentiment_prediction(inputs: pd.DataFrame) -> pd.DataFrame:\n    global _sentiment_model\n    return _sentiment_model(inputs[\"text\"])\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c14fec61c88911163e6bdc11e3fd50b8af3c3d424d65bbb1cb66cc73c457f46f",
+      "topic": "overview",
+      "subject": "Quick Reference / Key Commands",
+      "content": {
+        "summary": "### Key Commands For complete examples, see the [Configuration](#configuration) section above."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 646,
+        "quote": "### Key Commands\n\n```python\n# Initialize feature store\nstore = FeatureStore(\"feature_store.yaml\")\n\n# Get historical features (uses compute engine if configured)\nfeatures = store.get_historical_features(entity_df=df, features=[\"fv:feature\"])\n\n# Direct data access (uses offline store)\njob = RayOfflineStore.pull_latest_from_table_or_query(...)\ndf = job.to_df()\n\n# Offline write batch (materialization)\n# Create sample data for materialization\ndata = pa.table({\n    \"driver_id\": [1, 2, 3, 4, 5],\n    \"avg_daily_trips\": [10.5, 15.2, 8.7, 12.3, 9.8],\n    \"event_timestamp\": [datetime.now()] * 5\n})\n\n# Write batch to offline store\nRayOfflineStore.offline_write_batch(\n    config=store.config,\n    feature_view=driver_stats_fv,\n    table=data,\n    progress=lambda rows: print(f\"Processed {rows} rows\")\n)\n```\n\nFor complete examples, see the [Configuration](#configuration) section above."
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "952608a6cc4a8092be4d816873b897e5213eceb968b67b1f378209efd344f388",
+      "topic": "overview",
+      "subject": "Quick Start",
+      "content": {
+        "summary": "## Quick Start 1. First, create a new Python project or use our template: 2. Set up your Feast feature repository:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/denormalized.md",
+        "line": 14,
+        "quote": "## Quick Start\n\n1. First, create a new Python project or use our template:\n```bash\nmkdir my-feature-project\ncd my-feature-project\npython -m venv .venv\nsource .venv/bin/activate  # or `.venv\\Scripts\\activate` on Windows\npip install denormalized[feast] feast\n```\n\n2. Set up your Feast feature repository:\n```bash\nfeast init feature_repo\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-13T20:58:32+00:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "08c7bd365b49d2a14f4081b88cccde805921c07e667eb01307012303083ca481",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Authentication",
+      "content": {
+        "summary": "### Authentication The REST API supports Bearer token authentication. Include your token in the Authorization header:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 26,
+        "quote": "### Authentication\n\nThe REST API supports Bearer token authentication. Include your token in the Authorization header:\n\n```bash\nAuthorization: Bearer <your-token>\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "7fc7290373e606367ee70de8b109df556c43d00af12b0f061165c11cae342f14",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Common Query Parameters",
+      "content": {
+        "summary": "### Common Query Parameters Most endpoints support these common query parameters: - `project` (required for most endpoints): The project name - `allow_cache` (optional, default: `true`): Whether to al"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 34,
+        "quote": "### Common Query Parameters\n\nMost endpoints support these common query parameters:\n\n- `project` (required for most endpoints): The project name\n- `allow_cache` (optional, default: `true`): Whether to allow cached data\n- `tags` (optional): Filter results by tags in key=value format\n\n#### Relationship Parameters\n- `include_relationships` (optional, default: `false`): Include all relationships (both direct and indirect) for the object(s) in the response\n\n#### Pagination Parameters (List Endpoints Only)\n- `page` (optional): Page number (starts from 1)\n- `limit` (optional, max: 100): Number of items per page\n- `sort_by` (optional): Field to sort by\n- `sort_order` (optional): Sort order: \"asc\" or \"desc\" (default: \"asc\")\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "41f25dc81ba2950c48f11b74381c79c512419e0acfdcea7dc8041730f8597264",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Data Sources",
+      "content": {
+        "summary": "### Data Sources #### List Data Sources - **Endpoint**: `GET /api/v1/data_sources` - **Description**: Retrieve all data sources in a project - **Parameters**:   - `project` (required): Project name   "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 129,
+        "quote": "### Data Sources\n\n#### List Data Sources\n- **Endpoint**: `GET /api/v1/data_sources`\n- **Description**: Retrieve all data sources in a project\n- **Parameters**:\n  - `project` (required): Project name\n  - `include_relationships` (optional): Include relationships for each data source\n  - `allow_cache` (optional): Whether to allow cached data\n  - `tags` (optional): Filter by tags\n  - `page` (optional): Page number for pagination\n  - `limit` (optional): Number of items per page\n  - `sort_by` (optional): Field to sort by\n  - `sort_order` (optional): Sort order (\"asc\" or \"desc\")\n- **Examples**:\n  ```bash\n  # Basic list\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/data_sources?project=my_project\"\n  \n  # With pagination and relationships\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/data_sources?project=my_project&include_relationships=true&page=1&limit=10\"\n  ```\n\n#### Get Data Source\n- **Endpoint**: `GET /api/v1/data_sources/{name}`\n- **Description**: Retrieve a specific data source by name\n- **Parameters**:\n  - `name` (path): Data source name\n  - `project` (required): Project name\n  - `include_relationships` (optional): Include relationships for this data source\n  - `allow_cache` (optional): Whether to allow cached data\n- **Examples**:\n  ```bash\n  # Basic get\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/data_sources/user_data?project=my_project\"\n  \n  # With relationships\n… (+34 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8e8d591e635925eb4638a0c78a59f3802cc22c01878dd7ff0d96e81657fa5055",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Entities",
+      "content": {
+        "summary": "### Entities #### List Entities - **Endpoint**: `GET /api/v1/entities` - **Description**: Retrieve all entities in a project - **Parameters**:   - `project` (required): Project name   - `include_relat"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 51,
+        "quote": "### Entities\n\n#### List Entities\n- **Endpoint**: `GET /api/v1/entities`\n- **Description**: Retrieve all entities in a project\n- **Parameters**:\n  - `project` (required): Project name\n  - `include_relationships` (optional): Include relationships for each entity\n  - `allow_cache` (optional): Whether to allow cached data\n  - `page` (optional): Page number for pagination\n  - `limit` (optional): Number of items per page\n  - `sort_by` (optional): Field to sort by\n  - `sort_order` (optional): Sort order (\"asc\" or \"desc\")\n- **Examples**:\n  ```bash\n  # Basic list\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/entities?project=my_project\"\n  \n  # With pagination\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/entities?project=my_project&page=1&limit=10&sort_by=name\"\n  \n  # With relationships\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/entities?project=my_project&include_relationships=true\"\n  ```\n\n#### Get Entity\n- **Endpoint**: `GET /api/v1/entities/{name}`\n- **Description**: Retrieve a specific entity by name\n- **Parameters**:\n  - `name` (path): Entity name\n  - `project` (required): Project name\n  - `include_relationships` (optional): Include relationships for this entity\n  - `allow_cache` (optional): Whether to allow cached data\n- **Examples**:\n  ```bash\n  # Basic get\n  curl -H \"Authorization: Bearer <token>\" \\\n… (+38 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a9aff3d1741cbd6dadd45a65f3f1ee564495a34c4529d75457f3b775aa8379b9",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Error Handling",
+      "content": {
+        "summary": "### Error Handling The REST API provides consistent error responses with HTTP status codes included in the JSON response body. All error responses follow this format: #### Error Response Fields - **`status_code`**: The HTTP status code (e.g., 404, 422, 500) - **`detail`**: Human-readable error messa"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 804,
+        "quote": "### Error Handling\n\nThe REST API provides consistent error responses with HTTP status codes included in the JSON response body. All error responses follow this format:\n\n```json\n{\n  \"status_code\": 404,\n  \"detail\": \"Entity 'user_id' does not exist in project 'demo_project'\",\n  \"error_type\": \"FeastObjectNotFoundException\"\n}\n```\n\n#### Error Response Fields\n\n- **`status_code`**: The HTTP status code (e.g., 404, 422, 500)\n- **`detail`**: Human-readable error message describing the issue\n- **`error_type`**: The specific type of error that occurred\n\n#### HTTP Status Code Mapping\n\n| HTTP Status | Error Type | Description | Common Causes |\n|-------------|------------|-------------|---------------|\n| **400** | `HTTPException` | Bad Request | Invalid request format or parameters |\n| **401** | `HTTPException` | Unauthorized | Missing or invalid authentication token |\n| **403** | `FeastPermissionError` | Forbidden | Insufficient permissions to access the resource |\n| **404** | `FeastObjectNotFoundException` | Not Found | Requested entity, feature view, data source, etc. does not exist |\n| **422** | `ValidationError` / `RequestValidationError` / `ValueError` / `PushSourceNotFoundException` | Unprocessable Entity | Validation errors, missing required parameters, or invalid input |\n| **500** | `InternalServerError` | Internal Server Error | Unexpected server-side errors |\n\n\n#### Enhanced Response Formats\n\nThe REST API now supports enhanced response formats for relationships and pagination:\n\n**Single Object Endpoints (GET `/resource/{name}`):**\n\nWithout relationships:\n```json\n{\n  \"entity\": { ... }\n… (+92 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "6b82a59fba16c75d60b7016a67e5eaad1bf76c0ce3b57051a10469f9d35256b7",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Feature Services",
+      "content": {
+        "summary": "### Feature Services #### List Feature Services - **Endpoint**: `GET /api/v1/feature_services` - **Description**: Retrieve all feature services in a project - **Parameters**:   - `project` (required):"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 432,
+        "quote": "### Feature Services\n\n#### List Feature Services\n- **Endpoint**: `GET /api/v1/feature_services`\n- **Description**: Retrieve all feature services in a project\n- **Parameters**:\n  - `project` (required): Project name\n  - `include_relationships` (optional): Include relationships for each feature service\n  - `allow_cache` (optional): Whether to allow cached data\n  - `tags` (optional): Filter by tags\n  - `feature_view` (optional): Filter feature services by feature view name\n  - `page` (optional): Page number for pagination\n  - `limit` (optional): Number of items per page\n  - `sort_by` (optional): Field to sort by\n  - `sort_order` (optional): Sort order (\"asc\" or \"desc\")\n- **Examples**:\n  ```bash\n  # Basic list\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/feature_services?project=my_project\"\n  \n  # With pagination and relationships\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/feature_services?project=my_project&include_relationships=true&page=1&limit=10\"\n  \n  # Filter by feature view\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/feature_services?project=my_project&feature_view=user_profile\"\n  ```\n\n#### Get Feature Service\n- **Endpoint**: `GET /api/v1/feature_services/{name}`\n- **Description**: Retrieve a specific feature service by name\n- **Parameters**:\n  - `name` (path): Feature service name\n  - `project` (required): Project name\n  - `include_relationships` (optional): Include relationships for this feature service\n  - `allow_cache` (optional): Whether to allow cached data\n- **Examples**:\n  ```bash\n… (+39 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "509a072b75b00cfe00b8e5cbdd892a15eff89774ef88c5ae0cc264bf23ce9b03",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Feature Views",
+      "content": {
+        "summary": "### Feature Views #### List Feature Views - **Endpoint**: `GET /api/v1/feature_views` - **Description**: Retrieve all feature views in a project - **Parameters**:   - `project` (required): Project nam"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 203,
+        "quote": "### Feature Views\n\n#### List Feature Views\n- **Endpoint**: `GET /api/v1/feature_views`\n- **Description**: Retrieve all feature views in a project\n- **Parameters**:\n  - `project` (required): Project name\n  - `include_relationships` (optional): Include relationships for each feature view\n  - `allow_cache` (optional): Whether to allow cached data\n  - `tags` (optional): Filter by tags\n  - `entity` (optional): Filter feature views by entity name\n  - `feature` (optional): Filter feature views by feature name\n  - `feature_service` (optional): Filter feature views by feature service name\n  - `data_source` (optional): Filter feature views by data source name\n  - `page` (optional): Page number for pagination\n  - `limit` (optional): Number of items per page\n  - `sort_by` (optional): Field to sort by\n  - `sort_order` (optional): Sort order (\"asc\" or \"desc\")\n- **Examples**:\n  ```bash\n  # Basic list\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/feature_views?project=my_project\"\n  \n  # With pagination and relationships\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/feature_views?project=my_project&include_relationships=true&page=1&limit=5&sort_by=name\"\n  \n  # Filter by entity\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/feature_views?project=my_project&entity=user\"\n  \n  # Filter by feature\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/feature_views?project=my_project&feature=age\"\n  \n  # Filter by data source\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/feature_views?project=my_project&data_source=user_profile_source\"\n  \n… (+58 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "32eb40444e25340df439ffa4e1cd0fd2fa9ed3a3d69d82093872e5e293a02183",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Features",
+      "content": {
+        "summary": "### Features #### List Features - **Endpoint**: `GET /api/v1/features` - **Description**: Retrieve all features in a project - **Parameters**:   - `project` (required): Project name   - `feature_view`"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 301,
+        "quote": "### Features\n\n#### List Features\n- **Endpoint**: `GET /api/v1/features`\n- **Description**: Retrieve all features in a project\n- **Parameters**:\n  - `project` (required): Project name\n  - `feature_view` (optional): Filter by feature view name\n  - `name` (optional): Filter by feature name\n  - `include_relationships` (optional): Include relationships for each feature (relationships are keyed by feature name)\n  - `allow_cache` (optional): Whether to allow cached data\n  - `page` (optional): Page number for pagination\n  - `limit` (optional): Number of items per page\n  - `sort_by` (optional): Field to sort by\n  - `sort_order` (optional): Sort order (\"asc\" or \"desc\")\n- **Examples**:\n  ```bash\n  # Basic list\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/features?project=my_project\"\n\n  # With pagination and relationships\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/features?project=my_project&include_relationships=true&page=1&limit=5\"\n  ```\n- **Response Example**:\n  ```json\n  {\n    \"features\": [\n      { \"name\": \"conv_rate\", \"featureView\": \"driver_hourly_stats_fresh\", \"type\": \"Float32\" },\n      { \"name\": \"acc_rate\", \"featureView\": \"driver_hourly_stats_fresh\", \"type\": \"Float32\" },\n      { \"name\": \"avg_daily_trips\", \"featureView\": \"driver_hourly_stats_fresh\", \"type\": \"Int64\" },\n      { \"name\": \"conv_rate\", \"featureView\": \"driver_hourly_stats\", \"type\": \"Float32\" },\n      { \"name\": \"acc_rate\", \"featureView\": \"driver_hourly_stats\", \"type\": \"Float32\" }\n    ],\n    \"pagination\": {\n      \"page\": 1,\n      \"limit\": 5,\n      \"totalCount\": 10,\n      \"totalPages\": 2,\n… (+91 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "79b8f43f0759fceb12e376b263a22b681b66fbefbf7eccce44ed617755b64c5d",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Interactive API Documentation",
+      "content": {
+        "summary": "### Interactive API Documentation When the REST API server is running, you can access interactive documentation at: - **Swagger UI**: `http://localhost:6572/` (root path) - **ReDoc**: `http://localhos"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 971,
+        "quote": "### Interactive API Documentation\n\nWhen the REST API server is running, you can access interactive documentation at:\n\n- **Swagger UI**: `http://localhost:6572/` (root path)\n- **ReDoc**: `http://localhost:6572/docs`\n- **OpenAPI Schema**: `http://localhost:6572/openapi.json`\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "493b780406aec9061167a6802246edd23ab1d3dc0b7d5d7530537fa6967c46c9",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Lineage and Relationships",
+      "content": {
+        "summary": "### Lineage and Relationships #### Get Registry Lineage - **Endpoint**: `GET /api/v1/lineage/registry` - **Description**: Retrieve complete registry lineage with relationships and indirect relationshi"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 511,
+        "quote": "### Lineage and Relationships\n\n#### Get Registry Lineage\n- **Endpoint**: `GET /api/v1/lineage/registry`\n- **Description**: Retrieve complete registry lineage with relationships and indirect relationships\n- **Parameters**:\n  - `project` (required): Project name\n  - `allow_cache` (optional): Whether to allow cached data\n  - `filter_object_type` (optional): Filter by object type (`dataSource`, `entity`, `featureView`, `featureService`, `feature`)\n  - `filter_object_name` (optional): Filter by object name\n- **Example**:\n  ```bash\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/lineage/registry?project=my_project\"\n  ```\n\n#### Get Object Relationships\n- **Endpoint**: `GET /api/v1/lineage/objects/{object_type}/{object_name}`\n- **Description**: Retrieve relationships for a specific object\n- **Parameters**:\n  - `object_type` (path): Type of object (`dataSource`, `entity`, `featureView`, `featureService`, `feature`)\n  - `object_name` (path): Name of the object\n  - `project` (required): Project name\n  - `include_indirect` (optional): Whether to include indirect relationships\n  - `allow_cache` (optional): Whether to allow cached data\n- **Example**:\n  ```bash\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/lineage/objects/feature/conv_rate?project=my_project&include_indirect=true\"\n  ```\n- **Response Example**:\n  ```json\n  {\n    \"relationships\": [\n      { \"source\": { \"type\": \"feature\", \"name\": \"conv_rate\" }, \"target\": { \"type\": \"featureView\", \"name\": \"driver_hourly_stats_fresh\" } },\n      { \"source\": { \"type\": \"feature\", \"name\": \"conv_rate\" }, \"target\": { \"type\": \"featureView\", \"name\": \"driver_hourly_stats\" } }\n    ],\n    \"pagination\": { \"totalCount\": 2, \"totalPages\": 1 }\n  }\n  ```\n… (+92 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c875a19ef154d2ef727fff9eee19d9d56e162f609162a230176561a12e352d65",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Permissions",
+      "content": {
+        "summary": "### Permissions #### List Permissions - **Endpoint**: `GET /api/v1/permissions` - **Description**: Retrieve all permissions in a project - **Parameters**:   - `project` (required): Project name   - `i"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 643,
+        "quote": "### Permissions\n\n#### List Permissions\n- **Endpoint**: `GET /api/v1/permissions`\n- **Description**: Retrieve all permissions in a project\n- **Parameters**:\n  - `project` (required): Project name\n  - `include_relationships` (optional): Include relationships for each permission\n  - `allow_cache` (optional): Whether to allow cached data\n  - `page` (optional): Page number for pagination\n  - `limit` (optional): Number of items per page\n  - `sort_by` (optional): Field to sort by\n  - `sort_order` (optional): Sort order (\"asc\" or \"desc\")\n- **Examples**:\n  ```bash\n  # Basic list\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/permissions?project=my_project\"\n  \n  # With pagination and relationships\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/permissions?project=my_project&include_relationships=true&page=1&limit=10\"\n  ```\n\n#### Get Permission\n- **Endpoint**: `GET /api/v1/permissions/{name}`\n- **Description**: Retrieve a specific permission by name\n- **Parameters**:\n  - `name` (path): Permission name\n  - `project` (required): Project name\n  - `include_relationships` (optional): Include relationships for this permission\n  - `allow_cache` (optional): Whether to allow cached data\n- **Examples**:\n  ```bash\n  # Basic get\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/permissions/read_features?project=my_project\"\n  \n  # With relationships\n  curl -H \"Authorization: Bearer <token>\" \\\n… (+3 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0f714abb205e3133b69d0744e44f77f68d37c49d22e2353362eefe3ef3af7258",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Projects",
+      "content": {
+        "summary": "### Projects #### List Projects - **Endpoint**: `GET /api/v1/projects` - **Description**: Retrieve all projects - **Parameters**:   - `allow_cache` (optional): Whether to allow cached data   - `page` "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 686,
+        "quote": "### Projects\n\n#### List Projects\n- **Endpoint**: `GET /api/v1/projects`\n- **Description**: Retrieve all projects\n- **Parameters**:\n  - `allow_cache` (optional): Whether to allow cached data\n  - `page` (optional): Page number for pagination\n  - `limit` (optional): Number of items per page\n  - `sort_by` (optional): Field to sort by\n  - `sort_order` (optional): Sort order (\"asc\" or \"desc\")\n- **Examples**:\n  ```bash\n  # Basic list\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/projects\"\n  \n  # With pagination\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/projects?page=1&limit=10&sort_by=name\"\n  ```\n\n#### Get Project\n- **Endpoint**: `GET /api/v1/projects/{name}`\n- **Description**: Retrieve a specific project by name\n- **Parameters**:\n  - `name` (path): Project name\n  - `allow_cache` (optional): Whether to allow cached data\n- **Example**:\n  ```bash\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/projects/my_project\"\n  ```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0176bdd2363f8a3c97116b3deedc37d323d361870274d15bef738d9e3c36703d",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Response Formats",
+      "content": {
+        "summary": "### Response Formats All endpoints return JSON responses with the following general structure: - **Success (200)**: Returns the requested data - **Bad Request (400)**: Invalid parameters or request fo"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 794,
+        "quote": "### Response Formats\n\nAll endpoints return JSON responses with the following general structure:\n\n- **Success (200)**: Returns the requested data\n- **Bad Request (400)**: Invalid parameters or request format\n- **Unauthorized (401)**: Missing or invalid authentication token\n- **Not Found (404)**: Requested resource does not exist\n- **Internal Server Error (500)**: Server-side error\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "26f58de175375a39211a3ed0ab12250ca3ed745f16e51ce7429eb91e921ef40b",
+      "topic": "overview",
+      "subject": "REST API Endpoints / Saved Datasets",
+      "content": {
+        "summary": "### Saved Datasets #### List Saved Datasets - **Endpoint**: `GET /api/v1/saved_datasets` - **Description**: Retrieve all saved datasets in a project - **Parameters**:   - `project` (required): Project"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 720,
+        "quote": "### Saved Datasets\n\n#### List Saved Datasets\n- **Endpoint**: `GET /api/v1/saved_datasets`\n- **Description**: Retrieve all saved datasets in a project\n- **Parameters**:\n  - `project` (required): Project name\n  - `include_relationships` (optional): Include relationships for each saved dataset\n  - `allow_cache` (optional): Whether to allow cached data\n  - `tags` (optional): Filter by tags\n  - `page` (optional): Page number for pagination\n  - `limit` (optional): Number of items per page\n  - `sort_by` (optional): Field to sort by\n  - `sort_order` (optional): Sort order (\"asc\" or \"desc\")\n- **Examples**:\n  ```bash\n  # Basic list\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/saved_datasets?project=my_project\"\n  \n  # With pagination and relationships\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/saved_datasets?project=my_project&include_relationships=true&page=1&limit=10\"\n  ```\n\n#### Get Saved Dataset\n- **Endpoint**: `GET /api/v1/saved_datasets/{name}`\n- **Description**: Retrieve a specific saved dataset by name\n- **Parameters**:\n  - `name` (path): Saved dataset name\n  - `project` (required): Project name\n  - `include_relationships` (optional): Include relationships for this saved dataset\n  - `allow_cache` (optional): Whether to allow cached data\n- **Examples**:\n  ```bash\n  # Basic get\n  curl -H \"Authorization: Bearer <token>\" \\\n    \"http://localhost:6572/api/v1/saved_datasets/training_data?project=my_project\"\n  \n  # With relationships\n… (+34 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "7d5ec33983b8ae0384af0c15e0a88033c9ae8d12987511c19716ed0e8d6811ba",
+      "topic": "overview",
+      "subject": "Redis Online Store Format / Format",
+      "content": {
+        "summary": "### Format To compute Redis key, we convert entity values and names to a protobuf message of the following format: This message is then serialized to a byte array and used as a Redis key. The value in"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/online_store_format.md",
+        "line": 31,
+        "quote": "### Format\n\nTo compute Redis key, we convert entity values and names to a protobuf message of the following format:\n\n```protobuf\nmessage RedisKeyV2 {\n  string project = 1;\n  // alphabetical order (using `String::compareTo`).\n  repeated string entity_names = 2;\n  // same length as entity_names\n  repeated feast.types.Value entity_values = 3;\n}\n```\n\nThis message is then serialized to a byte array and used as a Redis key.\n\nThe value in Redis itself is a key-value map. It is a Redis Hash that stores feature names and corresponding feature values. To compute the Redis Hash field names used to look up feature values in the Hash, all feature references are hashed as `Murmur3_32(table_name + \":\" + feature_name)`, using the little-endian byte representation of the hash value. We also store the timestamp for that entity row (a set of features) under a field named  `\"_ts:\" + table_name` in the same Redis Hash.\n\nThe values in the Redis Hash are encoded as serialized `feast.types.Value` protos for feature values, and serialized `google.protobuf.Timestamp` protos for the entity row timestamp.\n\nHere's an example of how the entire thing looks like:\n\n![Redis Online Store Example](redis_online_example.png)\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-10-05T11:10:11-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "5a53a071ceb9a5c65f837779b7d128ec8a1920fbdd7fbe920590cf546582bd55",
+      "topic": "overview",
+      "subject": "Redis Online Store Format / Known Issues",
+      "content": {
+        "summary": "### Known Issues [According to the protobuf spec](https://developers.google.com/protocol-buffers/docs/encoding), generally speaking, you can't use serialized representation to compare protos for equal"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/online_store_format.md",
+        "line": 56,
+        "quote": "### Known Issues\n\n[According to the protobuf spec](https://developers.google.com/protocol-buffers/docs/encoding), generally speaking, you can't use serialized representation to compare protos for equality. Therefore, using a proto serialized to a byte array as a Redis key is not guaranteed to work. In practice we haven't yet run into issues, at least as long as entitiy values are relatively simple types.\n\nHowever, we'll address this issue in future versions of the protocol.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-10-05T11:10:11-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c02357f4a6e9fd55abd1212079de010c92b6369e8c74735f4d39e1df95be128b",
+      "topic": "overview",
+      "subject": "Redis Online Store Format / Overview",
+      "content": {
+        "summary": "### Overview When feature data is stored in Redis, we use it as a two-level map, by utilizing Redis Hashes. The first level of the map contains the Feast project name and entity key. The entity key is composed of entity names and values. The second level key (in Redis terminology, this is the \"field"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/online_store_format.md",
+        "line": 22,
+        "quote": "### Overview\nWhen feature data is stored in Redis, we use it as a two-level map, by utilizing [Redis Hashes](https://redis.io/topics/data-types#hashes).\n\nThe first level of the map contains the Feast project name and entity key. The entity key is composed of entity names and values. The second level key (in Redis terminology, this is the \"field\" in a Redis Hash) contains the feature table name and the feature name, and the Redis Hash value contains the feature value.\n\nTherefore, the high level hierarchy is:\n\n![Redis High Level Online Structure](high_level_hierarchy_redis.png)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-10-05T11:10:11-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "1aaf14904c1290ec88c9ac2e8cccbf87f6a20b3d33a5d862fa28a00f66559e37",
+      "topic": "overview",
+      "subject": "Reference",
+      "content": {
+        "summary": "## Reference 1. [Expedia Group's Go Feature Server Implementation (in Production)](https://github.com/EXPEbdodla/feast) 2. [A Go Feature server demo from Feast](https://github.com/feast-dev/feast-cred"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/go-feature-server.md",
+        "line": 52,
+        "quote": "## Reference\n1. [Expedia Group's Go Feature Server Implementation (in Production)](https://github.com/EXPEbdodla/feast)\n2. [A Go Feature server demo from Feast](https://github.com/feast-dev/feast-credit-score-local-tutorial)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-27T15:46:59-04:00"
+      },
+      "module": "reference",
+      "source": "extracted"
+    },
+    {
+      "id": "51afdc44974ca23b4ecd83797d63558b5cf1a4226e0175668a3e02fd9a4f8771",
+      "topic": "overview",
+      "subject": "Registering Transformations / Examples",
+      "content": {
+        "summary": "### Examples #### Example 1: On Demand Transformation on Read Using Pandas Mode #### Example 2: On Demand Transformation on Read Using Native Python Mode (List Inputs) #### **New** Example 3: On Deman"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/beta-on-demand-feature-view.md",
+        "line": 119,
+        "quote": "### Examples\n\n#### Example 1: On Demand Transformation on Read Using Pandas Mode\n\n```python\nfrom feast import Field, RequestSource\nfrom feast.on_demand_feature_view import on_demand_feature_view\nfrom feast.types import Float64, Int64\nimport pandas as pd\n\n# Define a request data source for request-time features\ninput_request = RequestSource(\n    name=\"vals_to_add\",\n    schema=[\n        Field(name=\"val_to_add\", dtype=Int64),\n        Field(name=\"val_to_add_2\", dtype=Int64),\n    ],\n)\n\n# Use input data and feature view features to create new features in Pandas mode\n@on_demand_feature_view(\n    sources=[driver_hourly_stats_view, input_request],\n    schema=[\n        Field(name=\"conv_rate_plus_val1\", dtype=Float64),\n        Field(name=\"conv_rate_plus_val2\", dtype=Float64),\n    ],\n    mode=\"pandas\",\n)\ndef transformed_conv_rate(features_df: pd.DataFrame) -> pd.DataFrame:\n    df = pd.DataFrame()\n    df[\"conv_rate_plus_val1\"] = features_df[\"conv_rate\"] + features_df[\"val_to_add\"]\n    df[\"conv_rate_plus_val2\"] = features_df[\"conv_rate\"] + features_df[\"val_to_add_2\"]\n    return df\n```\n\n#### Example 2: On Demand Transformation on Read Using Native Python Mode (List Inputs)\n\n```python\nfrom feast import Field, on_demand_feature_view\nfrom feast.types import Float64\n… (+98 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-22T17:08:58-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ffcd77d73d9aa031aed7642d0a3ec8e79f2b2c32efb5e8d3ebae194961153d1f",
+      "topic": "overview",
+      "subject": "Registering Transformations / Feature Retrieval",
+      "content": {
+        "summary": "### Feature Retrieval {% hint style=\"info\" %} **Note**: The name of the on demand feature view is the function name (e.g., `transformed_conv_rate`). {% endhint %} #### Offline Features Retrieve histor"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/beta-on-demand-feature-view.md",
+        "line": 257,
+        "quote": "### Feature Retrieval\n\n{% hint style=\"info\" %}\n**Note**: The name of the on demand feature view is the function name (e.g., `transformed_conv_rate`).\n{% endhint %}\n\n#### Offline Features\n\nRetrieve historical features by referencing individual features or using a feature service:\n\n```python\ntraining_df = store.get_historical_features(\n    entity_df=entity_df,\n    features=[\n        \"driver_hourly_stats:conv_rate\",\n        \"driver_hourly_stats:acc_rate\",\n        \"driver_hourly_stats:avg_daily_trips\",\n        \"transformed_conv_rate:conv_rate_plus_val1\",\n        \"transformed_conv_rate:conv_rate_plus_val2\",\n        \"transformed_conv_rate_singleton:conv_rate_plus_acc_singleton\",\n    ],\n).to_df()\n```\n\n#### Online Features\n\nRetrieve online features by referencing individual features or using a feature service:\n\n```python\nentity_rows = [\n    {\n        \"driver_id\": 1001,\n        \"val_to_add\": 1,\n        \"val_to_add_2\": 2,\n    }\n]\n\nonline_response = store.get_online_features(\n    entity_rows=entity_rows,\n    features=[\n… (+9 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-22T17:08:58-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "780d2a3f433701c8701852d0af448105bf33b3a9f984d250b840d0f64d81a0de",
+      "topic": "overview",
+      "subject": "Registering Transformations / Materializing Pre-transformed Data",
+      "content": {
+        "summary": "### Materializing Pre-transformed Data In some scenarios, you may have already transformed your data in batch (e.g., using Spark or another batch processing framework) and want to directly materialize the pre-transformed features without applying transformations during ingestion. Feast supports this"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/beta-on-demand-feature-view.md",
+        "line": 306,
+        "quote": "### Materializing Pre-transformed Data\n\nIn some scenarios, you may have already transformed your data in batch (e.g., using Spark or another batch processing framework) and want to directly materialize the pre-transformed features without applying transformations during ingestion. Feast supports this through the `transform_on_write` parameter.\n\nWhen using `write_to_online_store=True` with On Demand Feature Views, you can set `transform_on_write=False` to skip transformations during the write operation. This is particularly useful for optimizing performance when working with large pre-transformed datasets.\n\n```python\nfrom feast import FeatureStore\nimport pandas as pd\n\nstore = FeatureStore(repo_path=\".\")\n\n# Pre-transformed data (transformations already applied)\npre_transformed_data = pd.DataFrame({\n    \"driver_id\": [1001],\n    \"event_timestamp\": [pd.Timestamp.now()],\n    \"conv_rate\": [0.5],\n    # Pre-calculated values for the transformed features\n    \"conv_rate_adjusted\": [0.55],  # Already contains the adjusted value\n})\n\n# Write to online store, skipping transformations\nstore.write_to_online_store(\n    feature_view_name=\"transformed_conv_rate\",\n    df=pre_transformed_data,\n    transform_on_write=False  # Skip transformation during write\n)\n```\n\nThis approach allows for a hybrid workflow where you can:\n1. Transform data in batch using powerful distributed processing tools\n2. Materialize the pre-transformed data without reapplying transformations\n3. Still use the Feature Server to execute transformations during API calls when needed\n\nEven when features are materialized with transformations skipped (`transform_on_write=False`), the feature server can still apply transformations during API calls for any missing values or for features that require real-time computation.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-22T17:08:58-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2bf57d598e23b09d9a41ae074063a3655353031e773b2e00b76e94b5afa71a4f",
+      "topic": "overview",
+      "subject": "Related pages",
+      "content": {
+        "summary": "## Related pages * Ray Offline Store * Ray Compute Engine * Feature Retrieval"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/ray.md",
+        "line": 229,
+        "quote": "## Related pages\n\n* [Ray Offline Store](../offline-stores/ray.md)\n* [Ray Compute Engine](../compute-engine/ray.md)\n* [Feature Retrieval](../../getting-started/concepts/feature-retrieval.md)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "5b4eb918203d9ecce38897e361cb91487048847d749bc2d409b139cd2b84933a",
+      "topic": "overview",
+      "subject": "Resource Management and Testing / Overview",
+      "content": {
+        "summary": "### Overview **By default, Ray will use all available system resources (CPU and memory).** This can cause issues in test environments or when experimenting locally, potentially leading to system crashes or unresponsiveness."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 273,
+        "quote": "### Overview\n\n**By default, Ray will use all available system resources (CPU and memory).** This can cause issues in test environments or when experimenting locally, potentially leading to system crashes or unresponsiveness.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3b0a07b1177d8c3cf8e23ef16e61b377689321173dc8ee6557e1572dd7055c5b",
+      "topic": "overview",
+      "subject": "Resource Management and Testing / Resource Configuration Options",
+      "content": {
+        "summary": "### Resource Configuration Options | Setting | Default | Description | Testing Recommendation | |---------|---------|-------------|------------------------| | `broadcast_join_threshold_mb` | 100 | Siz"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 313,
+        "quote": "### Resource Configuration Options\n\n| Setting | Default | Description | Testing Recommendation |\n|---------|---------|-------------|------------------------|\n| `broadcast_join_threshold_mb` | 100 | Size threshold for broadcast joins (MB) | 25 |\n| `max_parallelism_multiplier` | 2 | Parallelism as multiple of CPU cores | 1 |\n| `target_partition_size_mb` | 64 | Target partition size (MB) | 16 |\n| `enable_ray_logging` | false | Enable Ray progress bars and logging | false |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "47ef8d319402022b5a1bd534cdc8a74b8508566a04f1b633992cb6bc81055602",
+      "topic": "overview",
+      "subject": "Resources",
+      "content": {
+        "summary": "## Resources * [Sample application with ScyllaDB](https://feature-store.scylladb.com/stable/) * [ScyllaDB website](https://www.scylladb.com/) * [ScyllaDB Cloud documentation](https://cloud.docs.scylla"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/scylladb.md",
+        "line": 90,
+        "quote": "## Resources\n\n* [Sample application with ScyllaDB](https://feature-store.scylladb.com/stable/)\n* [ScyllaDB website](https://www.scylladb.com/)\n* [ScyllaDB Cloud documentation](https://cloud.docs.scylladb.com/stable/)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-11-07T14:14:00-05:00"
+      },
+      "module": "resources",
+      "source": "extracted"
+    },
+    {
+      "id": "eb4ac14af6ace1775e3b2a22cb3b8acfec05716f1c79ba09d45bae22b28c6255",
+      "topic": "overview",
+      "subject": "Retrieving data as a Ray Dataset",
+      "content": {
+        "summary": "## Retrieving data as a Ray Dataset Once the feature view is materialised you can retrieve the offline features directly as a Ray Dataset using the first-class `to_ray_dataset()` method: ---"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/ray.md",
+        "line": 188,
+        "quote": "## Retrieving data as a Ray Dataset\n\nOnce the feature view is materialised you can retrieve the offline features\ndirectly as a Ray Dataset using the first-class `to_ray_dataset()` method:\n\n```python\nfrom feast import FeatureStore\n\nstore = FeatureStore(\".\")\n\n# Chain directly on the retrieval job — to_ray_dataset() is a first-class\n# method on every RetrievalJobs.\nds = store.get_historical_features(\n    features=[\"cheque_ocr_features:payee_name\", \"cheque_ocr_features:amount\"],\n    entity_df=entity_df,\n).to_ray_dataset()\n\n# Use the dataset downstream in Ray or ML pipelines\nds.show(3)\n```\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "1dc27cdf408b517c2f3b853dd1498340c78a12502b64219da771367d4f580110",
+      "topic": "overview",
+      "subject": "Retrieving historical features (for training data or batch scoring) / Step 1: Specifying Features",
+      "content": {
+        "summary": "### Step 1: Specifying Features Feast accepts either: - [feature services](feature-retrieval.md#feature-services), which group features needed for a model version - [feature references](feature-retrie"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-retrieval.md",
+        "line": 251,
+        "quote": "### Step 1: Specifying Features\nFeast accepts either:\n- [feature services](feature-retrieval.md#feature-services), which group features needed for a model version\n- [feature references](feature-retrieval.md#feature-references)\n\n#### Example: querying a feature service (recommended)\n```python\ntraining_df = store.get_historical_features(\n    entity_df=entity_df,\n    features=store.get_feature_service(\"model_v1\"),\n).to_df()\n```\n\n#### Example: querying a list of feature references\n```python\ntraining_df = store.get_historical_features(\n    entity_df=entity_df,\n    features=[\n        \"driver_hourly_stats:conv_rate\",\n        \"driver_hourly_stats:acc_rate\",\n        \"driver_daily_features:daily_miles_driven\"\n    ],\n).to_df()\n```"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-02T19:16:42+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8e453528583be4a63aee7955dd9f076e2d1cc58c2c92923e19aafdfc597bf1d2",
+      "topic": "overview",
+      "subject": "Retrieving historical features (for training data or batch scoring) / Step 2: Specifying Entities",
+      "content": {
+        "summary": "### Step 2: Specifying Entities Feast accepts either a **Pandas dataframe** as the entity dataframe (including entity keys and timestamps) or a **SQL query** to generate the entities. Both approaches "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-retrieval.md",
+        "line": 275,
+        "quote": "### Step 2: Specifying Entities\nFeast accepts either a **Pandas dataframe** as the entity dataframe (including entity keys and timestamps) or a **SQL query** to generate the entities.\n\nBoth approaches must specify the full **entity key** needed as well as the **timestamps**. Feast then joins features onto this dataframe.\n\n#### Example: entity dataframe for generating training data\n```python\nentity_df = pd.DataFrame.from_dict(\n    {\n        \"driver_id\": [1001, 1002, 1003, 1004, 1001],\n        \"event_timestamp\": [\n            datetime(2021, 4, 12, 10, 59, 42),\n            datetime(2021, 4, 12, 8, 12, 10),\n            datetime(2021, 4, 12, 16, 40, 26),\n            datetime(2021, 4, 12, 15, 1, 12),\n            datetime.now()\n        ]\n    }\n)\ntraining_df = store.get_historical_features(\n    entity_df=entity_df,\n    features=[\n        \"driver_hourly_stats:conv_rate\",\n        \"driver_hourly_stats:acc_rate\",\n        \"driver_daily_features:daily_miles_driven\"\n    ],\n).to_df()\n```\n\n#### Example: entity SQL query for generating training data\nYou can also pass a SQL string to generate the above dataframe. This is useful for getting all entities in a timeframe from some data source.\n\n```python\nentity_sql = f\"\"\"\n    SELECT\n        driver_id,\n        event_timestamp\n    FROM {store.get_data_source(\"driver_hourly_stats_source\").get_table_query_string()}\n    WHERE event_timestamp BETWEEN '2021-01-01' and '2021-12-31'\n\"\"\"\n… (+10 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-02T19:16:42+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "50e8744e807b6dd007d94c0ee4045849417080e8ce003b2163390174d116e7f8",
+      "topic": "overview",
+      "subject": "Retrieving historical features (for training data or batch scoring) / Step 3: Choosing an output format",
+      "content": {
+        "summary": "### Step 3: Choosing an output format `get_historical_features()` returns a `RetrievalJob` object. You can convert it to the format that suits your downstream pipeline: **Data conversion methods** | M"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-retrieval.md",
+        "line": 325,
+        "quote": "### Step 3: Choosing an output format\n\n`get_historical_features()` returns a `RetrievalJob` object. You can convert it\nto the format that suits your downstream pipeline:\n\n**Data conversion methods**\n\n| Method | Returns | When to use |\n|---|---|---|\n| `.to_df()` | `pandas.DataFrame` | General-purpose; scikit-learn, XGBoost, statsmodels |\n| `.to_feast_df()` | `FeastDataFrame` | Feast-native wrapper with engine metadata; preferred for Feast-internal tooling |\n| `.to_arrow()` | `pyarrow.Table` | Arrow-native pipelines, Polars, DuckDB, zero-copy interchange |\n| `.to_tensor(kind=\"torch\")` | `Dict[str, torch.Tensor]` | Direct PyTorch training loops; numeric columns become tensors |\n| `.to_ray_dataset()` | `ray.data.Dataset` | Ray Train, Ray Serve, distributed ML workloads |\n\n**Persistence methods**\n\n| Method | Effect | When to use |\n|---|---|---|\n| `.persist(storage)` | Writes result to offline storage | Save a training dataset for later reuse or auditing |\n| `.to_remote_storage()` | Exports result to S3/GCS as Parquet files | Hand off to external systems or data pipelines |\n\n#### Retrieving as a Ray Dataset\n\n`to_ray_dataset()` is a **first-class method** on every `RetrievalJob`. When\nthe underlying offline store is a `RayOfflineStore`, the dataset is returned\ndirectly without a copy through Arrow. For all other offline stores, a\nzero-copy Arrow → Ray Dataset conversion is used as a fallback.\n\n```python\nfrom feast import FeatureStore\n\nstore = FeatureStore(\".\")\n\n# to_ray_dataset() is a first-class method on the RetrievalJob — chain it\n# directly after get_historical_features().\nray_ds = store.get_historical_features(\n    entity_df=entity_df,\n    features=[\"driver_hourly_stats:conv_rate\", \"driver_hourly_stats:acc_rate\"],\n).to_ray_dataset()\n… (+13 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-02T19:16:42+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3c9fbd20b104a7f48df87692ded75cb02cb38425719af7a608d321a7dc34c1b2",
+      "topic": "overview",
+      "subject": "Retrieving online features (for model inference)",
+      "content": {
+        "summary": "## Retrieving online features (for model inference) Feast will ensure the latest feature values for registered features are available. At retrieval time, you need to supply a list of **entities** and "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-retrieval.md",
+        "line": 378,
+        "quote": "## Retrieving online features (for model inference)\nFeast will ensure the latest feature values for registered features are available. At retrieval time, you need to supply a list of **entities** and the corresponding **features** to be retrieved. Similar to `get_historical_features`, we recommend using feature services as a mechanism for grouping features in a model version.\n\n_Note: unlike `get_historical_features`, the `entity_rows`  **do not need timestamps** since you only want one feature value per entity key._\n\nThere are several options for retrieving online features: through the SDK, or through a feature server\n\n<details>\n\n<summary>Full example: retrieve online features for real-time model inference (Python SDK)</summary>\n\n```python\nfrom feast import RepoConfig, FeatureStore\nfrom feast.repo_config import RegistryConfig\n\nrepo_config = RepoConfig(\n    registry=RegistryConfig(path=\"gs://feast-test-gcs-bucket/registry.pb\"),\n    project=\"feast_demo_gcp\",\n    provider=\"gcp\",\n)\nstore = FeatureStore(config=repo_config)\n\nfeatures = store.get_online_features(\n    features=[\n        \"driver_hourly_stats:conv_rate\",\n        \"driver_hourly_stats:acc_rate\",\n        \"driver_daily_features:daily_miles_driven\",\n    ],\n    entity_rows=[\n        {\n            \"driver_id\": 1001,\n        }\n    ],\n).to_dict()\n```\n\n</details>\n\n<details>\n\n… (+20 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-02T19:16:42+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "41b7b64d2f880998c6a51f52dd0d66c0040059bd215a9ed82e863fc2fdf01c32",
+      "topic": "overview",
+      "subject": "SDK Configuration (Python) / Method 1: Direct Configuration in FeatureStore",
+      "content": {
+        "summary": "### Method 1: Direct Configuration in FeatureStore"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/user_token_provisioning.md",
+        "line": 22,
+        "quote": "### Method 1: Direct Configuration in FeatureStore\n\n```python\nfrom feast import FeatureStore\nfrom feast.permissions.auth_model import KubernetesAuthConfig\n\n# Create auth config with user token\nauth_config = KubernetesAuthConfig(\n    type=\"kubernetes\",\n    user_token=\"your-kubernetes-user-token-here\"\n)\n\n# Initialize FeatureStore with auth config\nfs = FeatureStore(\n    repo_path=\"path/to/feature_repo\",\n    auth_config=auth_config\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8d95f918aebcd66447cfc9d7b34f9f39d687b837b02a98e560a8aa5cb8fd30ef",
+      "topic": "overview",
+      "subject": "SDK Configuration (Python) / Method 2: Environment Variable",
+      "content": {
+        "summary": "### Method 2: Environment Variable"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/user_token_provisioning.md",
+        "line": 41,
+        "quote": "### Method 2: Environment Variable\n\n```python\nimport os\nfrom feast import FeatureStore\n\n# Set environment variable\nos.environ[\"LOCAL_K8S_TOKEN\"] = \"your-kubernetes-user-token-here\"\n\n# FeatureStore will automatically use the token\nfs = FeatureStore(\"path/to/feature_repo\")\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "643f2ab95d2f2ec0f59aef744a1f461d7947af340f07ffdc05b9726771bcccf4",
+      "topic": "overview",
+      "subject": "Schema Validation",
+      "content": {
+        "summary": "## Schema Validation Feature views support an optional `enable_validation` parameter that enables schema validation during materialization and historical feature retrieval. When enabled, Feast verifies that: - All declared feature columns are present in the input data. - Column data types match the"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-view.md",
+        "line": 184,
+        "quote": "## Schema Validation\n\nFeature views support an optional `enable_validation` parameter that enables schema validation during materialization and historical feature retrieval. When enabled, Feast verifies that:\n\n- All declared feature columns are present in the input data.\n- Column data types match the expected Feast types (mismatches are logged as warnings).\n\nThis is useful for catching data quality issues early in the pipeline. To enable it:\n\n```python\nfrom feast import FeatureView, Field\nfrom feast.types import Int32, Int64, Float32, Json, Map, String, Struct\n\nvalidated_fv = FeatureView(\n    name=\"validated_features\",\n    entities=[driver],\n    schema=[\n        Field(name=\"trips_today\", dtype=Int64),\n        Field(name=\"rating\", dtype=Float32),\n        Field(name=\"preferences\", dtype=Map),\n        Field(name=\"config\", dtype=Json),  # opaque JSON data\n        Field(name=\"address\", dtype=Struct({\"street\": String, \"city\": String, \"zip\": Int32})),  # typed struct\n    ],\n    source=my_source,\n    enable_validation=True,  # enables schema checks\n)\n```\n\n**JSON vs Map vs Struct**: These three complex types serve different purposes:\n- **`Map`**: Schema-free dictionary with string keys. Use when the keys and values are dynamic.\n- **`Json`**: Opaque JSON data stored as a string. Backends use native JSON types (`jsonb`, `VARIANT`). Use for configuration blobs or API responses where you don't need field-level typing.\n- **`Struct`**: Schema-aware structured type with named, typed fields. Persisted through the registry via Field tags. Use when you know the exact structure and want type safety.\n\nValidation is supported in all compute engines (Local, Spark, and Ray). When a required column is missing, a `ValueError` is raised. Type mismatches are logged as warnings but do not block execution, allowing for safe gradual adoption.\n\nThe `enable_validation` parameter is also available on `BatchFeatureView` and `StreamFeatureView`, as well as their respective decorators (`@batch_feature_view` and `@stream_feature_view`).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-27T23:00:47-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "08f63a3d4022343c164c28b0d1c534a0d830948b574f3dfe86e20b89e9bc4ffa",
+      "topic": "overview",
+      "subject": "See Also",
+      "content": {
+        "summary": "## See Also - Spark Data Source - Apache Iceberg Documentation - Delta Lake Documentation - Apache Hudi Documentation - Python API Reference - TableFormat"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 351,
+        "quote": "## See Also\n\n- [Spark Data Source](spark.md)\n- [Apache Iceberg Documentation](https://iceberg.apache.org/docs/latest/)\n- [Delta Lake Documentation](https://docs.delta.io/latest/index.html)\n- [Apache Hudi Documentation](https://hudi.apache.org/docs/overview)\n- [Python API Reference - TableFormat](https://rtd.feast.dev/en/master/#feast.table_format)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4dcf9625fce609ce4744d2c3795da11a91548063474b4b77ab54815d445f4502",
+      "topic": "overview",
+      "subject": "Server Example",
+      "content": {
+        "summary": "## Server Example The complete example can be found under remote-offline-store-example"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/offline-feature-server.md",
+        "line": 32,
+        "quote": "## Server Example\n\nThe complete example can be found under [remote-offline-store-example](../../../examples/remote-offline-store)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-13T18:01:23+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "39aa9c539b07affaf8f3b449b25c3945b13d334e9eb728b29cdfeb20ebb5c4c7",
+      "topic": "overview",
+      "subject": "Setup and Configuration / 1. Deploy Prometheus Operator",
+      "content": {
+        "summary": "### 1. Deploy Prometheus Operator Follow the [Prometheus Operator documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md) to i"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/open-telemetry.md",
+        "line": 40,
+        "quote": "### 1. Deploy Prometheus Operator\nFollow the [Prometheus Operator documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md) to install the operator.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-24T10:11:58-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "63b8a326da3588a5af8ff6e45e9c43ca7b3a4bc058c91500cef3c75b41758c17",
+      "topic": "overview",
+      "subject": "Setup and Configuration / 2. Deploy OpenTelemetry Operator",
+      "content": {
+        "summary": "### 2. Deploy OpenTelemetry Operator Before installing the OpenTelemetry Operator: 1. Install `cert-manager` 2. Validate that the `pods` are running 3. Apply the OpenTelemetry operator: For additional"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/open-telemetry.md",
+        "line": 43,
+        "quote": "### 2. Deploy OpenTelemetry Operator\nBefore installing the OpenTelemetry Operator:\n1. Install `cert-manager`\n2. Validate that the `pods` are running\n3. Apply the OpenTelemetry operator:\n```bash\nkubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml\n```\n\nFor additional installation steps, refer to the [OpenTelemetry Operator documentation](https://github.com/open-telemetry/opentelemetry-operator).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-24T10:11:58-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a8806ed2a9c3e237aa6b128e75351733b49ba6927f45a3d8a96fd20b52b25871",
+      "topic": "overview",
+      "subject": "Setup and Configuration / 6. Add Required Manifests",
+      "content": {
+        "summary": "### 6. Add Required Manifests Add the following components to your chart: - Instrumentation - OpenTelemetryCollector - ServiceMonitors - Prometheus Instance - RBAC rules"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/open-telemetry.md",
+        "line": 110,
+        "quote": "### 6. Add Required Manifests\nAdd the following components to your chart:\n- Instrumentation\n- OpenTelemetryCollector\n- ServiceMonitors\n- Prometheus Instance\n- RBAC rules\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-24T10:11:58-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "aa6f6243f99bde8e76883487b29dd8193a1c772b3e6b50a3ee26000602c21b75",
+      "topic": "overview",
+      "subject": "Setup and Configuration / 7. Deploy Feast",
+      "content": {
+        "summary": "### 7. Deploy Feast Deploy Feast with metrics enabled:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/open-telemetry.md",
+        "line": 118,
+        "quote": "### 7. Deploy Feast\nDeploy Feast with metrics enabled:\n\n```bash\nhelm install feast-release infra/charts/feast-feature-server --set metric=true --set feature_store_yaml_base64=\"\"\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-24T10:11:58-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9160fac6e5177fdb46d11c016bf20fa78ad72fa33d3dc52402ae092061221d4f",
+      "topic": "overview",
+      "subject": "Staged Publishing (`--no-promote`)",
+      "content": {
+        "summary": "## Staged Publishing (`--no-promote`)\r \r By default, `feast apply` atomically saves a version snapshot **and** promotes it to the active definition. For breaking schema changes, you may want to stage "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-feature-view-versioning.md",
+        "line": 95,
+        "quote": "## Staged Publishing (`--no-promote`)\r\n\r\nBy default, `feast apply` atomically saves a version snapshot **and** promotes it to the active definition. For breaking schema changes, you may want to stage the new version without disrupting unversioned consumers.\r\n\r\nThe `--no-promote` flag saves the version snapshot without updating the active feature view definition. The new version is accessible only via explicit `@v<N>` reads and `--version` materialization.\r\n\r\n**CLI usage:**\r\n\r\n```bash\r\nfeast apply --no-promote\r\n```\r\n\r\n**Python SDK equivalent:**\r\n\r\n```python\r\nstore.apply([entity, feature_view], no_promote=True)\r\n```\r\n\r\n### Phased rollout workflow\r\n\r\n1. **Stage the new version:**\r\n   ```bash\r\n   feast apply --no-promote\r\n   ```\r\n   This publishes v2 without promoting it. All unversioned consumers continue using v1.\r\n\r\n2. **Populate the v2 online table:**\r\n   ```bash\r\n   feast materialize --views driver_stats --version v2 ...\r\n   ```\r\n\r\n3. **Migrate consumers one at a time:**\r\n   - Consumer A switches to `driver_stats@v2:trips_today`\r\n   - Consumer B switches to `driver_stats@v2:avg_rating`\r\n\r\n4. **Promote v2 as the default:**\r\n   ```bash\r\n   feast apply\r\n   ```\r\n   Or pin to v2: set `version=\"v2\"` in the definition and run `feast apply`.\r\n… (+1 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:26:28+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "dea73c7a804018cb7dc936088b696aba08cd422102facc72209729c7f8211ccd",
+      "topic": "overview",
+      "subject": "Starting the Feature Server",
+      "content": {
+        "summary": "## Starting the Feature Server Start the feature server as usual: You'll see log messages indicating artifact loading:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-static-artifacts.md",
+        "line": 256,
+        "quote": "## Starting the Feature Server\n\nStart the feature server as usual:\n\n```bash\nfeast serve\n```\n\nYou'll see log messages indicating artifact loading:\n\n```\nINFO:fastapi:Loading static artifacts from static_artifacts.py\nINFO:fastapi:Static artifacts loading completed\nINFO:uvicorn:Application startup complete\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-22T20:04:28-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "94c54ec7a0f0ba4147486cc26905f0c6116b6435282d57ca99d2f256ccf39ebd",
+      "topic": "overview",
+      "subject": "Starting the feature server in TLS(SSL) mode / Obtaining a self-signed TLS certificate and key",
+      "content": {
+        "summary": "### Obtaining a self-signed TLS certificate and key In development mode we can generate a self-signed certificate for testing. In an actual production environment it is always recommended to get it from a trusted TLS certificate provider. The above command will generate two files * `key.pem` : certi"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 534,
+        "quote": "### Obtaining a self-signed TLS certificate and key\nIn development mode we can generate a self-signed certificate for testing. In an actual production environment it is always recommended to get it from a trusted TLS certificate provider.\n\n```shell\nopenssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes\n```\n\nThe above command will generate two files\n* `key.pem` : certificate private key\n* `cert.pem`: certificate public key\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "062a7a84676a419851796d8df76ad62b0935fca9748ee1d2f4affc1772465987",
+      "topic": "overview",
+      "subject": "Starting the feature server in TLS(SSL) mode / Starting the Online Server in TLS(SSL) Mode",
+      "content": {
+        "summary": "### Starting the Online Server in TLS(SSL) Mode To start the feature server in TLS mode, you need to provide the private and public keys using the `--key` and `--cert` arguments with the `feast serve` command."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 545,
+        "quote": "### Starting the Online Server in TLS(SSL) Mode\nTo start the feature server in TLS mode, you need to provide the private and public keys using the `--key` and `--cert` arguments with the `feast serve` command.\n\n```shell\nfeast serve --key /path/to/key.pem --cert /path/to/cert.pem\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "27649187dae9d8a652c5c5b34051313b509d636423764f957c2732a4b64805bf",
+      "topic": "overview",
+      "subject": "Stream Processor",
+      "content": {
+        "summary": "# Stream Processor A Stream Processor is responsible for consuming data from stream sources (such as Kafka, Kinesis, etc.) and loading it directly into the online (and optionally the offline store). A Stream Processor abstracts over specific technologies or frameworks that are used to materialize da"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/stream-processor.md",
+        "line": 1,
+        "quote": "# Stream Processor\n\nA Stream Processor is responsible for consuming data from stream sources (such as Kafka, Kinesis, etc.) and loading it directly into the online (and optionally the offline store).\n\nA Stream Processor abstracts over specific technologies or frameworks that are used to materialize data. An experimental Spark Processor for Kafka is available in Feast. \n\nIf the built-in processor is not sufficient, you can create your own custom processor. Please see [this tutorial](../../tutorials/building-streaming-features.md) for more details.\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2024-08-14T14:17:31-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "6470774937a2bdb93a4c477a5c5ba2f49b7c0740530db44070b87d25cc43e5c7",
+      "topic": "overview",
+      "subject": "Stream data ingestion",
+      "content": {
+        "summary": "## Stream data ingestion Ingesting from stream sources happens either via a Push API or via a contrib processor that leverages an existing Spark context. * To **push data into the offline or online stores**: see push sources for details. * (experimental) To **use a contrib Spark processor** to inges"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/data-ingestion.md",
+        "line": 97,
+        "quote": "## Stream data ingestion\n\nIngesting from stream sources happens either via a Push API or via a contrib processor that leverages an existing Spark context.\n\n* To **push data into the offline or online stores**: see [push sources](../../reference/data-sources/push.md) for details.\n* (experimental) To **use a contrib Spark processor** to ingest from a topic, see [Tutorial: Building streaming features](../../tutorials/building-streaming-features.md)\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-09-24T17:10:05+01:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b44a92e5418a7c49ca18a2e25264a45f12ad7def30dbc5407f71f40fdd111f90",
+      "topic": "overview",
+      "subject": "Structure of a feature repository",
+      "content": {
+        "summary": "## Structure of a feature repository The structure of a feature repository is as follows: * The root of the repository should contain a `feature_store.yaml` file and may contain a `.feastignore` file."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-repository.md",
+        "line": 19,
+        "quote": "## Structure of a feature repository\n\nThe structure of a feature repository is as follows:\n\n* The root of the repository should contain a `feature_store.yaml` file and may contain a `.feastignore` file.\n* The repository should contain Python files that contain feature definitions. \n* The repository can contain other files as well, including documentation and potentially data files.\n\nAn example structure of a feature repository is shown below:\n\n```text\n$ tree -a\n.\n├── data\n│   └── driver_stats.parquet\n├── driver_features.py\n├── feature_store.yaml\n└── .feastignore\n\n1 directory, 4 files\n```\n\nA couple of things to note about the feature repository:\n\n* Feast reads _all_ Python files recursively when `feast apply` is ran, including subdirectories, even if they don't contain feature definitions.\n* It's recommended to add `.feastignore` and add paths to all imperative scripts if you need to store them inside the feature registry.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-08-05T15:51:41-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a86e41ea859b7183085daae7a0f7024b8c21e10ef1c3df8b328a0245539863f7",
+      "topic": "overview",
+      "subject": "Summary",
+      "content": {
+        "summary": "## Summary Tiling with Intermediate Representations provides a powerful optimization for **streaming time-windowed aggregations** in Feast."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/tiling.md",
+        "line": 288,
+        "quote": "## Summary\n\nTiling with Intermediate Representations provides a powerful optimization for **streaming time-windowed aggregations** in Feast.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "summary",
+      "source": "extracted"
+    },
+    {
+      "id": "df528ad27b070399722280aa9bc95209e3e76c0acce42d5910f3b2281dcdf562",
+      "topic": "overview",
+      "subject": "Supported APIs",
+      "content": {
+        "summary": "## Supported APIs Here is the list of supported APIs: | Method | API | Comment | |:---: | :---: | :---: | | POST   | /get-online-features | Retrieve features of one or many entities | | GET    | /health              | Status of the Go Feature Server |"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/go-feature-server.md",
+        "line": 34,
+        "quote": "## Supported APIs\nHere is the list of supported APIs:\n| Method | API | Comment |\n|:---: | :---: | :---: |\n| POST   | /get-online-features | Retrieve features of one or many entities |\n| GET    | /health              | Status of the Go Feature Server |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-27T15:46:59-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9936b3045bbb18181786c63df2a5e05067428f60b78025f71382baa53540f93f",
+      "topic": "overview",
+      "subject": "Supported Artifact Types / Not Recommended",
+      "content": {
+        "summary": "### Not Recommended - **Large Language Models**: Use dedicated serving solutions (vLLM, TensorRT-LLM, TGI) - **Models requiring specialized hardware**: GPU clusters, TPUs - **Frequently updated models"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-static-artifacts.md",
+        "line": 221,
+        "quote": "### Not Recommended\n- **Large Language Models**: Use dedicated serving solutions (vLLM, TensorRT-LLM, TGI)\n- **Models requiring specialized hardware**: GPU clusters, TPUs\n- **Frequently updated models**: Consider model registries with versioning\n- **Large datasets**: Use feature views with proper data sources instead\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-22T20:04:28-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "92f640ff7c62a9cb23df87ab01cd21f10973ef149a769c2a4fe325d60c491cf3",
+      "topic": "overview",
+      "subject": "Supported Artifact Types / Recommended Artifacts",
+      "content": {
+        "summary": "### Recommended Artifacts - **Small ML models**: Sentiment analysis, text classification, small neural networks - **Lookup tables**: Label mappings, category dictionaries, user segments - **Configurat"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-static-artifacts.md",
+        "line": 215,
+        "quote": "### Recommended Artifacts\n- **Small ML models**: Sentiment analysis, text classification, small neural networks\n- **Lookup tables**: Label mappings, category dictionaries, user segments\n- **Configuration data**: Model parameters, feature mappings, business rules\n- **Pre-computed embeddings**: User vectors, item features, static representations\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-22T20:04:28-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4aa19e84cb020c1bde066a6f65eac264a5d2cf82b746983743e63d32d5640356",
+      "topic": "overview",
+      "subject": "Supported Feature View Types",
+      "content": {
+        "summary": "## Supported Feature View Types\r \r Versioning is supported on all three feature view types:\r \r * `FeatureView` (and `BatchFeatureView`)\r * `StreamFeatureView`\r * `OnDemandFeatureView`"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-feature-view-versioning.md",
+        "line": 189,
+        "quote": "## Supported Feature View Types\r\n\r\nVersioning is supported on all three feature view types:\r\n\r\n* `FeatureView` (and `BatchFeatureView`)\r\n* `StreamFeatureView`\r\n* `OnDemandFeatureView`\r\n\r"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:26:28+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "eac2e641d92e2dfa47ef9e2069ec2d4d42a63e2f518e253bde8d943358dafe3a",
+      "topic": "overview",
+      "subject": "Supported Table Formats / Apache Hudi",
+      "content": {
+        "summary": "### Apache Hudi Apache Hudi (Hadoop Upserts Deletes and Incrementals) is a data lake storage framework for simplifying incremental data processing. It provides: - **Upserts and deletes**: Efficient record-level updates - **Incremental queries**: Process only changed data - **Time travel**: Query his"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 134,
+        "quote": "### Apache Hudi\n\n[Apache Hudi](https://hudi.apache.org/) (Hadoop Upserts Deletes and Incrementals) is a data lake storage framework for simplifying incremental data processing. It provides:\n- **Upserts and deletes**: Efficient record-level updates\n- **Incremental queries**: Process only changed data\n- **Time travel**: Query historical versions\n- **Multiple table types**: Optimize for read vs. write workloads\n- **Change data capture**: Track data changes over time\n\n#### Basic Configuration\n\n```python\nfrom feast.table_format import HudiFormat\n\nhudi_format = HudiFormat(\n    table_type=\"COPY_ON_WRITE\",\n    record_key=\"user_id\",\n    precombine_field=\"updated_at\"\n)\n```\n\n#### Configuration Options\n\n| Parameter | Type | Description |\n|-----------|------|-------------|\n| `table_type` | `str` (optional) | `COPY_ON_WRITE` or `MERGE_ON_READ` |\n| `record_key` | `str` (optional) | Field(s) that uniquely identify a record |\n| `precombine_field` | `str` (optional) | Field used to determine the latest version |\n| `properties` | `dict` (optional) | Additional Hudi configuration properties |\n\n#### Table Types\n\n**COPY_ON_WRITE (COW)**\n- Stores data in columnar format (Parquet)\n- Updates create new file versions\n- Best for **read-heavy workloads**\n- Lower query latency\n\n```python\nhudi_format = HudiFormat(\n… (+64 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "302e0ab7d3461bfd0f830a149cbe17e3653ca1de266e22d530540d5955622e0e",
+      "topic": "overview",
+      "subject": "Supported Table Formats / Apache Iceberg",
+      "content": {
+        "summary": "### Apache Iceberg Apache Iceberg is an open table format designed for huge analytic datasets. It provides: - **ACID transactions**: Atomic commits with snapshot isolation - **Time travel**: Query data as of any snapshot - **Schema evolution**: Add, drop, rename, or reorder columns safely - **Hidden"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 11,
+        "quote": "### Apache Iceberg\n\n[Apache Iceberg](https://iceberg.apache.org/) is an open table format designed for huge analytic datasets. It provides:\n- **ACID transactions**: Atomic commits with snapshot isolation\n- **Time travel**: Query data as of any snapshot\n- **Schema evolution**: Add, drop, rename, or reorder columns safely\n- **Hidden partitioning**: Partitioning is transparent to users\n- **Performance**: Advanced pruning and filtering\n\n#### Basic Configuration\n\n```python\nfrom feast.table_format import IcebergFormat\n\niceberg_format = IcebergFormat(\n    catalog=\"my_catalog\",\n    namespace=\"my_database\"\n)\n```\n\n#### Configuration Options\n\n| Parameter | Type | Description |\n|-----------|------|-------------|\n| `catalog` | `str` (optional) | Iceberg catalog name |\n| `namespace` | `str` (optional) | Namespace/schema within the catalog |\n| `properties` | `dict` (optional) | Additional Iceberg configuration properties |\n\n#### Common Properties\n\n```python\niceberg_format = IcebergFormat(\n    catalog=\"spark_catalog\",\n    namespace=\"production\",\n    properties={\n        # Snapshot selection\n        \"snapshot-id\": \"123456789\",\n        \"as-of-timestamp\": \"1609459200000\",  # Unix timestamp in ms\n\n        # Performance tuning\n… (+24 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "cae82f1620095196a8ddae5587fe2be0cc86ea321d224db43966a2024f8f2533",
+      "topic": "overview",
+      "subject": "Supported Table Formats / Delta Lake",
+      "content": {
+        "summary": "### Delta Lake Delta Lake is an open-source storage layer that brings ACID transactions to Apache Spark and big data workloads. It provides: - **ACID transactions**: Serializable isolation for reads and writes - **Time travel**: Access and revert to earlier versions - **Schema enforcement**: Prevent"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 75,
+        "quote": "### Delta Lake\n\n[Delta Lake](https://delta.io/) is an open-source storage layer that brings ACID transactions to Apache Spark and big data workloads. It provides:\n- **ACID transactions**: Serializable isolation for reads and writes\n- **Time travel**: Access and revert to earlier versions\n- **Schema enforcement**: Prevent bad data from corrupting tables\n- **Unified batch and streaming**: Process data incrementally\n- **Audit history**: Full history of all changes\n\n#### Basic Configuration\n\n```python\nfrom feast.table_format import DeltaFormat\n\ndelta_format = DeltaFormat()\n```\n\n#### Configuration Options\n\n| Parameter | Type | Description |\n|-----------|------|-------------|\n| `checkpoint_location` | `str` (optional) | Location for Delta transaction log checkpoints |\n| `properties` | `dict` (optional) | Additional Delta configuration properties |\n\n#### Common Properties\n\n```python\ndelta_format = DeltaFormat(\n    checkpoint_location=\"s3://my-bucket/checkpoints\",\n    properties={\n        # Time travel\n        \"versionAsOf\": \"5\",\n        \"timestampAsOf\": \"2024-01-01 00:00:00\",\n\n        # Performance optimization\n        \"delta.autoOptimize.optimizeWrite\": \"true\",\n        \"delta.autoOptimize.autoCompact\": \"true\",\n\n        # Data skipping\n        \"delta.dataSkippingNumIndexedCols\": \"32\",\n… (+19 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0196945f72d08bf923d9ced0043eefdc92e235e1ddcd7af6b27de08d3040ded2",
+      "topic": "overview",
+      "subject": "Supported Types / Array Types",
+      "content": {
+        "summary": "### Array Types All primitive types have corresponding array (list) types: | Feast Type | Python Type | Description | |------------|-------------|-------------| | `Array(Int32)` | `List[int]` | List o"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 44,
+        "quote": "### Array Types\n\nAll primitive types have corresponding array (list) types:\n\n| Feast Type | Python Type | Description |\n|------------|-------------|-------------|\n| `Array(Int32)` | `List[int]` | List of 32-bit integers |\n| `Array(Int64)` | `List[int]` | List of 64-bit integers |\n| `Array(Float32)` | `List[float]` | List of 32-bit floats |\n| `Array(Float64)` | `List[float]` | List of 64-bit floats |\n| `Array(String)` | `List[str]` | List of strings |\n| `Array(Bytes)` | `List[bytes]` | List of binary data |\n| `Array(Bool)` | `List[bool]` | List of booleans |\n| `Array(UnixTimestamp)` | `List[datetime]` | List of timestamps |\n| `Array(Uuid)` | `List[uuid.UUID]` | List of UUIDs |\n| `Array(TimeUuid)` | `List[uuid.UUID]` | List of time-based UUIDs |\n| `Array(Decimal)` | `List[decimal.Decimal]` | List of arbitrary-precision decimals |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9bbbf64ca8279a0401c09bc3429565f0d2f47e03fac55fe34230ee76a0d6786e",
+      "topic": "overview",
+      "subject": "Supported Types / Domain-Specific Primitive Types",
+      "content": {
+        "summary": "### Domain-Specific Primitive Types These types are semantic aliases over `Bytes` for domain-specific use cases (e.g., RAG pipelines, image processing). They are stored as `bytes` at the proto level. "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 31,
+        "quote": "### Domain-Specific Primitive Types\n\nThese types are semantic aliases over `Bytes` for domain-specific use cases (e.g., RAG pipelines, image processing). They are stored as `bytes` at the proto level.\n\n| Feast Type | Python Type | Description |\n|------------|-------------|-------------|\n| `PdfBytes` | `bytes` | PDF document binary data (used in RAG / document processing pipelines) |\n| `ImageBytes` | `bytes` | Image binary data (used in image processing / multimodal pipelines) |\n\n{% hint style=\"warning\" %}\n`PdfBytes` and `ImageBytes` are not natively supported by any backend's type inference. You must explicitly declare them in your feature view schema. Backend storage treats them as raw `bytes`.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a4e3b35de3a2d3c850e4bd1b3cd89e33c6e0a12739fc0541cf2ac1b6b0f643ee",
+      "topic": "overview",
+      "subject": "Supported Types / JSON Type",
+      "content": {
+        "summary": "### JSON Type The `Json` type represents opaque JSON data. Unlike `Map`, which is schema-free key-value storage, `Json` is stored as a string at the proto level but backends use native JSON types wher"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 139,
+        "quote": "### JSON Type\n\nThe `Json` type represents opaque JSON data. Unlike `Map`, which is schema-free key-value storage, `Json` is stored as a string at the proto level but backends use native JSON types where available.\n\n| Feast Type | Python Type | Description |\n|------------|-------------|-------------|\n| `Json` | `str` (JSON-encoded) | JSON data stored as a string at the proto level |\n| `Array(Json)` | `List[str]` | List of JSON strings |\n\n**Backend support for Json:**\n\n| Backend | Native Type |\n|---------|-------------|\n| PostgreSQL | `jsonb` |\n| Snowflake | `JSON` / `VARIANT` |\n| Redshift | `json` |\n| BigQuery | `JSON` |\n| Spark | Not natively distinguished from `String` |\n| MSSQL | `nvarchar(max)` |\n\n{% hint style=\"info\" %}\nWhen a backend's native type is ambiguous (e.g., PostgreSQL `jsonb` could be `Map` or `Json`), **the schema-declared Feast type takes precedence**. The backend-to-Feast mappings are only used during schema inference when no explicit type is provided.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d8891e1d03ca940db9dcb0179d03cdc8a4f33466a397b7ed04e625cbc23a4d7c",
+      "topic": "overview",
+      "subject": "Supported Types / Map Types",
+      "content": {
+        "summary": "### Map Types Map types allow storing dictionary-like data structures: | Feast Type | Python Type | Description | |------------|-------------|-------------| | `Map` | `Dict[str, Any]` | Dictionary wit"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 111,
+        "quote": "### Map Types\n\nMap types allow storing dictionary-like data structures:\n\n| Feast Type | Python Type | Description |\n|------------|-------------|-------------|\n| `Map` | `Dict[str, Any]` | Dictionary with string keys and values of any supported Feast type (including nested maps) |\n| `Array(Map)` | `List[Dict[str, Any]]` | List of dictionaries |\n| `ScalarMap` | `Dict[Any, Any]` | Dictionary with non-string scalar keys (int, float, bool, UUID, Decimal, bytes, datetime) and values of any supported Feast type |\n\n**Note:** `Map` keys must always be strings. `ScalarMap` supports non-string scalar keys — Feast infers `ScalarMap` automatically when the first key of a dict is not a string. Map values can be any supported Feast type, including primitives, arrays, or nested maps at the proto level. However, the PyArrow representation is `map<string, string>`, which means backends that rely on PyArrow schemas (e.g., during materialization) treat Map as string-to-string.\n\n{% hint style=\"warning\" %}\n`ScalarMap` is **not** inferred from any backend schema. You must declare it explicitly in your feature view schema. It is best suited for online serving use cases where the online store serializes proto bytes directly (e.g., Redis, DynamoDB, SQLite).\n{% endhint %}\n\n**Backend support for Map:**\n\n| Backend | Native Type | Notes |\n|---------|-------------|-------|\n| PostgreSQL | `jsonb`, `jsonb[]` | `jsonb` → `Map`, `jsonb[]` → `Array(Map)` |\n| Snowflake | `VARIANT`, `OBJECT` | Inferred as `Map` |\n| Redshift | `SUPER` | Inferred as `Map` |\n| Spark | `map<string,string>` | `map<>` → `Map`, `array<map<>>` → `Array(Map)` |\n| Athena | `map` | Inferred as `Map` |\n| MSSQL | `nvarchar(max)` | Serialized as string |\n| DynamoDB / Redis | Proto bytes | Full proto Map and ScalarMap support |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "bbde217aea0364c33b7bdda2d54e548df329409f83f85f43b1856b7a403db54a",
+      "topic": "overview",
+      "subject": "Supported Types / Nested Collection Types",
+      "content": {
+        "summary": "### Nested Collection Types Feast supports arbitrarily nested collections using a recursive `VALUE_LIST` / `VALUE_SET` design. The outer container determines the proto enum (`VALUE_LIST` for `Array(…)"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 92,
+        "quote": "### Nested Collection Types\n\nFeast supports arbitrarily nested collections using a recursive `VALUE_LIST` / `VALUE_SET` design. The outer container determines the proto enum (`VALUE_LIST` for `Array(…)`, `VALUE_SET` for `Set(…)`), while the full inner type structure is persisted via a mandatory `feast:nested_inner_type` Field tag.\n\n| Feast Type | Python Type | ValueType | Description |\n|------------|-------------|-----------|-------------|\n| `Array(Array(T))` | `List[List[T]]` | `VALUE_LIST` | List of lists |\n| `Array(Set(T))` | `List[List[T]]` | `VALUE_LIST` | List of sets |\n| `Set(Array(T))` | `List[List[T]]` | `VALUE_SET` | Set of lists |\n| `Set(Set(T))` | `List[List[T]]` | `VALUE_SET` | Set of sets |\n| `Array(Array(Array(T)))` | `List[List[List[T]]]` | `VALUE_LIST` | 3-level nesting |\n\nWhere `T` is any supported primitive type (Int32, Int64, Float32, Float64, String, Bytes, Bool, UnixTimestamp) or another nested collection type.\n\n**Notes:**\n- Nesting depth is **unlimited**. `Array(Array(Array(T)))`, `Set(Array(Set(T)))`, etc. are all supported.\n- Inner type information is preserved via Field tags (`feast:nested_inner_type`) and restored during deserialization. This tag is mandatory for nested collection types.\n- Empty inner collections (`[]`) are stored as empty proto values and round-trip as `None`. For example, `[[1, 2], [], [3]]` becomes `[[1, 2], None, [3]]` after a write-read cycle.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "78c0876bc25df3eb55fa6d686c24f4f5abc69db71a2de20546867db08694af1b",
+      "topic": "overview",
+      "subject": "Supported Types / Primitive Types",
+      "content": {
+        "summary": "### Primitive Types | Feast Type | Python Type | Description | |------------|-------------|-------------| | `Int32` | `int` | 32-bit signed integer | | `Int64` | `int` | 64-bit signed integer | | `Flo"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 15,
+        "quote": "### Primitive Types\n\n| Feast Type | Python Type | Description |\n|------------|-------------|-------------|\n| `Int32` | `int` | 32-bit signed integer |\n| `Int64` | `int` | 64-bit signed integer |\n| `Float32` | `float` | 32-bit floating point |\n| `Float64` | `float` | 64-bit floating point |\n| `String` | `str` | String/text value |\n| `Bytes` | `bytes` | Binary data |\n| `Bool` | `bool` | Boolean value |\n| `UnixTimestamp` | `datetime` | Unix timestamp (nullable) |\n| `Uuid` | `uuid.UUID` | UUID (any version) |\n| `TimeUuid` | `uuid.UUID` | Time-based UUID (version 1) |\n| `Decimal` | `decimal.Decimal` | Arbitrary-precision decimal number |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "7aaa4698a481d4cc3fe5bfa9e77c9661530a3f7540d2627fd5c1bf888a70d529",
+      "topic": "overview",
+      "subject": "Supported Types / Set Types",
+      "content": {
+        "summary": "### Set Types All primitive types (except `Map` and `Json`) have corresponding set types for storing unique values: | Feast Type | Python Type | Description | |------------|-------------|-------------"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 62,
+        "quote": "### Set Types\n\nAll primitive types (except `Map` and `Json`) have corresponding set types for storing unique values:\n\n| Feast Type | Python Type | Description |\n|------------|-------------|-------------|\n| `Set(Int32)` | `Set[int]` | Set of unique 32-bit integers |\n| `Set(Int64)` | `Set[int]` | Set of unique 64-bit integers |\n| `Set(Float32)` | `Set[float]` | Set of unique 32-bit floats |\n| `Set(Float64)` | `Set[float]` | Set of unique 64-bit floats |\n| `Set(String)` | `Set[str]` | Set of unique strings |\n| `Set(Bytes)` | `Set[bytes]` | Set of unique binary data |\n| `Set(Bool)` | `Set[bool]` | Set of unique booleans |\n| `Set(UnixTimestamp)` | `Set[datetime]` | Set of unique timestamps |\n| `Set(Uuid)` | `Set[uuid.UUID]` | Set of unique UUIDs |\n| `Set(TimeUuid)` | `Set[uuid.UUID]` | Set of unique time-based UUIDs |\n| `Set(Decimal)` | `Set[decimal.Decimal]` | Set of unique arbitrary-precision decimals |\n\n**Note:** Set types automatically remove duplicate values. When converting from lists or other iterables to sets, duplicates are eliminated.\n\n{% hint style=\"warning\" %}\n**Backend limitations for Set types:**\n\n- **No backend infers Set types from schema.** No offline store (BigQuery, Snowflake, Redshift, PostgreSQL, Spark, Athena, MSSQL) maps its native types to Feast Set types. You **must** explicitly declare Set types in your feature view schema.\n- **No native PyArrow set type.** Feast converts Sets to `pyarrow.list_()` internally, but `feast_value_type_to_pa()` in `type_map.py` does not include Set mappings, which can cause errors in some code paths.\n- **Online stores** that serialize proto bytes (e.g., SQLite, Redis, DynamoDB) handle Sets correctly.\n- **Offline stores** may not handle Set types correctly during retrieval. For example, the Ray offline store only special-cases `_LIST` types, not `_SET`.\n- Set types are best suited for **online serving** use cases where feature values are written as Python sets and retrieved via `get_online_features`.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0e0c8d6bc5d094efabbaec04aa877742c626f953bfad1a7aa6774eb150bd2e37",
+      "topic": "overview",
+      "subject": "Supported Types / Struct Type",
+      "content": {
+        "summary": "### Struct Type The `Struct` type represents a schema-aware structured type with named, typed fields. Unlike `Map` (which is schema-free), a `Struct` declares its field names and their types, enabling"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 163,
+        "quote": "### Struct Type\n\nThe `Struct` type represents a schema-aware structured type with named, typed fields. Unlike `Map` (which is schema-free), a `Struct` declares its field names and their types, enabling schema validation.\n\n| Feast Type | Python Type | Description |\n|------------|-------------|-------------|\n| `Struct({\"field\": Type, ...})` | `Dict[str, Any]` | Named fields with typed values |\n| `Array(Struct({\"field\": Type, ...}))` | `List[Dict[str, Any]]` | List of structs |\n\n**Example:**\n```python\nfrom feast.types import Struct, String, Int32, Array\n\n# Struct with named, typed fields\naddress_type = Struct({\"street\": String, \"city\": String, \"zip\": Int32})\nField(name=\"address\", dtype=address_type)\n\n# Array of structs\nitems_type = Array(Struct({\"name\": String, \"quantity\": Int32}))\nField(name=\"order_items\", dtype=items_type)\n```\n\n**Backend support for Struct:**\n\n| Backend | Native Type |\n|---------|-------------|\n| BigQuery | `STRUCT` / `RECORD` |\n| Spark | `struct<...>` / `array<struct<...>>` |\n| PostgreSQL | `jsonb` (serialized) |\n| Snowflake | `VARIANT` (serialized) |\n| MSSQL | `nvarchar(max)` (serialized) |\n| DynamoDB / Redis | Proto bytes |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "407b9d24dba399e49dbd35bf2e2e65bddb25613b7c0076624135e50a1d1dc32e",
+      "topic": "overview",
+      "subject": "Supported `reader_type` values",
+      "content": {
+        "summary": "## Supported `reader_type` values | `reader_type` | Underlying Ray API | Notes | |---|---|---| | `parquet` | `ray.data.read_parquet` | S3, GCS, HDFS, local | | `csv` | `ray.data.read_csv` | | | `json`"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/ray.md",
+        "line": 39,
+        "quote": "## Supported `reader_type` values\n\n| `reader_type` | Underlying Ray API | Notes |\n|---|---|---|\n| `parquet` | `ray.data.read_parquet` | S3, GCS, HDFS, local |\n| `csv` | `ray.data.read_csv` | |\n| `json` | `ray.data.read_json` | |\n| `text` | `ray.data.read_text` | |\n| `images` | `ray.data.read_images` | |\n| `binary_files` | `ray.data.read_binary_files` | |\n| `tfrecords` | `ray.data.read_tfrecords` | |\n| `webdataset` | `ray.data.read_webdataset` | |\n| `huggingface` | `ray.data.from_huggingface` | Wraps `datasets.load_dataset` |\n| `mongo` | `ray.data.read_mongo` | |\n| `sql` | `ray.data.read_sql` | Pass `connection_url` in `reader_options` |\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "cb130282bc1ece32e49bfb74c4ba69ab08b3303fcf622e48a5daaf853b14eadb",
+      "topic": "overview",
+      "subject": "Synapse offline store (contrib) / Description",
+      "content": {
+        "summary": "## Description The MsSQL offline store provides support for reading MsSQL Sources. Specifically, it is developed to read from Synapse SQL on Microsoft Azure * Entity dataframes can be provided as a SQL query or can be provided as a Pandas dataframe."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/mssql.md",
+        "line": 3,
+        "quote": "## Description\n\nThe MsSQL offline store provides support for reading [MsSQL Sources](../data-sources/mssql.md). Specifically, it is developed to read from [Synapse SQL](https://docs.microsoft.com/en-us/azure/synapse-analytics/sql/overview-features) on Microsoft Azure\n\n* Entity dataframes can be provided as a SQL query or can be provided as a Pandas dataframe.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-09-26T10:00:57-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "23de4e55c5ee5a60d74c2f0daf38c8fb863dcd0668abb89799cb584d00ff677b",
+      "topic": "overview",
+      "subject": "Synapse offline store (contrib) / Disclaimer",
+      "content": {
+        "summary": "## Disclaimer The MsSQL offline store does not achieve full test coverage. Please do not assume complete stability."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/mssql.md",
+        "line": 12,
+        "quote": "## Disclaimer\n\nThe MsSQL offline store does not achieve full test coverage.\nPlease do not assume complete stability.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-09-26T10:00:57-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "54827ad22b74ae67ee7f86d93f5bb92dd24403eafb7a2bf3cab4612ff4a5d1b9",
+      "topic": "overview",
+      "subject": "Synapse offline store (contrib) / Functionality Matrix",
+      "content": {
+        "summary": "## Functionality Matrix The set of functionality supported by offline stores is described in detail here. Below is a matrix indicating which functionality is supported by the Spark offline store. |                                                                    | MsSql | | :----------------------"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/mssql.md",
+        "line": 35,
+        "quote": "## Functionality Matrix\n\nThe set of functionality supported by offline stores is described in detail [here](overview.md#functionality).\nBelow is a matrix indicating which functionality is supported by the Spark offline store.\n\n|                                                                    | MsSql |\n| :----------------------------------------------------------------- | :---- |\n| `get_historical_features` (point-in-time correct join)             | yes   |\n| `pull_latest_from_table_or_query` (retrieve latest feature values) | yes   |\n| `pull_all_from_table_or_query` (retrieve a saved dataset)          | yes   |\n| `offline_write_batch` (persist dataframes to offline store)        | no    |\n| `write_logged_features` (persist logged features to offline store) | no    |\n\nBelow is a matrix indicating which functionality is supported by `MsSqlServerRetrievalJob`.\n\n|                                                       | MsSql |\n| ----------------------------------------------------- | ----- |\n| export to dataframe                                   | yes   |\n| export to arrow table                                 | yes   |\n| export to arrow batches                               | no    |\n| export to SQL                                         | no    |\n| export to data lake (S3, GCS, etc.)                   | no    |\n| export to data warehouse                              | no    |\n| local execution of Python-based on-demand transforms  | no    |\n| remote execution of Python-based on-demand transforms | no    |\n| persist results in the offline store                  | yes   |\n\nTo compare this set of functionality against other offline stores, please see the full [functionality matrix](overview.md#functionality-matrix).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-09-26T10:00:57-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "5c1cfd8a29a9a6459308b4074a3eeff4d925e2fee375863b0f35e0fc96dc7595",
+      "topic": "overview",
+      "subject": "Synapse offline store (contrib) / Getting started",
+      "content": {
+        "summary": "## Getting started In order to use this offline store, you'll need to run `pip install 'feast[azure]'`. You can get started by then following this [tutorial](https://github.com/feast-dev/feast/blob/ma"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/mssql.md",
+        "line": 9,
+        "quote": "## Getting started\nIn order to use this offline store, you'll need to run `pip install 'feast[azure]'`. You can get started by then following this [tutorial](https://github.com/feast-dev/feast/blob/master/docs/tutorials/azure/README.md).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-09-26T10:00:57-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "80b9ea599f3b6cd5d2158186538540148daa17ef8530074320d1daeab45bb461",
+      "topic": "overview",
+      "subject": "Table Format vs File Format",
+      "content": {
+        "summary": "## Table Format vs File Format It's important to understand the distinction: | Aspect | File Format | Table Format | |--------|-------------|--------------| | **What it is** | Physical encoding of dat"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/table-formats.md",
+        "line": 238,
+        "quote": "## Table Format vs File Format\n\nIt's important to understand the distinction:\n\n| Aspect | File Format | Table Format |\n|--------|-------------|--------------|\n| **What it is** | Physical encoding of data | Metadata and transaction layer |\n| **Examples** | Parquet, Avro, ORC, CSV | Iceberg, Delta Lake, Hudi |\n| **Handles** | Data serialization | ACID, versioning, schema evolution |\n| **Layer** | Storage layer | Metadata layer |\n\n### Can be used together\n\n```python\n# Table format (metadata layer) built on top of file format (storage layer)\nfrom feast.infra.offline_stores.contrib.spark_offline_store.spark_source import SparkSource\nfrom feast.table_format import IcebergFormat\n\niceberg = IcebergFormat(catalog=\"my_catalog\", namespace=\"db\")\n\nsource = SparkSource(\n    name=\"features\",\n    path=\"catalog.db.table\",\n    file_format=\"parquet\",      # Underlying storage format\n    table_format=iceberg,        # Table metadata format\n    timestamp_field=\"event_timestamp\"\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-11-05T23:20:33-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4afa8d5b9e43b08dc23f0e65a57caa00c980bdd3252aad93cba4c51426d230aa",
+      "topic": "overview",
+      "subject": "Table of Contents",
+      "content": {
+        "summary": "## Table of Contents - [SDK Configuration (Python)](#sdk-configuration-python) - [CLI Usage](#cli-usage) - [API Usage (REST/gRPC)](#api-usage-restgrpc) - [Programmatic SDK Usage](#programmatic-sdk-usa"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/user_token_provisioning.md",
+        "line": 9,
+        "quote": "## Table of Contents\n\n- [SDK Configuration (Python)](#sdk-configuration-python)\n- [CLI Usage](#cli-usage)\n- [API Usage (REST/gRPC)](#api-usage-restgrpc)\n- [Programmatic SDK Usage](#programmatic-sdk-usage)\n- [Configuration Priority](#configuration-priority)\n- [Security Best Practices](#security-best-practices)\n- [Complete Examples](#complete-examples)\n- [Troubleshooting](#troubleshooting)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a6eb20d5f2f744e196cd64fb4bdea09f329d635f341b0a3b8d9d25f75d7358d0",
+      "topic": "overview",
+      "subject": "Table schema",
+      "content": {
+        "summary": "## Table schema Feature data is stored in tables in the DWH. There is one DWH table per Feast Feature Table. Each table in DWH is expected to have three groups of columns: * One or more Entity columns"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/offline_store_format.md",
+        "line": 20,
+        "quote": "## Table schema\nFeature data is stored in tables in the DWH. There is one DWH table per Feast Feature Table. Each table in DWH is expected to have three groups of columns:\n* One or more Entity columns. Together they compose an [Entity Key](https://github.com/feast-dev/feast/blob/master/docs/concepts/glossary.md#entity-key). Their types should match Entity type definitions in Feast metadata, according to the mapping for the specific DWH engine being used. The name of the column must match the entity name.\n* One [Entity timestamp](https://github.com/feast-dev/feast/blob/master/docs/concepts/glossary.md#entity-timestamp) column, also called \"event timestamp\". The type is DWH-specific timestamp type. The name of the column is set when you configure the offline data source.\n* Optional \"created timestamp\" column. This is typically wallclock time of when the feature value was computed. If there are two feature values with the same Entity Key and Event Timestamp, the one with more recent Created Timestamp will take precedence. The type is DWH-specific timestamp type. The name of the column is set when you configure the offline data source.\n* One or more feature value columns. Their types should match Feature type defined in Feast metadata, according to the mapping for the specific DWH engine being used. The names must match feature names, but can optionally be remapped when configuring the offline data source.\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-02-26T09:07:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0379d271ffb6fef475414a1e4dc7d73877ad6e0b18e1e58f5255a32726b81094",
+      "topic": "overview",
+      "subject": "Tags KWARGs Actions:",
+      "content": {
+        "summary": "## Tags KWARGs Actions: \"snowflake-online-store/online_path\": Adding the \"snowflake-online-store/online_path\" key to a FeatureView tags parameter allows you to choose the online table path for the online serving table (ex. \"{database}\".\"{schema}\"). {% code title=\"example_config.py\" %} {% endcode %}"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/snowflake.md",
+        "line": 39,
+        "quote": "## Tags KWARGs Actions:\n\n\"snowflake-online-store/online_path\": Adding the \"snowflake-online-store/online_path\" key to a FeatureView tags parameter allows you to choose the online table path for the online serving table (ex. \"{database}\".\"{schema}\").\n\n{% code title=\"example_config.py\" %}\n```python\ndriver_stats_fv = FeatureView(\n    ...\n    tags={\"snowflake-online-store/online_path\": '\"FEAST\".\"ONLINE\"'},\n)\n```\n{% endcode %}\n\nThe full set of configuration options is available in [SnowflakeOnlineStoreConfig](https://rtd.feast.dev/en/latest/#feast.infra.online_stores.snowflake.SnowflakeOnlineStoreConfig).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-09-26T10:00:57-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2c05455d0868eb865caba8adac168334ac6effd4e197d56cb6422345f5bf90bb",
+      "topic": "overview",
+      "subject": "Teardown",
+      "content": {
+        "summary": "## Teardown Tear down deployed feature store infrastructure"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 486,
+        "quote": "## Teardown\n\nTear down deployed feature store infrastructure\n\n```text\nfeast teardown\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "teardown",
+      "source": "extracted"
+    },
+    {
+      "id": "aa2fed616b0b28a2e8a10d626307df2b09499958f15ec32270b8a308bb4e1093",
+      "topic": "overview",
+      "subject": "Template Example",
+      "content": {
+        "summary": "## Template Example The PyTorch NLP template demonstrates static artifacts loading: This template includes a complete example with sentiment analysis model loading, lookup tables, and integration with"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-static-artifacts.md",
+        "line": 272,
+        "quote": "## Template Example\n\nThe PyTorch NLP template demonstrates static artifacts loading:\n\n```bash\nfeast init my-nlp-project -t pytorch_nlp\ncd my-nlp-project/feature_repo\nfeast serve\n```\n\nThis template includes a complete example with sentiment analysis model loading, lookup tables, and integration with on-demand feature views.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-22T20:04:28-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "792a5b06add201e79e5448d5cc4a5263b4c07cd09c61cd10ba68d4fa893fb5f8",
+      "topic": "overview",
+      "subject": "Terminology",
+      "content": {
+        "summary": "## Terminology For brevity, below we'll use just \"DWH\" for the data warehouse that is used as an offline storage engine for feature data. For common Feast terms, like \"Feature Table\", \"Entity\" please "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/offline_store_format.md",
+        "line": 15,
+        "quote": "## Terminology\nFor brevity, below we'll use just \"DWH\" for the data warehouse that is used as an offline storage engine for feature data.\n\nFor common Feast terms, like \"Feature Table\", \"Entity\" please refer to [Feast glossary](https://github.com/feast-dev/feast/blob/master/docs/concepts/glossary.md).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-02-26T09:07:14+05:30"
+      },
+      "module": "terminology",
+      "source": "extracted"
+    },
+    {
+      "id": "3afaa0ca2d7291f88c9fa0e6579837287fe5d0520d5f5432c747acbaf77b2cf3",
+      "topic": "overview",
+      "subject": "The .feastignore file",
+      "content": {
+        "summary": "## The .feastignore file This file contains paths that should be ignored when running `feast apply`. An example `.feastignore` is shown below: {% code title=\".feastignore\" %} {% endcode %} See .feastignore for more details."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-repository.md",
+        "line": 62,
+        "quote": "## The .feastignore file\n\nThis file contains paths that should be ignored when running `feast apply`. An example `.feastignore` is shown below:\n\n{% code title=\".feastignore\" %}\n```text\n# Ignore virtual environment\nvenv\n\n# Ignore a specific Python file\nscripts/foo.py\n\n# Ignore all Python files directly under scripts directory\nscripts/*.py\n\n# Ignore all \"foo.py\" anywhere under scripts directory\nscripts/**/foo.py\n```\n{% endcode %}\n\nSee [.feastignore](feast-ignore.md) for more details.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-08-05T15:51:41-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8544875f8650679a0a4db9c4d18089284d4729a9a32cc9757c0375d84db57eb5",
+      "topic": "overview",
+      "subject": "The Problem: Why Intermediate Representations?",
+      "content": {
+        "summary": "## The Problem: Why Intermediate Representations? Traditional approaches to time-windowed aggregations either: 1. **Recompute from raw data** every time → Slow, expensive 2. **Store final aggregated values** per tile → Fast but often **incorrect** when merging ### The Merging Problem You **cannot co"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/tiling.md",
+        "line": 20,
+        "quote": "## The Problem: Why Intermediate Representations?\n\nTraditional approaches to time-windowed aggregations either:\n1. **Recompute from raw data** every time → Slow, expensive\n2. **Store final aggregated values** per tile → Fast but often **incorrect** when merging\n\n### The Merging Problem\n\nYou **cannot correctly merge** many common aggregations:\n\n```\nWRONG: avg(tile1, tile2) ≠ (avg_tile1 + avg_tile2) / 2\n\nExample:\n  tile1: [10, 20, 30] → avg = 20\n  tile2: [100]        → avg = 100\n  \n  Correct merged avg: (10+20+30+100) / 4 = 40\n  Wrong merged avg:   (20 + 100) / 2     = 60\n```\n\n**The same problem exists for:**\n- Standard deviation (`std`)\n- Variance (`var`)\n- Median and percentiles\n- Any \"holistic\" aggregation that requires knowledge of all values\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "382d3cf6d2c93bb7cc577193f6501e116688abca46691302db5af66f318f902e",
+      "topic": "overview",
+      "subject": "The Solution: Intermediate Representations (IRs)",
+      "content": {
+        "summary": "## The Solution: Intermediate Representations (IRs) Instead of storing **final aggregated values**, store **intermediate data** that preserves the mathematical properties needed for correct merging. ### Example: Average **Traditional (Incorrect)**: **With IRs (Correct)**: ---"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/tiling.md",
+        "line": 49,
+        "quote": "## The Solution: Intermediate Representations (IRs)\n\nInstead of storing **final aggregated values**, store **intermediate data** that preserves the mathematical properties needed for correct merging.\n\n### Example: Average\n\n**Traditional (Incorrect)**:\n```\nTile 1: avg = 20\nTile 2: avg = 20\nMerged avg = (20 + 20) / 2 = 20 - WRONG\n```\n\n**With IRs (Correct)**:\n```\nTile 1: sum = 60, count = 3\nTile 2: sum = 100, count = 1\nMerged: sum = 160, count = 4\nMerged avg = 160 / 4 = 40 - CORRECT\n```\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9ea0a7f4a46a732e285b29828b14f65320906688775dd0701a0aa6def53a530a",
+      "topic": "overview",
+      "subject": "Tiling Algorithm",
+      "content": {
+        "summary": "## Tiling Algorithm ### Sawtooth Window Tiling 1. **Partition events** into hop-sized intervals (e.g., 5 minutes) 2. **Compute cumulative tail aggregations** for each hop from the start of the materia"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/tiling.md",
+        "line": 169,
+        "quote": "## Tiling Algorithm\n\n### Sawtooth Window Tiling\n\n1. **Partition events** into hop-sized intervals (e.g., 5 minutes)\n2. **Compute cumulative tail aggregations** for each hop from the start of the materialization window\n3. **Subtract tiles** to form windowed aggregations (current_tile - previous_tile)\n4. **Store IRs** for correct merging of holistic aggregations\n5. **At materialization**, store windowed aggregations in online store\n\n**Benefits**:\n- Efficient query-time performance (pre-computed windows)\n- Minimal storage overhead (only hop-sized tiles)\n- Mathematically correct for all aggregation types\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "cc4398fe975938ed0cd4c8c46b4a4f9e2e4289f7e810f1113e5ad7687863a5a9",
+      "topic": "overview",
+      "subject": "Transformation Modes",
+      "content": {
+        "summary": "## Transformation Modes When defining an ODFV, you can specify the transformation mode using the `mode` parameter. Feast supports the following modes: - **Pandas Mode (`mode=\"pandas\"`)**: The transformation function takes a Pandas DataFrame as input and returns a Pandas DataFrame as output. This mod"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/beta-on-demand-feature-view.md",
+        "line": 29,
+        "quote": "## Transformation Modes\n\nWhen defining an ODFV, you can specify the transformation mode using the `mode` parameter. Feast supports the following modes:\n\n- **Pandas Mode (`mode=\"pandas\"`)**: The transformation function takes a Pandas DataFrame as input and returns a Pandas DataFrame as output. This mode is useful for batch transformations over multiple rows.\n- **Native Python Mode (`mode=\"python\"`)**: The transformation function uses native Python and can operate on inputs as lists of values or as single dictionaries representing a singleton (single row).\n\n### Singleton Transformations in Native Python Mode\n\nNative Python mode supports transformations on singleton dictionaries by setting `singleton=True`. This allows you to\nwrite transformation functions that operate on a single row at a time, making the code more intuitive and aligning with\nhow data scientists typically think about data transformations.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-22T17:08:58-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "462c06963f09020aca0e67030a0b0f36550757b400bde664e9b46848b4fc400f",
+      "topic": "overview",
+      "subject": "Type System in Practice / Feature inference",
+      "content": {
+        "summary": "### Feature inference During `feast apply`, Feast runs schema inference on the data sources underlying feature views. For example, if the `schema` parameter is not specified for a feature view, Feast "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 498,
+        "quote": "### Feature inference\n\nDuring `feast apply`, Feast runs schema inference on the data sources underlying feature views.\nFor example, if the `schema` parameter is not specified for a feature view, Feast will examine the schema of the underlying data source to determine the event timestamp column, feature columns, and entity columns.\nEach of these columns must be associated with a Feast type, which requires conversion from the data source type system to the Feast type system.\n* The feature inference logic calls `_infer_features_and_entities`.\n* `_infer_features_and_entities` calls `source_datatype_to_feast_value_type`.\n* `source_datatype_to_feast_value_type` calls the appropriate method in `type_map.py`. For example, if a `SnowflakeSource` is being examined, `snowflake_python_type_to_feast_value_type` from `type_map.py` will be called.\n\n{% hint style=\"info\" %}\n**Types that cannot be inferred:** `Set`, `Json`, `Struct`, `Decimal`, `ScalarMap`, `PdfBytes`, and `ImageBytes` types are never inferred from backend schemas. If you use these types, you must declare them explicitly in your feature view schema.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "6e925af57ff85c7f35b011aafc664c2a80b69bf1b5284917172030af0680665c",
+      "topic": "overview",
+      "subject": "Type System in Practice / Feature serving",
+      "content": {
+        "summary": "### Feature serving As mentioned above in the section on [materialization](#materialization), Feast persists feature values into the online store as `Value` proto objects. A call to `get_online_featur"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 526,
+        "quote": "### Feature serving\n\nAs mentioned above in the section on [materialization](#materialization), Feast persists feature values into the online store as `Value` proto objects.\nA call to `get_online_features` will return an `OnlineResponse` object, which essentially wraps a bunch of `Value` protos with some metadata.\nThe `OnlineResponse` object can then be converted into a Python dictionary, which calls `feast_value_type_to_python_type` from `type_map.py`, a utility that converts the Feast internal types to Python native types.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a9e76ba01c92fe67eaad7f92e3e18f11b47ead1eef299d98f592439756b582a2",
+      "topic": "overview",
+      "subject": "Type System in Practice / Historical feature retrieval",
+      "content": {
+        "summary": "### Historical feature retrieval The Feast type system is typically not necessary when retrieving historical features. A call to `get_historical_features` will return a `RetrievalJob` object, which allows the user to export the results to one of several possible locations: a Pandas dataframe, a pyar"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 519,
+        "quote": "### Historical feature retrieval\n\nThe Feast type system is typically not necessary when retrieving historical features.\nA call to `get_historical_features` will return a `RetrievalJob` object, which allows the user to export the results to one of several possible locations: a Pandas dataframe, a pyarrow table, a data lake (e.g. S3 or GCS), or the offline store (e.g. a Snowflake table).\nIn all of these cases, the type conversion is handled natively by the offline store.\nFor example, a BigQuery query exposes a `to_dataframe` method that will automatically convert the result to a dataframe, without requiring any conversions within Feast.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "968783eaa93a34f27222f4a895e934261c66082f081d6f1520da2beddde62bfb",
+      "topic": "overview",
+      "subject": "Type System in Practice / Materialization",
+      "content": {
+        "summary": "### Materialization Feast serves feature values as [`Value`](https://github.com/feast-dev/feast/blob/master/protos/feast/types/Value.proto) proto objects, which have a type corresponding to Feast type"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 511,
+        "quote": "### Materialization\n\nFeast serves feature values as [`Value`](https://github.com/feast-dev/feast/blob/master/protos/feast/types/Value.proto) proto objects, which have a type corresponding to Feast types.\nThus Feast must materialize feature values into the online store as `Value` proto objects.\n* The local materialization engine first pulls the latest historical features and converts it to pyarrow.\n* Then it calls `_convert_arrow_to_proto` to convert the pyarrow table to proto format.\n* This calls `python_values_to_proto_values` in `type_map.py` to perform the type conversion.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "841e1bb01f40238849a9db8575b7ebf861af8f6eb4350d512a9a9c59895d10eb",
+      "topic": "overview",
+      "subject": "Type mappings / BigQuery types",
+      "content": {
+        "summary": "#### BigQuery types Here's how Feast types map to BigQuery types when using BigQuery for offline storage when reading data from BigQuery to the online store: | Feast Type | BigQuery Type | |----------"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/offline_store_format.md",
+        "line": 65,
+        "quote": "#### BigQuery types\nHere's how Feast types map to BigQuery types when using BigQuery for offline storage when reading data from BigQuery to the online store:\n\n| Feast Type | BigQuery Type |\n|-------------|--|\n| Event Timestamp |   `DATETIME` |\n| BYTES | `BYTES` |\n| STRING | `STRING` |\n| INT32 | `INT64 / INTEGER` |\n| INT64 | `INT64 / INTEGER` |\n| UNIX_TIMESTAMP | `INT64 / INTEGER` |\n| DOUBLE | `FLOAT64 / FLOAT` |\n| FLOAT | `FLOAT64 / FLOAT` |\n| BOOL | `BOOL`|\n| BYTES\\_LIST | `ARRAY<BYTES>` |\n| STRING\\_LIST | `ARRAY<STRING>`|\n| INT32\\_LIST | `ARRAY<INT64>`|\n| INT64\\_LIST | `ARRAY<INT64>`|\n| UNIX_TIMESTAMP\\_LIST | `ARRAY<INT64>`|\n| DOUBLE\\_LIST | `ARRAY<FLOAT64>`|\n| FLOAT\\_LIST | `ARRAY<FLOAT64>`|\n| BOOL\\_LIST | `ARRAY<BOOL>`|\n| MAP | `JSON` / `STRUCT` |\n| MAP\\_LIST | `ARRAY<JSON>` / `ARRAY<STRUCT>` |\n| JSON | `JSON` |\n| JSON\\_LIST | `ARRAY<JSON>` |\n| STRUCT | `STRUCT` / `RECORD` |\n| STRUCT\\_LIST | `ARRAY<STRUCT>` |\n\nValues that are not specified by the table above will cause an error on conversion.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-02-26T09:07:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "67a40c913c1fd46586a7a30cab67eafdf9aeec86278aee269ec1524ccf5dfaee",
+      "topic": "overview",
+      "subject": "Type mappings / Pandas types",
+      "content": {
+        "summary": "#### Pandas types Here's how Feast types map to Pandas types for Feast APIs that take in or return a Pandas dataframe: | Feast Type | Pandas Type | |-------------|--| | Event Timestamp |   `datetime64"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/offline_store_format.md",
+        "line": 30,
+        "quote": "#### Pandas types\nHere's how Feast types map to Pandas types for Feast APIs that take in or return a Pandas dataframe:\n\n| Feast Type | Pandas Type |\n|-------------|--|\n| Event Timestamp |   `datetime64[ns]` |\n| BYTES | `bytes` |\n| STRING | `str` , `category`|\n| INT32 | `int16`, `uint16`, `int32`, `uint32` |\n| INT64 | `int64`, `uint64` |\n| UNIX_TIMESTAMP | `datetime64[ns]`, `datetime64[ns, tz]` |\n| DOUBLE | `float64` |\n| FLOAT | `float32` |\n| BOOL | `bool`|\n| BYTES\\_LIST | `list[bytes]` |\n| STRING\\_LIST | `list[str]`|\n| INT32\\_LIST | `list[int]`|\n| INT64\\_LIST | `list[int]`|\n| UNIX_TIMESTAMP\\_LIST | `list[unix_timestamp]`|\n| DOUBLE\\_LIST | `list[float]`|\n| FLOAT\\_LIST | `list[float]`|\n| BOOL\\_LIST | `list[bool]`|\n| MAP | `dict` (`Dict[str, Any]`)|\n| MAP\\_LIST | `list[dict]` (`List[Dict[str, Any]]`)|\n| JSON | `object` (parsed Python dict/list/str)|\n| JSON\\_LIST | `list[object]`|\n| STRUCT | `dict` (`Dict[str, Any]`)|\n| STRUCT\\_LIST | `list[dict]` (`List[Dict[str, Any]]`)|\n\nNote that this mapping is non-injective, that is more than one Pandas type may corresponds to one Feast type (but not vice versa). In these cases, when converting Feast values to Pandas, the **first** Pandas type in the table above is used.\n\nFeast array types are mapped to a pandas column with object dtype, that contains a Python array of corresponding type.\n\nAnother thing to note is Feast doesn't support timestamp type for entity and feature columns. Values of datetime type in pandas dataframe are converted to int64 if they are found in entity and feature columns. In order to easily differentiate int64 to timestamp features, there is a UNIX_TIMESTAMP type that is an int64 under the hood.  \n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-02-26T09:07:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b16b49867daced1ba716b7de2be004b5b87e8dd4499a433ac9e149f80360613c",
+      "topic": "overview",
+      "subject": "Type mappings / Redshift Types",
+      "content": {
+        "summary": "#### Redshift Types Here's how Feast types map to Redshift types when using Redshift for offline storage: | Feast Type | Redshift Type | |-------------|--| | Event Timestamp | `TIMESTAMP` / `TIMESTAMP"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/offline_store_format.md",
+        "line": 112,
+        "quote": "#### Redshift Types\nHere's how Feast types map to Redshift types when using Redshift for offline storage:\n\n| Feast Type | Redshift Type |\n|-------------|--|\n| Event Timestamp | `TIMESTAMP` / `TIMESTAMPTZ` |\n| BYTES | `VARBYTE` |\n| STRING | `VARCHAR` |\n| INT32 | `INT4` / `SMALLINT` |\n| INT64 | `INT8` / `BIGINT` |\n| DOUBLE | `FLOAT8` / `DOUBLE PRECISION` |\n| FLOAT | `FLOAT4` / `REAL` |\n| BOOL | `BOOL` |\n| MAP | `SUPER` |\n| JSON | `json` / `SUPER` |\n\nNote: Redshift's `SUPER` type stores semi-structured JSON data. During materialization, Feast automatically handles `SUPER` columns that are exported as JSON strings by parsing them back into Python dictionaries before converting to `MAP` proto values.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-02-26T09:07:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "e2158922349c9ab131398d9c4625d5e6775c93394160a0eff94f584e472d881e",
+      "topic": "overview",
+      "subject": "Type mappings / Snowflake Types",
+      "content": {
+        "summary": "#### Snowflake Types Here's how Feast types map to Snowflake types when using Snowflake for offline storage See source here: https://docs.snowflake.com/en/user-guide/python-connector-pandas.html#snowf"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/specs/offline_store_format.md",
+        "line": 96,
+        "quote": "#### Snowflake Types\nHere's how Feast types map to Snowflake types when using Snowflake for offline storage\nSee source here:\nhttps://docs.snowflake.com/en/user-guide/python-connector-pandas.html#snowflake-to-pandas-data-mapping\n\n| Feast Type | Snowflake Python Type |\n|-------------|--|\n| Event Timestamp |   `DATETIME64[NS]` |\n| UNIX_TIMESTAMP | `DATETIME64[NS]` |\n| STRING | `STR` |\n| INT32 | `INT8 / UINT8 / INT16 / UINT16 / INT32 / UINT32` |\n| INT64 | `INT64 / UINT64` |\n| DOUBLE | `FLOAT64` |\n| MAP | `VARIANT` / `OBJECT` |\n| JSON | `JSON` / `VARIANT` |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-02-26T09:07:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b2a970e6f3cb33a76f4bb373b1b64c85bbe24930754889f85a77a471a6f8b05e",
+      "topic": "overview",
+      "subject": "Updating the registry",
+      "content": {
+        "summary": "## Updating the registry We recommend users store their Feast feature definitions in a version controlled repository, which then via CI/CD automatically stays synced with the registry. Users will often also want multiple registries to correspond to different environments (e.g. dev vs staging vs prod"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/registry.md",
+        "line": 7,
+        "quote": "## Updating the registry\n\nWe recommend users store their Feast feature definitions in a version controlled repository, which then via CI/CD\nautomatically stays synced with the registry. Users will often also want multiple registries to correspond to\ndifferent environments (e.g. dev vs staging vs prod), with staging and production registries with locked down write\naccess since they can impact real user traffic. See [Running Feast in Production](../../how-to-guides/running-feast-in-production.md#1.-automatically-deploying-changes-to-your-feature-definitions) for details on how to set this up.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-14T10:41:09-05:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "143aa8c60ba8a84ca3a4a9243b24fdd389eb71f20edae3eb83d6791ad82e2966",
+      "topic": "overview",
+      "subject": "Usage",
+      "content": {
+        "summary": "## Usage Once configured, lineage is tracked automatically:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 64,
+        "quote": "## Usage\n\nOnce configured, lineage is tracked automatically:\n\n```python\nfrom feast import FeatureStore\nfrom datetime import datetime, timedelta\n\n# Create FeatureStore - OpenLineage is initialized automatically if configured\nfs = FeatureStore(repo_path=\"feature_repo\")\n\n# Apply operations emit lineage events automatically\nfs.apply([driver_entity, driver_hourly_stats_view])\n\n# Materialize emits START, COMPLETE/FAIL events automatically\nfs.materialize(\n    start_date=datetime.now() - timedelta(days=1),\n    end_date=datetime.now()\n)\n\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "usage",
+      "source": "extracted"
+    },
+    {
+      "id": "4f188678efd0fcd968ce9ab0e6214925c5af4375dcaefc1078b8bec24d7b197d",
+      "topic": "overview",
+      "subject": "Usage / Automatic logging (zero code)",
+      "content": {
+        "summary": "### Automatic logging (zero code) With the configuration above, feature metadata is logged automatically whenever there is an active MLflow run. No explicit `import mlflow` is needed — just use `store"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 156,
+        "quote": "### Automatic logging (zero code)\n\nWith the configuration above, feature metadata is logged automatically whenever there is an active MLflow run. No explicit `import mlflow` is needed — just use `store.mlflow`:\n\n```python\nfrom feast import FeatureStore\n\nstore = FeatureStore(\".\")\n\nwith store.mlflow.start_run(run_name=\"my_training\"):\n    training_df = store.get_historical_features(\n        features=store.get_feature_service(\"driver_activity_v1\"),\n        entity_df=entity_df,\n    ).to_df()\n    # The run is now tagged with feast.feature_refs, feast.feature_views, etc.\n\n    model = train(training_df)\n    store.mlflow.log_model(model, \"model\")\n```\n\nNo extra code needed — the tags are written automatically.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "96b4bbe253b57b7cd18a8c3d6c76b92eaa44af43f16ab242c5a8dd02d4207892",
+      "topic": "overview",
+      "subject": "Usage / Feast CLI",
+      "content": {
+        "summary": "### Feast CLI The easiest way to get started is to run the `feast ui` command within a feature repository: Output of `feast ui --help`: This will spin up a Web UI on localhost which automatically refr"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-web-ui.md",
+        "line": 18,
+        "quote": "### Feast CLI\n\nThe easiest way to get started is to run the `feast ui` command within a feature repository:\n\nOutput of `feast ui --help`:\n\n```bash\nUsage: feast ui [OPTIONS]\n\nShows the Feast UI over the current directory\n\nOptions:\n-h, --host TEXT                 Specify a host for the server [default: 0.0.0.0]\n-p, --port INTEGER              Specify a port for the server [default: 8888]\n-r, --registry_ttl_sec INTEGER  Number of seconds after which the registry is refreshed. Default is 5 seconds.\n--help                          Show this message and exit.\n```\n\nThis will spin up a Web UI on localhost which automatically refreshes its view of the registry every `registry_ttl_sec`\n\n#### Curl Generator Feature Server URL\n\nThe Curl Generator uses a default Feature Server URL when building the example curl command. You can configure\nthis default at build time using:\n\n```bash\nREACT_APP_FEAST_FEATURE_SERVER_URL=\"http://your-server:6566\"\n```\n\nIf this environment variable is not set, the UI falls back to `http://localhost:6566`. A user-edited value in\nthe UI is still stored in localStorage and will take precedence for that browser.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-18T11:49:04+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "1f03b84cc0af59f0c6cb2e5778bbc702d5c6c2ceef8bd4085fe6841c24ebc605",
+      "topic": "overview",
+      "subject": "Usage / Feast-enhanced functions",
+      "content": {
+        "summary": "### Feast-enhanced functions These functions add automatic Feast tagging and lineage on top of their MLflow counterparts: | Function | Enhancement | |----------|-------------| | `store.mlflow.start_ru"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 251,
+        "quote": "### Feast-enhanced functions\n\nThese functions add automatic Feast tagging and lineage on top of their MLflow counterparts:\n\n| Function | Enhancement |\n|----------|-------------|\n| `store.mlflow.start_run(run_name, tags)` | Auto-tags run with `feast.project` |\n| `store.mlflow.log_model(model, path, flavor)` | Auto-attaches `feast_features.json` artifact |\n| `store.mlflow.register_model(model_uri, name)` | Auto-tags model version with `feast.feature_service` |\n| `store.mlflow.load_model(model_uri)` | Auto-tags prediction run with training lineage |\n\n**Supported model flavors for `log_model()`:** `sklearn`, `pytorch`, `xgboost`, `lightgbm`, `tensorflow`, `keras`, `pyfunc`.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "93f8282c7a1cd60e895bced004a756769daea88f4ff84e4c24c6df33a206f317",
+      "topic": "overview",
+      "subject": "Usage / Feast-only functions",
+      "content": {
+        "summary": "### Feast-only functions These are unique to the Feast integration and have no `mlflow` equivalent: | Function | Description | |----------|-------------| | `store.mlflow.resolve_features(model_uri)` |"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 264,
+        "quote": "### Feast-only functions\n\nThese are unique to the Feast integration and have no `mlflow` equivalent:\n\n| Function | Description |\n|----------|-------------|\n| `store.mlflow.resolve_features(model_uri)` | Resolve model URI to Feast feature service name |\n| `store.mlflow.get_training_entity_df(run_id, ...)` | Recover entity DataFrame from a past MLflow run |\n| `store.mlflow.log_training_dataset(df, dataset_name)` | Log a training DataFrame as an MLflow dataset input |\n| `store.mlflow.active_run_id` | Current active MLflow run ID (or `None`) |\n| `store.mlflow.client` | The underlying `MlflowClient` instance for advanced queries |\n| `feast.mlflow.init(store)` | Explicitly bind `feast.mlflow` module to a `FeatureStore` (optional) |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "7de572a2f5ba35e172be8665adfe4ac2839a432b58a9f828f0ece7fce551b22b",
+      "topic": "overview",
+      "subject": "Usage / Importing as a module to integrate with an existing React App",
+      "content": {
+        "summary": "### Importing as a module to integrate with an existing React App This is the recommended way to use Feast UI for teams maintaining their own internal UI for their deployment of Feast. Start with boot"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-web-ui.md",
+        "line": 50,
+        "quote": "### Importing as a module to integrate with an existing React App\n\nThis is the recommended way to use Feast UI for teams maintaining their own internal UI for their deployment of Feast.\n\nStart with bootstrapping a React app with `create-react-app`\n\n```\nnpx create-react-app your-feast-ui\n```\n\nThen, in your app folder, install Feast UI and optionally its peer dependencies. Assuming you use yarn\n\n```\nyarn add @feast-dev/feast-ui\n# For custom UI using the Elastic UI Framework (optional):\nyarn add @elastic/eui\n# For general custom styling (optional):\nyarn add @emotion/react\n```\n\nEdit `index.js` in the React app to use Feast UI.\n\n```js\nimport React from \"react\";\nimport ReactDOM from \"react-dom\";\nimport \"./index.css\";\n\nimport FeastUI from \"@feast-dev/feast-ui\";\nimport \"@feast-dev/feast-ui/dist/feast-ui.css\";\n\nReactDOM.render(\n  <React.StrictMode>\n    <FeastUI />\n  </React.StrictMode>,\n  document.getElementById(\"root\")\n);\n```\n\nWhen you start the React app, it will look for `projects-list.json` to find a list of your projects. The JSON should look something like this.\n\n… (+67 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-18T11:49:04+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ca8d0a7e03e6c0227eea3c60b1e2c12e8513106fb60a9792cb18a0180d02ee8f",
+      "topic": "overview",
+      "subject": "Usage / Passthrough behavior",
+      "content": {
+        "summary": "### Passthrough behavior The `feast.mlflow` module delegates any attribute not listed above to the raw `mlflow` module. This means you can use `feast.mlflow` as a drop-in replacement for `import mlflo"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 277,
+        "quote": "### Passthrough behavior\n\nThe `feast.mlflow` module delegates any attribute not listed above to the raw `mlflow` module. This means you can use `feast.mlflow` as a drop-in replacement for `import mlflow`:\n\n```python\nfeast.mlflow.log_params(params)             # passes through to mlflow.log_params\nfeast.mlflow.log_metrics(metrics)\nfeast.mlflow.set_tag(\"env\", \"staging\")\nfeast.mlflow.MlflowClient()\n```\n\n`store.mlflow` does **not** have this passthrough — it only exposes the Feast-enhanced and Feast-only methods listed above. To access raw `mlflow` functions from `store.mlflow`, use the escape hatches:\n\n```python\nstore.mlflow.client.log_param(run_id, \"lr\", \"0.01\")  # via MlflowClient instance\nstore.mlflow.mlflow.log_params(params)                # via raw mlflow module\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a2aca8bf5336199968fdeb306ff8f914b30c15212ba0fd72df542d42843eff38",
+      "topic": "overview",
+      "subject": "Usage / Reproduce training from a past run",
+      "content": {
+        "summary": "### Reproduce training from a past run This requires `auto_log_entity_df: true` to have been enabled when the original run was recorded."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 309,
+        "quote": "### Reproduce training from a past run\n\n```python\nfrom feast import FeatureStore\n\nstore = FeatureStore(\".\")\n\nentity_df = store.mlflow.get_training_entity_df(run_id=\"abc123\")\n\nwith store.mlflow.start_run(run_name=\"retrain_v2\"):\n    new_df = store.get_historical_features(\n        features=store.get_feature_service(\"driver_activity_v1\"),\n        entity_df=entity_df,\n    ).to_df()\n    model = train(new_df)\n    store.mlflow.log_model(model, \"model\")\n```\n\nThis requires `auto_log_entity_df: true` to have been enabled when the original run was recorded.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "00e89c93f67bfdc1f59dca9b0afeb3204ac8c114b3c63b44ee8f6b9a768fde24",
+      "topic": "overview",
+      "subject": "Usage / Resolve a model back to its feature service",
+      "content": {
+        "summary": "### Resolve a model back to its feature service Resolution order: 1. Model version tag `feast.feature_service` (set by `register_model()`) 2. Training run tag `feast.feature_service` (set by auto-logg"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 295,
+        "quote": "### Resolve a model back to its feature service\n\n```python\nfrom feast import FeatureStore\n\nstore = FeatureStore(\".\")\nfs_name = store.mlflow.resolve_features(\"models:/driver_model/1\")\n# Returns: \"driver_activity_v1\"\n```\n\nResolution order:\n1. Model version tag `feast.feature_service` (set by `register_model()`)\n2. Training run tag `feast.feature_service` (set by auto-logging)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c9c92e039e29815d85e5ea92f0d09013820b1cc2358771592578c640a4955b2c",
+      "topic": "overview",
+      "subject": "Usage / `feast.mlflow` module API (alternative)",
+      "content": {
+        "summary": "### `feast.mlflow` module API (alternative) For users who prefer a module-level import, `feast.mlflow` is a **drop-in replacement for `import mlflow`** that delegates to the same `store.mlflow` client"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 212,
+        "quote": "### `feast.mlflow` module API (alternative)\n\nFor users who prefer a module-level import, `feast.mlflow` is a **drop-in replacement for `import mlflow`** that delegates to the same `store.mlflow` client under the hood:\n\n```python\nimport feast.mlflow\nfrom feast import FeatureStore\n\nstore = FeatureStore(\".\")   # auto-registers with feast.mlflow\n\nwith feast.mlflow.start_run(run_name=\"training\"):\n    df = store.get_historical_features(...).to_df()\n    feast.mlflow.log_params({\"lr\": \"0.01\"})     # plain passthrough\n    feast.mlflow.log_metrics({\"f1\": 0.85})       # plain passthrough\n    feast.mlflow.log_model(model, \"model\")       # Feast-enhanced\n```\n\n#### Store resolution\n\n`feast.mlflow` resolves its `FeatureStore` in this order:\n\n1. **Explicit `feast.mlflow.init(store)`** — if called, overrides everything\n2. **Auto-registered** — the most recently created `FeatureStore` with `mlflow.enabled=true` registers itself automatically\n3. **Auto-discovery** — falls back to `FeatureStore(\".\")` from the current directory\n\nIn most cases, simply creating a `FeatureStore(...)` is enough — no `init()` needed.\n\n#### Error handling\n\n`feast.mlflow` raises clear errors on first use if something is misconfigured:\n\n| Condition | Error |\n|-----------|-------|\n| No `feature_store.yaml` in cwd and no store created | `RuntimeError` with guidance to call `feast.mlflow.init(store)` |\n| `mlflow.enabled` is not set to `true` | `RuntimeError` with guidance to set `mlflow.enabled=true` |\n| `mlflow` pip package not installed | `ImportError` with guidance to run `pip install feast[mlflow]` |\n\nWhen `mlflow.enabled` is `false` (or omitted), `store.mlflow` returns `None`, allowing callers to guard with `if store.mlflow:`. The `feast.mlflow` module raises `RuntimeError` only when you attempt to use it without an enabled store.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "24d61b95c458cb04bcd6b28acaafc2836eed1dede75f81d4702fa211573f8042",
+      "topic": "overview",
+      "subject": "Usage / `store.mlflow` API (recommended)",
+      "content": {
+        "summary": "### `store.mlflow` API (recommended) `store.mlflow` is the primary way to interact with the Feast–MLflow integration. It provides Feast-enhanced versions of common MLflow operations, and delegates everything else to the raw `mlflow` module:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 178,
+        "quote": "### `store.mlflow` API (recommended)\n\n`store.mlflow` is the primary way to interact with the Feast–MLflow integration. It provides Feast-enhanced versions of common MLflow operations, and delegates everything else to the raw `mlflow` module:\n\n```python\nfrom feast import FeatureStore\nfrom sklearn.linear_model import LogisticRegression\n\nstore = FeatureStore(\".\")\n\n# Training\nwith store.mlflow.start_run(run_name=\"v1_training\"):\n    df = store.get_historical_features(\n        features=store.get_feature_service(\"driver_activity_v1\"),\n        entity_df=entity_df,\n    ).to_df()\n\n    model = LogisticRegression().fit(X, y)\n    store.mlflow.log_model(model, \"model\")     # Feast-enhanced: saves feast_features.json\n    train_run_id = store.mlflow.active_run_id\n\n# Register model (auto-tags version with feast.feature_service)\nstore.mlflow.register_model(f\"runs:/{train_run_id}/model\", \"driver_model\")\n\n# Prediction (auto-links to training run)\nwith store.mlflow.start_run(run_name=\"prediction\"):\n    model = store.mlflow.load_model(\"models:/driver_model/1\")\n    online_features = store.get_online_features(\n        features=store.get_feature_service(\"driver_activity_v1\"),\n        entity_rows=[{\"driver_id\": 1001}],\n    )\n    predictions = model.predict(...)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "1adf832045a13ecbb505ac5a91fb190916864124573a2aa6424d0674fd504434",
+      "topic": "overview",
+      "subject": "Usage Examples / Applying Permissions",
+      "content": {
+        "summary": "### Applying Permissions Run `feast apply` from CLI/API/SDK on server or from client(if permitted) to apply the permissions."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/kubernetes_auth_setup.md",
+        "line": 137,
+        "quote": "### Applying Permissions\n\nRun `feast apply` from CLI/API/SDK on server or from client(if permitted) to apply the permissions.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "319794261dca46f058809764f12f492816c8bad4126d491411b28e1d2ed6237b",
+      "topic": "overview",
+      "subject": "Usage Examples / Basic Historical Feature Retrieval",
+      "content": {
+        "summary": "### Basic Historical Feature Retrieval"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 106,
+        "quote": "### Basic Historical Feature Retrieval\n\n```python\nfrom feast import FeatureStore\nimport pandas as pd\nfrom datetime import datetime\n\n# Initialize feature store with Ray compute engine\nstore = FeatureStore(\"feature_store.yaml\")\n\n# Create entity DataFrame\nentity_df = pd.DataFrame({\n    \"driver_id\": [1, 2, 3, 4, 5],\n    \"event_timestamp\": [datetime.now()] * 5\n})\n\n# Get historical features using Ray compute engine\nfeatures = store.get_historical_features(\n    entity_df=entity_df,\n    features=[\n        \"driver_stats:avg_daily_trips\",\n        \"driver_stats:total_distance\"\n    ]\n)\n\n# Convert to DataFrame\ndf = features.to_df()\nprint(f\"Retrieved {len(df)} rows with {len(df.columns)} columns\")\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8bd3226c254cdb4c3d6b37cf5c0983258d8ba23d2e2f08287044fdbfb877bf93",
+      "topic": "overview",
+      "subject": "Usage Examples / Batch Writing",
+      "content": {
+        "summary": "### Batch Writing The Ray offline store supports batch writing for materialization:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 406,
+        "quote": "### Batch Writing\n\nThe Ray offline store supports batch writing for materialization:\n\n```python\nimport pyarrow as pa\nfrom feast import FeatureView\n\n# Create sample data\ndata = pa.table({\n    \"driver_id\": [1, 2, 3, 4, 5],\n    \"avg_daily_trips\": [10.5, 15.2, 8.7, 12.3, 9.8],\n    \"event_timestamp\": [datetime.now()] * 5\n})\n\n# Write batch data\nRayOfflineStore.offline_write_batch(\n    config=store.config,\n    feature_view=driver_stats,\n    table=data,\n    progress=lambda x: print(f\"Wrote {x} rows\")\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "05abcc503bb8a1a15c8fbe1122f17c0944247c8d5deeb1b88ff27868edf277cc",
+      "topic": "overview",
+      "subject": "Usage Examples / Data Source Validation",
+      "content": {
+        "summary": "### Data Source Validation The Ray offline store validates data sources to ensure compatibility:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 555,
+        "quote": "### Data Source Validation\n\nThe Ray offline store validates data sources to ensure compatibility:\n\n```python\nfrom feast.infra.offline_stores.contrib.ray_offline_store.ray import RayOfflineStore\n\n# Validate a data source\ntry:\n    RayOfflineStore.validate_data_source(store.config, driver_stats.source)\n    print(\"Data source is valid\")\nexcept Exception as e:\n    print(f\"Data source validation failed: {e}\")\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "21c81a393f46280b5cfa17321a5f89937675f4be1c957f846ecc7360a1f1d775",
+      "topic": "overview",
+      "subject": "Usage Examples / Direct Data Access",
+      "content": {
+        "summary": "### Direct Data Access The Ray offline store provides direct access to underlying data:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 375,
+        "quote": "### Direct Data Access\n\nThe Ray offline store provides direct access to underlying data:\n\n```python\nfrom feast.infra.offline_stores.contrib.ray_offline_store.ray import RayOfflineStore\nfrom datetime import datetime, timedelta\n\n# Pull latest data from a table\njob = RayOfflineStore.pull_latest_from_table_or_query(\n    config=store.config,\n    data_source=driver_stats.source,\n    join_key_columns=[\"driver_id\"],\n    feature_name_columns=[\"avg_daily_trips\"],\n    timestamp_field=\"event_timestamp\",\n    created_timestamp_column=None,\n    start_date=datetime.now() - timedelta(days=7),\n    end_date=datetime.now(),\n)\n\n# Convert to pandas DataFrame\ndf = job.to_df()\nprint(f\"Retrieved {len(df)} rows\")\n\n# Convert to Arrow Table\narrow_table = job.to_arrow()\n\n# Get Ray dataset directly\nray_dataset = job.to_ray_dataset()\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "fe55992d93d68aaf3660c0bd3cb839d2f81af1ccec89964ef2f2e0877f73c884",
+      "topic": "overview",
+      "subject": "Usage Examples / GPU Support",
+      "content": {
+        "summary": "### GPU Support The Ray offline store supports GPU scheduling via the `num_gpus` and `gpu_batch_format` config options. This works across all execution modes (local, remote, and KubeRay). For full con"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 549,
+        "quote": "### GPU Support\n\nThe Ray offline store supports GPU scheduling via the `num_gpus` and `gpu_batch_format` config options. This works across all execution modes (local, remote, and KubeRay).\n\nFor full configuration details, examples, and KubeRay GPU setup, see the [Ray Compute Engine GPU Support](../compute-engine/ray.md#gpu-support) section.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d6a78194dc071a7698e93a7ac6ec1f80178539fbb124b1344c2d8b2e70657faf",
+      "topic": "overview",
+      "subject": "Usage Examples / Large-Scale Feature Retrieval",
+      "content": {
+        "summary": "### Large-Scale Feature Retrieval"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 155,
+        "quote": "### Large-Scale Feature Retrieval\n\n```python\n# Handle large entity datasets efficiently\nlarge_entity_df = pd.DataFrame({\n    \"driver_id\": range(1, 1000000),  # 1M entities\n    \"event_timestamp\": [datetime.now()] * 1000000\n})\n\n# Ray compute engine automatically:\n# - Partitions data optimally\n# - Selects appropriate join strategies\n# - Distributes computation across cluster\nfeatures = store.get_historical_features(\n    entity_df=large_entity_df,\n    features=[\n        \"driver_stats:avg_daily_trips\",\n        \"driver_stats:total_distance\",\n        \"customer_stats:lifetime_value\"\n    ]\n).to_df()\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0212885d515543f82cc3f4a6a3cb62e3a10d5f4875cbaaaa98c013b72dbe527a",
+      "topic": "overview",
+      "subject": "Usage Examples / Remote Storage Support",
+      "content": {
+        "summary": "### Remote Storage Support The Ray offline store supports various remote storage backends:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 454,
+        "quote": "### Remote Storage Support\n\nThe Ray offline store supports various remote storage backends:\n\n```python\n# S3 storage\ns3_storage = SavedDatasetFileStorage(path=\"s3://my-bucket/datasets/driver_features.parquet\")\njob.persist(s3_storage, allow_overwrite=True)\n\n# Google Cloud Storage\ngcs_storage = SavedDatasetFileStorage(path=\"gs://my-project-bucket/datasets/driver_features.parquet\")\njob.persist(gcs_storage, allow_overwrite=True)\n\n# HDFS\nhdfs_storage = SavedDatasetFileStorage(path=\"hdfs://namenode:8020/datasets/driver_features.parquet\")\njob.persist(hdfs_storage, allow_overwrite=True)\n\n# Azure Blob Storage / Azure Data Lake Storage Gen2\n# By setting AZURE_STORAGE_ANON=False it uses DefaultAzureCredential\naz_storage = SavedDatasetFileStorage(path=\"abfss://container@stc_account.dfs.core.windows.net/datasets/driver_features.parquet\")\njob.persist(az_storage, allow_overwrite=True)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d4306f6ae04b1b2d6f90449a5ad7eea1b819a59d42e0cf0c6497abac8ad25031",
+      "topic": "overview",
+      "subject": "Usage Examples / Saved Dataset Persistence",
+      "content": {
+        "summary": "### Saved Dataset Persistence The Ray offline store supports persisting datasets for later analysis:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 430,
+        "quote": "### Saved Dataset Persistence\n\nThe Ray offline store supports persisting datasets for later analysis:\n\n```python\nfrom feast.infra.offline_stores.file_source import SavedDatasetFileStorage\n\n# Create storage destination\nstorage = SavedDatasetFileStorage(path=\"data/training_dataset.parquet\")\n\n# Persist the dataset\njob.persist(storage, allow_overwrite=False)\n\n# Create a saved dataset in the registry\nsaved_dataset = store.create_saved_dataset(\n    from_=job,\n    name=\"driver_training_dataset\",\n    storage=storage,\n    tags={\"purpose\": \"data_access\", \"version\": \"v1\"}\n)\n\nprint(f\"Saved dataset created: {saved_dataset.name}\")\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0d6524495105f9dfc8af7d98d5d7369212cb501efc78ebaf119b3faab1345287",
+      "topic": "overview",
+      "subject": "Usage examples / HuggingFace dataset",
+      "content": {
+        "summary": "### HuggingFace dataset Load a dataset from the [HuggingFace Hub](https://huggingface.co/datasets) directly into Feast."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/ray.md",
+        "line": 101,
+        "quote": "### HuggingFace dataset\n\nLoad a dataset from the [HuggingFace Hub](https://huggingface.co/datasets)\ndirectly into Feast.\n\n```python\nfrom feast.infra.offline_stores.contrib.ray_offline_store.ray_source import RaySource\n\ncheque_images = RaySource(\n    name=\"cheque_images_hf\",\n    reader_type=\"huggingface\",\n    reader_options={\n        \"dataset_name\": \"cheques_sample_data\",\n        \"split\": \"train\",\n    },\n    timestamp_field=\"event_timestamp\",\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "283443f8293ff283180bd8e0fbb79c3c3df4a3e4a47765c96d410689ee6d1bcc",
+      "topic": "overview",
+      "subject": "Usage examples / SQL (via connection URL)",
+      "content": {
+        "summary": "### SQL (via connection URL) ---"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/ray.md",
+        "line": 135,
+        "quote": "### SQL (via connection URL)\n\n```python\nuser_features = RaySource(\n    name=\"user_features_sql\",\n    reader_type=\"sql\",\n    reader_options={\n        \"connection_url\": \"postgresql+psycopg2://user:password@host:5432/db\",  # pragma: allowlist secret\n        \"query\": \"SELECT * FROM user_features\",\n    },\n    timestamp_field=\"event_timestamp\",\n)\n```\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "49c2667f8edc6ab231f53d763b8de884967a3c3272ea6fbf56aa57e810c3f757",
+      "topic": "overview",
+      "subject": "Use case #1: Defining and storing features",
+      "content": {
+        "summary": "### Use case #1: Defining and storing features Feast's primary object for defining features is a _feature view,_ which is a collection of features. Feature views map to 0 or more entities, since a feature can be associated with: * zero entities (e.g. a global feature like _num\\_daily\\_global\\_transa"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/entity.md",
+        "line": 13,
+        "quote": "### Use case #1: Defining and storing features\n\nFeast's primary object for defining features is a _feature view,_ which is a collection of features. Feature views map to 0 or more entities, since a feature can be associated with:\n\n* zero entities (e.g. a global feature like _num\\_daily\\_global\\_transactions_)\n* one entity (e.g. a user feature like _user\\_age_ or _last\\_5\\_bought\\_items_)\n* multiple entities, aka a composite key (e.g. a user + merchant category feature like _num\\_user\\_purchases\\_in\\_merchant\\_category)_\n\nFeast refers to this collection of entities for a feature view as an **entity key**.\n\n![](<../../.gitbook/assets/image (15).png>)\n\nEntities should be reused across feature views. This helps with discovery of features, since it enables data scientists understand how other teams build features for the entity they are most interested in.\n\nFeast will use the feature view concept to then define the schema of groups of features in a low-latency online store.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-08-22T15:01:58-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d2adc5d6ad7086044227af4f1ad4eb2e8be52cf056320461c91d0dcaf1b9eccf",
+      "topic": "overview",
+      "subject": "Use case #2: Retrieving features",
+      "content": {
+        "summary": "### Use case #2: Retrieving features At _training time_, users control what entities they want to look up, for example corresponding to train / test / validation splits. A user specifies a list of _en"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/entity.md",
+        "line": 29,
+        "quote": "### Use case #2: Retrieving features\n\nAt _training time_, users control what entities they want to look up, for example corresponding to train / test / validation splits. A user specifies a list of _entity keys + timestamps_ they want to fetch [point-in-time](./point-in-time-joins.md) correct features for to generate a training dataset.\n\nAt _serving time_, users specify _entity key(s)_ to fetch the latest feature values which can power real-time model prediction (e.g. a fraud detection model that needs to fetch the latest transaction user's features to make a prediction).\n\n{% hint style=\"info\" %}\n**Q: Can I retrieve features for all entities?**\n\nKind of.\n\nIn practice, this is most relevant for _batch scoring models_ (e.g. predict user churn for all existing users) that are offline only. For these use cases, Feast supports generating features for a SQL-backed list of entities. There is an [open GitHub issue](https://github.com/feast-dev/feast/issues/1611) that welcomes contribution to make this a more intuitive API.\n\nFor _real-time feature retrieval_, there is no out of the box support for this because it would promote expensive and slow scan operations which can affect the performance of other operations on your data sources. Users can still pass in a large list of entities for retrieval, but this does not scale well.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-08-22T15:01:58-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0c9a84a1ec907a8929c35ff106fd01bc01c7b752b2ce7f30c1d1c3868e5e1726",
+      "topic": "overview",
+      "subject": "Using Dragonfly as a drop-in Feast online store instead of Redis / 1. Create a feature repository",
+      "content": {
+        "summary": "### 1. Create a feature repository Bootstrap a new feature repository: Update `feature_repo/feature_store.yaml` with the below contents:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/dragonfly.md",
+        "line": 21,
+        "quote": "### 1. Create a feature repository\n\nBootstrap a new feature repository:\n\n```\nfeast init feast_dragonfly\ncd feast_dragonfly/feature_repo\n```\n\nUpdate `feature_repo/feature_store.yaml` with the below contents:\n\n```\nproject: feast_dragonfly\nregistry: data/registry.db\nprovider: local\nonline_store:\ntype: redis\nconnection_string: \"localhost:6379\"\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-15T22:29:15+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4d0037466a16dc5adb76e5e4fcad6921683522402ba9a408a4e7739485482a06",
+      "topic": "overview",
+      "subject": "Using Dragonfly as a drop-in Feast online store instead of Redis / 2. Start Dragonfly",
+      "content": {
+        "summary": "### 2. Start Dragonfly There are several options available to get Dragonfly up and running quickly. We will be using Docker for this tutorial. `docker run --network=host --ulimit memlock=-1 docker.dragonflydb.io/dragonflydb/dragonfly`"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/dragonfly.md",
+        "line": 41,
+        "quote": "### 2. Start Dragonfly\n\nThere are several options available to get Dragonfly up and running quickly. We will be using Docker for this tutorial.\n\n`docker run --network=host --ulimit memlock=-1 docker.dragonflydb.io/dragonflydb/dragonfly`\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-15T22:29:15+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "e8c19138b8e9b638480eaf9fdcb5363f7dfc48fea70e335b9c1e068416fe5f43",
+      "topic": "overview",
+      "subject": "Using Dragonfly as a drop-in Feast online store instead of Redis / 3. Register feature definitions and deploy your feature store",
+      "content": {
+        "summary": "### 3. Register feature definitions and deploy your feature store `feast apply` The `apply` command scans python files in the current directory (`feature_definitions.py` in this case) for feature view"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/dragonfly.md",
+        "line": 47,
+        "quote": "### 3. Register feature definitions and deploy your feature store\n\n`feast apply`\n\nThe `apply` command scans python files in the current directory (`feature_definitions.py` in this case) for feature view/entity definitions, registers the objects, and deploys infrastructure.\nYou should see the following output:\n\n```\n....\nCreated entity driver\nCreated feature view driver_hourly_stats_fresh\nCreated feature view driver_hourly_stats\nCreated on demand feature view transformed_conv_rate\nCreated on demand feature view transformed_conv_rate_fresh\nCreated feature service driver_activity_v1\nCreated feature service driver_activity_v3\nCreated feature service driver_activity_v2\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-12-15T22:29:15+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ca558b1eebf5051ff2b348d639db1be71073023695fb6e1935c3da9db5e6395b",
+      "topic": "overview",
+      "subject": "Using RaySource in a BatchFeatureView",
+      "content": {
+        "summary": "## Using RaySource in a BatchFeatureView ---"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/ray.md",
+        "line": 151,
+        "quote": "## Using RaySource in a BatchFeatureView\n\n```python\nfrom datetime import timedelta\nfrom feast import BatchFeatureView, Entity, Field\nfrom feast.types import Float32, Int64, String\nfrom feast.infra.offline_stores.contrib.ray_offline_store.ray_source import RaySource\n\ncheque = Entity(name=\"cheque_id\", description=\"Unique cheque identifier\")\n\ncheque_source = RaySource(\n    name=\"cheque_images_hf\",\n    reader_type=\"huggingface\",\n    reader_options={\n        \"dataset_name\": \"cheques_sample_data\",\n        \"split\": \"train\",\n    },\n    timestamp_field=\"event_timestamp\",\n)\n\ncheque_ocr_fv = BatchFeatureView(\n    name=\"cheque_ocr_features\",\n    entities=[cheque],\n    ttl=timedelta(days=365),\n    schema=[\n        Field(name=\"cheque_id\", dtype=Int64),\n        Field(name=\"payee_name\", dtype=String),\n        Field(name=\"amount\", dtype=String),\n        Field(name=\"bank_name\", dtype=String),\n        Field(name=\"raw_text\", dtype=String),\n    ],\n    source=cheque_source,\n)\n```\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d088fed1487d8313de6fd4b543f0ca39257e90256dd04ee84cae630422e873de",
+      "topic": "overview",
+      "subject": "Validating Training Dataset",
+      "content": {
+        "summary": "### Validating Training Dataset During retrieval of historical features, `validation_reference` can be passed as a parameter to methods `.to_df(validation_reference=...)` or `.to_arrow(validation_refe"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/dqm.md",
+        "line": 61,
+        "quote": "### Validating Training Dataset\nDuring retrieval of historical features, `validation_reference` can be passed as a parameter to methods `.to_df(validation_reference=...)` or `.to_arrow(validation_reference=...)` of RetrievalJob.\nIf parameter is provided Feast will run validation once dataset is materialized. In case if validation successful materialized dataset is returned.\nOtherwise, `feast.dqm.errors.ValidationFailed` exception would be raised. It will consist of all details for expectations that didn't pass.\n\n```python\nfrom feast import FeatureStore\n\nfs = FeatureStore(\".\")\n\njob = fs.get_historical_features(...)\njob.to_df(\n    validation_reference=fs\n        .get_saved_dataset(\"my_reference_dataset\")\n        .as_reference(profiler=manual_profiler)\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-02-02T07:01:43-08:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f0951f8ea80be095cb114863e51d3a38adf99c719a5499c2c77ea5afc28e0c91",
+      "topic": "overview",
+      "subject": "Vector Search / Defining a Feature View with Vector Index",
+      "content": {
+        "summary": "### Defining a Feature View with Vector Index Mark embedding fields with `vector_index=True` and specify `vector_length`: When `feast apply` (or `store.update()`) runs with `vector_enabled=True`, Mong"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/mongodb.md",
+        "line": 49,
+        "quote": "### Defining a Feature View with Vector Index\n\nMark embedding fields with `vector_index=True` and specify `vector_length`:\n\n```python\nfrom feast import Entity, FeatureView, Field, FileSource\nfrom feast.types import Array, Float32, Int64, String\nfrom datetime import timedelta\n\nitem_embeddings = FeatureView(\n    name=\"item_embeddings\",\n    entities=[Entity(name=\"item_id\", join_keys=[\"item_id\"])],\n    schema=[\n        Field(\n            name=\"embedding\",\n            dtype=Array(Float32),\n            vector_index=True,\n            vector_length=384,\n            vector_search_metric=\"cosine\",\n        ),\n        Field(name=\"title\", dtype=String),\n        Field(name=\"item_id\", dtype=Int64),\n    ],\n    source=FileSource(path=\"items.parquet\", timestamp_field=\"event_timestamp\"),\n    ttl=timedelta(hours=24),\n)\n```\n\nWhen `feast apply` (or `store.update()`) runs with `vector_enabled=True`, MongoDB vector search indexes are automatically created for any field with `vector_index=True`. Indexes are also automatically dropped when feature views are removed.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ae822b9363d9af0b96ce4f2dffa7033089872fbf889b5f1c55f2cc07cce43ec3",
+      "topic": "overview",
+      "subject": "Vector Search / How It Works",
+      "content": {
+        "summary": "### How It Works - **Index creation**: `update()` creates a MongoDB vector search index named `<feature_view>__<field>__vs_index` for each vector-indexed field. It waits for the index to reach `READY`"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/mongodb.md",
+        "line": 92,
+        "quote": "### How It Works\n\n- **Index creation**: `update()` creates a MongoDB vector search index named `<feature_view>__<field>__vs_index` for each vector-indexed field. It waits for the index to reach `READY` status before proceeding.\n- **Query execution**: `retrieve_online_documents_v2()` builds a `$vectorSearch` aggregation pipeline with `numCandidates = max(top_k * 10, 100)` and the specified `limit`.\n- **Score**: Results include a `distance` field populated from `$meta: \"vectorSearchScore\"`.\n- **BSON compatibility**: Query vectors are coerced to native Python floats to avoid numpy serialization issues.\n- **Idempotency**: Calling `update()` multiple times will not duplicate indexes.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a35ae61ab1f4817e97baf8236e272a17b78a3dde5bde481abbf1cb05b07a876a",
+      "topic": "overview",
+      "subject": "Vector Search / Retrieving Documents via Vector Search",
+      "content": {
+        "summary": "### Retrieving Documents via Vector Search Use `retrieve_online_documents_v2()` to perform similarity search:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/mongodb.md",
+        "line": 79,
+        "quote": "### Retrieving Documents via Vector Search\n\nUse `retrieve_online_documents_v2()` to perform similarity search:\n\n```python\nstore = FeatureStore(repo_path=\".\")\nresults = store.retrieve_online_documents_v2(\n    features=[\"item_embeddings:embedding\", \"item_embeddings:title\"],\n    query=[0.1, 0.2, ...],  # query vector\n    top_k=5,\n)\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0fcb93471c8367f10746c757f6d0e2740d85efed04a736e8b5be4d02b6ab3f28",
+      "topic": "overview",
+      "subject": "Version",
+      "content": {
+        "summary": "## Version Print the current Feast version"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feast-cli-commands.md",
+        "line": 494,
+        "quote": "## Version\n\nPrint the current Feast version\n\n```text\nfeast version\n```\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-13T11:48:27+05:30"
+      },
+      "module": "version",
+      "source": "extracted"
+    },
+    {
+      "id": "71b4cf6a819efdd8876695a5c81c24ae349099d720eb2fc4a3040ad13538f122",
+      "topic": "overview",
+      "subject": "Version-Qualified Feature References",
+      "content": {
+        "summary": "## Version-Qualified Feature References\r \r You can read features from a **specific version** of a feature view by using version-qualified feature references with the `@v<N>` syntax:\r \r \r \r **How it wo"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-feature-view-versioning.md",
+        "line": 160,
+        "quote": "## Version-Qualified Feature References\r\n\r\nYou can read features from a **specific version** of a feature view by using version-qualified feature references with the `@v<N>` syntax:\r\n\r\n```python\r\nonline_features = store.get_online_features(\r\n    features=[\r\n        \"driver_stats:trips_today\",           # latest version (default)\r\n        \"driver_stats@v2:trips_today\",        # specific version\r\n        \"driver_stats@latest:trips_today\",    # explicit latest\r\n    ],\r\n    entity_rows=[{\"driver_id\": 1001}],\r\n)\r\n```\r\n\r\n**How it works:**\r\n\r\n* `driver_stats:trips_today` is equivalent to `driver_stats@latest:trips_today` — it reads from the currently active version\r\n* `driver_stats@v2:trips_today` reads from the v2 snapshot stored in version history, using a version-specific online store table\r\n* Multiple versions of the same feature view can be queried in a single request (e.g., `driver_stats@v1:trips` and `driver_stats@v2:trips_daily`)\r\n\r\n**Backward compatibility:**\r\n\r\n* The unversioned online store table (e.g., `project_driver_stats`) is treated as v0\r\n* Only versions >= 1 get `_v{N}` suffixed tables (e.g., `project_driver_stats_v1`)\r\n* Pre-versioning users' existing data continues to work without changes — `@latest` resolves to the active version, which for existing unversioned FVs is v0\r\n\r\n**Materialization:** Each version requires its own materialization. After applying a new version, run `feast materialize` to populate the versioned table before querying it with `@v<N>`.\r\n\r"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:26:28+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0af44684ba8dacf4b80e078991005cb008b9ae50dd626fdc275aa15302261e48",
+      "topic": "overview",
+      "subject": "Web UI",
+      "content": {
+        "summary": "## Web UI The `ui/` directory contains the Web UI. See [here](https://github.com/feast-dev/feast/blob/master/ui/CONTRIBUTING.md) for more details on the structure of the Web UI."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/codebase-structure.md",
+        "line": 133,
+        "quote": "## Web UI\n\nThe `ui/` directory contains the Web UI.\nSee [here](https://github.com/feast-dev/feast/blob/master/ui/CONTRIBUTING.md) for more details on the structure of the Web UI.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-07-18T21:43:37-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "681de854568d1eba93dc1a3f020db473ecdc6c2be6a3ea9647ff3a52ed748a71",
+      "topic": "overview",
+      "subject": "What gets logged / Artifacts",
+      "content": {
+        "summary": "### Artifacts When `auto_log_entity_df: true` and the entity DataFrame has fewer than `entity_df_max_rows` rows: | Artifact | Description | |----------|-------------| | `entity_df.parquet` | Full enti"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 100,
+        "quote": "### Artifacts\n\nWhen `auto_log_entity_df: true` and the entity DataFrame has fewer than `entity_df_max_rows` rows:\n\n| Artifact | Description |\n|----------|-------------|\n| `entity_df.parquet` | Full entity DataFrame used in the retrieval |\n\nWhen a model is logged via `store.mlflow.log_model()`:\n\n| Artifact | Description |\n|----------|-------------|\n| `feast_features.json` | JSON list of feature references the model was trained on |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "e712c45cbe527765bfb7c5032f3fffed8c3b6777afa2c33215e6729917cc490e",
+      "topic": "overview",
+      "subject": "What gets logged / Entity DataFrame metadata",
+      "content": {
+        "summary": "### Entity DataFrame metadata Regardless of `auto_log_entity_df`, the following metadata is logged when present: | Tag / Param | When | Description | |-------------|------|-------------| | `feast.enti"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 114,
+        "quote": "### Entity DataFrame metadata\n\nRegardless of `auto_log_entity_df`, the following metadata is logged when present:\n\n| Tag / Param | When | Description |\n|-------------|------|-------------|\n| `feast.entity_df_type` | Always | `dataframe`, `sql`, or `range` |\n| `feast.entity_df_rows` | DataFrame input | Row count |\n| `feast.entity_df_columns` | DataFrame input | Column names |\n| `feast.entity_df_query` | SQL input | The SQL query string |\n| `feast.start_date` / `feast.end_date` | Range-based input | Date range |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b0e47656e9c6d7f3df5d7b45b7d6a87db10b2bd497611e66727a3971006016f9",
+      "topic": "overview",
+      "subject": "What gets logged / Metrics",
+      "content": {
+        "summary": "### Metrics | Metric | Example | Description | |--------|---------|-------------| | `feast.job_submission_sec` | `0.4321` | Feature retrieval duration in seconds |"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 94,
+        "quote": "### Metrics\n\n| Metric | Example | Description |\n|--------|---------|-------------|\n| `feast.job_submission_sec` | `0.4321` | Feature retrieval duration in seconds |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2b08a9b6372aa8b027e0e791b4692e872226016d31d318ede5f559eb5d033762",
+      "topic": "overview",
+      "subject": "What gets logged / Operation logs",
+      "content": {
+        "summary": "### Operation logs When `log_operations: true`, `feast apply` and `feast materialize` create self-contained runs in the `{project}{ops_experiment_suffix}` experiment (default: `my_project-feast-ops`):"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 126,
+        "quote": "### Operation logs\n\nWhen `log_operations: true`, `feast apply` and `feast materialize` create self-contained runs in the `{project}{ops_experiment_suffix}` experiment (default: `my_project-feast-ops`):\n\n**Apply runs:**\n\n| Tag / Metric | Example |\n|--------------|---------|\n| `feast.operation` | `apply` |\n| `feast.project` | `my_project` |\n| `feast.feature_views_changed` | `driver_hourly_stats,order_stats` |\n| `feast.feature_services_changed` | `driver_activity_v1` |\n| `feast.entities_changed` | `driver,restaurant` |\n| `feast.apply.feature_views_count` | `2` |\n| `feast.apply.feature_services_count` | `1` |\n| `feast.apply.entities_count` | `2` |\n\n**Materialize runs:**\n\n| Tag / Metric | Example |\n|--------------|---------|\n| `feast.operation` | `materialize` / `materialize_incremental` |\n| `feast.project` | `my_project` |\n| `feast.materialize.feature_views` | `driver_hourly_stats` |\n| `feast.materialize.start_date` | `2024-01-01T00:00:00` |\n| `feast.materialize.end_date` | `2024-01-02T00:00:00` |\n| `feast.materialize.duration_sec` | `12.3456` |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c090482da668bcc0b40757ac3c84542f31b7b3eb2fb3952c5604972d51d95d98",
+      "topic": "overview",
+      "subject": "What gets logged / Tags on retrieval runs",
+      "content": {
+        "summary": "### Tags on retrieval runs When `auto_log: true` and an active MLflow run exists, each `get_historical_features()` or `get_online_features()` call records: | Tag | Example | Description | |-----|-----"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/mlflow.md",
+        "line": 80,
+        "quote": "### Tags on retrieval runs\n\nWhen `auto_log: true` and an active MLflow run exists, each `get_historical_features()` or `get_online_features()` call records:\n\n| Tag | Example | Description |\n|-----|---------|-------------|\n| `feast.project` | `my_project` | Feast project name |\n| `feast.retrieval_type` | `historical` / `online` | Type of feature retrieval |\n| `feast.feature_service` | `driver_activity_v1` | Auto-resolved feature service name (if matched) |\n| `feast.feature_views` | `driver_hourly_stats` | Comma-separated feature view names |\n| `feast.feature_refs` | `driver_hourly_stats:conv_rate,...` | All feature references |\n| `feast.entity_count` | `200` | Number of entities in the request |\n| `feast.feature_count` | `5` | Number of features retrieved |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-21T14:33:22+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "66d1edf3ff30daf45fb85468bc6361e9b9deb5374f39db983e9aaaa3993a0012",
+      "topic": "overview",
+      "subject": "What is a feature repository?",
+      "content": {
+        "summary": "## What is a feature repository? A feature repository consists of: * A collection of Python files containing feature declarations. * A `feature_store.yaml` file containing infrastructural configuration. * A `.feastignore` file containing paths in the feature repository to ignore. {% hint style=\"info"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-repository.md",
+        "line": 7,
+        "quote": "## What is a feature repository?\n\nA feature repository consists of:\n\n* A collection of Python files containing feature declarations.\n* A `feature_store.yaml` file containing infrastructural configuration.\n* A `.feastignore` file containing paths in the feature repository to ignore.\n\n{% hint style=\"info\" %}\nTypically, users store their feature repositories in a Git repository, especially when working in teams. However, using Git is not a requirement.\n{% endhint %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-08-05T15:51:41-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3f233a7ac5afde7298b94bf5f88c88ad48ae252be6b415d0e326cc492fcdb34c",
+      "topic": "overview",
+      "subject": "When to use RaySource vs FileSource",
+      "content": {
+        "summary": "## When to use RaySource vs FileSource | Scenario | Recommended source | |---|---| | Parquet files on disk / S3 / GCS (existing setup) | `FileSource` (backward compatible) | | Parquet via Ray reader ("
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/ray.md",
+        "line": 17,
+        "quote": "## When to use RaySource vs FileSource\n\n| Scenario | Recommended source |\n|---|---|\n| Parquet files on disk / S3 / GCS (existing setup) | `FileSource` (backward compatible) |\n| Parquet via Ray reader (pipelines, remote auth) | `RaySource(reader_type=\"parquet\")` |\n| CSV, JSON, text, images via Ray | `RaySource` |\n| HuggingFace `datasets` library | `RaySource(reader_type=\"huggingface\")` |\n| MongoDB, SQL, TFRecords, WebDataset | `RaySource` |\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "4469232e81c8b0eb7a57fa713b5a681e08b55440728e4af3bf00d48265fedfb7",
+      "topic": "overview",
+      "subject": "Worker Resource Scheduling / Common `worker_task_options` keys",
+      "content": {
+        "summary": "### Common `worker_task_options` keys | Key | Type | Description | |-----|------|-------------| | `num_cpus` | float | CPUs per task (default: 1). Fractional values supported. | | `memory` | int | Hea"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/compute-engine/ray.md",
+        "line": 368,
+        "quote": "### Common `worker_task_options` keys\n\n| Key | Type | Description |\n|-----|------|-------------|\n| `num_cpus` | float | CPUs per task (default: 1). Fractional values supported. |\n| `memory` | int | Heap memory in **bytes** (e.g. `8589934592` for 8 GB). |\n| `accelerator_type` | string | Pin tasks to a specific GPU model — `\"A100\"`, `\"T4\"`, `\"V100\"`, etc. Useful on KubeRay clusters with mixed GPU node pools. |\n| `resources` | dict | Custom/Kubernetes extended resource labels, e.g. `{\"intel.com/gpu\": 1}`. |\n| `runtime_env` | dict | Per-task [Ray runtime environment](https://docs.ray.io/en/latest/ray-core/handling-dependencies.html) — `pip`, `conda`, `env_vars`, `working_dir`, etc. For KubeRay, use this to install packages on worker pods without rebuilding images. |\n| `max_retries` | int | Task retry count on worker failure (default: 3). |\n| `scheduling_strategy` | string | `\"DEFAULT\"`, `\"SPREAD\"`, or a placement group strategy. |\n\n> For the full list of supported keys see the [Ray RemoteFunction.options() API docs](https://docs.ray.io/en/latest/ray-core/api/doc/ray.remote_function.RemoteFunction.options.html).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-28T13:39:50+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c536e7f830df60bf046911f19501f6c0d0630135f3c681cb8b3da76df8aa706b",
+      "topic": "overview",
+      "subject": "\\[Alpha\\] Versioning",
+      "content": {
+        "summary": "## \\[Alpha\\] Versioning Feature views support automatic version tracking. Every time `feast apply` detects a schema or UDF change, a versioned snapshot is saved to the registry. This enables auditing "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-view.md",
+        "line": 165,
+        "quote": "## \\[Alpha\\] Versioning\n\nFeature views support automatic version tracking. Every time `feast apply` detects a schema or UDF change, a versioned snapshot is saved to the registry. This enables auditing what changed, reverting to a prior version, querying specific versions via `@v<N>` syntax, and staging new versions without promoting them.\n\nVersion history tracking is **always active** with no configuration needed. The `version` parameter is fully optional — omitting it preserves existing behavior.\n\n```python\n# Pin to a specific version (reverts the active definition to v2's snapshot)\ndriver_stats = FeatureView(\n    name=\"driver_stats\",\n    entities=[driver],\n    schema=[...],\n    source=my_source,\n    version=\"v2\",\n)\n```\n\nFor full details on version pinning, version-qualified reads, staged publishing (`--no-promote`), online store support, and known limitations, see the **[\\[Alpha\\] Feature View Versioning](../../reference/alpha-feature-view-versioning.md)** reference page.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-27T23:00:47-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "149e8bee3fdb9e835929129d4b609905ac41bfb2296c653604949b1b51857408",
+      "topic": "overview",
+      "subject": "\\[Alpha] On demand feature views",
+      "content": {
+        "summary": "## \\[Alpha] On demand feature views On demand feature views allows data scientists to use existing features and request time data (features only available at request time) to transform and create new features. Users define python transformation logic which is executed in both the historical retrieva"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-view.md",
+        "line": 221,
+        "quote": "## \\[Alpha] On demand feature views\n\nOn demand feature views allows data scientists to use existing features and request time data (features only available at request time) to transform and create new features. Users define python transformation logic which is executed in both the historical retrieval and online retrieval paths.\n\nCurrently, these transformations are executed locally. This is fine for online serving, but does not scale well to offline retrieval.\n\n### Why use on demand feature views?\n\nThis enables data scientists to easily impact the online feature retrieval path. For example, a data scientist could\n\n1. Call `get_historical_features` to generate a training dataframe\n2. Iterate in notebook on feature engineering in Pandas\n3. Copy transformation logic into on demand feature views and commit to a dev branch of the feature repository\n4. Verify with `get_historical_features` (on a small dataset) that the transformation gives expected output over historical data\n5. Verify with `get_online_features` on dev branch that the transformation correctly outputs online features\n6. Submit a pull request to the staging / prod branches which impact production traffic\n\n```python\nfrom feast import Field, RequestSource\nfrom feast.on_demand_feature_view import on_demand_feature_view\nfrom feast.types import Float64\n\n# Define a request data source which encodes features / information only\n# available at request time (e.g. part of the user initiated HTTP request)\ninput_request = RequestSource(\n    name=\"vals_to_add\",\n    schema=[\n        Field(name=\"val_to_add\", dtype=PrimitiveFeastType.INT64),\n        Field(name=\"val_to_add_2\": dtype=PrimitiveFeastType.INT64),\n    ]\n)\n\n# Use the input data and feature view features to create new features\n@on_demand_feature_view(\n   sources=[\n       driver_hourly_stats_view,\n       input_request\n   ],\n   schema=[\n     Field(name='conv_rate_plus_val1', dtype=Float64),\n… (+10 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-27T23:00:47-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "7dd6f7c19e5a7f1f395c8366ffb901d2b646067a69157bc738fc051d424605c9",
+      "topic": "overview",
+      "subject": "\\[Alpha] Stream feature views",
+      "content": {
+        "summary": "## \\[Alpha] Stream feature views A stream feature view is an extension of a normal feature view. The primary difference is that stream feature views have both stream and batch data sources, whereas a "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/feature-view.md",
+        "line": 271,
+        "quote": "## \\[Alpha] Stream feature views\n\nA stream feature view is an extension of a normal feature view. The primary difference is that stream feature views have both stream and batch data sources, whereas a normal feature view only has a batch data source.\n\nStream feature views should be used instead of normal feature views when there are stream data sources (e.g. Kafka and Kinesis) available to provide fresh features in an online setting. Like regular feature views, stream feature views support the optional `org` field for grouping by organizational unit. Here is an example definition of a stream feature view with an attached transformation:\n\n```python\nfrom datetime import timedelta\n\nfrom feast import Field, FileSource, KafkaSource, stream_feature_view\nfrom feast.data_format import JsonFormat\nfrom feast.types import Float32\n\ndriver_stats_batch_source = FileSource(\n    name=\"driver_stats_source\",\n    path=\"data/driver_stats.parquet\",\n    timestamp_field=\"event_timestamp\",\n)\n\ndriver_stats_stream_source = KafkaSource(\n    name=\"driver_stats_stream\",\n    kafka_bootstrap_servers=\"localhost:9092\",\n    topic=\"drivers\",\n    timestamp_field=\"event_timestamp\",\n    batch_source=driver_stats_batch_source,\n    message_format=JsonFormat(\n        schema_json=\"driver_id integer, event_timestamp timestamp, conv_rate double, acc_rate double, created timestamp\"\n    ),\n    watermark_delay_threshold=timedelta(minutes=5),\n)\n\n@stream_feature_view(\n    entities=[driver],\n    ttl=timedelta(seconds=8640000000),\n    mode=\"spark\",\n    schema=[\n        Field(name=\"conv_percentage\", dtype=Float32),\n        Field(name=\"acc_percentage\", dtype=Float32),\n    ],\n    timestamp_field=\"event_timestamp\",\n… (+16 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-27T23:00:47-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "507dbb2ea133202d51a4176dd66cdf31ad5b68d56e203e581ac1eb9bdef18953",
+      "topic": "overview",
+      "subject": "`materialization` configuration / `pull_latest_features`",
+      "content": {
+        "summary": "### `pull_latest_features` | Field | Type | Default | | --- | --- | --- | | `pull_latest_features` | `bool` | `false` | When `false` (default), the offline store retrieves **all** feature values withi"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-repository/feature-store-yaml.md",
+        "line": 85,
+        "quote": "### `pull_latest_features`\n\n| Field | Type | Default |\n| --- | --- | --- |\n| `pull_latest_features` | `bool` | `false` |\n\nWhen `false` (default), the offline store retrieves **all** feature values within the requested time range for each entity.\n\nWhen `true`, only the **latest** value per entity is retrieved. This reduces I/O and memory for feature views where historical values are not needed (e.g., slowly changing dimensions). It is equivalent to running a `GROUP BY entity, MAX(event_timestamp)` on the offline data before writing.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:27:21+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "bb85dade6825d4fdbccef4c7a1fd42adff64775e5b9ce3be6460b2dc6ea85861",
+      "topic": "overview",
+      "subject": "gRPC) / REST API",
+      "content": {
+        "summary": "### REST API #### Method 1: Authorization Header #### Method 2: Using requests Session"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/user_token_provisioning.md",
+        "line": 119,
+        "quote": "### REST API\n\n#### Method 1: Authorization Header\n\n```python\nimport requests\n\n# For REST API\nheaders = {\n    \"Authorization\": \"Bearer your-kubernetes-user-token-here\",\n    \"Content-Type\": \"application/json\"\n}\n\n# Get features\nresponse = requests.get(\n    \"http://feast-server/features\",\n    headers=headers\n)\n\n# Get online features\nresponse = requests.post(\n    \"http://feast-server/get-online-features\",\n    headers=headers,\n    json={\n        \"features\": [\"feature1\", \"feature2\"],\n        \"entity_rows\": [{\"entity_id\": \"123\"}]\n    }\n)\n```\n\n#### Method 2: Using requests Session\n\n```python\nimport requests\nfrom requests.auth import HTTPBearerAuth\n\n# Create session with auth\nsession = requests.Session()\nsession.auth = HTTPBearerAuth(\"your-kubernetes-user-token-here\")\n\n… (+4 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "8fad6fe4fd4d2996f435d6b14807a7243e0d1712346dec906e7a4fc2255aa8cd",
+      "topic": "overview",
+      "subject": "gRPC) / gRPC API",
+      "content": {
+        "summary": "### gRPC API #### Method 1: gRPC Metadata #### Method 2: gRPC Interceptor"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/user_token_provisioning.md",
+        "line": 163,
+        "quote": "### gRPC API\n\n#### Method 1: gRPC Metadata\n\n```python\nimport grpc\nfrom feast.protos.feast.serving.ServingService_pb2_grpc import ServingServiceStub\nfrom feast.protos.feast.serving.ServingService_pb2 import GetOnlineFeaturesRequest\n\n# Create gRPC channel\nchannel = grpc.insecure_channel('feast-server:6565')\nstub = ServingServiceStub(channel)\n\n# Create metadata with auth token\nmetadata = [('authorization', 'Bearer your-kubernetes-user-token-here')]\n\n# Create request\nrequest = GetOnlineFeaturesRequest(\n    features=[\"feature1\", \"feature2\"],\n    entity_rows=[{\"entity_id\": \"123\"}]\n)\n\n# Make gRPC call\nresponse = stub.GetOnlineFeatures(request, metadata=metadata)\n```\n\n#### Method 2: gRPC Interceptor\n\n```python\nimport grpc\nfrom feast.protos.feast.serving.ServingService_pb2_grpc import ServingServiceStub\n\nclass AuthInterceptor(grpc.UnaryUnaryClientInterceptor):\n    def __init__(self, token):\n        self.token = token\n    \n    def intercept_unary_unary(self, continuation, client_call_details, request):\n        # Add auth metadata\n        metadata = list(client_call_details.metadata or [])\n        metadata.append(('authorization', f'Bearer {self.token}'))\n… (+14 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "0c5d24f9ee24630ae4a3d800f443a28e06e31ee848a5573d8c226e5107f7f2c6",
+      "topic": "overview",
+      "subject": "⚙️ How Materialization Works",
+      "content": {
+        "summary": "## ⚙️ How Materialization Works - If the `BatchFeatureView` is backed by a base source (`FileSource`, `BigQuerySource`, `SparkSource` etc), the `batch_source` is used directly. - If the source is another feature view (i.e., chained views), the `sink_source` must be provided to define the materializa"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/batch-feature-view.md",
+        "line": 125,
+        "quote": "## ⚙️ How Materialization Works\n\n- If the `BatchFeatureView` is backed by a base source (`FileSource`, `BigQuerySource`, `SparkSource` etc), the `batch_source` is used directly.\n- If the source is another feature view (i.e., chained views), the `sink_source` must be provided to define the materialization target data source.\n- During DAG planning, `SparkWriteNode` uses the `sink_source` as the batch sink.\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "e577b3f95ee1f15aee481d5fd0dd876d034e39dedb5dd12e61f10a82330db157",
+      "topic": "overview",
+      "subject": "⚠️ Important: Resource Management",
+      "content": {
+        "summary": "## ⚠️ Important: Resource Management **By default, Ray will use all available system resources (CPU and memory).** This can cause issues in test environments or when experimenting locally, potentially"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 59,
+        "quote": "## ⚠️ Important: Resource Management\n\n**By default, Ray will use all available system resources (CPU and memory).** This can cause issues in test environments or when experimenting locally, potentially leading to system crashes or unresponsiveness.\n\n**For testing and local experimentation, we strongly recommend:**\n\n1. **Configure resource limits** in your `feature_store.yaml` (see [Resource Management and Testing](#resource-management-and-testing) section below)\n\nThis will limit Ray to safe resource levels for testing and development.\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2a5de6d561c109927620cba57c8cfdf67a649811143e096815271aa97d447a0f",
+      "topic": "overview",
+      "subject": "✅ Key Capabilities",
+      "content": {
+        "summary": "## ✅ Key Capabilities - **Composable DAG of FeatureViews**: Supports defining a `BatchFeatureView` on top of one or more other `FeatureView`s. - **Transformations**: Apply [transformation](../../getti"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/batch-feature-view.md",
+        "line": 13,
+        "quote": "## ✅ Key Capabilities\n\n- **Composable DAG of FeatureViews**: Supports defining a `BatchFeatureView` on top of one or more other `FeatureView`s.\n- **Transformations**: Apply [transformation](../../getting-started/architecture/feature-transformation.md) logic (`feature_transformation` or `udf`) to raw data source, can also be used to deal with multiple data sources.\n- **Aggregations**: Define time-windowed aggregations (e.g. `sum`, `avg`) over event-timestamped data.\n- **Feature resolution & execution**: Automatically resolves and executes DAGs of dependent views during materialization or retrieval. More details in the [Compute engine documentation](../../reference/compute-engine/README.md).\n- **Materialization Sink Customization**: Specify a custom `sink_source` to define where derived feature data should be persisted.\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d8b30d80a495a866ee66ac7d4f286e7e64e2e9af7fcb66ab7b72780f6191b498",
+      "topic": "overview",
+      "subject": "🔄 Execution Flow",
+      "content": {
+        "summary": "## 🔄 Execution Flow Feast automatically resolves the DAG of `BatchFeatureView` dependencies during: - `materialize()`: recursively resolves and executes the feature view graph. - `get_historical_features()`: builds the execution plan for retrieving point-in-time correct features. - `apply()`: regist"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/batch-feature-view.md",
+        "line": 113,
+        "quote": "## 🔄 Execution Flow\n\nFeast automatically resolves the DAG of `BatchFeatureView` dependencies during:\n\n- `materialize()`: recursively resolves and executes the feature view graph.\n- `get_historical_features()`: builds the execution plan for retrieving point-in-time correct features.\n- `apply()`: registers the feature view DAG structure to the registry.\n\nEach transformation and aggregation is turned into a DAG node (e.g., `SparkTransformationNode`, `SparkAggregationNode`) executed by the compute engine (e.g., `SparkComputeEngine`).\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "93f4a3050c8a1f1e0f0d1c4b2de69aed0246b988a48f7f225498c5da7ca67c7a",
+      "topic": "overview",
+      "subject": "🔮 Future Directions",
+      "content": {
+        "summary": "## 🔮 Future Directions - Support additional offline stores (e.g., Snowflake, Redshift) with auto-generated sink sources. - Enable fully declarative transform logic (SQL + UDF mix). - Introduce optimization passes for DAG pruning and fusion."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/batch-feature-view.md",
+        "line": 152,
+        "quote": "## 🔮 Future Directions\n\n- Support additional offline stores (e.g., Snowflake, Redshift) with auto-generated sink sources.\n- Enable fully declarative transform logic (SQL + UDF mix).\n- Introduce optimization passes for DAG pruning and fusion.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9f7e44bf38f419c3342b8daf898ba0b04da5723bc067510a6dd1001991d8313d",
+      "topic": "overview",
+      "subject": "🛑 Gotchas",
+      "content": {
+        "summary": "## 🛑 Gotchas - `sink_source` is **required** when chaining views (i.e., `source` is another FeatureView or list of them). - `source` is optional; if omitted (`None`), the feature view has no associate"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/batch-feature-view.md",
+        "line": 142,
+        "quote": "## 🛑 Gotchas\n\n- `sink_source` is **required** when chaining views (i.e., `source` is another FeatureView or list of them).\n- `source` is optional; if omitted (`None`), the feature view has no associated batch data source.\n- Schema fields must be consistent with `sink_source`, `batch_source.field_mapping` if field mappings exist.\n- Aggregation logic must reference columns present in the raw source or transformed inputs.\n- The output feature name for an aggregation defaults to `{function}_{column}` (e.g., `sum_conv_rate`). Use the `name` parameter to override it (e.g., `name=\"total_conv_rate_1d\"`).\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a2098a807a59255b6fb029f92f705e473a41aa9fc9b3df61fc8e950015ec8785",
+      "topic": "overview",
+      "subject": "🧠 Usage / 1. Simple Feature View from Data Source",
+      "content": {
+        "summary": "### 1. Simple Feature View from Data Source ---"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/batch-feature-view.md",
+        "line": 50,
+        "quote": "### 1. Simple Feature View from Data Source\n\n```python\nfrom feast import BatchFeatureView, Field\nfrom feast.types import Float32, Int32\nfrom feast import FileSource\nfrom feast.aggregation import Aggregation\nfrom datetime import timedelta\n\nsource = FileSource(\n    path=\"s3://bucket/path/data.parquet\",\n    timestamp_field=\"event_timestamp\",\n    created_timestamp_column=\"created\",\n)\n\ndriver_fv = BatchFeatureView(\n    name=\"driver_hourly_stats\",\n    entities=[\"driver_id\"],\n    schema=[\n        Field(name=\"driver_id\", dtype=Int32),\n        Field(name=\"conv_rate\", dtype=Float32),\n    ],\n    aggregations=[\n        Aggregation(column=\"conv_rate\", function=\"sum\", time_window=timedelta(days=1), name=\"total_conv_rate_1d\"),\n    ],\n    source=source,\n)\n```\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c39145c796706abacb03f5bdaae9502f260ee51a78215c84e51edadf82bc3bf9",
+      "topic": "overview",
+      "subject": "🧠 Usage / 2. Derived Feature View from Another View",
+      "content": {
+        "summary": "### 2. Derived Feature View from Another View You can build feature views on top of other features by deriving a feature view from another view. Let's take a look at an example. ---"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/batch-feature-view.md",
+        "line": 81,
+        "quote": "### 2. Derived Feature View from Another View\nYou can build feature views on top of other features by deriving a feature view from another view. Let's take a look at an example.\n```python\nfrom feast import BatchFeatureView, Field\nfrom pyspark.sql import DataFrame\nfrom feast.types import Float32, Int32\nfrom feast import FileSource\n\ndef transform(df: DataFrame) -> DataFrame:\n    return df.withColumn(\"conv_rate\", df[\"conv_rate\"] * 2)\n\ndaily_driver_stats = BatchFeatureView(\n    name=\"daily_driver_stats\",\n    entities=[\"driver_id\"],\n    schema=[\n        Field(name=\"driver_id\", dtype=Int32),\n        Field(name=\"conv_rate\", dtype=Float32),\n    ],\n    udf=transform,\n    source=driver_fv,\n    sink_source=FileSource(  # Required to specify where to sink the derived view\n        name=\"daily_driver_stats_sink\",\n        path=\"s3://bucket/daily_stats/\",\n        file_format=\"parquet\",\n        timestamp_field=\"event_timestamp\",\n        created_timestamp_column=\"created\",\n    ),\n)\n```\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "29aad3f30a0df96ac15b02d0b1e8f7f92de42fba808b9914d5ca590c28b19061",
+      "topic": "overview",
+      "subject": "🧪 Example Tests",
+      "content": {
+        "summary": "## 🧪 Example Tests See: - `test_spark_dag_materialize_recursive_view()`: Validates chaining of two feature views and output validation. - `test_spark_compute_engine_materialize()`: Validates transformation and write of features into offline and online stores. ---"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/batch-feature-view.md",
+        "line": 133,
+        "quote": "## 🧪 Example Tests\n\nSee:\n\n- `test_spark_dag_materialize_recursive_view()`: Validates chaining of two feature views and output validation.\n- `test_spark_compute_engine_materialize()`: Validates transformation and write of features into offline and online stores.\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9f29aea5620a07fdc0ca02c865450b2ec9e92b0cba25dd3de10dbfa51ae4d664",
+      "topic": "data",
+      "subject": "Configuration",
+      "content": {
+        "fields": {
+          "project": "my_project",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "sqlite",
+          "path": "data/online_store.db",
+          "enabled": "true",
+          "transport_type": "http",
+          "transport_url": "http://localhost:5000",
+          "transport_endpoint": "api/v1/lineage",
+          "namespace": "feast",
+          "emit_on_apply": "true",
+          "emit_on_materialize": "true"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 28,
+        "quote": "## Configuration\n\nAdd the `openlineage` section to your `feature_store.yaml`:\n\n```yaml\nproject: my_project\nregistry: data/registry.db\nprovider: local\nonline_store:\n  type: sqlite\n  path: data/online_store.db\n\nopenlineage:\n  enabled: true\n  transport_type: http\n  transport_url: http://localhost:5000\n  transport_endpoint: api/v1/lineage\n  namespace: feast\n  emit_on_apply: true\n  emit_on_materialize: true\n```\n\nOnce configured, all Feast operations will automatically emit lineage events.\n\n### Environment Variables\n\nYou can also configure via environment variables:\n\n```bash\nexport FEAST_OPENLINEAGE_ENABLED=true\nexport FEAST_OPENLINEAGE_TRANSPORT_TYPE=http\nexport FEAST_OPENLINEAGE_URL=http://localhost:5000\nexport FEAST_OPENLINEAGE_ENDPOINT=api/v1/lineage\nexport FEAST_OPENLINEAGE_NAMESPACE=feast\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "b880e368a805d0238e4e5943b11db48e4b3ab9a6fe23f9c37d83fb608e80f9f0",
+      "topic": "data",
+      "subject": "Example",
+      "content": {
+        "fields": {
+          "project": "my_project",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "mongodb",
+          "connection_string": "\"mongodb+srv://user:pass@cluster.mongodb.net\"",
+          "database": "feast",
+          "collection": "feature_history",
+          "database_name": "feast_online_store",
+          "collection_suffix": "latest"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/mongodb.md",
+        "line": 11,
+        "quote": "## Example\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_project\nregistry: data/registry.db\nprovider: local\noffline_store:\n  type: feast.infra.offline_stores.contrib.mongodb_offline_store.mongodb.MongoDBOfflineStore\n  connection_string: \"mongodb+srv://user:pass@cluster.mongodb.net\"  # pragma: allowlist secret\n  database: feast\n  collection: feature_history\nonline_store:\n  type: mongodb\n  connection_string: \"mongodb+srv://user:pass@cluster.mongodb.net\"  # pragma: allowlist secret\n  database_name: feast_online_store\n  collection_suffix: latest\n  client_kwargs: {}\n```\n{% endcode %}\n\nThe full set of configuration options is available in [MongoDBOfflineStoreConfig](https://rtd.feast.dev/en/master/#feast.infra.offline_stores.contrib.mongodb_offline_store.mongodb.MongoDBOfflineStoreConfig).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "18b3dd40ba78c59f4b70795f9720a3fe7c48fdefac8db1adbf72ab12c1502d73",
+      "topic": "data",
+      "subject": "Examples",
+      "content": {
+        "fields": {
+          "project": "my_feature_repo",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "redis",
+          "connection_string": "\"redis1:26379,ssl=true,password=my_password\"",
+          "redis_type": "redis_sentinel",
+          "sentinel_master": "mymaster"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/redis.md",
+        "line": 24,
+        "quote": "## Examples\n\nConnecting to a single Redis instance:\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n  type: redis\n  connection_string: \"localhost:6379\"\n```\n{% endcode %}\n\nConnecting to a Redis Cluster with SSL enabled and password authentication:\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n  type: redis\n  redis_type: redis_cluster\n  connection_string: \"redis1:6379,redis2:6379,ssl=true,password=my_password\"\n```\n{% endcode %}\n\nConnecting to a Redis Sentinel with SSL enabled and password authentication:\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nproject: my_feature_repo\nregistry: data/registry.db\nprovider: local\nonline_store:\n  type: redis\n  redis_type: redis_sentinel\n  sentinel_master: mymaster\n… (+4 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:27:21+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "ad4828a63d4ace7e0ffcf3b5b9e4a3e44c64c00b99af47e5b61d963ef9f2b49c",
+      "topic": "data",
+      "subject": "How to configure the client",
+      "content": {
+        "fields": {
+          "registry_type": "remote",
+          "path": "localhost:6570"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/registries/remote.md",
+        "line": 7,
+        "quote": "## How to configure the client\n\nUser needs to create a client side `feature_store.yaml` file, set the `registry_type` to `remote` and provide the server connection configuration.\nThe `path` parameter is a URL with a port (default is 6570) used by the client to connect with the Remote Registry server.\n\n{% code title=\"feature_store.yaml\" %}\n```yaml\nregistry:\n  registry_type: remote\n  path: localhost:6570\n```\n{% endcode %}\n\nThe optional `cert` parameter can be configured as well, it should point to the public certificate path when the Registry Server starts in SSL mode. This may be needed if the Registry Server is started with a self-signed certificate, typically this file ends with *.crt, *.cer, or *.pem.\nMore info about the `cert` parameter can be found in [feast-client-connecting-to-remote-registry-sever-started-in-tls-mode](../../how-to-guides/starting-feast-servers-tls-mode.md#feast-client-connecting-to-remote-registry-sever-started-in-tls-mode)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-04-17T21:24:48-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "6e6cef92c7dc4edb2594e9448a68f0ef3941fa3cc12def7eccf4042e8e78fd90",
+      "topic": "data",
+      "subject": "Overview",
+      "content": {
+        "fields": {
+          "project": "loyal_spider",
+          "registry": "data/registry.db",
+          "provider": "local",
+          "type": "sqlite",
+          "path": "data/online_store.db"
+        }
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-store-yaml.md",
+        "line": 3,
+        "quote": "## Overview\n\n`feature_store.yaml` is a file that is placed at the root of the [Feature Repository](feature-repository.md). This file contains configuration about how the feature store runs. An example `feature_store.yaml` is shown below:\n\n{% code title=\"feature\\_store.yaml\" %}\n```yaml\nproject: loyal_spider\nregistry: data/registry.db\nprovider: local\nonline_store:\n    type: sqlite\n    path: data/online_store.db\n```\n{% endcode %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-15T11:47:10+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f2b9b42146a4534b154361e464cfdd0c2e2cad0c6494d9e55591f5c8bfa85573",
+      "topic": "overview",
+      "subject": "API Endpoints and Permissions",
+      "content": {
+        "summary": "## API Endpoints and Permissions | Endpoint                   | Resource Type                   | Permission                                            | Description                                   "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 596,
+        "quote": "## API Endpoints and Permissions\n\n| Endpoint                   | Resource Type                   | Permission                                            | Description                                                    |\n|----------------------------|---------------------------------|-------------------------------------------------------|----------------------------------------------------------------|\n| /get-online-features       | FeatureView,OnDemandFeatureView | Read Online                                           | Get online features from the feature store                     |\n| /retrieve-online-documents | FeatureView                     | Read Online                                           | Retrieve online documents from the feature store for RAG       |\n| /push                      | FeatureView                     | Write Online, Write Offline, Write Online and Offline | Push features to the feature store (online, offline, or both)  |\n| /write-to-online-store     | FeatureView                     | Write Online                                          | Write features to the online store                             |\n| /materialize               | FeatureView                     | Write Online                                          | Materialize features within a specified time range             |\n| /materialize-incremental   | FeatureView                     | Write Online                                          | Incrementally materialize features up to a specified timestamp |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "9c38a8bb9bdced4ca1cdff9f73bda6ed0d17a0835a961c843a2fedf2a8ea558b",
+      "topic": "overview",
+      "subject": "Architecture",
+      "content": {
+        "summary": "## Architecture The Ray offline store follows Feast's architectural separation: - **Ray Offline Store**: Handles data I/O operations (reading/writing data) - **Ray Compute Engine**: Handles complex feature computation and joins - **Clear Separation**: Each component has a single responsibility For c"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 70,
+        "quote": "## Architecture\n\nThe Ray offline store follows Feast's architectural separation:\n- **Ray Offline Store**: Handles data I/O operations (reading/writing data)\n- **Ray Compute Engine**: Handles complex feature computation and joins\n- **Clear Separation**: Each component has a single responsibility\n\nFor complex feature processing, historical feature retrieval, and distributed joins, use the [Ray Compute Engine](../compute-engine/ray.md).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "architecture",
+      "source": "extracted"
+    },
+    {
+      "id": "b7c65119e896ac20ae099959b6eaba9eda7b0053e61a46e5b5d5881082ff6372",
+      "topic": "overview",
+      "subject": "CLI",
+      "content": {
+        "summary": "## CLI There is a CLI command that starts the Registry server: `feast serve_registry`. By default, remote Registry Server uses port 6570, the port can be overridden with a `--port` flag. To start the "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 981,
+        "quote": "## CLI\n\nThere is a CLI command that starts the Registry server: `feast serve_registry`. By default, remote Registry Server uses port 6570, the port can be overridden with a `--port` flag.\nTo start the Registry Server in TLS mode, you need to provide the private and public keys using the `--key` and `--cert` arguments.\nMore info about TLS mode can be found in [feast-client-connecting-to-remote-registry-sever-started-in-tls-mode](../../how-to-guides/starting-feast-servers-tls-mode.md#starting-feast-registry-server-in-tls-mode)\n\nTo enable REST API support along with gRPC, start the registry server with REST mode enabled : \n\n`feast serve_registry --rest-api`\n\nThis launches both the gRPC and REST servers concurrently. The REST server listens on port 6572 by default.\n\nTo run a REST-only server (no gRPC):\n\n`feast serve_registry --rest-api --no-grpc`\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "cli",
+      "source": "extracted"
+    },
+    {
+      "id": "e5c07c133817fc5ea3d80884ff88b206e46fc31a763708c2e5304dc57ae20250",
+      "topic": "overview",
+      "subject": "Components",
+      "content": {
+        "summary": "### Components  The compute engine is responsible for executing the materialization and retrieval tasks defined in the feature views. It builds a directed acyclic graph (DAG) of operations that need to be performed to generate the features. The Core components of the compute engine are: #### Feature"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/compute-engine.md",
+        "line": 97,
+        "quote": "### Components \nThe compute engine is responsible for executing the materialization and retrieval tasks defined in the feature views. It\nbuilds a directed acyclic graph (DAG) of operations that need to be performed to generate the features.\nThe Core components of the compute engine are:\n\n\n#### Feature Builder\n\nThe Feature builder is responsible for resolving the features from the feature views and executing the operations\ndefined in the DAG. It handles the execution of transformations, aggregations, joins, and filters.\n\n#### Feature Resolver\n\nThe Feature resolver is the core component of the compute engine that constructs the execution plan for feature\ngeneration. It takes the definitions from feature views and builds a directed acyclic graph (DAG) of operations that\nneed to be performed to generate the features.\n\n#### DAG\nThe DAG represents the directed acyclic graph of operations that need to be performed to generate the features. It\ncontains nodes for each operation, such as transformations, aggregations, joins, and filters. The DAG is built by the\nFeature Resolver and executed by the Feature Builder.\n\nDAG nodes are defined as follows:\n```\n   +---------------------+\n   |   SourceReadNode    |  <- Read data from offline store (e.g. Snowflake, BigQuery, etc. or custom source)\n   +---------------------+\n             |\n             v\n   +--------------------------------------+\n   |  TransformationNode / JoinNode (*)   |   <- Merge data sources, custom transformations by user, or default join\n   +--------------------------------------+ \n             |\n             v\n   +---------------------+\n   |    FilterNode       |   <- used for point-in-time filtering \n   +---------------------+\n             |\n             v\n   +---------------------+\n… (+23 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-29T14:42:40-04:00"
+      },
+      "module": "components",
+      "source": "extracted"
+    },
+    {
+      "id": "8206141b8dbfda5e180561318a7d3022b7f0fafa9c9ad1e010b54a3da7263d8d",
+      "topic": "overview",
+      "subject": "Configuration",
+      "content": {
+        "summary": "## Configuration\r \r {% hint style=\"info\" %}\r Version history tracking is **always active** — no configuration needed. Every `feast apply` that changes a feature view automatically records a version sn"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-feature-view-versioning.md",
+        "line": 40,
+        "quote": "## Configuration\r\n\r\n{% hint style=\"info\" %}\r\nVersion history tracking is **always active** — no configuration needed. Every `feast apply` that changes a feature view automatically records a version snapshot.\r\n\r\nTo enable **versioned online reads** (e.g., `fv@v2:feature`), add `enable_online_feature_view_versioning: true` to your registry config in `feature_store.yaml`:\r\n\r\n```yaml\r\nregistry:\r\n  path: data/registry.db\r\n  enable_online_feature_view_versioning: true\r\n```\r\n\r\nWhen this flag is off, version-qualified refs (e.g., `fv@v2:feature`) in online reads will raise errors, but version history, version listing, version pinning, and version lookups all work normally.\r\n{% endhint %}\r\n\r"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:26:28+05:30"
+      },
+      "module": "configuration",
+      "source": "extracted"
+    },
+    {
+      "id": "176642722d55ba51a3799daaec4020f38fc24a6da0b6f8768cc2f40c91915cf8",
+      "topic": "overview",
+      "subject": "Configuration / Configuration Options",
+      "content": {
+        "summary": "### Configuration Options #### Ray Offline Store Options | Option | Type | Default | Description | |--------|------|---------|-------------| | `type` | string | Required | Must be `feast.offline_store"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 232,
+        "quote": "### Configuration Options\n\n#### Ray Offline Store Options\n\n| Option | Type | Default | Description |\n|--------|------|---------|-------------|\n| `type` | string | Required | Must be `feast.offline_stores.contrib.ray_offline_store.ray.RayOfflineStore` or `ray` |\n| `storage_path` | string | None | Path for storing temporary files and datasets |\n| `ray_address` | string | None | Ray cluster address (triggers REMOTE mode, e.g., \"ray://host:10001\") |\n| `use_kuberay` | boolean | None | Enable KubeRay mode (overrides ray_address) |\n| `kuberay_conf` | dict | None | **KubeRay configuration dict** with keys: `cluster_name` (required), `namespace` (default: \"default\"), `auth_token`, `auth_server`, `skip_tls` (default: false) |\n| `enable_ray_logging` | boolean | false | Enable Ray progress bars and verbose logging |\n| `ray_conf` | dict | None | Ray initialization parameters for resource management (e.g., memory, CPU limits) |\n| `broadcast_join_threshold_mb` | int | 100 | Size threshold for broadcast joins (MB) |\n| `enable_distributed_joins` | boolean | true | Enable distributed joins for large datasets |\n| `max_parallelism_multiplier` | int | 2 | Parallelism as multiple of CPU cores |\n| `target_partition_size_mb` | int | 64 | Target partition size (MB) |\n| `window_size_for_joins` | string | \"1H\" | Time window for distributed joins |\n| `num_gpus` | float | None | GPUs per worker task. Supported in all modes. See [Worker Resource Scheduling](../compute-engine/ray.md#worker-resource-scheduling). |\n| `gpu_batch_format` | string | `\"pandas\"` | Batch format for `map_batches` when `num_gpus` is set (`\"numpy\"` or `\"pyarrow\"` for GPU-native libs). |\n| `worker_task_options` | dict | None | Arbitrary Ray `.options()` kwargs (num_cpus, memory, accelerator_type, resources, runtime_env, …). See [Worker Resource Scheduling](../compute-engine/ray.md#worker-resource-scheduling) for the full reference. |\n\n#### Mode Detection Precedence\n\nThe Ray offline store automatically detects the execution mode using the following precedence:\n\n1. **Environment Variables** (highest priority)\n   - `FEAST_RAY_USE_KUBERAY`, `FEAST_RAY_CLUSTER_NAME`, etc.\n2. **Config `kuberay_conf`**\n   - If present → KubeRay mode\n3. **Config `ray_address`**\n   - If present → Remote mode\n4. **Default**\n   - Local mode (lowest priority)\n\n#### Ray Compute Engine Options\n\nFor Ray compute engine configuration options, see the [Ray Compute Engine documentation](../compute-engine/ray.md#configuration-options).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d0c0b7f190121559c4c0011ad35f899606f0307c0150e937ca79a8746c52ee07",
+      "topic": "overview",
+      "subject": "Configuration Options",
+      "content": {
+        "summary": "## Configuration Options | Option | Default | Description | |--------|---------|-------------| | `enabled` | `false` | Enable/disable OpenLineage integration | | `transport_type` | `None` | Transport "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 86,
+        "quote": "## Configuration Options\n\n| Option | Default | Description |\n|--------|---------|-------------|\n| `enabled` | `false` | Enable/disable OpenLineage integration |\n| `transport_type` | `None` | Transport type: `http`, `console`, `file`, `kafka`. When unset, defers to OpenLineage SDK defaults. |\n| `transport_url` | - | URL for HTTP transport (required) |\n| `transport_endpoint` | `api/v1/lineage` | API endpoint for HTTP transport |\n| `api_key` | - | Optional API key for authentication |\n| `namespace` | `feast` | Namespace for lineage events (uses project name if set to \"feast\") |\n| `producer` | `feast` | Producer identifier |\n| `emit_on_apply` | `true` | Emit events on `feast apply` |\n| `emit_on_materialize` | `true` | Emit events on materialization |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "81796aea900c07fa0337773018319f25e1e59aefe71320567b85c53c0f669569",
+      "topic": "overview",
+      "subject": "Description",
+      "content": {
+        "summary": "## Description MongoDB data sources are MongoDB collections that can be used as a source for feature data. The `MongoDBSource` points at a MongoDB collection and provides the metadata Feast needs to read historical features from the offline store's collection."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/mongodb.md",
+        "line": 3,
+        "quote": "## Description\n\nMongoDB data sources are [MongoDB](https://www.mongodb.com/) collections that can be used as a source for feature data. The `MongoDBSource` points at a MongoDB collection and provides the metadata Feast needs to read historical features from the offline store's collection.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "description",
+      "source": "extracted"
+    },
+    {
+      "id": "5d0ffd12e31bf4d10d18f4057cb14b22699b32f6ed591bd41244d3692d78dbc3",
+      "topic": "overview",
+      "subject": "Disclaimer",
+      "content": {
+        "summary": "## Disclaimer The Athena offline store does not achieve full test coverage. Please do not assume complete stability."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/athena.md",
+        "line": 8,
+        "quote": "## Disclaimer\n\nThe Athena offline store does not achieve full test coverage.\nPlease do not assume complete stability.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-31T19:47:32+05:30"
+      },
+      "module": "disclaimer",
+      "source": "extracted"
+    },
+    {
+      "id": "b716f8d5c1d7d723db0dfcf5d409c5b0359ed5bade1e2577cd3e81de03802015",
+      "topic": "overview",
+      "subject": "Example",
+      "content": {
+        "summary": "## Example See [https://github.com/feast-dev/on-demand-feature-views-demo](https://github.com/feast-dev/on-demand-feature-views-demo) for an example on how to use on demand feature views."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/beta-on-demand-feature-view.md",
+        "line": 108,
+        "quote": "## Example\nSee [https://github.com/feast-dev/on-demand-feature-views-demo](https://github.com/feast-dev/on-demand-feature-views-demo) for an example on how to use on demand feature views.\n\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-22T17:08:58-07:00"
+      },
+      "module": "example",
+      "source": "extracted"
+    },
+    {
+      "id": "b776e6db2b888cd46f9232ab44b131a8355eb7418ae334264c4e77d1e3cdc934",
+      "topic": "overview",
+      "subject": "Example / Ingesting data",
+      "content": {
+        "summary": "### Ingesting data See [here](https://github.com/feast-dev/streaming-tutorial) for a example of how to ingest data from a Kafka source into Feast. The approach used in the tutorial can be easily adapt"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/kinesis.md",
+        "line": 73,
+        "quote": "### Ingesting data\nSee [here](https://github.com/feast-dev/streaming-tutorial) for a example of how to ingest data from a Kafka source into Feast. The approach used in the tutorial can be easily adapted to work for Kinesis as well.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2022-06-23T13:33:01-07:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "f54226f32f682583c0ed36322034ca26bbf061e1e0a1c7e9e85c19f4117b96df",
+      "topic": "overview",
+      "subject": "Examples",
+      "content": {
+        "summary": "## Examples Defining a MongoDB source: The `name` field becomes the `feature_view` discriminator stored in every document in the `feature_history` collection. Configuration options such as `connection"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/mongodb.md",
+        "line": 7,
+        "quote": "## Examples\n\nDefining a MongoDB source:\n\n```python\nfrom feast.infra.offline_stores.contrib.mongodb_offline_store.mongodb import (\n    MongoDBSource,\n)\n\ndriver_stats_source = MongoDBSource(\n    name=\"driver_stats\",\n    timestamp_field=\"event_timestamp\",\n    created_timestamp_column=\"created_at\",\n)\n```\n\nThe `name` field becomes the `feature_view` discriminator stored in every document in the `feature_history` collection.\n\nConfiguration options such as `connection_string`, `database`, and `collection` are inherited from the offline store configuration in `feature_store.yaml`.\n\nThe full set of configuration options is available [here](https://rtd.feast.dev/en/master/#feast.infra.offline_stores.contrib.mongodb_offline_store.mongodb.MongoDBSource).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "examples",
+      "source": "extracted"
+    },
+    {
+      "id": "a2f7b9b2967d34f39ef6dcb3a41a3c33670c08be4e131451294cfd6d97002406",
+      "topic": "overview",
+      "subject": "Feast Ignore Patterns",
+      "content": {
+        "summary": "## Feast Ignore Patterns | Pattern             | Example matches                                                 | Explanation                                                                                                              | | ------------------- | --------------------------------------"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-repository/feast-ignore.md",
+        "line": 25,
+        "quote": "## Feast Ignore Patterns\n\n| Pattern             | Example matches                                                 | Explanation                                                                                                              |\n| ------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |\n| venv                | <p>venv/foo.py<br>venv/a/foo.py</p>                             | You can specify a path to a specific directory. Everything in that directory will be ignored.                            |\n| scripts/foo.py      | scripts/foo.py                                                  | You can specify a path to a specific file. Only that file will be ignored.                                               |\n| scripts/\\*.py       | <p>scripts/foo.py<br>scripts/bar.py</p>                         | You can specify an asterisk (\\*) anywhere in the expression. An asterisk matches zero or more characters, except \"/\".    |\n| scripts/\\*\\*/foo.py | <p>scripts/foo.py<br>scripts/a/foo.py<br>scripts/a/b/foo.py</p> | You can specify a double asterisk (\\*\\*) anywhere in the expression. A double asterisk matches zero or more directories. |\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2021-10-15T21:01:59+00:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a636eefc861b6a18d7c4144c386a955c29a0c9abc97629a3cc5a0736dbda7e3d",
+      "topic": "overview",
+      "subject": "Functionality",
+      "content": {
+        "summary": "## Functionality In Feast, each batch data source is associated with corresponding offline stores. For example, a `SnowflakeSource` can only be processed by the Snowflake offline store, while a `FileS"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/overview.md",
+        "line": 3,
+        "quote": "## Functionality\n\nIn Feast, each batch data source is associated with corresponding offline stores.\nFor example, a `SnowflakeSource` can only be processed by the Snowflake offline store, while a `FileSource` can be processed by both File and DuckDB offline stores.\nOtherwise, the primary difference between batch data sources is the set of supported types.\nFeast has an internal type system that supports primitive types (`bytes`, `string`, `int32`, `int64`, `float32`, `float64`, `bool`, `timestamp`), array types, set types, map/JSON types, and struct types.\nHowever, not every batch data source supports all of these types.\n\nFor more details on the Feast type system, see [here](../type-system.md).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-16T08:36:00-04:00"
+      },
+      "module": "functionality",
+      "source": "extracted"
+    },
+    {
+      "id": "2a4d7c2141e40555e80a5fc9085b44dfed07ce21dca940209b26b74537181ad4",
+      "topic": "overview",
+      "subject": "Functionality Matrix",
+      "content": {
+        "summary": "## Functionality Matrix The set of functionality supported by offline stores is described in detail here. Below is a matrix indicating which functionality is supported by the MongoDB offline store. |                                                                    | MongoDB | | :------------------"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/mongodb.md",
+        "line": 71,
+        "quote": "## Functionality Matrix\n\nThe set of functionality supported by offline stores is described in detail [here](overview.md#functionality).\nBelow is a matrix indicating which functionality is supported by the MongoDB offline store.\n\n|                                                                    | MongoDB |\n| :----------------------------------------------------------------- | :------ |\n| `get_historical_features` (point-in-time correct join)             | yes     |\n| `pull_latest_from_table_or_query` (retrieve latest feature values) | yes     |\n| `pull_all_from_table_or_query` (retrieve a saved dataset)          | yes     |\n| `offline_write_batch` (persist dataframes to offline store)        | yes     |\n| `write_logged_features` (persist logged features to offline store) | no      |\n\nBelow is a matrix indicating which functionality is supported by `MongoDBRetrievalJob`.\n\n|                                                       | MongoDB |\n| ----------------------------------------------------- | ------- |\n| export to dataframe                                   | yes     |\n| export to arrow table                                 | yes     |\n| export to arrow batches                               | no      |\n| export to SQL                                         | no      |\n| export to data lake (S3, GCS, etc.)                   | no      |\n| export to data warehouse                              | no      |\n| export as Spark dataframe                             | no      |\n| local execution of Python-based on-demand transforms  | yes     |\n| remote execution of Python-based on-demand transforms | no      |\n| persist results in the offline store                  | yes     |\n| preview the query plan before execution               | no      |\n| read partitioned data                                 | no      |\n\nTo compare this set of functionality against other offline stores, please see the full [functionality matrix](overview.md#functionality-matrix).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "fe41efd37975c20da8e70671c258dc7a711610452edffd3a5aae1ac2967e6f9d",
+      "topic": "overview",
+      "subject": "Getting started",
+      "content": {
+        "summary": "## Getting started In order to use this offline store, you'll need to run `pip install 'feast[mongodb]'`."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/mongodb.md",
+        "line": 7,
+        "quote": "## Getting started\n\nIn order to use this offline store, you'll need to run `pip install 'feast[mongodb]'`.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "d0070d0f0f9df6daa2691d0d9e25a2b941017b0e3e770a690db6984e5e9b10d7",
+      "topic": "overview",
+      "subject": "How It Works",
+      "content": {
+        "summary": "## How It Works\r \r Version tracking is fully automatic. You don't need to set any version parameter — just use `feast apply` as usual:\r \r 1. **First apply** — Your feature view definition is saved as "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/alpha-feature-view-versioning.md",
+        "line": 16,
+        "quote": "## How It Works\r\n\r\nVersion tracking is fully automatic. You don't need to set any version parameter — just use `feast apply` as usual:\r\n\r\n1. **First apply** — Your feature view definition is saved as **v0**.\r\n2. **Change something and re-apply** — Feast detects the change, saves the old definition as a snapshot, and saves the new one as **v1**. The version number auto-increments on each real change.\r\n3. **Re-apply without changes** — Nothing happens. Feast compares the new definition against the active one and skips creating a version if they're identical (idempotent).\r\n4. **Another change** — Creates **v2**, and so on.\r\n\r\n```\r\nfeast apply                  # First apply → v0\r\n# ... edit schema ...\r\nfeast apply                  # Detects change → v1\r\nfeast apply                  # No change detected → still v1 (no new version)\r\n# ... edit source ...\r\nfeast apply                  # Detects change → v2\r\n```\r\n\r\n**Key details:**\r\n\r\n* **Automatic snapshots**: Versions are created only when Feast detects an actual change to the feature view definition (schema or UDF). Metadata-only changes (description, tags, TTL) update in place without creating a new version.\r\n* **Separate history storage**: Version history is stored separately from the active feature view definition, keeping the main registry lightweight.\r\n* **Backward compatible**: The `version` parameter is fully optional. Omitting it (or setting `version=\"latest\"`) preserves existing behavior — you get automatic versioning with zero changes to your code.\r\n\r"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:26:28+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "00f2dd63a87b53a8391de2e90495302a8c5aa0430d3c740c68a400b1a048b034",
+      "topic": "overview",
+      "subject": "How to configure the client",
+      "content": {
+        "summary": "## How to configure the client Please see the detail how to configure Remote Registry client [remote.md](../registries/remote.md)"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/registry-server.md",
+        "line": 998,
+        "quote": "## How to configure the client\n\nPlease see the detail how to configure Remote Registry client [remote.md](../registries/remote.md)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-01-13T18:36:57+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2a7d974d688c915e9c6c12a478c09a5e624c177eba5a75557cc0bdc04e5fa845",
+      "topic": "overview",
+      "subject": "How to configure the server",
+      "content": {
+        "summary": "## How to configure the server Please see the detail how to configure registry server [registry-server.md](../feature-servers/registry-server.md)"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/registries/remote.md",
+        "line": 23,
+        "quote": "## How to configure the server\n\nPlease see the detail how to configure registry server [registry-server.md](../feature-servers/registry-server.md)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-04-17T21:24:48-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "57bcebf49dd1937a1c2c6e66709a4ab5ebeb662b71dbf052e58e02537cef8489",
+      "topic": "overview",
+      "subject": "Installation",
+      "content": {
+        "summary": "## Installation OpenLineage is an optional dependency. Install it with: Or install Feast with the OpenLineage extra:"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/openlineage.md",
+        "line": 14,
+        "quote": "## Installation\n\nOpenLineage is an optional dependency. Install it with:\n\n```bash\npip install openlineage-python\n```\n\nOr install Feast with the OpenLineage extra:\n\n```bash\npip install feast[openlineage]\n```\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T10:32:17-04:00"
+      },
+      "module": "installation",
+      "source": "extracted"
+    },
+    {
+      "id": "6a783248c4f98bf8e681f569ce67d672b00c98a93976b1d58118a9ea4f35fe04",
+      "topic": "overview",
+      "subject": "Key Features",
+      "content": {
+        "summary": "## Key Features 1. **Automated Instrumentation:** Python auto-instrumentation for comprehensive metric collection 2. **Metric Collection:** Track key performance indicators including:    - Memory usag"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/components/open-telemetry.md",
+        "line": 24,
+        "quote": "## Key Features\n\n1. **Automated Instrumentation:** Python auto-instrumentation for comprehensive metric collection\n2. **Metric Collection:** Track key performance indicators including:\n   - Memory usage\n   - CPU utilization\n   - Request latencies\n   - Feature retrieval statistics\n3. **Flexible Configuration:** Customizable metric collection and export settings\n4. **Kubernetes Integration:** Native support for Kubernetes deployments\n5. **Prometheus Compatibility:** Integration with Prometheus for metrics visualization\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-24T10:11:58-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "19ebb60d51e55543da77d122f25ce95c53fff295fdebe70c1522a20f32c7bd40",
+      "topic": "overview",
+      "subject": "Limitations",
+      "content": {
+        "summary": "## Limitations The Ray offline store has one known limitation: * **`online_write_batch` not implemented**: The `OfflineStore.online_write_batch()` interface   is not supported by the Ray offline store"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 599,
+        "quote": "## Limitations\n\nThe Ray offline store has one known limitation:\n\n* **`online_write_batch` not implemented**: The `OfflineStore.online_write_batch()` interface\n  is not supported by the Ray offline store. This does **not** affect materialization —\n  `feast materialize` writes to the online store correctly via the\n  [Ray Compute Engine](../compute-engine/ray.md). The restriction only applies to callers\n  that invoke `online_write_batch` on the offline store object directly, which is an\n  uncommon pattern outside of custom tooling.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "limitations",
+      "source": "extracted"
+    },
+    {
+      "id": "87352812bc8a34685b9a538637218f21bfe77eb5e15d1651457c11b22ee8542d",
+      "topic": "overview",
+      "subject": "Motivation",
+      "content": {
+        "summary": "## Motivation Feast uses an internal type system to provide guarantees on training and serving data. Feast supports primitive types, array types, set types, map types, JSON, and struct types for featu"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/type-system.md",
+        "line": 3,
+        "quote": "## Motivation\n\nFeast uses an internal type system to provide guarantees on training and serving data.\nFeast supports primitive types, array types, set types, map types, JSON, and struct types for feature values.\nNull types are not supported, although the `UNIX_TIMESTAMP` type is nullable.\nThe type system is controlled by [`Value.proto`](https://github.com/feast-dev/feast/blob/master/protos/feast/types/Value.proto) in protobuf and by [`types.py`](https://github.com/feast-dev/feast/blob/master/sdk/python/feast/types.py) in Python.\nType conversion logic can be found in [`type_map.py`](https://github.com/feast-dev/feast/blob/master/sdk/python/feast/type_map.py).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-07T17:07:25-07:00"
+      },
+      "module": "motivation",
+      "source": "extracted"
+    },
+    {
+      "id": "ed7f031dfcd24c9913a531c92daf8c1b69103836ad68ec03516a5dff9c63d369",
+      "topic": "overview",
+      "subject": "Overview",
+      "content": {
+        "summary": "## Overview The Python feature server is an HTTP endpoint that serves features with JSON I/O. This enables users to write and read features from the online store using any programming language that can make HTTP requests."
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/feature-servers/python-feature-server.md",
+        "line": 3,
+        "quote": "## Overview\n\nThe Python feature server is an HTTP endpoint that serves features with JSON I/O. This enables users to write and read features from the online store using any programming language that can make HTTP requests.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-06-03T12:58:14+05:30"
+      },
+      "module": "overview",
+      "source": "extracted"
+    },
+    {
+      "id": "44e258760d5ac9b851af52e30c8a98111c571ef20634578ca545db71e1c53a81",
+      "topic": "overview",
+      "subject": "Permissions",
+      "content": {
+        "summary": "## Permissions Feast requires the following permissions in order to execute commands for DynamoDB online store: | **Command**             | Permissions                                                 "
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/dynamodb.md",
+        "line": 66,
+        "quote": "## Permissions\n\nFeast requires the following permissions in order to execute commands for DynamoDB online store:\n\n| **Command**             | Permissions                                                                         | Resources                                         |\n| ----------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------- |\n| **Apply**               | <p>dynamodb:CreateTable</p><p>dynamodb:DescribeTable</p><p>dynamodb:DeleteTable</p><p>dynamodb:TagResource</p> | arn:aws:dynamodb:\\<region>:\\<account_id>:table/\\* |\n| **Materialize**         | dynamodb.BatchWriteItem                                                             | arn:aws:dynamodb:\\<region>:\\<account_id>:table/\\* |\n| **Get Online Features** | dynamodb.BatchGetItem                                                               | arn:aws:dynamodb:\\<region>:\\<account_id>:table/\\* |\n\nThe following inline policy can be used to grant Feast the necessary permissions:\n\n```javascript\n{\n    \"Statement\": [\n        {\n            \"Action\": [\n                \"dynamodb:CreateTable\",\n                \"dynamodb:DescribeTable\",\n                \"dynamodb:DeleteTable\",\n                \"dynamodb:TagResource\",\n                \"dynamodb:BatchWriteItem\",\n                \"dynamodb:BatchGetItem\"\n            ],\n            \"Effect\": \"Allow\",\n            \"Resource\": [\n                \"arn:aws:dynamodb:<region>:<account_id>:table/*\"\n            ]\n        }\n    ],\n    \"Version\": \"2012-10-17\"\n}\n```\n\nLastly, this IAM role needs to be associated with the desired Redshift cluster. Please follow the official AWS guide for the necessary steps [here](https://docs.aws.amazon.com/redshift/latest/dg/c-getting-started-using-spectrum-add-role.html).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-25T08:53:08-04:00"
+      },
+      "module": "permissions",
+      "source": "extracted"
+    },
+    {
+      "id": "a689029fc3c79578679c2aa4bda1bd2e9e5e33b6591de3518a0f76653e12598a",
+      "topic": "overview",
+      "subject": "Quick Start with Ray Template",
+      "content": {
+        "summary": "## Quick Start with Ray Template The easiest way to get started with Ray offline store is to use the built-in Ray template: This template includes: - Pre-configured Ray offline store and compute engine setup - Sample feature definitions optimized for Ray processing - Demo workflow showcasing Ray cap"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/offline-stores/ray.md",
+        "line": 8,
+        "quote": "## Quick Start with Ray Template\n\nThe easiest way to get started with Ray offline store is to use the built-in Ray template:\n\n```bash\nfeast init -t ray my_ray_project\ncd my_ray_project/feature_repo\n```\n\nThis template includes:\n- Pre-configured Ray offline store and compute engine setup\n- Sample feature definitions optimized for Ray processing\n- Demo workflow showcasing Ray capabilities\n- Resource settings for local development\n\nThe template provides a complete working example with sample datasets and demonstrates both Ray offline store data I/O operations and Ray compute engine distributed processing.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-30T22:21:03+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "2f6e0cf744d54469304f295f5ae07cf22e179af5aa1931b9f27a9535e514f305",
+      "topic": "overview",
+      "subject": "Related Documentation",
+      "content": {
+        "summary": "## Related Documentation - [Groups and Namespaces Authentication](./groups_namespaces_auth.md) - [Authorization Manager](../../getting-started/components/authz_manager.md) - [Permission Model](../../g"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/auth/user_token_provisioning.md",
+        "line": 284,
+        "quote": "## Related Documentation\n\n- [Groups and Namespaces Authentication](./groups_namespaces_auth.md)\n- [Authorization Manager](../../getting-started/components/authz_manager.md)\n- [Permission Model](../../getting-started/concepts/permission.md)\n- [RBAC Architecture](../../getting-started/architecture/rbac.md)\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-10-10T09:10:10-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "a3855c62426ed81c5d52a02e8a2386221ad4ef679d8be132d4861953a66ab894",
+      "topic": "overview",
+      "subject": "Retrieving online document vectors",
+      "content": {
+        "summary": "## Retrieving online document vectors The ElasticSearch online store supports retrieving document vectors for a given list of entity keys. The document vectors are returned as a dictionary where the k"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/online-stores/elasticsearch.md",
+        "line": 54,
+        "quote": "## Retrieving online document vectors\n\nThe ElasticSearch online store supports retrieving document vectors for a given list of entity keys. The document vectors are returned as a dictionary where the key is the entity key and the value is the document vector. The document vector is a dense vector of floats.\n\n{% code title=\"python\" %}\n```python\nfrom feast import FeatureStore\n\nfeature_store = FeatureStore(repo_path=\"feature_store.yaml\")\n\nquery_vector = [1.0, 2.0, 3.0, 4.0, 5.0]\ntop_k = 5\n\n# Retrieve the top k closest features to the query vector\n\nfeature_values = feature_store.retrieve_online_documents_v2(\n    features=[\"my_feature\"],\n    query=query_vector,\n    top_k=top_k,\n)\n```\n{% endcode %}\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-04-25T12:07:08-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "525f5d752e632cfa2911dc3cde23a1003d7d5ebace5c3940a28aa7693273302f",
+      "topic": "overview",
+      "subject": "Stream sources",
+      "content": {
+        "summary": "## Stream sources Streaming data sources are important sources of feature values. A typical setup with streaming data looks like: 1. Raw events come in (stream 1) 2. Streaming transformations applied (e.g. generating features like `last_N_purchased_categories`) (stream 2) 3. Write stream 2 values to"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/push.md",
+        "line": 13,
+        "quote": "## Stream sources\n\nStreaming data sources are important sources of feature values. A typical setup with streaming data looks like:\n\n1. Raw events come in (stream 1)\n2. Streaming transformations applied (e.g. generating features like `last_N_purchased_categories`) (stream 2)\n3. Write stream 2 values to an offline store as a historical log for training (optional)\n4. Write stream 2 values to an online store for low latency feature serving\n5. Periodically materialize feature values from the offline store into the online store for decreased training-serving skew and improved model performance\n\nFeast allows users to push features previously registered in a feature view to the online store for fresher features. It also allows users to push batches of stream data to the offline store by specifying that the push be directed to the offline store. This will push the data to the offline store declared in the repository configuration used to initialize the feature store.\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2025-06-17T12:53:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "c537c613d64aa82dcc0073604ea8c29d8663639011765293375d60f2c16f4755",
+      "topic": "overview",
+      "subject": "Supported Compute Engines",
+      "content": {
+        "summary": "## Supported Compute Engines - [x] LocalComputeEngine - [x] SparkComputeEngine - [ ] LambdaComputeEngine - [ ] KubernetesComputeEngine ---"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/getting-started/concepts/batch-feature-view.md",
+        "line": 5,
+        "quote": "## Supported Compute Engines\n- [x] LocalComputeEngine\n- [x] SparkComputeEngine\n- [ ] LambdaComputeEngine\n- [ ] KubernetesComputeEngine\n\n---\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-03-10T13:40:45-04:00"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "1e255051a2dd71b4e20d444fccaeebcf37e82e5e48e9263a59483c56b6bc547a",
+      "topic": "overview",
+      "subject": "Supported Types",
+      "content": {
+        "summary": "## Supported Types MongoDB data sources support all eight primitive types (`bytes`, `string`, `int32`, `int64`, `float32`, `float64`, `bool`, `timestamp`) and their corresponding array types. Complex types such as `Map` and `Struct` are preserved through the MongoDB document model. For a comparison"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/data-sources/mongodb.md",
+        "line": 100,
+        "quote": "## Supported Types\n\nMongoDB data sources support all eight primitive types (`bytes`, `string`, `int32`, `int64`, `float32`, `float64`, `bool`, `timestamp`) and their corresponding array types. Complex types such as `Map` and `Struct` are preserved through the MongoDB document model.\nFor a comparison against other batch data sources, please see [here](overview.md#functionality-matrix).\n"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-05-14T11:56:32+05:30"
+      },
+      "module": "_shared",
+      "source": "extracted"
+    },
+    {
+      "id": "3b37ea494265c5338275fa607ab6c3142fde8cc955b1b7495af58e6ae150fe0b",
+      "topic": "overview",
+      "subject": "Troubleshooting",
+      "content": {
+        "summary": "## Troubleshooting ### Validation Issues with Complex Transformations When defining On Demand Feature Views with complex transformations, you may encounter validation errors during `feast apply`. Feast validates ODFVs by constructing random inputs and running the transformation function to infer the"
+      },
+      "kind": "definition",
+      "provenance": {
+        "file": "docs/reference/beta-on-demand-feature-view.md",
+        "line": 348,
+        "quote": "## Troubleshooting\n\n### Validation Issues with Complex Transformations\n\nWhen defining On Demand Feature Views with complex transformations, you may encounter validation errors during `feast apply`. Feast validates ODFVs by constructing random inputs and running the transformation function to infer the output schema. This validation can sometimes be overly strict or fail for complex transformation logic.\n\nIf you encounter validation errors that you believe are incorrect, you can skip feature view validation:\n\n**Python SDK:**\n```python\nfrom feast import FeatureStore\n\nstore = FeatureStore(repo_path=\".\")\nstore.apply([my_odfv], skip_feature_view_validation=True)\n```\n\n**CLI:**\n```bash\nfeast apply --skip-feature-view-validation\n```\n\n{% hint style=\"warning\" %}\nSkipping validation bypasses important checks. Use this option only when the validation system is being overly strict. We encourage you to report validation issues on the [Feast GitHub repository](https://github.com/feast-dev/feast/issues) so the team can improve the validation system.\n{% endhint %}\n\n**When to use skip_feature_view_validation:**\n- Your ODFV transformation uses complex logic that fails the random input validation\n- You've verified your transformation works correctly with real data\n- The validation error doesn't reflect an actual issue with your transformation\n\n**What validation is skipped:**\n- Feature view name uniqueness checks\n- ODFV transformation validation via `_construct_random_input()`\n- Schema inference for features\n\n**What is NOT skipped:**\n- Data source validation (use `--skip-source-validation` to skip)\n- Registry operations\n- Infrastructure updates\n\n… (+2 more lines)"
+      },
+      "metadata": {
+        "docKind": "unknown",
+        "lastTouched": "2026-04-22T17:08:58-07:00"
+      },
+      "module": "troubleshooting",
+      "source": "extracted"
+    }
+  ]
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/specs/decisions.json
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/specs/decisions.json
@@ -1,0 +1,340 @@
+{
+  "version": 1,
+  "decisions": [
+    {
+      "conflictId": "d8b39cf0bf3aa75cbc5d756b74767104589055191ae0852d33ca1cff78621184",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 2
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "b4b53851cbfec61dbb340446a687cabd1c8a0a9fac042def1e685e3c5c4e4938"
+    },
+    {
+      "conflictId": "bf2fde7a4a52932a6e450b856f28df4ed79ca8dad856c0f15cf68e1eb25e68de",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 38
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "ec23666e214eb4bcd8502042e4b69a80b4a5a13e2915fb82cf4d252908f27640"
+    },
+    {
+      "conflictId": "020f8283a2cd0ffb496b7602d6917174eccd90ed3ef24a4f629ff5a9c40fd128",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 3
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "b692357af572dce183fb509ef838c61378c6c059419dc978994277adc2ef6eb5"
+    },
+    {
+      "conflictId": "62ccc637c9a742c3291be177f10ad2a65add724e45ef1af51e6a7f86bc571f95",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "15bb9b2956df295bd45d71888ecfc5109cc7102fc6d9136378ea88577b365842"
+    },
+    {
+      "conflictId": "848782908d7b23e0bc1ed52eb316f2b7217ba8ed14ac4bb1bd9f97a7a00bf8eb",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 2
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "0f7d07ab19c122fd7b98037fb9d83e5839428d7c6128ab18414ae7041cc182bd"
+    },
+    {
+      "conflictId": "3e2846a8db442766b6f4bb59445e4ab3015f604d73acb61fda96837a1c6de7ef",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 2
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "e3f4868f7cd9692d2579b54effa5de66830f54a117c498a6f0dab8658c69c22b"
+    },
+    {
+      "conflictId": "f1d3b013a30f62a6ee0253a945b146c6f84527c4dc991480a826138c307e39c9",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 4
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "35d79dbe9741ac2c1a4241579f9078425f83657753576cd1f68abd5f8e8668fd"
+    },
+    {
+      "conflictId": "fcfddedcac3983621c17894d010ee30fb2f24dabb517d7fd082f0420e85c201d",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "1c2f0a0872157e8efd9281562539d0db332975ae991466c73d7eb65f31c7d636"
+    },
+    {
+      "conflictId": "c1af643b7b85ae01e0d3bc3ba7313b1254e15040042b700d50123dcf2d5656fd",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "d0df72656ff7da6d5e4b656cf5b2f826f24d5c3366847e1e938f6bfedc902400"
+    },
+    {
+      "conflictId": "7944611c5ae44637e4fedc0541ff07ca0430c06d51aa5cdf93c42f352d783061",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 2
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "8ff4648f2f9c4915d03c54ea2894a75813ee2351a2dc0c648a65eca58617bb85"
+    },
+    {
+      "conflictId": "90cb52625e4ec2b0b71e9c04c50258c519f34c75bd7c92b573788b7ae82df6ca",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 2
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "63cdab6d10cf7f08c883a155f37c262cdf4a2575858f586cadef29a371d05bc8"
+    },
+    {
+      "conflictId": "591c5713a4bd48b1fd215a1cd0896860a9188f8fc11d614828b351f5f0d45779",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "d85ee74f9678a8865836f7b3b8c148e597ea011b2c9a0756daf5f2943929c0c0"
+    },
+    {
+      "conflictId": "5e65369f5d8218d584205910a14c38c3cb2eeb7158de41bf2f3e70ad4f81199c",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 65
+      },
+      "resolvedAt": "2026-06-05T02:49:42.685Z",
+      "candidateFingerprint": "43691cf3662cdc5c3ad6769d0ac6b2c05339c0d37508186ccf3283ba8b9845d3"
+    },
+    {
+      "conflictId": "46bb2afb9095e0e3059d5d9485f499d6307b5f16177a8d57152cbc71bc6aca74",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 14
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "ca204d5428317a4664da72fc737a8c98bc0f9ba99208f0244e7541ade011a2ea"
+    },
+    {
+      "conflictId": "3bda15b81e6bcc4fb381b9b76a86ca593ada979bce9d0f340b3ccc8c4d86a902",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "192029cea5f12ea98ad576137394505bac682793471ca1fc0fee79ccf5308d56"
+    },
+    {
+      "conflictId": "ddab32341c5e92d9ff59b13db3c6c72ba01433b4ab7ad0a2689020d91a058504",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 0
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "ae83c0eeb07bdbfe1e156f4fd7bf053aad1d1c634fb8b2b9fae0219fc1bb49be"
+    },
+    {
+      "conflictId": "dfc2dd459fe036abf962d7409b3a032c7cbc6953321acdb0d7c8bd512c904683",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 11
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "71e12b78c24304e486df2b717decaf80cccdef6f916222627c9420159aaad21e"
+    },
+    {
+      "conflictId": "47bf4bd3b93b0a10bb68935ac64a8644045bdf12cbda33e7eebad9125e59ea63",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "82b780b30d0d461f5eff4cd7c4b4139227670979dfebd69652aee41572a6de5f"
+    },
+    {
+      "conflictId": "254c24a3ecbf37960bc34f84b40ebc2ed6ef0b3d0f879572acf57e68e1f1768a",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 2
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "f65ed23bd4644d9d5ab70ae1f1cdcfdc15cb12cb738a51ef02677a450fe2c253"
+    },
+    {
+      "conflictId": "c4be87e33d5862d7c9312a5cd65572158dce17893126fade04e57f324d7f7f46",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 39
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "94eb29e736042bdf132d718f4462a800a03d103ed8911e725da7bdbc0d5ab948"
+    },
+    {
+      "conflictId": "5dd28038b68e1f81814e68c9996192ee5f23096fde6fc243924712b4a1e94b10",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 32
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "da98ee856751b04e480322dd6c2e107e64453f3a3899216d3d01812991ca0dc8"
+    },
+    {
+      "conflictId": "e51da24d01ad51395ead267b26ec2c110fc0da2b335c4f2705b4004d79947fb0",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "7e06fdb87910cad60d71b7d03dee48047c5e3fa8ee0b4e1a3242f82e7d275e85"
+    },
+    {
+      "conflictId": "4e25acc35d407bcbcd91511c3ec361eed7fcf4524462ca38ea96332af7303d87",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "af18642eeb6c7620d0567704b47ff354b6ea132cea167a7d9b30b17dd45256b7"
+    },
+    {
+      "conflictId": "a49ea5fb1ec236bd80c26ba009eddba314d7eda4ef60ac8097fc4c785796255c",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "5a1f6fb957113ea134faeb98fcb2d7d47af0a781cd24eb759b8515cc3d907cd5"
+    },
+    {
+      "conflictId": "919554194c94b45ff4e9341475ea5cb2112a162049f98c1e1e5ce2ecb6d8acad",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 2
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "088f17ba220bfc30652e41c99f7ef28fca717dae72824486e9ad9b6b1ab617ec"
+    },
+    {
+      "conflictId": "7eb28a628064eaad8feaa5c70bc88fc5519e764afcdc22e97a165aa3dc4c1232",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 2
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "0e0c37ac700b8eec499181f15ea03c37e0408be28469ed17c521fce4c046240f"
+    },
+    {
+      "conflictId": "b97a0493ad0eebd28896b2ae1ae02212d577689ad71e33c4551b7ddefa303e00",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "70317d98879828dc1ed93e68bfb8f9cb2cd0ea69710498d01852aa08d2ffa43a"
+    },
+    {
+      "conflictId": "2bf9852e5ae4d9cafccdc90104e6de0ba342f50e9846ef72f9afd8f3de2a231c",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 2
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "e104171d8254d3cd7f2f571cf69fe77357c4c9a6c330904f94419ddfe0b65571"
+    },
+    {
+      "conflictId": "df6069d72d25332b37663f146b604bc1a99f64b213a3c966408fda299c987422",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 26
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "473d10eca052fd2e851cbbdb1b0e945918881e22b2718928cf1fb8722f1e3bed"
+    },
+    {
+      "conflictId": "4a4104c280b0dfd4e06c8ed72baefa4456ed67479fcc68121a5746214106b408",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "424bfb203b940141d45ec7160545412345666b94cc66bc79d74823bde5e332aa"
+    },
+    {
+      "conflictId": "155093404929d1f92decc4eb4b1ed80db6ecf27cc58857cff192d5aac02b7448",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "8cb2d6adc5c5d9da60948741b8cb9e8ca0fbde4db8601bd0e7e1352ebaba1c41"
+    },
+    {
+      "conflictId": "6c8368d7c8b9a883fd5d13ac2a3f56f42ad50971bed4298eb690fced50666195",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 0
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "b067c0ae3729f1cfc8703076a1cccf0b059b431ca46ef0bf5a5d7da9380ae8c1"
+    },
+    {
+      "conflictId": "e446e9ed4e289aadee84a70ff964ce9cef7c70758b9d0f16e11d6e2dee8af5a7",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "c2cd5c0edc82af5aebe97d5f6447e9e4aaa76a2ea45187eb329831b16a133b94"
+    },
+    {
+      "conflictId": "58692095a270437e6626f3dd1b09bfc83deffda0a8fdf012470e8a40af72b3b4",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 2
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "f28e9331cb3ee17cbd80de82489c589a8d62cebb5da187f89bbf1bff33061d2a"
+    },
+    {
+      "conflictId": "80cbeaa969f0f2fff3558bc746d57f7a7688342d46cbe46d705491c24f6863a2",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 1
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "6b255e1b36e05de20976e0941dee1173d70db7cc492d3f2ca077d0b65ebf50e0"
+    },
+    {
+      "conflictId": "e6199935eb1800c0ea114b919641a89f909485e106d38e2f65e820ccc78a3b3f",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 11
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "fc1c045e8f7e9aebc33eaa55c52d9c46ad6e4ac849662178f0848e43263ac0e2"
+    },
+    {
+      "conflictId": "513bf820014bfe8f2fd88cf9413f5303eef4513a52d135ab48a878f3c19731c2",
+      "resolution": {
+        "kind": "pick",
+        "candidateIndex": 3
+      },
+      "resolvedAt": "2026-06-05T02:49:42.686Z",
+      "candidateFingerprint": "2ea6fb01c5c0f39f036597c71261a36d785d90468b13f3a072449337eb99c6ca"
+    }
+  ],
+  "manualChains": [],
+  "manualIncludes": []
+}

--- a/docs/drift-fp-automation/contracts/feast-dev-feast/truecourseignore
+++ b/docs/drift-fp-automation/contracts/feast-dev-feast/truecourseignore
@@ -1,0 +1,5 @@
+*.md
+!docs/getting-started/concepts/**
+!docs/getting-started/components/**
+!docs/reference/**
+!docs/specs/**


### PR DESCRIPTION
⚠️ **DO NOT MERGE** — storage branch for the `feast-dev/feast` drift campaign; deleted automatically at campaign close by `drift-fp-campaign-close`.

---

## Contracts store: `feast-dev/feast`

| Field | Value |
|-------|-------|
| `target_ref` | `276b6df562e16fefba7efb493736ff32046d4a76` |
| Generated at | 2026-06-05 |
| Tool version | truecourse 0.6.2 |
| Transport | `agent` (LLM answered prompts in-session) |

### Doc scope

```
docs/getting-started/concepts
docs/getting-started/components
docs/reference
docs/specs
```

139 docs scanned, 742 claims extracted, 37 conflicts resolved (all accepted defaults — generic heading collisions across 130+ reference docs).

### Artifact counts

**59 .tc contracts:**
- ArchitectureDecision: 2
- AuthRequirement: 2 (OIDC Bearer, Kubernetes RBAC)
- NamedConstant: 15 (auth type strings, env var names, config defaults, port defaults)
- UnenforceableObligation: 40 (narrative overview content)

`contracts validate` — 59 artifacts, no issues.

### Notes

feast is a Python feature store SDK, so the behavioral docs are primarily configuration reference (online/offline store types, compute engines, auth schemes) rather than HTTP API specs. The spec surface yields:
- Auth type constants: `"no_auth"`, `"oidc"`, `"kubernetes"` (verifiable against Python auth module)
- Env var names: `FEAST_OIDC_TOKEN`, `LOCAL_K8S_TOKEN`
- Config defaults: `online_write_batch_size=null`, `pull_latest_features=false`
- Port defaults: remote offline store 8815, remote registry 6570
- CLI flag names: `--skip-source-validation`, `--skip-feature-view-validation`

The probe found NamedConstant 189, Operation 71, Enum 20 — the current extraction is conservative (59 contracts). The `discover` run will test whether these map cleanly to Python code.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHVcjjd7J7iYEHW8x2LQWE)_