### PR TITLE
chore(drift-fp): start discovery for directus/directus

### DIFF
--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -81,7 +81,7 @@ campaigns:
     doc_scope:
       - api/src/ai/tools   # 13 prompt.md files, ~3K lines of behavioral spec for the AI tool surface (flows, operations, items, fields, …)
     priority: 3
-    status: pending
+    status: discovering
     baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes: ["Narrow but real overlap: Flows TriggerType/accountability/status enums in prompt.md ↔ code enums. Docs mostly live in a separate repo, so spec surface is thin.", "doc_scope filled 2026-06-05: 13 api/src/ai/tools/*/prompt.md files (~3K lines) cover the AI tool surface; biggest is flows/prompt.md (540 lines) which contains the trigger/status/accountability enums called out in the campaign hint."]

--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -82,9 +82,9 @@ campaigns:
       - api/src/ai/tools   # 13 prompt.md files, ~3K lines of behavioral spec for the AI tool surface (flows, operations, items, fields, …)
     priority: 3
     status: discovering
-    baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    baseline: { verified_at: "2026-06-05", target_ref: "0d9f641d32ed16c6af66a35be713cbd6030d7c68", total_drifts: 6, tp: 1, fp: 3, info: 2, fp_rate: 0.75 }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
-    notes: ["Narrow but real overlap: Flows TriggerType/accountability/status enums in prompt.md ↔ code enums. Docs mostly live in a separate repo, so spec surface is thin.", "doc_scope filled 2026-06-05: 13 api/src/ai/tools/*/prompt.md files (~3K lines) cover the AI tool surface; biggest is flows/prompt.md (540 lines) which contains the trigger/status/accountability enums called out in the campaign hint."]
+    notes: ["Narrow but real overlap: Flows TriggerType/accountability/status enums in prompt.md ↔ code enums. Docs mostly live in a separate repo, so spec surface is thin.", "doc_scope filled 2026-06-05: 13 api/src/ai/tools/*/prompt.md files (~3K lines) cover the AI tool surface; biggest is flows/prompt.md (540 lines) which contains the trigger/status/accountability enums called out in the campaign hint.", "Discovery run (2026-06-05): 6 drifts, 3 FP, 1 TP, 2 info. FP kinds: enum/missing-value (1 FP — CollectionAccountability collides onto FlowItemInputSchema's accountability Zod enum, entity collision), enum/no-code-counterpart (2 FPs — FlowStatus name mismatch: type Status in flows.ts; OperationType handler-id pattern not lifted). TP: FlowAccountability.missing-value.null (Flow Zod schema genuinely excludes null). Info: CollectionStatus [contract quality — extracted from example field choices, not a system enum], WebhookTriggerUrlPattern [borderline — URL pattern exists as Express route, not a named constant]."]
 
   # ---- Add more campaigns below once validated (probe via `infer --dry-run`) ----
   # Bar: concrete .md specs in REAL (non-dot) folders that OVERLAP liftable app


### PR DESCRIPTION
Starting drift discovery run for `directus/directus`.

The contracts were generated by `drift-fp-generate` onto storage branch `claude/drift-fp-store/directus-directus` (PR #510). This PR marks the campaign as `discovering` and will accumulate commits as the verifier runs and issues are filed.

**Campaign details:**
- Target: `directus/directus`
- Target ref: `0d9f641d32ed16c6af66a35be713cbd6030d7c68`
- Code dir: `.`
- Contracts branch: `claude/drift-fp-store/directus-directus`
- Contracts path: `docs/drift-fp-automation/contracts/directus-directus`

Next steps happening in this session: build truecourse from source, clone the target at the pinned ref, run `verify` against the stored contracts, triage drifts, and file `[drift-fp-fix]` issues for any false-positive drift-kinds found.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_018Swwyf59SzXEghyXipYJw2)_