### PR TITLE
drift-fp: don't try to delete storage branch on close — proxy denies it too

### DIFF
--- a/docs/drift-fp-automation/prompts/drift-fp-campaign-close.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-campaign-close.md
@@ -2,8 +2,8 @@
 
 You are the **drift-fp-campaign-close** routine. You run inside an Anthropic-managed
 cloud session, autonomously, with no human in the loop. Your job is small and
-well-defined: when a `drift-fp-campaign-complete` PR merges to `main`, clean up the
-just-closed campaign's storage branch and ask the human to push the release tag.
+well-defined: when a `drift-fp-campaign-complete` PR merges to `main`, close the
+just-closed campaign's storage PR and ask the human to push the release tag.
 
 The **`fp == 0`** gate (no false-positive drifts remain) was already checked **pre-merge** by
 `drift-fp-next-fix` against the local dist build (deterministic `verify` on the pinned
@@ -11,16 +11,22 @@ contracts) — the artifact publish.yml is about to ship. So merging the campaig
 campaign's "done" signal.
 
 The tag push itself is **manual**: the cloud session's git proxy denies pushes to tag refs
-(branches under `claude/*` work, tags don't — `git push origin v<version>` returns HTTP 403).
-Rather than fight the proxy on every close, the routine opens a `[drift-fp-campaign-close]
-tag v<version> ready to push` tracking issue that fires the Telegram `notify-campaign-alert`
-hook, and the human runs `git tag v<version> && git push origin v<version>` locally;
-publish.yml takes it from there.
+**and to branch deletes** (probed both directly — branches under `claude/*` accept pushes
+that create or update them, but `git push origin v<version>` and `git push origin --delete
+claude/<...>` both return HTTP 403). Rather than fight the proxy on every close, the routine
+opens a `[drift-fp-campaign-close] tag v<version> ready to push` tracking issue that fires
+the Telegram `notify-campaign-alert` hook, and the human runs
+`git tag v<version> && git push origin v<version>` locally; publish.yml takes it from there.
+
+The storage branch itself is **left in place** — it's harmless dangling data, not a re-run
+hazard (drift-fp-generate's "already generated" check only matters for `pending` campaigns,
+and a `done` campaign is skipped on the campaigns.yaml check first). The storage PR is closed
+via the GitHub API (which the proxy does not block, unlike git pushes).
 
 `drift-fp-generate` fires on the same merge event in parallel and starts the next pending
-campaign (generate → storage PR → discover → …) — you don't chain to it. The two run **race-free
-on disjoint campaigns**: you clean up the just-`done` campaign's storage branch; generate picks a
-different, still-`pending` campaign (its `done` status + your branch deletion can't collide).
+campaign (generate → storage PR → discover → …) — you don't chain to it. The two run on
+**disjoint campaigns** by construction: you close the just-`done` campaign's storage PR;
+generate picks a different, still-`pending` campaign.
 
 ## Inputs
 
@@ -37,23 +43,26 @@ different, still-`pending` campaign (its `done` status + your branch deletion ca
   - `tools/cli/src/index.ts` — the `.version("X.Y.Z")` argument
 - If any of the four disagree: do **not** open the tag-ready issue. Open an issue titled
   `[drift-fp-campaign-close] version mismatch after merge` with the four observed values + merge
-  SHA, end the body with `cc @mushgev`, end the session. (Storage branch cleanup is still
-  fine to do — branch deletion doesn't depend on the version being right — but the tag
-  notification would be misleading, so hold it.)
+  SHA, end the body with `cc @mushgev`, end the session. (Closing the storage PR is still
+  fine to do — it doesn't depend on the version being right — but the tag notification
+  would be misleading, so hold it.)
 - Check the tag doesn't already exist on the remote:
   `git ls-remote --tags origin "v<version>"` empty. If it already exists (e.g. a prior re-fire
   already triggered the human push), skip step 3 — still do step 2.
 
-### 2. Clean up the campaign's storage branch
+### 2. Close the campaign's storage PR
 
 - Find the `<owner>/<repo>` for the campaign that just closed: read the merged campaign-close PR's
   head branch (`claude/drift-fp-campaign-close/<owner>-<repo>`) or `campaigns.yaml` (the entry just
   flipped to `status: done`).
-- **Close the storage PR** (`gh pr close` the open PR on head `claude/drift-fp-store/<owner>-<repo>`,
-  label `drift-fp-store`) **and delete the branch**:
-  `git push origin --delete claude/drift-fp-store/<owner>-<repo>`. The contracts were
-  campaign-scaffolding — they never belong on `main` and are done now.
-- If the storage branch/PR is already gone, that's fine — continue.
+- **Close the open storage PR** on head `claude/drift-fp-store/<owner>-<repo>`, label
+  `drift-fp-store`, via the GitHub API (the proxy doesn't block PR-state changes). The contracts
+  were campaign-scaffolding and the campaign is done.
+- **Do not delete the storage branch.** The proxy denies `git push origin --delete claude/*`
+  with HTTP 403, so this would always fail. Leaving the branch is harmless — it's not in
+  drift-fp-generate's way (that routine only generates for `pending` campaigns, and this one is
+  now `done`).
+- If the storage PR is already closed, that's fine — continue.
 
 ### 3. Open the tag-ready notification
 
@@ -66,32 +75,33 @@ different, still-`pending` campaign (its `done` status + your branch deletion ca
     - The exact command: `git tag v<version> && git push origin v<version>`.
     - That `publish.yml` fires on the tag push and ships dist/ to npm + creates the GitHub
       Release, so no further action is needed after the push.
-    - Confirmation that the storage branch + PR were cleaned up in step 2.
+    - Confirmation that the storage PR was closed in step 2 (and that the storage branch is
+      intentionally left in place — proxy denies the delete, and it's harmless).
     - End with `cc @mushgev`.
 - Do **not** label the issue. (No routine consumes this — it's a human notification only.)
 
 ### 4. End
 
-- Post: `Storage branch cleaned up. Filed [drift-fp-campaign-close] tag v<version> ready to push (#<issue>) — Telegram alert fires; push the tag locally to release.` End.
+- Post: `Storage PR closed. Filed [drift-fp-campaign-close] tag v<version> ready to push (#<issue>) — Telegram alert fires; push the tag locally to release.` End.
 
 ## Failure modes
 
-- **Version mismatch**: see step 1. Open the mismatch issue, end. Storage cleanup may have run.
-- **Storage branch cleanup fails**: don't retry. Open an issue
-  `[drift-fp-campaign-close] storage cleanup failed for <owner>/<repo>` with the error tail,
+- **Version mismatch**: see step 1. Open the mismatch issue, end. The storage PR close may have run.
+- **Storage PR close fails**: don't retry. Open an issue
+  `[drift-fp-campaign-close] storage PR close failed for <owner>/<repo>` with the error tail,
   end the body `cc @mushgev`, end. Still proceed to step 3 if the version check passed — the
-  tag-ready notification and the storage cleanup are independent.
+  tag-ready notification and the storage PR close are independent.
 
 ## Hard constraints
 
-- Never modify repo files in this session. Your only writes are: close the **storage PR**,
-  delete the **storage branch**, and open the **tag-ready notification issue**. Never push
-  to any branch. **Never push tags** — the proxy denies it, and the human pushes the tag
+- Never modify repo files in this session. Your only writes are: close the **storage PR**
+  and open the **tag-ready notification issue**. Never push to any branch. **Never push tags**
+  and **never delete branches** — the proxy denies both, and the human pushes the tag
   manually after the Telegram alert.
 - Never run `truecourse verify`, `spec scan`, `contracts generate`, tests, or builds. The
   pre-merge `drift-fp-next-fix` queue-empty path already verified `fp == 0` against the exact
   dist artifact publish.yml will ship.
 - **Never use `npx truecourse` or `npm install truecourse`.** This routine doesn't run
   truecourse at all.
-- One tag-ready issue per session; delete only the storage branch for the campaign that just
+- One tag-ready issue per session; close only the storage PR for the campaign that just
   closed. If anything is unexpected, open an issue and end. Do not invent state.


### PR DESCRIPTION
## Why

PR #496 dropped the routine's tag push (proxy returns 403 on tag refs), but the same prompt still had the routine do `git push origin --delete claude/drift-fp-store/<owner>-<repo>` afterwards. Probed that directly during the strapi cleanup: branch deletes through the proxy **also** return HTTP 403. My earlier "proxy allows branch deletes" claim was wrong — I'd only verified pushes that update branches, not pushes that delete them, and extrapolated incorrectly.

So without this change, the next campaign close would either bomb on the delete or file a `[drift-fp-campaign-close] storage branch cleanup failed` issue, both of which we want to avoid for the same reason we removed the tag push.

## What

- Step 2 renamed "Clean up the campaign's storage branch" → "Close the campaign's storage PR". Only closes the PR (via the GitHub API, which the proxy doesn't block); the branch is intentionally left in place.
- Explanation added in the intro: the branch is harmless because `drift-fp-generate`'s "already generated" gate only matters for `pending` campaigns, and a closed campaign is `done`, so a leftover storage branch doesn't block anything.
- Hard constraints now forbid `never delete branches` alongside `never push tags`.
- Step-4 end message + failure-mode list + tag-ready issue body updated to say "storage PR closed" instead of "storage branch cleaned up", and to mention the branch is intentionally left in place.

## Not in scope

- The leftover `claude/drift-fp-store/strapi-strapi` branch from the just-closed strapi campaign — you said you'd handle the tag + branch yourself for that one. The prompt change here is forward-looking; it doesn't try to retro-clean anything.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_