### PR TITLE
fix(drift-fp): resolve 2 drift FPs from feast-dev/feast

### DIFF
--- a/packages/contract-verifier/src/comparator/architecture-decision.ts
+++ b/packages/contract-verifier/src/comparator/architecture-decision.ts
@@ -46,6 +46,10 @@ export function compareArchitectureDecision(input: ArchitectureDecisionCompareIn
   const { category, chosen, reason } = contract;
   const why = reason ? ` Rationale: ${reason}` : '';
 
+  // No structured choice — the contract body contained only free-form `decision` text;
+  // the lifter defaulted `chosen` to ''. Nothing to compare.
+  if (!chosen) return [];
+
   // Inconclusive — no signal either way. Info, never a false positive.
   if (detected.confidence === 'inconclusive') {
     return [

--- a/tests/fixtures/sample-python-project-il/code/app/architecture-fp-guard-description-only.py
+++ b/tests/fixtures/sample-python-project-il/code/app/architecture-fp-guard-description-only.py
@@ -1,0 +1,9 @@
+"""Architecture FP-guard: description-only contract.
+
+The contract `arch.fp-guard.description-only` contains only a `decision "..."`
+prose field — no `category` or `chosen` keywords. The lifter defaults both to
+`'data-store'` and `''` respectively. The comparator must NOT fire any drift for
+a contract that makes no structured choice.
+
+# FP-GUARD: architecture-decision/data-store-unmet-choice — must NOT drift
+"""

--- a/tests/fixtures/sample-python-project-il/code/app/architecture-fp-guard-forbidden-alt.py
+++ b/tests/fixtures/sample-python-project-il/code/app/architecture-fp-guard-forbidden-alt.py
@@ -1,0 +1,12 @@
+"""Architecture FP-guard: forbidden-alternative from description-only contract.
+
+When an `architecture-decision` block contains only a free-form `decision "..."`
+field (no `category` or `chosen` keywords), the lifter defaults `chosen` to `''`.
+The comparator then fires `forbidden-alternative` for every detected data-store
+alternative because any real value satisfies `observed_value != ''`.
+
+The contract `arch.fp-guard.description-only` exercises this shape. After the
+fix (`if (!chosen) return []`), no `forbidden-alternative` drift is emitted.
+
+# FP-GUARD: architecture-decision/data-store-forbidden-alternative — must NOT drift
+"""

--- a/tests/fixtures/sample-python-project-il/code/app/architecture-regression-data-store-chosen-absent.py
+++ b/tests/fixtures/sample-python-project-il/code/app/architecture-regression-data-store-chosen-absent.py
@@ -1,0 +1,13 @@
+"""Architecture regression: spec asserts a data-store that is not detected.
+
+Contract `arch.regression.data-store-chosen-absent` asserts `chosen dynamodb`.
+The codebase (requirements.txt) has `psycopg2-binary` (postgres signal) but no
+DynamoDB package — so `dynamodb` is never observed while `postgres` is.
+
+Expected drifts:
+  - unmet-choice:           dynamodb not detected in the code
+  - forbidden-alternative:  postgres is detected but is not the chosen value
+
+# IL-DRIFT: ArchitectureDecision:arch.regression.data-store-chosen-absent / architecture.data-store.unmet-choice
+# IL-DRIFT: ArchitectureDecision:arch.regression.data-store-chosen-absent / architecture.data-store.forbidden-alternative
+"""

--- a/tests/fixtures/sample-python-project-il/code/app/architecture-regression-forbidden-alt-only.py
+++ b/tests/fixtures/sample-python-project-il/code/app/architecture-regression-forbidden-alt-only.py
@@ -1,0 +1,10 @@
+"""Architecture regression: forbidden-alternative fires when chosen is present but
+another data-store is also in use.
+
+Contract `arch.regression.forbidden-alt-only` asserts `chosen postgres`.
+The codebase (requirements.txt) has both `psycopg2-binary` (postgres) and
+`pymongo` (mongodb). Postgres IS detected, so no `unmet-choice`. But mongodb
+is also detected and is not the chosen value, so `forbidden-alternative` fires.
+
+# IL-DRIFT: ArchitectureDecision:arch.regression.forbidden-alt-only / architecture.data-store.forbidden-alternative
+"""

--- a/tests/fixtures/sample-python-project-il/reference/contracts/architecture-decision-description-only.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/architecture-decision-description-only.tc
@@ -1,0 +1,4 @@
+architecture-decision arch.fp-guard.description-only {
+  origin "docs/adr/ADR-001-data-store.md" "System overview" 1..5
+  decision "The system is composed of a registry, an offline store, an online store, and a feature server"
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/architecture-decision-regression-forbidden-alt.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/architecture-decision-regression-forbidden-alt.tc
@@ -1,0 +1,6 @@
+architecture-decision arch.regression.forbidden-alt-only {
+  origin "docs/adr/ADR-001-data-store.md" "Decision" 10..15
+  category data-store
+  chosen postgres
+  reason "Primary write path relies on relational consistency guarantees"
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/architecture-decision-regression-unmet.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/architecture-decision-regression-unmet.tc
@@ -1,0 +1,6 @@
+architecture-decision arch.regression.data-store-chosen-absent {
+  origin "docs/adr/ADR-001-data-store.md" "Decision" 10..15
+  category data-store
+  chosen dynamodb
+  reason "Serverless NoSQL required for the feature-store backend"
+}


### PR DESCRIPTION
Closes #503
Closes #504

## Fixes

| drift_kind | issue | fp-guard fixture | regression fixture |
|---|---|---|---|
| `architecture-decision/data-store-unmet-choice` | #503 | `architecture-decision-description-only.tc` + `architecture-fp-guard-description-only.py` | `architecture-decision-regression-unmet.tc` + `architecture-regression-data-store-chosen-absent.py` |
| `architecture-decision/data-store-forbidden-alternative` | #504 | `architecture-decision-description-only.tc` + `architecture-fp-guard-forbidden-alt.py` | `architecture-decision-regression-forbidden-alt.tc` + `architecture-regression-forbidden-alt-only.py` |

---

## architecture-decision/data-store-unmet-choice

**OSS source URLs:** none (no code location — misfire from description-only contracts)

**Contract paths:**
- `docs/drift-fp-automation/contracts/feast-dev-feast/contracts/arch/arch.feature-store.components.tc`
- `docs/drift-fp-automation/contracts/feast-dev-feast/contracts/arch/arch.permissions.enforcement-boundary.tc`

Both contracts contain only a `decision "..."` prose field with no `category` or `chosen` keywords — they describe what the system *is*, not what data-store it *chose*.

**FP-guard fixture diff:**

`tests/fixtures/sample-python-project-il/reference/contracts/architecture-decision-description-only.tc`
```diff
+architecture-decision arch.fp-guard.description-only {
+  origin "docs/adr/ADR-001-data-store.md" "System overview" 1..5
+  decision "The system is composed of a registry, an offline store, an online store, and a feature server"
+}
```

`tests/fixtures/sample-python-project-il/code/app/architecture-fp-guard-description-only.py`
```diff
+"""Architecture FP-guard: description-only contract.
+
+The contract `arch.fp-guard.description-only` contains only a `decision "..."`
+prose field — no `category` or `chosen` keywords. The lifter defaults both to
+`'data-store'` and `''` respectively. The comparator must NOT fire any drift for
+a contract that makes no structured choice.
+
+# FP-GUARD: architecture-decision/data-store-unmet-choice — must NOT drift
+"""
```

**Regression fixture diff:**

`tests/fixtures/sample-python-project-il/reference/contracts/architecture-decision-regression-unmet.tc`
```diff
+architecture-decision arch.regression.data-store-chosen-absent {
+  origin "docs/adr/ADR-001-data-store.md" "Decision" 10..15
+  category data-store
+  chosen dynamodb
+  reason "Serverless NoSQL required for the feature-store backend"
+}
```

`tests/fixtures/sample-python-project-il/code/app/architecture-regression-data-store-chosen-absent.py`
```diff
+"""Architecture regression: spec asserts a data-store that is not detected.
+
+Contract `arch.regression.data-store-chosen-absent` asserts `chosen dynamodb`.
+The codebase (requirements.txt) has `psycopg2-binary` (postgres signal) but no
+DynamoDB package — so `dynamodb` is never observed while `postgres` is.
+
+# IL-DRIFT: ArchitectureDecision:arch.regression.data-store-chosen-absent / architecture.data-store.unmet-choice
+# IL-DRIFT: ArchitectureDecision:arch.regression.data-store-chosen-absent / architecture.data-store.forbidden-alternative
+"""
```

**Fix summary:** Added guard `if (!chosen) return []` in `compareArchitectureDecision` (`packages/contract-verifier/src/comparator/architecture-decision.ts`). The lifter defaults `chosen = ''` for contracts whose body lacks `category`/`chosen` keywords; the comparator was running the full data-store comparison against that empty string, which always produced `unmet-choice` (empty string not in any observed set) and `forbidden-alternative` (every real alternative ≠ ''). The guard short-circuits before any comparison when no choice was specified.

---

## architecture-decision/data-store-forbidden-alternative

**OSS source URLs:** ``https://github.com/feast-dev/feast/blob/276b6df562e16fefba7efb493736ff32046d4a76/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py#L23`` (cited as signal, not the root cause)

**Contract paths:** same as above (`arch.feature-store.components.tc`, `arch.permissions.enforcement-boundary.tc`)

The `forbidden-alternative` misfire is the second symptom of the same empty-`chosen` bug. The comparator's forbidden-alternative loop fires for every observed alternative where `o.value !== chosen` — with `chosen = ''` any real alternative satisfies this condition.

**FP-guard fixture diff:**

`tests/fixtures/sample-python-project-il/code/app/architecture-fp-guard-forbidden-alt.py`
```diff
+"""Architecture FP-guard: forbidden-alternative from description-only contract.
+
+When an `architecture-decision` block contains only a free-form `decision "..."`
+field (no `category` or `chosen` keywords), the lifter defaults `chosen` to `''`.
+The comparator then fires `forbidden-alternative` for every detected data-store
+alternative because any real value satisfies `observed_value != ''`.
+
+# FP-GUARD: architecture-decision/data-store-forbidden-alternative — must NOT drift
+"""
```

(Uses the same contract `arch.fp-guard.description-only` added for issue #503.)

**Regression fixture diff:**

`tests/fixtures/sample-python-project-il/reference/contracts/architecture-decision-regression-forbidden-alt.tc`
```diff
+architecture-decision arch.regression.forbidden-alt-only {
+  origin "docs/adr/ADR-001-data-store.md" "Decision" 10..15
+  category data-store
+  chosen postgres
+  reason "Primary write path relies on relational consistency guarantees"
+}
```

`tests/fixtures/sample-python-project-il/code/app/architecture-regression-forbidden-alt-only.py`
```diff
+"""Architecture regression: forbidden-alternative fires when chosen is present
+but another data-store is also in use.
+
+Contract `arch.regression.forbidden-alt-only` asserts `chosen postgres`.
+The codebase (requirements.txt) has both `psycopg2-binary` (postgres) and
+`pymongo` (mongodb). Postgres IS detected, so no `unmet-choice`. But mongodb
+is also detected and is not the chosen value, so `forbidden-alternative` fires.
+
+# IL-DRIFT: ArchitectureDecision:arch.regression.forbidden-alt-only / architecture.data-store.forbidden-alternative
+"""
```

**Fix summary:** Resolved as a side-effect of the issue #503 comparator fix — the same `if (!chosen) return []` guard suppresses `forbidden-alternative` because both drift kinds are emitted inside `compareArchitectureDecision` after the guard. Added a dedicated FP-guard documentation file and a `forbidden-alternative`-only regression (uses `chosen postgres` with mongodb also detected, confirming that real forbidden-alternative drifts still fire correctly).

---

## Drift-count delta (vs `276b6df562e16fefba7efb493736ff32046d4a76` on `feast-dev/feast`, pinned contracts)

| Drift-kind | Before | After | Delta |
|---|---:|---:|---:|
| `architecture-decision/data-store-unmet-choice`        | 2  | 0  | **-2** |
| `architecture-decision/data-store-forbidden-alternative` | 2  | 0  | **-2** |
| **Total (these 2 kinds)**                              | **4** | **0** | **-4** |
| **All-kinds total on target**                          | **15** | **11** | **-4** |

After-state classification: `tp=0, fp=0, info=11` (all remaining drifts are `[info]` severity `named-constant/no-code-counterpart`, correctly emitted). `fp_rate=0`.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVfMt7WSfRnzVP1EgReSo5)_