### PR TITLE
drift-fp: drop PR-event trigger labels from prompts — head-branch prefix is sufficient

### DIFF
--- a/docs/drift-fp-automation/prompts/drift-fp-campaign-close.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-campaign-close.md
@@ -55,9 +55,10 @@ generate picks a different, still-`pending` campaign.
 - Find the `<owner>/<repo>` for the campaign that just closed: read the merged campaign-close PR's
   head branch (`claude/drift-fp-campaign-close/<owner>-<repo>`) or `campaigns.yaml` (the entry just
   flipped to `status: done`).
-- **Close the open storage PR** on head `claude/drift-fp-store/<owner>-<repo>`, label
-  `drift-fp-store`, via the GitHub API (the proxy doesn't block PR-state changes). The contracts
-  were campaign-scaffolding and the campaign is done.
+- **Close the open storage PR** on head `claude/drift-fp-store/<owner>-<repo>` via the GitHub
+  API (the proxy doesn't block PR-state changes). The branch prefix is unique to this campaign,
+  so the head-ref alone identifies the PR — no label lookup needed. The contracts were
+  campaign-scaffolding and the campaign is done.
 - **Do not delete the storage branch.** The proxy denies `git push origin --delete claude/*`
   with HTTP 403, so this would always fail. Leaving the branch is harmless — it's not in
   drift-fp-generate's way (that routine only generates for `pending` campaigns, and this one is

--- a/docs/drift-fp-automation/prompts/drift-fp-discover.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-discover.md
@@ -17,8 +17,10 @@ contracts were generated and committed upstream by `drift-fp-generate` onto the 
 
 - `truecourse-ai/truecourse` is cloned at the default branch.
 - Fires when a **storage PR is opened** (`pull_request.opened`, head-branch starts-with
-  `claude/drift-fp-store/`, label `drift-fp-store`) — so the campaign's contracts now exist on that
-  branch. Derive `<owner>-<repo>` from the head branch name; no human review of the contracts.
+  `claude/drift-fp-store/`) — so the campaign's contracts now exist on that branch. The
+  head-branch prefix is uniquely owned by `drift-fp-generate`, so no label is required for the
+  trigger to fire. Derive `<owner>-<repo>` from the head branch name; no human review of the
+  contracts.
 
 ## Step-by-step
 
@@ -50,9 +52,9 @@ contracts were generated and committed upstream by `drift-fp-generate` onto the 
   All commits this step makes go on this branch.
 - Set the campaign's `status: discovering` in `campaigns.yaml` and commit on that branch.
 - Open a PR titled `chore(drift-fp): start discovery for <owner>/<repo>`. Body explains you're
-  starting a drift discovery run. End the body with `cc @mushgev`.
-- **Apply label `drift-fp-discover` to this PR** — this is what fires `drift-fp-next-fix` when
-  the PR merges. Without it, the chain doesn't start.
+  starting a drift discovery run. End the body with `cc @mushgev`. **No label is required** —
+  `drift-fp-next-fix` triggers on the merge of any PR whose head branch starts with
+  `claude/drift-fp-discover/`, which is uniquely owned by this routine.
 - **Verify your branch before pushing.** Run `git rev-parse --abbrev-ref HEAD` and confirm it is
   exactly `claude/drift-fp-discover/<owner>-<repo>`. If it isn't, STOP, recreate the correct branch
   from `origin/main`, cherry-pick the commit, delete the wrong branch, then push.

--- a/docs/drift-fp-automation/prompts/drift-fp-generate.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-generate.md
@@ -139,38 +139,34 @@ contracts.
   cherry-pick or re-stage the commit from step 5, delete the wrong branch, then push. Pushing from
   the wrong branch produces a PR whose head doesn't match the `drift-fp-discover` trigger filter
   (`Head Branch starts-with claude/drift-fp-store/`), and the chain stalls before discover fires.
-- **Open the PR with the `drift-fp-store` label applied atomically — in a single command.** The
-  `drift-fp-discover` routine triggers on `pull_request.opened` filtered by
-  `Labels is-one-of drift-fp-store`. GitHub fires `pull_request.opened` once, at the moment the
-  PR is created, with the labels present **at that moment**. If you `gh pr create` first and
-  `gh pr edit --add-label` second, the `opened` event carries no labels, the trigger never
-  matches, and discover never fires — the chain stalls. So use one command:
+- **Open the PR — no label required.** The `drift-fp-discover` routine triggers on
+  `pull_request.opened` filtered **only on head-branch prefix** (`Head Branch starts-with
+  claude/drift-fp-store/`). The branch prefix is uniquely owned by this routine, so it's
+  sufficient on its own; no label is needed for the trigger to fire. Use whatever PR-creation
+  tool your session has — `gh pr create` if `gh` is on PATH, otherwise the GitHub MCP
+  `create_pull_request` tool. Either works.
 
   ```bash
+  # Example with gh if available:
   gh pr create \
     --base main \
     --head claude/drift-fp-store/<owner>-<repo> \
-    --label drift-fp-store \
     --title 'chore(drift-fp): contracts store for <owner>/<repo> @ <short-sha>' \
     --body-file /tmp/storage-pr-body.md
   ```
 
   Write the body to a file first (next bullet) so you don't have to escape multi-line markdown
-  inline. Do **not** add the label as a separate step.
-- **PR body** (write to `/tmp/storage-pr-body.md` before the `gh pr create` call): a clear
-  "⚠️ DO NOT MERGE — storage branch for the <owner>/<repo> drift campaign; deleted automatically
+  inline.
+- **PR body** (write to `/tmp/storage-pr-body.md` before the create call): a clear
+  "⚠️ DO NOT MERGE — storage branch for the <owner>/<repo> drift campaign; closed automatically
   at campaign close" banner, plus target_ref, doc_scope, artifact counts from `contracts list`
   (e.g. "98 .tc: 21 operation, 3 enum, 21 named-constant, …"), and any `contracts validate`
   warnings. End with `cc @mushgev`.
 - **This PR is never merged**; it's pure storage + the discover trigger.
-  `drift-fp-campaign-close` closes it + deletes the branch when the campaign finishes.
-- **Verify the label landed.** After `gh pr create` returns, immediately
-  `gh pr view <number> --json labels --jq '.labels[].name'`. If `drift-fp-store` isn't in the
-  output, the label-on-creation failed silently (rare — but if it does, the trigger won't fire).
-  In that case post a one-line failure note (`cc @mushgev`) and stop so a human can recover —
-  do **not** attempt a second `--add-label` call to recover, because the `pull_request.opened`
-  event has already fired without the label and the trigger has already missed it.
-- Stop. Opening the labeled PR fires `drift-fp-discover`.
+  `drift-fp-campaign-close` closes it when the campaign finishes (the branch is intentionally
+  left in place — proxy denies branch deletes, and a closed campaign's branch doesn't block
+  anything).
+- Stop. Opening the PR fires `drift-fp-discover`.
 
 ## Hard constraints
 

--- a/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
@@ -239,17 +239,10 @@ If step 1/2 throws, still write the section with `unavailable: <concrete reason>
       ```
       (or `unavailable: <reason>` if measurement failed).
     - End with `cc @mushgev`.
-  - **Open the PR with `--label drift-fp-fix` in the same `gh pr create` call.**
-    `drift-fp-next-fix` (the next iteration of this routine) triggers on this PR's merge filtered
-    by `Labels is-one-of drift-fp-fix`. If the PR is merged without the label, the trigger
-    doesn't fire and the inner loop stalls (this is what happened on PR #483: the label was
-    never applied, the PR was merged label-less, and the next batch had to be kicked manually).
-    Do **not** specify the label as a follow-up `gh pr edit --add-label` step — sessions have
-    silently dropped that second call.
-  - **Verify the label landed.** Right after `gh pr create` returns, check
-    `gh pr view <number> --json labels --jq '.labels[].name'`. If `drift-fp-fix` isn't in the
-    output, post a one-line failure note on the most recent fixed issue (`cc @mushgev`) and stop
-    — do **not** attempt a follow-up `--add-label` to recover. Surface to a human.
+  - **Open the PR — no label required.** `drift-fp-next-fix` (the next iteration of this routine)
+    triggers on the merge of any PR whose head branch starts with `claude/drift-fp-fix/`, which
+    is uniquely owned by this routine. Use whatever PR-creation tool the session has —
+    `gh pr create` if `gh` is on PATH, otherwise the GitHub MCP `create_pull_request` tool.
   - For each fixed issue: comment the PR URL, then remove `drift-fp-in-progress` (merge
     auto-closes via `Closes #N`).
 - End the session.
@@ -288,11 +281,14 @@ Enter when the **pickable** queue is empty AND `successes == 0` (includes all-re
      `apps/dashboard/server/package.json`, and the `.version("X.Y.Z")` in `tools/cli/src/index.ts`.
    - **No** fixture/comparator changes.
    - Title `chore(drift-fp): close <owner>/<repo> campaign, bump to vX.Y.Z`.
-   - Labels `drift-fp-campaign-complete`. Body: merged drift-fp-fix PRs (search label
-     `drift-fp-target:<owner>-<repo>`, state merged), baseline→final `fp` (e.g. `fp: 33 → 0`),
-     new version, note that `fp == 0` was measured against `node dist/cli.mjs` on the pinned
-     contracts. End `cc @mushgev`.
-   - End. Merge fires `drift-fp-campaign-close` (tags) + `drift-fp-generate` (next campaign).
+   - **No label required.** `drift-fp-campaign-close` + `drift-fp-generate` both trigger on the
+     merge of any PR whose head branch starts with `claude/drift-fp-campaign-close/`, which is
+     uniquely owned by this routine.
+   - Body: merged drift-fp-fix PRs (search label `drift-fp-target:<owner>-<repo>`, state
+     merged), baseline→final `fp` (e.g. `fp: 33 → 0`), new version, note that `fp == 0` was
+     measured against `node dist/cli.mjs` on the pinned contracts. End `cc @mushgev`.
+   - End. Merge fires `drift-fp-campaign-close` (closes storage PR, notifies for tag push) +
+     `drift-fp-generate` (next campaign).
 6. **If `fp > 0`** — leave `status: discovering`, no close PR. File new issues, **dedupe
    first**: for each drift-kind still showing FPs, skip if an open `drift-fp-fix` issue
    (any label, including `drift-fp-blocked`) already exists; else file one (discovery shape).


### PR DESCRIPTION
## Why

The "apply this label atomically when opening the PR" choreography in the drift-fp prompts has now failed twice:

- **PR #483** (strapi storage PR) — opened without `drift-fp-store` label, discover trigger missed.
- **PR #497** (feast storage PR) — same failure, with the routine itself diagnosing it: *"the MCP tool used in this session has no `labels` parameter, so the `drift-fp-store` label was not present on the `pull_request.opened` event."*

The root cause is that the routine session has `mcp__github__create_pull_request` (no `labels` param) but no `gh` CLI. Atomically applying a label at `pull_request.opened` time is physically impossible from that environment, and my previous "fix" (PR #484, telling the routine to use `gh pr create --label X` in one command) was unachievable.

## What

The branch prefix is the actual unique signal — each routine owns one prefix exclusively:

| PR                           | Head branch                                | Was-gate label                |
| ---------------------------- | ------------------------------------------ | ----------------------------- |
| storage PR (generate)        | `claude/drift-fp-store/<owner>-<repo>`     | `drift-fp-store`              |
| discovery PR (discover)      | `claude/drift-fp-discover/<owner>-<repo>`  | `drift-fp-discover`           |
| fix PR (next-fix)            | `claude/drift-fp-fix/batch-<ts>`           | `drift-fp-fix`                |
| campaign-close PR (next-fix) | `claude/drift-fp-campaign-close/<o>-<r>`   | `drift-fp-campaign-complete`  |

The labels were belt-and-suspenders the execution env can't deliver. Removing the "set this label / verify the label landed" instruction from each prompt:

- `drift-fp-generate.md` — drops the elaborate label-on-creation block for the storage PR.
- `drift-fp-discover.md` — drops the `drift-fp-discover` label on the discovery PR; also drops the label mention from the trigger description in Inputs.
- `drift-fp-next-fix.md` — drops `drift-fp-fix` on fix PRs and `drift-fp-campaign-complete` on campaign-close PRs (plus the verification dance).
- `drift-fp-campaign-close.md` — drops the storage-PR-lookup-by-label (head ref alone is unique).

## What stays

Issue labels are untouched — they're work-queue markers, not trigger gates, and have no branch alternative:

- `drift-fp-fix` + `drift-fp-target:<owner>-<repo>` on the issues discover files
- `drift-fp-blocked` / `drift-fp-in-progress` on those issues

## On the human side

You said you'll drop the label filter from each PR-event trigger on FleetView. After that, the chain fires on branch prefix alone — no more label races.

## Immediate recovery for PR #497

This PR is forward-looking — it doesn't unstick #497 (feast storage PR). For that one, after you drop the discover trigger's label filter, just merge this prompt PR and either close+reopen #497 from your machine via `gh pr close 497 && gh pr create --base main --head claude/drift-fp-store/feast-dev-feast --title '…' --body-file …` (fresh `opened` event, no label needed under the new filter), or kick discover manually via Run-now.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_