### PR TITLE
fix(cli): treat soft contract validation as warnings

### DIFF
--- a/tests/cli/contracts-generate.test.ts
+++ b/tests/cli/contracts-generate.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import type { ValidationIssue } from '../../packages/contract-extractor/src/validator';
+import { partitionValidationIssues } from '../../tools/cli/src/commands/contracts';
+
+describe('contracts generate validation issues', () => {
+  it('keeps soft validation issues non-blocking and de-duplicated', () => {
+    const issues: ValidationIssue[] = [
+      {
+        artifactKey: 'ErrorEnvelope:error.envelope.standard',
+        message: "cross-reference ErrorEnvelope:error.envelope.standard doesn't resolve",
+        severity: 'soft',
+      },
+      {
+        artifactKey: 'ErrorEnvelope:error.envelope.standard',
+        message: "cross-reference ErrorEnvelope:error.envelope.standard doesn't resolve",
+        severity: 'soft',
+      },
+    ];
+
+    const { hardIssues, softIssues } = partitionValidationIssues(issues);
+
+    expect(hardIssues).toEqual([]);
+    expect(softIssues).toHaveLength(1);
+    expect(softIssues[0].severity).toBe('soft');
+  });
+
+  it('keeps hard validation issues blocking', () => {
+    const issues: ValidationIssue[] = [
+      {
+        artifactKey: 'resolver',
+        message: 'duplicate identity Operation:GET /api/orders',
+        severity: 'hard',
+      },
+      {
+        artifactKey: 'ErrorEnvelope:error.envelope.standard',
+        message: "cross-reference ErrorEnvelope:error.envelope.standard doesn't resolve",
+        severity: 'soft',
+      },
+    ];
+
+    const { hardIssues, softIssues } = partitionValidationIssues(issues);
+
+    expect(hardIssues).toHaveLength(1);
+    expect(hardIssues[0].artifactKey).toBe('resolver');
+    expect(softIssues).toHaveLength(1);
+  });
+});

--- a/tools/cli/src/commands/contracts.ts
+++ b/tools/cli/src/commands/contracts.ts
@@ -8,6 +8,7 @@ import {
   hasCanonicalSpec,
   spawnRunner,
 } from "@truecourse/contract-extractor";
+import type { ValidationIssue } from "@truecourse/contract-extractor/validator";
 import { agentTransport } from "@truecourse/shared/llm";
 import { stampGeneratedMarker } from "@truecourse/core/commands/spec-in-process";
 import { trackEvent, bucketFileCount, bucketDuration } from "@truecourse/core/services/telemetry";
@@ -24,6 +25,30 @@ export interface RunContractsGenerateOptions {
   llm?: "cli" | "agent";
   /** I/O dir for the `agent` transport's request/response mailbox. */
   io?: string;
+}
+
+export function partitionValidationIssues(issues: ValidationIssue[]): {
+  hardIssues: ValidationIssue[];
+  softIssues: ValidationIssue[];
+} {
+  const seenSoft = new Set<string>();
+  const hardIssues: ValidationIssue[] = [];
+  const softIssues: ValidationIssue[] = [];
+
+  for (const issue of issues) {
+    if (issue.severity === "hard") {
+      hardIssues.push(issue);
+      continue;
+    }
+
+    const key = `${issue.artifactKey}\0${issue.message}`;
+    if (!seenSoft.has(key)) {
+      softIssues.push(issue);
+      seenSoft.add(key);
+    }
+  }
+
+  return { hardIssues, softIssues };
 }
 
 export async function runContractsGenerate(
@@ -119,14 +144,26 @@ export async function runContractsGenerate(
     }
   }
 
-  // Surface validation issues — these block the write.
-  if (result.validationIssues.length > 0) {
-    p.log.error(`Validation gate failed (${result.validationIssues.length} issue${result.validationIssues.length === 1 ? "" : "s"}):`);
-    for (const issue of result.validationIssues) {
+  const { hardIssues, softIssues } = partitionValidationIssues(result.validationIssues);
+
+  // Surface hard validation issues — these block the write.
+  if (hardIssues.length > 0) {
+    p.log.error(`Validation gate failed (${hardIssues.length} issue${hardIssues.length === 1 ? "" : "s"}):`);
+    for (const issue of hardIssues) {
       console.log(`  ${issue.artifactKey}: ${issue.message}`);
     }
     p.outro("No contracts were written. Edit the spec or re-run after fixing.");
     process.exit(1);
+  }
+
+  // Soft validation issues are diagnostics from otherwise usable contracts.
+  // The extractor writes the resolvable contracts and returns these warnings
+  // so users can fix unresolved cross-references without losing generated output.
+  if (softIssues.length > 0) {
+    p.log.warn(`Validation warning${softIssues.length === 1 ? "" : "s"} (${softIssues.length} soft issue${softIssues.length === 1 ? "" : "s"}):`);
+    for (const issue of softIssues) {
+      console.log(`  ${issue.artifactKey}: ${issue.message}`);
+    }
   }
 
   // Surface merge diagnostics (non-blocking). Repair "re-prompting" lines were


### PR DESCRIPTION
## Summary

Fixes #492.

`contracts generate` currently exits 1 whenever `result.validationIssues` is non-empty. That contradicts the contract extractor's severity model: unresolved cross-references are `soft` diagnostics, and the orchestrator still writes resolvable contracts when there are no hard validation issues.

This PR updates the CLI to:

- split validation issues into hard vs soft
- keep hard issues blocking with the existing failure message
- report soft issues as warnings and continue to the normal success path
- de-duplicate identical soft validation messages so repeated unresolved refs do not print byte-for-byte duplicates

## Validation

- `npx pnpm@9.15.0 exec turbo build --filter=@truecourse/contract-extractor --filter=truecourse`
- `PATH=/Users/macbookair/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/vitest run tests/cli/contracts-generate.test.ts tests/contract-extractor/orchestrator.test.ts`

Note: local `corepack pnpm` failed on this machine due to a Corepack npm signature key mismatch, so I used `npx pnpm@9.15.0` matching the repo's packageManager.
