### PR TITLE
spec-scan: require completeness on enumerated lists

### DIFF
--- a/packages/spec-consolidator/src/prompt.ts
+++ b/packages/spec-consolidator/src/prompt.ts
@@ -143,6 +143,14 @@ You are given ONE block of markdown from a documentation file (a PRD, ADR, RFC, 
 
 6. The faithfulness rule. Encode ONLY what the spec STATES. Never guess. Never default to common patterns. If the spec doesn't say what status code is returned, don't assume 200. If the spec doesn't say auth is required, don't add an auth claim.
 
+7. The completeness rule (enumerations). When the spec presents an enumeration — a bulleted list, a numbered list, a markdown table column of values, or an inline comma-separated list — capture EVERY entry. Never summarize, never include a "representative subset", never drop entries because they look similar to ones you already captured. This applies regardless of how you structure the claim:
+
+   - If you emit ONE claim whose \`content.fields\` lists the entries (e.g. an entity's columns, an enum's value-to-description map), every enumerated value must be a key in \`fields\`. A 15-item bulleted list must produce 15 keys, not 8.
+   - If you emit ONE claim per entry (the forbidden-artifact pattern), emit exactly N claims for N enumerated items.
+   - If the spec lists values across multiple sections of the same doc, each section contributes its own claim; the merger handles the union downstream — don't pre-dedupe across sections.
+
+   Counting check before you return: if the source block contains a bulleted or numbered list under a heading like "Available <X>", "Supported <X> types", "Operation types", "Roles", "Statuses", or similar, count the bullets in that list, then count the entries you've emitted. The counts MUST match. If they don't, you've summarized — re-extract the missed entries before returning.
+
 # Content shapes per topic
 
 ## endpoints


### PR DESCRIPTION
## Why

Concrete bug: the directus drift-fp campaign produced an `OperationType` enum contract with 8 values when the spec explicitly enumerates 15. The source markdown (`api/src/ai/tools/operations/prompt.md:71-79`) has all 15 in a single bulleted list:

```
- **condition** - Evaluate filter rules to determine execution path
- **exec** - Execute custom JavaScript/TypeScript code in sandboxed environment
- **item-create** - Create items in a collection
... (all 15 in the same format)
- **trigger** - Execute another flow with iteration modes
```

The spec-scan LLM call captured one claim (`Operation / type options`) whose `content.fields` listed only 8 — dropping `json-web-token`, `log`, `request`, `sleep`, `throw-error`, `transform`, `trigger`. Every downstream stage passed through what it was given, so the directus discovery run filed 7 `enum/extra-value` drifts (#516) that look like FPs but are really contract-quality artifacts of a silent under-extraction. `drift-fp-next-fix` correctly identified this as a bad-contract issue, refused to bend the comparator to silence it, and stalled the campaign (#517).

## Root cause

The `SYSTEM_PROMPT` (`packages/spec-consolidator/src/prompt.ts`) has a faithfulness rule (#6: "encode only what the spec STATES") but no completeness rule for enumerations. The forbidden-artifact example mentions "ONE claim per bullet" but only for that one topic. Nothing in the general guidance forbids summarizing a 15-item enumeration into a representative subset, so the LLM did the natural language-model thing.

## Fix

Add a rule 7 that's explicit:

> **The completeness rule (enumerations).** When the spec presents an enumeration — a bulleted list, a numbered list, a markdown table column of values, or an inline comma-separated list — capture EVERY entry. Never summarize, never include a "representative subset", never drop entries because they look similar to ones you already captured. […]
>
> Counting check before you return: if the source block contains a bulleted or numbered list under a heading like "Available <X>", "Supported <X> types", "Operation types", "Roles", "Statuses", or similar, count the bullets in that list, then count the entries you've emitted. The counts MUST match. If they don't, you've summarized — re-extract the missed entries before returning.

8 added lines, no schema change.

## Cache invalidation (intentional)

`SYSTEM_PROMPT` is hashed into the block-cache key (`packages/spec-consolidator/src/cache.ts:34`), so this change invalidates every existing cached extraction across all campaigns. The next `spec scan` re-runs all blocks under the tightened rule. This is the established cache-bust pattern that the existing `kind` field docstring already calls out.

## What this doesn't fix

The directus storage branch is **frozen** — `claude/drift-fp-store/directus-directus` still has the under-extracted `operationtype.tc`. Two options to unblock that specific campaign:

- Hand-patch the 7 missing values into the contract on the storage branch and let the chain close normally.
- Regenerate the directus storage branch with this fix, end-to-end proof.

Future campaigns get the completeness rule on first generation.

## Tests

164 / 164 `spec-consolidator` tests pass. No new test added here — the failure mode is LLM-side and not deterministically reproducible against a mock. A live-LLM regression test (a fixture spec with a 15-item bulleted list, asserting all 15 entries appear in the resulting claim) would be a good follow-up but lives behind the `LLM_TESTS=1` gate.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_