### PR TITLE
chore(drift-fp): close payloadcms/payload campaign, bump to v0.6.5

### DIFF
--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -100,10 +100,12 @@ campaigns:
       - docs/rich-text           # 11 — rich-text editor features + node types
       - docs/custom-components   # 8 — extension points + lifecycle hooks
     priority: 4
-    status: discovering
-    baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
-    final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
-    notes: ["Probe 2026-06-06: 147 .md + 154 .mdx in-repo. docs/fields and docs/plugins describe field-type enums + plugin config constants — same drift-fp surface as strapi (collections / content-manager) but a different codebase. Tests whether strapi-era comparator fixes generalize across TS CMS implementations."]
+    status: done
+    baseline: { verified_at: "2026-06-07", target_ref: "a6e494ed6b8488e186e7e1b02d3bb0a9309c0bbd", total_drifts: 3, tp: 0, fp: 0, info: 3, fp_rate: 0 }
+    final:    { verified_at: "2026-06-07", target_ref: "a6e494ed6b8488e186e7e1b02d3bb0a9309c0bbd", total_drifts: 3, tp: 0, fp: 0, info: 3, fp_rate: 0, tp_rate: 1.0 }
+    notes:
+      - "Probe 2026-06-06: 147 .md + 154 .mdx in-repo. docs/fields and docs/plugins describe field-type enums + plugin config constants — same drift-fp surface as strapi (collections / content-manager) but a different codebase. Tests whether strapi-era comparator fixes generalize across TS CMS implementations."
+      - "Close verified at fp=0 on first run (2026-06-07). 3 drifts, all info: named-constant/no-code-counterpart for overrideLock.default (parameter default, not named constant), widget.maxWidth.default and widget.minWidth.default (optional API property defaults, not named constants). WidgetWidth enum and entity/auth contracts verified cleanly. Also fixed a WASM heap exhaustion bug: source walkers were not calling tree.delete() after parsing each file, causing the heap to fill after ~6000 parses and timing out verify on large monorepos (payloadcms/payload exposed this at 4493 TypeScript files)."
 
   # ---- Python — prefect (orchestration, state-machine-heavy enums) ----
   - target_repo: PrefectHQ/prefect

--- a/packages/contract-verifier/src/extractor/auth-presence.ts
+++ b/packages/contract-verifier/src/extractor/auth-presence.ts
@@ -87,14 +87,18 @@ export async function detectAuthPresence(rootDir: string): Promise<AuthPresenceR
       if (!TS_EXT.has(ext)) continue;
       const source = fs.readFileSync(full, 'utf-8');
       const lang = ext === '.tsx' ? 'tsx' : ext === '.ts' ? 'typescript' : 'javascript';
-      let tree: Tree;
+      let tree: Tree | undefined;
       try {
         tree = parseFile(full, source, lang);
       } catch {
         continue;
       }
       scanned.push(full);
-      collectFromTree(tree, source, full, edges, fileDefaultExports, fileImports, routerVarsByFile);
+      try {
+        collectFromTree(tree, source, full, edges, fileDefaultExports, fileImports, routerVarsByFile);
+      } finally {
+        tree.delete();
+      }
     }
   };
   visit(rootDir);

--- a/packages/contract-verifier/src/extractor/file-based-routes.ts
+++ b/packages/contract-verifier/src/extractor/file-based-routes.ts
@@ -156,30 +156,34 @@ function walkRoot(rootAbs: string, root: RouteRoot, out: ExtractedOperation[]): 
 
       const source = fs.readFileSync(full, 'utf-8');
       const lang = ext === '.tsx' ? 'tsx' : ext === '.ts' ? 'typescript' : 'javascript';
-      let tree: Tree;
+      let tree: Tree | undefined;
       try {
         tree = parseFile(full, source, lang);
       } catch {
         continue;
       }
-      const exports = collectHttpMethodExports(tree.rootNode, source);
-      for (const exp of exports) {
-        const contract: OperationContract = {
-          protocol: 'http',
-          method: exp.method.toUpperCase(),
-          path: url,
-          tags: [],
-          responses: extractResponsesFromBody(exp.body, source),
-        };
-        out.push({
-          identity: `${exp.method.toUpperCase()} ${url}`,
-          contract,
-          filePath: full,
-          declarationLine: exp.line,
-          observed: collectHandlerObservationsFromBody(exp.body, source),
-          handlerBody: exp.body,
-          handlerSource: source,
-        });
+      try {
+        const exports = collectHttpMethodExports(tree.rootNode, source);
+        for (const exp of exports) {
+          const contract: OperationContract = {
+            protocol: 'http',
+            method: exp.method.toUpperCase(),
+            path: url,
+            tags: [],
+            responses: extractResponsesFromBody(exp.body, source),
+          };
+          out.push({
+            identity: `${exp.method.toUpperCase()} ${url}`,
+            contract,
+            filePath: full,
+            declarationLine: exp.line,
+            observed: collectHandlerObservationsFromBody(exp.body, source),
+            handlerBody: exp.body,
+            handlerSource: source,
+          });
+        }
+      } finally {
+        tree.delete();
       }
     }
   };

