### PR TITLE
chore(drift-fp): start discovery for directus/directus

### DIFF
--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -81,7 +81,7 @@ campaigns:
     doc_scope:
       - api/src/ai/tools   # 13 prompt.md files, ~3K lines of behavioral spec for the AI tool surface (flows, operations, items, fields, …)
     priority: 3
-    status: pending
+    status: discovering
     baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes: ["Narrow but real overlap: Flows TriggerType/accountability/status enums in prompt.md ↔ code enums. Docs mostly live in a separate repo, so spec surface is thin.", "doc_scope filled 2026-06-05: 13 api/src/ai/tools/*/prompt.md files (~3K lines) cover the AI tool surface; biggest is flows/prompt.md (540 lines) which contains the trigger/status/accountability enums called out in the campaign hint.", "First discovery run (2026-06-05, contracts on now-deleted claude/drift-fp-store/directus-directus): 6 drifts, 3 FP, 1 TP, 2 info. Discovery filed #516 (enum/extra-value × 7) which the next-fix routine triaged as a bad-contract artifact: the OperationType contract captured 8 of 15 spec-documented values, dropping json-web-token/log/request/sleep/throw-error/transform/trigger. Campaign was stuck (#517) until the under-extraction was root-caused.", "Reset to pending 2026-06-06: PR #518 fixed the spec-scan completeness rule that caused the OperationType under-extraction; storage branch deleted to force regeneration with the fixed prompt. Issues #516 #517 superseded by this regeneration and closed."]

--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -82,7 +82,7 @@ campaigns:
       - api/src/ai/tools   # 13 prompt.md files, ~3K lines of behavioral spec for the AI tool surface (flows, operations, items, fields, …)
     priority: 3
     status: discovering
-    baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    baseline: { verified_at: "2026-06-06", target_ref: "2f4e667c81119c565d6ac1529510560835f59908", total_drifts: 7, tp: 1, fp: 1, info: 5, fp_rate: 0.50 }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes: ["Narrow but real overlap: Flows TriggerType/accountability/status enums in prompt.md ↔ code enums. Docs mostly live in a separate repo, so spec surface is thin.", "doc_scope filled 2026-06-05: 13 api/src/ai/tools/*/prompt.md files (~3K lines) cover the AI tool surface; biggest is flows/prompt.md (540 lines) which contains the trigger/status/accountability enums called out in the campaign hint.", "First discovery run (2026-06-05, contracts on now-deleted claude/drift-fp-store/directus-directus): 6 drifts, 3 FP, 1 TP, 2 info. Discovery filed #516 (enum/extra-value × 7) which the next-fix routine triaged as a bad-contract artifact: the OperationType contract captured 8 of 15 spec-documented values, dropping json-web-token/log/request/sleep/throw-error/transform/trigger. Campaign was stuck (#517) until the under-extraction was root-caused.", "Reset to pending 2026-06-06: PR #518 fixed the spec-scan completeness rule that caused the OperationType under-extraction; storage branch deleted to force regeneration with the fixed prompt. Issues #516 #517 superseded by this regeneration and closed."]
 


### PR DESCRIPTION
Starting a drift discovery run for the `directus/directus` campaign.

This PR:
1. Marks the campaign `discovering` in `campaigns.yaml`
2. Will accumulate further commits as the verify run completes and drift triage results + baseline stats are recorded

Target repo: `directus/directus`
Target ref: `2f4e667c81119c565d6ac1529510560835f59908`
Contracts branch: `claude/drift-fp-store/directus-directus`

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbbaiu1XsRKTvcmse6aS7n)_