### PR TITLE
chore(drift-fp): start discovery for feast-dev/feast

### DIFF
--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -66,7 +66,7 @@ campaigns:
     code_dir: "."
     doc_scope: []        # fill before generating (keep the behavioral docs/ .md; drop the 93 .rst)
     priority: 2
-    status: pending
+    status: discovering
     baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes: ["Probe histogram: NamedConstant 189, Operation 71, Enum 20, Formula 6, Pagination present. Has 93 .rst (invisible to the tool) alongside .md."]

--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -67,7 +67,7 @@ campaigns:
     doc_scope: []        # fill before generating (keep the behavioral docs/ .md; drop the 93 .rst)
     priority: 2
     status: discovering
-    baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    baseline: { verified_at: "2026-06-05", target_ref: "276b6df562e16fefba7efb493736ff32046d4a76", total_drifts: 17, tp: 0, fp: 13, info: 4, fp_rate: 1.00 }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes: ["Probe histogram: NamedConstant 189, Operation 71, Enum 20, Formula 6, Pagination present. Has 93 .rst (invisible to the tool) alongside .md."]
 


### PR DESCRIPTION
Starting a drift discovery run for `feast-dev/feast`.

- Storage branch: `claude/drift-fp-store/feast-dev-feast` (PR #497)
- Target ref: `276b6df562e16fefba7efb493736ff32046d4a76`
- Code dir: `.`
- Contracts generated: 59 `.tc` files (ArchitectureDecision ×2, AuthRequirement ×2, NamedConstant ×15, UnenforceableObligation ×40)

This PR marks the campaign `discovering`. The routine will run `truecourse verify` against the pinned contracts, triage each drift-kind for TP/FP, file `[drift-fp-fix]` issues for any FP drift-kinds, and update the baseline in `campaigns.yaml`. Additional commits will follow on this branch as the discovery progresses.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_018uAfRTGCXvBE4jMuV33DgS)_