--- a/packages/contract-verifier/src/extractor/idempotency-presence.ts
+++ b/packages/contract-verifier/src/extractor/idempotency-presence.ts
@@ -107,14 +107,18 @@ export async function detectIdempotencyPresence(
   // ---- Pass 2: per route, decide protected-or-not.
   const protectedRoutes = new Set<string>();
   for (const [filePath, { tree, source }] of fileTrees) {
-    walkRoutes(tree.rootNode, source, (declarationLine, middlewareIdents, handlerBody) => {
-      if (
-        anyIdentIsAware(middlewareIdents, filePath, fileBindings) ||
-        (handlerBody && nodeReadsHeader(handlerBody, source, headerLower))
-      ) {
-        protectedRoutes.add(routeKey(filePath, declarationLine));
-      }
-    });
+    try {
+      walkRoutes(tree.rootNode, source, (declarationLine, middlewareIdents, handlerBody) => {
+        if (
+          anyIdentIsAware(middlewareIdents, filePath, fileBindings) ||
+          (handlerBody && nodeReadsHeader(handlerBody, source, headerLower))
+        ) {
+          protectedRoutes.add(routeKey(filePath, declarationLine));
+        }
+      });
+    } finally {
+      tree.delete();
+    }
   }
 
   return { protectedRoutes, scannedFiles: scanned };

--- a/packages/contract-verifier/src/extractor/index.ts
+++ b/packages/contract-verifier/src/extractor/index.ts
@@ -6,6 +6,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import type { Tree } from 'web-tree-sitter';
 import { initParsers, parseFile } from '@truecourse/analyzer';
 import { loadTcIgnore } from '@truecourse/shared';
 import { extractOperationsFromFile, extractPluginStyleRoutesFromFile, type ExtractedOperation } from './operation.js';
@@ -100,8 +101,9 @@ export async function extractOperationsFromDir(rootDir: string): Promise<Extract
       const source = fs.readFileSync(full, 'utf-8');
       const lang =
         ext === '.ts' || ext === '.tsx' ? (ext === '.tsx' ? 'tsx' : 'typescript') : 'javascript';
+      let tree: Tree | undefined;
       try {
-        const tree = parseFile(full, source, lang);
+        tree = parseFile(full, source, lang);
         rawOps.push(...extractOperationsFromFile(full, source, tree));
         rawOps.push(...extractPluginStyleRoutesFromFile(full, source, tree));
         fileAnalyses.push(analyzeRouterFile(full, source, tree));
@@ -109,6 +111,8 @@ export async function extractOperationsFromDir(rootDir: string): Promise<Extract
         // Parse failures are silent — the verifier flags them via a
         // separate diagnostic channel later. Don't crash the whole
         // extraction pass on one bad file.
+      } finally {
+        tree?.delete();
       }
     }
   };

--- a/packages/contract-verifier/src/extractor/source-walker.ts
+++ b/packages/contract-verifier/src/extractor/source-walker.ts
@@ -91,11 +91,17 @@ export async function eachParsedSource(
       } catch {
         continue;
       }
+      let tree: Tree | undefined;
       try {
-        const tree = parseFile(full, source, lang);
+        tree = parseFile(full, source, lang);
         visit({ filePath: full, source, tree, lang });
       } catch {
         // Parse failure on one file is non-fatal.
+      } finally {
+        // Explicitly free the WASM heap allocation. Without this, long-running
+        // processes that walk thousands of files exhaust the tree-sitter WASM
+        // heap, causing abort() on subsequent parses.
+        tree?.delete();
       }
     }
   };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -63,7 +63,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.6.4")
+  .version("0.6.5")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## Campaign close: payloadcms/payload

### Merged drift-fp-fix PRs for this campaign

None — the campaign closed at fp=0 on the first verify run (the fix loop never needed to file issues).

### Baseline → final

| Metric | Baseline | Final |
|---|---:|---:|
| total_drifts | 3 | 3 |
| tp | 0 | 0 |
| fp | 0 | 0 |
| info | 3 | 3 |
| fp_rate | 0 | 0 |

fp: null → 0. Close gate `fp == 0` satisfied on first run (2026-06-07).

All 3 drifts are `named-constant/no-code-counterpart [info]`: `overrideLock.default`, `widget.maxWidth.default`, and `widget.minWidth.default` are documented API defaults but stored as parameter defaults/inline values rather than named constants — not false positives, not genuine behavioural drift, and the same classification pattern established in the feast campaign.

### Measurement

fp == 0 was measured against `node dist/cli.mjs` on pinned contracts from `claude/drift-fp-store/payloadcms-payload`, target ref `a6e494ed6b8488e186e7e1b02d3bb0a9309c0bbd`.

### Included fix: WASM tree-sitter heap exhaustion (v0.6.5)

This campaign also surfaced a latent correctness bug: source walkers in `packages/contract-verifier/src/extractor/` were not calling `tree.delete()` after parsing each file. For large monorepos (payloadcms/payload has 4493 TypeScript files) this causes WASM heap objects to accumulate across the entire verify run, exhausting the heap and triggering `abort()` on subsequent parsers.

Five walkers fixed — each now calls `tree?.delete()` (or `tree.delete()`) in a `finally` block:
- `extractor/source-walker.ts` — shared `eachParsedSource()` used by most extractors
- `extractor/auth-presence.ts` — independent directory walker in `detectAuthPresence()`
- `extractor/index.ts` — independent directory walker in `extractOperationsFromDir()`
- `extractor/idempotency-presence.ts` — stores trees across two passes; delete after Pass 2
- `extractor/file-based-routes.ts` — independent walker in `walkRoot()`

After the fix, verify on payloadcms/payload completed in ~84 s with zero `Aborted()` messages (previously timed out at 300+ s).

### Version

New version: **v0.6.5** — bumped in all four CLAUDE.md locations (`tools/cli/package.json`, `packages/core/package.json`, `apps/dashboard/server/package.json`, `tools/cli/src/index.ts`).

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_016zsxffxw6PPA3A8ymtUbu1)_