### PR TITLE
fix(drift-fp): resolve 1 drift FP from feast-dev/feast

### DIFF
--- a/packages/contract-verifier/src/comparator/named-constant.ts
+++ b/packages/contract-verifier/src/comparator/named-constant.ts
@@ -39,16 +39,29 @@ export function compareNamedConstant(input: NamedConstantCompareInput): Contract
   const target = normalizeName(ref.identity);
   let matches = codeConstants.filter((c) => normalizeName(c.name) === target);
 
-  // For namespaced spec identities (e.g. "widget.EMBED_THEME"), fall back to
-  // matching the last segment ("EMBED_THEME") against window-global constants
-  // only. This covers browser globals declared as window.X in code but named
-  // with a namespace prefix in the spec.
+  // For namespaced spec identities (e.g. "auth.type.kubernetes"), fall back to
+  // matching the last segment ("kubernetes") against window-global constants
+  // and flat const-literal constants. This covers browser globals (window.X)
+  // and Python/TS flat SCREAMING_SNAKE names paired with hierarchical spec
+  // identities (e.g. KUBERNETES = "kubernetes" ↔ auth.type.kubernetes).
+  //
+  // For const-literal shapes the match also requires value equality when the
+  // spec carries an expectedValue — this avoids spurious value-mismatch drifts
+  // from unrelated constants that happen to share a last-segment name.
   if (matches.length === 0 && ref.identity.includes('.')) {
     const lastPart = ref.identity.split('.').pop()!;
     const lastTarget = normalizeName(lastPart);
-    matches = codeConstants.filter(
-      (c) => c.shape === 'window-global' && normalizeName(c.name) === lastTarget,
-    );
+    matches = codeConstants.filter((c) => {
+      if (normalizeName(c.name) !== lastTarget) return false;
+      if (c.shape === 'window-global') return true;
+      if (c.shape === 'const-literal') {
+        return (
+          contract.expectedValue === undefined ||
+          deepEqual(contract.expectedValue, c.value, /*allowExtraCodeKeys*/ true)
+        );
+      }
+      return false;
+    });
   }
 
   if (matches.length === 0) {

--- a/tests/fixtures/sample-python-project-il/code/app/named-constant-no-code-counterpart-genuine-absent.py
+++ b/tests/fixtures/sample-python-project-il/code/app/named-constant-no-code-counterpart-genuine-absent.py
@@ -1,0 +1,8 @@
+"""Storage writer configuration.
+
+The spec pins storage.writer.batch_depth_limit = 500 as a named constant,
+but the code has no corresponding declaration — the limit is hard-wired
+inline and never named.
+
+# IL-DRIFT: NamedConstant:storage.writer.batch_depth_limit / constant.storage.writer.batch_depth_limit.no-code-counterpart
+"""

--- a/tests/fixtures/sample-python-project-il/code/app/named-constant-no-code-counterpart-last-segment-const-literal.py
+++ b/tests/fixtures/sample-python-project-il/code/app/named-constant-no-code-counterpart-last-segment-const-literal.py
@@ -1,0 +1,13 @@
+"""Provider connection type tokens.
+
+Spec uses a hierarchical dotted identity (provider.auth.type.api_key);
+code uses flat SCREAMING_SNAKE names (API_KEY). The comparator's last-segment
+fallback should match the final segment "api_key" (normalized: "apikey")
+against API_KEY (normalized: "apikey") for const-literal shapes.
+
+# FP-GUARD: named-constant/no-code-counterpart — must NOT drift
+"""
+
+# Auth type constants used to configure provider connections.
+API_KEY = "api_key"
+OAUTH2 = "oauth2"

--- a/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/api-key/apikey.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/api-key/apikey.tc
@@ -1,0 +1,7 @@
+constant API_KEY {
+  // inferred — policy constant defined in code but documented in no spec
+  inferred-from "app/named-constant-no-code-counterpart-last-segment-const-literal.py" 12..12
+  confidence high
+  type string
+  expected-value "api_key"
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/named-constant-no-code-counterpart-genuine-absent.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/named-constant-no-code-counterpart-genuine-absent.tc
@@ -1,0 +1,5 @@
+constant storage.writer.batch_depth_limit {
+  origin "reference/specs/storage.md" "Writer configuration" 5..25
+  type number
+  expected-value 500
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/named-constant-no-code-counterpart-last-segment-const-literal.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/named-constant-no-code-counterpart-last-segment-const-literal.tc
@@ -1,0 +1,5 @@
+constant provider.auth.type.api_key {
+  origin "reference/specs/providers.md" "Connection type tokens" 1..20
+  type string
+  expected-value "api_key"
+}


### PR DESCRIPTION
Closes #501

## Fixes

| drift_kind | issue | fp-guard fixture | regression fixture |
|---|---|---|---|
| `named-constant/no-code-counterpart` | #501 | `tests/fixtures/sample-python-project-il/code/app/named-constant-no-code-counterpart-last-segment-const-literal.py` + `.tc` | `tests/fixtures/sample-python-project-il/code/app/named-constant-no-code-counterpart-genuine-absent.py` + `.tc` |

## named-constant/no-code-counterpart

**OSS source:** https://github.com/feast-dev/feast/blob/276b6df562e16fefba7efb493736ff32046d4a76/sdk/python/feast/permissions/auth/auth_type.py#L9-L11

**Cited contracts:** `docs/drift-fp-automation/contracts/feast-dev-feast/contracts/auth/auth.type.kubernetes.tc`, `auth.type.oidc.tc`

**Root cause.** The named-constant comparator's last-segment fallback (for spec identities like `auth.type.kubernetes` where the full name doesn't normalize-match any code constant) was gated exclusively on `c.shape === 'window-global'`. Python module-level and class-level assignments — which the extractor labels `const-literal` — were never considered. Feast's `AuthType` enum defines `KUBERNETES = "kubernetes"` and `OIDC = "oidc"` as class-body `const-literal` constants. The last segment `kubernetes` normalizes to `kubernetes`; `KUBERNETES` normalizes to `kubernetes` — they match. But the gate excluded them, causing `no-code-counterpart` FPs.

**Fix.** Extend the gate from `window-global`-only to `window-global | const-literal`. For `const-literal` shapes, the fallback additionally requires value equality (when the spec carries an `expectedValue`) — this prevents spurious `value-mismatch` drifts from unrelated constants that happen to share a last-segment name (e.g. `DataFrameEngine.SPARK = "spark"` nearly matched `config.batch_engine.type.spark` which expects `"spark.engine"`; the value guard keeps it as `no-code-counterpart` unchanged).

**FP-guard fixture diff (code + .tc):**

```diff
+++ tests/fixtures/sample-python-project-il/code/app/named-constant-no-code-counterpart-last-segment-const-literal.py
+"""Provider connection type tokens.
+
+Spec uses a hierarchical dotted identity (provider.auth.type.api_key);
+code uses flat SCREAMING_SNAKE names (API_KEY). The comparator's last-segment
+fallback should match the final segment "api_key" (normalized: "apikey")
+against API_KEY (normalized: "apikey") for const-literal shapes.
+
+# FP-GUARD: named-constant/no-code-counterpart — must NOT drift
+"""
+
+# Auth type constants used to configure provider connections.
+API_KEY = "api_key"
+OAUTH2 = "oauth2"
```

```diff
+++ tests/fixtures/sample-python-project-il/reference/contracts/named-constant-no-code-counterpart-last-segment-const-literal.tc
+constant provider.auth.type.api_key {
+  origin "reference/specs/providers.md" "Connection type tokens" 1..20
+  type string
+  expected-value "api_key"
+}
```

**Regression fixture diff (code + .tc):**

```diff
+++ tests/fixtures/sample-python-project-il/code/app/named-constant-no-code-counterpart-genuine-absent.py
+"""Storage writer configuration.
+
+The spec pins storage.writer.batch_depth_limit = 500 as a named constant,
+but the code has no corresponding declaration — the limit is hard-wired
+inline and never named.
+
+# IL-DRIFT: NamedConstant:storage.writer.batch_depth_limit / constant.storage.writer.batch_depth_limit.no-code-counterpart
+"""
```

```diff
+++ tests/fixtures/sample-python-project-il/reference/contracts/named-constant-no-code-counterpart-genuine-absent.tc
+constant storage.writer.batch_depth_limit {
+  origin "reference/specs/storage.md" "Writer configuration" 5..25
+  type number
+  expected-value 500
+}
```

**fix_summary.** Extended `compareNamedConstant` last-segment fallback to accept `const-literal` constants (not just `window-global`). Added a value-equality guard for `const-literal` candidates to prevent wrong-constant matches where values differ. The guard keeps `no-code-counterpart` semantics for constants like `SPARK = "spark"` that match by name but not value, avoiding new spurious `value-mismatch` drifts. The IL fixture adds an `api-key/apikey.tc` entry to the Python `_inferred` corpus because `API_KEY` (a `const-literal`) is correctly seen as undocumented by the infer engine (which uses direct name matching, not last-segment).

## Drift-count delta (vs 276b6df56 on feast-dev/feast, pinned contracts)

| Drift-kind | Before | After | Delta |
|---|---:|---:|---:|
| `NamedConstant/no-code-counterpart` | 13 | 11 | -2 |
| `ArchitectureDecision/unmet-choice` | 2 | 2 | 0 |
| `ArchitectureDecision/forbidden-alternative` | 2 | 2 | 0 |
| **Total (fixed kinds)** | 13 | 11 | **-2** |
| **All-kinds total on target** | 17 | 15 | **-2** |

Fixed: `auth.type.kubernetes` (KUBERNETES = "kubernetes") and `auth.type.oidc` (OIDC = "oidc") — both now matched via last-segment + value equality. The remaining 11 `no-code-counterpart` FPs require separate fixes (decorator-arg extraction, annotated-assignment extraction, or value-based fallback for config port defaults).

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvUQ2boKJteAX5proQWTzv)_