### PR TITLE
drift-fp(directus): fill doc_scope so drift-fp-generate can run

### DIFF
--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -78,12 +78,13 @@ campaigns:
   - target_repo: directus/directus
     tech_stack: [typescript, knex]
     code_dir: "."
-    doc_scope: []        # narrow: Directus's behavioral .md is sparse (api/src/ai/tools/*/prompt.md); fill before generating
+    doc_scope:
+      - api/src/ai/tools   # 13 prompt.md files, ~3K lines of behavioral spec for the AI tool surface (flows, operations, items, fields, …)
     priority: 3
     status: pending
     baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
-    notes: ["Narrow but real overlap: Flows TriggerType/accountability/status enums in prompt.md ↔ code enums. Docs mostly live in a separate repo, so spec surface is thin."]
+    notes: ["Narrow but real overlap: Flows TriggerType/accountability/status enums in prompt.md ↔ code enums. Docs mostly live in a separate repo, so spec surface is thin.", "doc_scope filled 2026-06-05: 13 api/src/ai/tools/*/prompt.md files (~3K lines) cover the AI tool surface; biggest is flows/prompt.md (540 lines) which contains the trigger/status/accountability enums called out in the campaign hint."]
 
   # ---- Add more campaigns below once validated (probe via `infer --dry-run`) ----
   # Bar: concrete .md specs in REAL (non-dot) folders that OVERLAP liftable app


### PR DESCRIPTION
Resolves #508.

## What

Fills the empty `doc_scope` for `directus/directus` in `campaigns.yaml` so `drift-fp-generate` can run.

## How I picked the scope

Shallow-cloned `directus/directus` at HEAD and listed every `.md` file outside `node_modules/` and `.git/`. Two categories of result:

**Behavioral spec content (13 files, ~3K lines)** — all under `api/src/ai/tools/<tool>/prompt.md`:

| Tool | Lines |
|---|---:|
| `flows/prompt.md` | 540 |
| `fields/prompt.md` | 521 |
| `relations/prompt.md` | 386 |
| `collections/prompt.md` | 336 |
| `items/prompt.md` | 319 |
| `operations/prompt.md` | 299 |
| `trigger-flow/prompt.md` | 214 |
| `files/prompt.md` | 180 |
| `schema/prompt.md` | 130 |
| `system/prompt.md` | 44 |
| `folders/prompt.md` | 34 |
| `assets/prompt.md` | 8 |
| `system/prompt-description.md` | 1 |

Spot-checked `flows/prompt.md` — confirmed it contains exactly the enums the campaign note called out:

```
trigger: event | webhook | schedule | operation | manual
status:  active | inactive
accountability: all | activity | null
```

**Noise (everything else)** — `.changeset/*.md` (release notes), `*/readme.md` (package READMEs), `.github/*.md` (CI/PR templates), `code_of_conduct.md`, `security.md`. Nothing describes runtime behavior worth lifting.

## The change

```diff
-    doc_scope: []        # narrow: Directus's behavioral .md is sparse (api/src/ai/tools/*/prompt.md); fill before generating
+    doc_scope:
+      - api/src/ai/tools   # 13 prompt.md files, ~3K lines of behavioral spec for the AI tool surface
```

Single directory entry covers all 13 prompt.md files at once.

## After merge

Run-now `drift-fp-generate`. Directus is still the only `pending` campaign and the `claude/drift-fp-store/directus-directus` branch still doesn't exist, so the routine will pick it up.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_