### PR TITLE
fix(cli): fail spec scan when extraction fully fails

### DIFF
--- a/tests/cli/spec-scan.test.ts
+++ b/tests/cli/spec-scan.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  representativeExtractionFailures,
+  scanSuccessOutro,
+  totalExtractionFailure,
+} from '../../tools/cli/src/commands/spec';
+
+describe('spec scan extraction failures', () => {
+  it('treats all-block extraction failure as fatal', () => {
+    expect(totalExtractionFailure({
+      blocksAttempted: 2,
+      claims: [],
+      failures: [
+        { block: { filePath: 'docs/a.md', headingPath: ['A'] }, error: 'claude exited 1: login expired' },
+        { block: { filePath: 'docs/b.md', headingPath: ['B'] }, error: 'claude exited 1: login expired' },
+      ],
+    })).toBe(true);
+  });
+
+  it('does not treat partial extraction failure as fatal', () => {
+    expect(totalExtractionFailure({
+      blocksAttempted: 2,
+      claims: [{ subject: 'GET /health' }],
+      failures: [
+        { block: { filePath: 'docs/a.md', headingPath: ['A'] }, error: 'timeout' },
+      ],
+    })).toBe(false);
+  });
+
+  it('does not suggest contract generation when no claims were extracted', () => {
+    expect(scanSuccessOutro(0, 0)).toBe('No claims extracted.');
+    expect(scanSuccessOutro(1, 0)).toBe('No open conflicts — run `truecourse contracts generate`.');
+    expect(scanSuccessOutro(1, 2)).toBe('2 open.');
+  });
+
+  it('formats representative extraction failures with location and error', () => {
+    expect(representativeExtractionFailures([
+      { block: { filePath: 'docs/a.md', headingPath: ['API', 'Auth'] }, error: 'claude exited 1: login expired' },
+    ])).toEqual([
+      'docs/a.md :: API → Auth\n    → claude exited 1: login expired',
+    ]);
+  });
+});

--- a/tools/cli/src/commands/spec.ts
+++ b/tools/cli/src/commands/spec.ts
@@ -49,6 +49,43 @@ function withTracker(stepDefs: readonly { key: string; label: string }[]) {
   return { renderer, tracker };
 }
 
+type ScanExtractSummary = {
+  blocksAttempted: number;
+  failures: Array<{ block: { filePath: string; headingPath: string[] }; error: string }>;
+  claims: unknown[];
+};
+
+export function totalExtractionFailure(extract: ScanExtractSummary): boolean {
+  return extract.blocksAttempted > 0
+    && extract.claims.length === 0
+    && extract.failures.length === extract.blocksAttempted;
+}
+
+export function scanSuccessOutro(claimCount: number, openConflictCount: number): string {
+  if (openConflictCount > 0) return `${openConflictCount} open.`;
+  if (claimCount === 0) return "No claims extracted.";
+  return "No open conflicts — run `truecourse contracts generate`.";
+}
+
+export function representativeExtractionFailures(
+  failures: ScanExtractSummary['failures'],
+  limit = 3,
+): string[] {
+  const seen = new Set<string>();
+  const lines: string[] = [];
+
+  for (const failure of failures) {
+    const location = `${failure.block.filePath} :: ${failure.block.headingPath.join(" → ")}`;
+    const line = `${location}\n    → ${failure.error}`;
+    if (seen.has(line)) continue;
+    seen.add(line);
+    lines.push(line);
+    if (lines.length >= limit) break;
+  }
+
+  return lines;
+}
+
 // ---------------------------------------------------------------------------
 // scan
 // ---------------------------------------------------------------------------
@@ -69,6 +106,20 @@ export async function runSpecScan(opts: RunSpecOptions = {}): Promise<void> {
     p.log.step(`decided     ${merge.decidedConflicts.length}`);
     p.log.step(`open        ${merge.openConflicts.length}`);
 
+    if (totalExtractionFailure(extract)) {
+      p.log.error(
+        `All ${extract.blocksAttempted} block extraction${extract.blocksAttempted === 1 ? "" : "s"} failed; no claims were produced.`,
+      );
+      for (const line of representativeExtractionFailures(extract.failures)) {
+        console.log(`  ${line}`);
+      }
+      if (extract.failures.length > 3) {
+        console.log(`  … and ${extract.failures.length - 3} more failure${extract.failures.length - 3 === 1 ? "" : "s"}`);
+      }
+      p.outro("Aborted. Fix extraction before generating contracts.");
+      process.exit(1);
+    }
+
     if (merge.openConflicts.length > 0) {
       p.log.message("");
       p.log.message("Open conflicts:");
@@ -87,11 +138,7 @@ export async function runSpecScan(opts: RunSpecOptions = {}): Promise<void> {
       p.log.message('                      truecourse spec conflicts custom <id> --text "…"');
       p.log.message("  • accept defaults:  truecourse spec resolve --all-defaults");
     }
-    p.outro(
-      merge.openConflicts.length === 0
-        ? "No open conflicts — run `truecourse contracts generate`."
-        : `${merge.openConflicts.length} open.`,
-    );
+    p.outro(scanSuccessOutro(extract.claims.length, merge.openConflicts.length));
   } catch (e) {
     renderer.dispose();
     p.cancel(`Failed: ${(e as Error).message}`);


### PR DESCRIPTION
## Summary

Fixes #474.

`spec scan` currently prints a success outro when every extraction block fails and no claims are produced. In that case the absence of open conflicts is not evidence that the docs are clean; it means the scan produced no usable claims.

This PR updates the CLI scan path to:

- treat `blocksAttempted > 0`, `failures === blocksAttempted`, and `claims.length === 0` as a fatal extraction failure
- print representative failure locations and errors so auth/subprocess failures are visible
- avoid suggesting `contracts generate` when the scan produced zero claims
- preserve partial-failure behavior when at least some claims are extracted

## Validation

- `npx pnpm@9.15.0 exec turbo build --filter=truecourse`
- `PATH=/Users/macbookair/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/vitest run tests/cli/spec-scan.test.ts tests/core/spec-telemetry.test.ts`

Note: local `corepack pnpm` fails on this machine due to a Corepack npm signature key mismatch, so I used `npx pnpm@9.15.0` matching the repo's packageManager.
