### PR TITLE
fix(drift-fp): resolve 1 drift FP from directus/directus

### DIFF
--- a/packages/contract-verifier/src/comparator/enum.ts
+++ b/packages/contract-verifier/src/comparator/enum.ts
@@ -63,10 +63,10 @@ export function compareEnum(input: EnumCompareInput): ContractDrift[] {
     });
   } else {
     for (const m of nameMatches) {
-      const specSet = new Set(contract.values);
-      const codeSet = new Set(m.values);
-      const missing = contract.values.filter((v) => !codeSet.has(v));
-      const extra = m.values.filter((v) => !specSet.has(v));
+      const specNorm = new Map(contract.values.map((v) => [normalizeValue(v), v]));
+      const codeNorm = new Map(m.values.map((v) => [normalizeValue(v), v]));
+      const missing = contract.values.filter((v) => !codeNorm.has(normalizeValue(v)));
+      const extra = m.values.filter((v) => !specNorm.has(normalizeValue(v)));
       for (const v of missing) {
         drifts.push(mkValueDrift(ref, 'missing-value', v, m, contract.values));
       }
@@ -96,10 +96,10 @@ export function compareEnum(input: EnumCompareInput): ContractDrift[] {
       continue;
     }
     for (const m of subsetMatches) {
-      const specSet = new Set(subset.values);
-      const codeSet = new Set(m.values);
-      const missing = subset.values.filter((v) => !codeSet.has(v));
-      const extra = m.values.filter((v) => !specSet.has(v));
+      const specNorm = new Map(subset.values.map((v) => [normalizeValue(v), v]));
+      const codeNorm = new Map(m.values.map((v) => [normalizeValue(v), v]));
+      const missing = subset.values.filter((v) => !codeNorm.has(normalizeValue(v)));
+      const extra = m.values.filter((v) => !specNorm.has(normalizeValue(v)));
       for (const v of missing) {
         drifts.push(mkSubsetDrift(ref, subset.name, 'missing-value', v, m, subset.values));
       }
@@ -196,9 +196,14 @@ function matchByName(
   return out;
 }
 
+/** Strip non-alphanumeric separators and lowercase so SET_NULL ≡ SET NULL ≡ set-null. */
+function normalizeValue(v: string): string {
+  return v.replace(/[^A-Za-z0-9]/g, '').toLowerCase();
+}
+
 function valueSetOverlap(a: string[], b: string[]): number {
-  const aSet = new Set(a);
-  const bSet = new Set(b);
+  const aSet = new Set(a.map(normalizeValue));
+  const bSet = new Set(b.map(normalizeValue));
   const intersection = [...aSet].filter((v) => bSet.has(v)).length;
   const union = new Set([...aSet, ...bSet]).size;
   return union === 0 ? 0 : intersection / union;

--- a/tests/fixtures/sample-js-project-il/code/src/db.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/db.ts
@@ -12,3 +12,10 @@ export const db = knex({
 });
 
 export const prisma = new PrismaClient();
+
+// FP-GUARD: enum/no-code-counterpart — must NOT drift
+// The FK constraint action type uses space-separated values matching the
+// database driver's convention (e.g. 'SET NULL'); the spec contract records
+// them with underscore separators (SET_NULL). The comparator must normalise
+// value separators before similarity matching so both formats are equivalent.
+export type ForeignKeyAction = 'CASCADE' | 'RESTRICT' | 'SET NULL' | 'NO ACTION' | 'SET DEFAULT';

--- a/tests/fixtures/sample-js-project-il/code/src/services/sync-pipeline.service.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/services/sync-pipeline.service.ts
@@ -6,6 +6,11 @@
 // intentional and the verifier must report it.
 //
 // IL-DRIFT: Enum:PipelineStage / enum.PipelineStage.no-code-counterpart
+//
+// DataSyncStrategy is declared in the spec; the pipeline service expresses
+// merge/replace behaviour via boolean flags rather than a named enum, so
+// no code counterpart exists for the spec-side strategy values.
+// IL-DRIFT: Enum:DataSyncStrategy / enum.DataSyncStrategy.no-code-counterpart
 
 // FP-GUARD: enum/no-code-counterpart — must NOT drift
 // A module-scoped 2-value type alias (`RunState`) that matches the

--- a/tests/fixtures/sample-js-project-il/reference/contracts/_inferred/foreignkeyaction/foreignkeyaction.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/_inferred/foreignkeyaction/foreignkeyaction.tc
@@ -1,0 +1,8 @@
+enum ForeignKeyAction {
+  // inferred — enum defined in code but documented in no spec
+  inferred-from "src/db.ts" 21..21
+  confidence high
+  representation string-literal
+  closed
+  values [CASCADE, NO ACTION, RESTRICT, SET DEFAULT, SET NULL]
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/enum-data-sync-strategy-regression.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/enum-data-sync-strategy-regression.tc
@@ -1,0 +1,4 @@
+enum DataSyncStrategy {
+  origin "reference/specs/fp-guards/enums.md" "Data synchronisation strategy values" 36..41
+  values [MERGE, REPLACE, SKIP, APPEND]
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/enum-fk-constraint-action.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/enum-fk-constraint-action.tc
@@ -1,0 +1,4 @@
+enum FkConstraintAction {
+  origin "reference/specs/fp-guards/enums.md" "Foreign key constraint action values" 30..35
+  values [CASCADE, SET_NULL, NO_ACTION, RESTRICT, SET_DEFAULT]
+}


### PR DESCRIPTION
Closes #522

## Fixes

| drift_kind | issue | fp-guard fixture | regression fixture |
|---|---|---|---|
| enum/no-code-counterpart | #522 | `tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/enum-fk-constraint-action.tc` + `code/src/db.ts` | `tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/enum-data-sync-strategy-regression.tc` + `code/src/services/sync-pipeline.service.ts` |

## enum/no-code-counterpart

**OSS source:** https://github.com/directus/directus/blob/2f4e667c81119c565d6ac1529510560835f59908/api/src/ai/tools/schema.ts#L218

**Contract:** `docs/drift-fp-automation/contracts/directus-directus/contracts/relationondeleteaction/relationondeleteaction.tc`

The contract declares `RelationOnDeleteAction` with underscore-separated values (`SET_NULL`, `NO_ACTION`, `SET_DEFAULT`), while `FkActionEnum` in the code uses space-separated values (`SET NULL`, `NO ACTION`, `SET DEFAULT`). The `valueSetOverlap` function compared values as raw strings — only `CASCADE` and `RESTRICT` matched, yielding a Jaccard score of 2/8 = 0.25, below the 0.6 threshold, so no code counterpart was found and `no-code-counterpart` fired spuriously.

**FP-guard fixture diff (code + contract):**

```typescript
// tests/fixtures/sample-js-project-il/code/src/db.ts (added)
// FP-GUARD: enum/no-code-counterpart — must NOT drift
// The FK constraint action type uses space-separated values matching the
// database driver's convention (e.g. 'SET NULL'); the spec contract records
// them with underscore separators (SET_NULL). The comparator must normalise
// value separators before similarity matching so both formats are equivalent.
export type ForeignKeyAction = 'CASCADE' | 'RESTRICT' | 'SET NULL' | 'NO ACTION' | 'SET DEFAULT';
```

```
// tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/enum-fk-constraint-action.tc (new)
enum FkConstraintAction {
  origin "reference/specs/fp-guards/enums.md" "Foreign key constraint action values" 30..35
  values [CASCADE, SET_NULL, NO_ACTION, RESTRICT, SET_DEFAULT]
}
```

**Regression fixture diff (code + contract):**

```typescript
// tests/fixtures/sample-js-project-il/code/src/services/sync-pipeline.service.ts (added)
// DataSyncStrategy is declared in the spec; the pipeline service expresses
// merge/replace behaviour via boolean flags rather than a named enum, so
// no code counterpart exists for the spec-side strategy values.
// IL-DRIFT: Enum:DataSyncStrategy / enum.DataSyncStrategy.no-code-counterpart
```

```
// tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/enum-data-sync-strategy-regression.tc (new)
enum DataSyncStrategy {
  origin "reference/specs/fp-guards/enums.md" "Data synchronisation strategy values" 36..41
  values [MERGE, REPLACE, SKIP, APPEND]
}
```

**Fix summary:** Added a `normalizeValue` helper in `packages/contract-verifier/src/comparator/enum.ts` that strips non-alphanumeric separators and lowercases (so `SET_NULL ≡ SET NULL ≡ set-null`). Updated `valueSetOverlap` to compare normalized values when computing the Jaccard similarity used for code-counterpart matching. Also updated the main value-diff loop to use the same normalization, so purely format-different values (e.g. `SET_NULL` vs `SET NULL`) don't generate spurious `missing-value`/`extra-value` drifts once a match is found. The `_inferred` corpus was updated to reflect the new `ForeignKeyAction` type the infer engine picks up from the fixture.

## Drift-count delta (vs 2f4e667c81119c565d6ac1529510560835f59908 on directus/directus, pinned contracts)

| Drift-kind | Before | After | Delta |
|---|---:|---:|---:|
| enum/no-code-counterpart | 6 | 5 | -1 |
| **Total (these 1 kinds)** | 6 | 5 | **-1** |
| **All-kinds total on target** | 7 | 6 | **-1** |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_017Yz59Mq7onT95ffyyLcK1t)_