### PR TITLE
chore(drift-fp): start discovery for payloadcms/payload

### DIFF
--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -100,7 +100,7 @@ campaigns:
       - docs/rich-text           # 11 — rich-text editor features + node types
       - docs/custom-components   # 8 — extension points + lifecycle hooks
     priority: 4
-    status: pending
+    status: discovering
     baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes: ["Probe 2026-06-06: 147 .md + 154 .mdx in-repo. docs/fields and docs/plugins describe field-type enums + plugin config constants — same drift-fp surface as strapi (collections / content-manager) but a different codebase. Tests whether strapi-era comparator fixes generalize across TS CMS implementations."]


### PR DESCRIPTION
Starting drift discovery run for **payloadcms/payload**.

This PR marks the campaign `status: discovering` and will accumulate all discovery commits:
- verify results
- FP/TP triage
- baseline update in campaigns.yaml

Contracts are on storage branch `claude/drift-fp-store/payloadcms-payload`, pinned at `a6e494ed6b8488e186e7e1b02d3bb0a9309c0bbd`.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_019zc7ahYvEEnQe2Zgyd88FX)_