### PR TITLE
contract-verifier: defer tree-sitter Tree disposal to end of verify()/infer()

### DIFF
--- a/packages/contract-verifier/src/extractor/auth-presence.ts
+++ b/packages/contract-verifier/src/extractor/auth-presence.ts
@@ -24,6 +24,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { Node as SyntaxNode, Tree } from 'web-tree-sitter';
 import { initParsers, parseFile } from '@truecourse/analyzer';
+import { trackTree } from './source-walker.js';
 import { loadTcIgnore } from '@truecourse/shared';
 import { eachParsedSource } from './source-walker.js';
 import { fastApiFileHasAuthRouter } from './operation-fastapi.js';
@@ -93,6 +94,7 @@ export async function detectAuthPresence(rootDir: string): Promise<AuthPresenceR
       } catch {
         continue;
       }
+      trackTree(tree);
       scanned.push(full);
       collectFromTree(tree, source, full, edges, fileDefaultExports, fileImports, routerVarsByFile);
     }

--- a/packages/contract-verifier/src/extractor/file-based-routes.ts
+++ b/packages/contract-verifier/src/extractor/file-based-routes.ts
@@ -34,6 +34,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { Node as SyntaxNode, Tree } from 'web-tree-sitter';
 import { initParsers, parseFile } from '@truecourse/analyzer';
+import { trackTree } from './source-walker.js';
 import { loadTcIgnore } from '@truecourse/shared';
 import type { OperationContract } from '../types/index.js';
 import { extractResponsesFromBody, collectHandlerObservationsFromBody } from './operation.js';
@@ -162,6 +163,7 @@ function walkRoot(rootAbs: string, root: RouteRoot, out: ExtractedOperation[]): 
       } catch {
         continue;
       }
+      trackTree(tree);
       const exports = collectHttpMethodExports(tree.rootNode, source);
       for (const exp of exports) {
         const contract: OperationContract = {

--- a/packages/contract-verifier/src/extractor/idempotency-presence.ts
+++ b/packages/contract-verifier/src/extractor/idempotency-presence.ts
@@ -29,6 +29,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { Node as SyntaxNode, Tree } from 'web-tree-sitter';
 import { initParsers, parseFile } from '@truecourse/analyzer';
+import { trackTree } from './source-walker.js';
 import { loadTcIgnore } from '@truecourse/shared';
 
 const TS_EXT = new Set(['.ts', '.tsx', '.js', '.jsx']);
@@ -97,6 +98,7 @@ export async function detectIdempotencyPresence(
       } catch {
         continue;
       }
+      trackTree(tree);
       scanned.push(full);
       fileTrees.set(full, { tree, source });
       fileBindings.set(full, collectBindings(tree, source, full, headerLower));

--- a/packages/contract-verifier/src/extractor/index.ts
+++ b/packages/contract-verifier/src/extractor/index.ts
@@ -10,7 +10,7 @@ import { initParsers, parseFile } from '@truecourse/analyzer';
 import { loadTcIgnore } from '@truecourse/shared';
 import { extractOperationsFromFile, extractPluginStyleRoutesFromFile, type ExtractedOperation } from './operation.js';
 import { extractFastApiOperationsFromFile } from './operation-fastapi.js';
-import { eachParsedSource } from './source-walker.js';
+import { eachParsedSource, trackTree } from './source-walker.js';
 import { extractFileBasedRoutesFromDir } from './file-based-routes.js';
 import {
   analyzeRouterFile,
@@ -102,6 +102,7 @@ export async function extractOperationsFromDir(rootDir: string): Promise<Extract
         ext === '.ts' || ext === '.tsx' ? (ext === '.tsx' ? 'tsx' : 'typescript') : 'javascript';
       try {
         const tree = parseFile(full, source, lang);
+        trackTree(tree);
         rawOps.push(...extractOperationsFromFile(full, source, tree));
         rawOps.push(...extractPluginStyleRoutesFromFile(full, source, tree));
         fileAnalyses.push(analyzeRouterFile(full, source, tree));

--- a/packages/contract-verifier/src/extractor/source-walker.ts
+++ b/packages/contract-verifier/src/extractor/source-walker.ts
@@ -11,6 +11,19 @@
  * per-language matcher map and let `makeDirExtractor` drive the dispatch
  * — adding a language is a new entry in the map, never a structural
  * change.
+ *
+ * Tree lifetime: tree-sitter `Tree` objects are backed by a fixed-size
+ * WASM heap allocation that is NOT freed until `tree.delete()` is called.
+ * Long verify runs over large monorepos (~6000+ files) exhaust the heap
+ * if trees are never disposed. We can't dispose per-file because many
+ * extractors RETURN values that retain `SyntaxNode` references into the
+ * tree (e.g. `ExtractedOperation.handlerBody` for downstream effect /
+ * authorization analysis). So we track every parsed tree in a
+ * module-level registry and free them all in one shot at the end of
+ * verify() / infer() via `disposeAllTrackedTrees()`. Eager per-file
+ * deletion was attempted in PR #531 and produced
+ * `RuntimeError: memory access out of bounds` because downstream
+ * comparators / facts harvesters walked the deleted nodes.
  */
 
 import fs from 'node:fs';
@@ -27,6 +40,39 @@ export interface ParsedSource {
   source: string;
   tree: Tree;
   lang: SupportedLanguage;
+}
+
+// ---------------------------------------------------------------------------
+// Tree lifetime registry — see file header.
+// ---------------------------------------------------------------------------
+
+const trackedTrees: Tree[] = [];
+
+/**
+ * Register a freshly-parsed tree. Every call site that invokes `parseFile`
+ * inside the verifier must call this so the tree is eventually freed.
+ * `eachParsedSource` calls it automatically; direct `parseFile` callers
+ * (auth-presence, file-based-routes, idempotency-presence, the operation
+ * extractor in `extractor/index.ts`) must call it explicitly.
+ */
+export function trackTree(tree: Tree): void {
+  trackedTrees.push(tree);
+}
+
+/**
+ * Dispose every tracked tree. Call once at the end of verify() / infer().
+ * Safe to call multiple times (deletion is idempotent — a subsequent
+ * `delete()` on an already-freed tree throws, which we swallow).
+ */
+export function disposeAllTrackedTrees(): void {
+  for (const tree of trackedTrees) {
+    try {
+      tree.delete();
+    } catch {
+      // Already disposed — ignore.
+    }
+  }
+  trackedTrees.length = 0;
 }
 
 /** Extension → tree-sitter language. The single source of truth for
@@ -93,6 +139,7 @@ export async function eachParsedSource(
       }
       try {
         const tree = parseFile(full, source, lang);
+        trackTree(tree);
         visit({ filePath: full, source, tree, lang });
       } catch {
         // Parse failure on one file is non-fatal.

--- a/packages/contract-verifier/src/infer/index.ts
+++ b/packages/contract-verifier/src/infer/index.ts
@@ -41,6 +41,7 @@ import {
   type ExtractedQuery,
   type ExtractedOperation,
 } from '../extractor/index.js';
+import { disposeAllTrackedTrees } from '../extractor/source-walker.js';
 import type {
   ArchitectureCategory,
   ArchitectureDecisionContract,
@@ -86,30 +87,36 @@ export interface InferResult {
 }
 
 export async function infer(opts: InferOptions): Promise<InferResult> {
-  const authored = loadAuthored(opts.contractsDir);
-  const coverage = buildCoverage(authored);
+  try {
+    const authored = loadAuthored(opts.contractsDir);
+    const coverage = buildCoverage(authored);
 
-  // All code-side data flows through one shared, lazily-memoized extraction
-  // set — the same layer `verify` reads (see extractor/code-contracts.ts).
-  const code = extractCodeContracts(opts.codeDir);
-  const ops = await code.operations();
+    // All code-side data flows through one shared, lazily-memoized extraction
+    // set — the same layer `verify` reads (see extractor/code-contracts.ts).
+    const code = extractCodeContracts(opts.codeDir);
+    const ops = await code.operations();
 
-  const decisions: InferredDecision[] = [];
-  decisions.push(...inferOperations(ops, code.codeDir, coverage));
-  decisions.push(...(await inferConstants(code, coverage)));
-  decisions.push(...(await inferEnums(code, coverage)));
-  decisions.push(...(await inferQueryRules(code, coverage)));
-  decisions.push(...(await inferEffectGroups(code, coverage)));
-  decisions.push(...(await inferEntities(code, coverage)));
-  decisions.push(...(await inferFormulas(code, coverage)));
-  decisions.push(...(await inferStateMachines(code, coverage)));
-  decisions.push(...(await inferCrossCutting(ops, code, coverage)));
-  decisions.push(...(await inferArchitecture(code, coverage)));
+    const decisions: InferredDecision[] = [];
+    decisions.push(...inferOperations(ops, code.codeDir, coverage));
+    decisions.push(...(await inferConstants(code, coverage)));
+    decisions.push(...(await inferEnums(code, coverage)));
+    decisions.push(...(await inferQueryRules(code, coverage)));
+    decisions.push(...(await inferEffectGroups(code, coverage)));
+    decisions.push(...(await inferEntities(code, coverage)));
+    decisions.push(...(await inferFormulas(code, coverage)));
+    decisions.push(...(await inferStateMachines(code, coverage)));
+    decisions.push(...(await inferCrossCutting(ops, code, coverage)));
+    decisions.push(...(await inferArchitecture(code, coverage)));
 
-  // Stable order so output is deterministic across runs (and diffable in tests).
-  decisions.sort((a, b) => `${a.kind}:${a.identity}`.localeCompare(`${b.kind}:${b.identity}`));
+    // Stable order so output is deterministic across runs (and diffable in tests).
+    decisions.sort((a, b) => `${a.kind}:${a.identity}`.localeCompare(`${b.kind}:${b.identity}`));
 
-  return { decisions, coveredCounts: coverage.counts };
+    return { decisions, coveredCounts: coverage.counts };
+  } finally {
+    // Mirror verify(): free every tree parsed during inference.
+    // See source-walker.ts file header for why deferred deletion is required.
+    disposeAllTrackedTrees();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/contract-verifier/src/verify.ts
+++ b/packages/contract-verifier/src/verify.ts
@@ -19,6 +19,7 @@ import {
   getArchitectureDetector,
   type DetectedArchitectureChoice,
 } from './extractor/index.js';
+import { disposeAllTrackedTrees } from './extractor/source-walker.js';
 import {
   compareOperation,
   compareErrorEnvelope,
@@ -83,6 +84,21 @@ export interface VerifyResult {
 }
 
 export async function verify(opts: VerifyOptions): Promise<VerifyResult> {
+  try {
+    return await verifyImpl(opts);
+  } finally {
+    // Free every tree-sitter Tree that any extractor parsed during this run.
+    // Without this, the WASM heap grows monotonically (~6000+ trees on a
+    // large monorepo exhausts it and produces abort() on subsequent parses).
+    // We dispose at the very end because many extractor return values retain
+    // SyntaxNode references that downstream comparators / facts harvesters
+    // walk — disposing per-file (as PR #531 tried) crashes those walks with
+    // `RuntimeError: memory access out of bounds`.
+    disposeAllTrackedTrees();
+  }
+}
+
+async function verifyImpl(opts: VerifyOptions): Promise<VerifyResult> {
   // ---- Spec side: parse + resolve every .tc file ----
   const specFiles: ReturnType<typeof parseFile>[] = [];
   walkTcFiles(opts.contractsDir, (filePath) => {


### PR DESCRIPTION
## Why

WASM tree-sitter `Tree` objects are backed by a fixed-size WASM heap allocation that isn't freed until `tree.delete()` is called. Verify runs over large monorepos (payloadcms/payload's 4493 TypeScript files surfaced it) exhaust the heap and produce `abort()` on subsequent parses.

[Closed PR #531](https://github.com/truecourse-ai/truecourse/pull/531) tried the obvious eager fix — `tree.delete()` in a per-file `try/finally` across 5 walkers. That **broke tests** with `RuntimeError: memory access out of bounds` because multiple extractor return types retain `SyntaxNode` references into the tree:

- `ExtractedOperation.handlerBody` — walked downstream by `effect/emission-facts.ts isCall(node)` and `authorization-rule.ts`
- `analyzeRouterFile` outputs — walked by `buildMountGraph` / `rewriteOperationsWithMounts` after the per-file loop exits

Eagerly disposing per file walks downstream into freed WASM memory.

## What

Module-level tree registry in `source-walker.ts`, disposed at the very end of `verify()` / `infer()`:

- `trackTree(tree)` — push onto a shared `Tree[]`
- `disposeAllTrackedTrees()` — iterate and free all, safe to call multiple times

Wired in:

- `eachParsedSource` (shared walker) — automatic tracking
- 4 direct `parseFile` callers — explicit `trackTree(tree)` after parse: `auth-presence.ts`, `file-based-routes.ts`, `idempotency-presence.ts`, `extractor/index.ts`
- `verify()` and `infer()` — body wrapped in `try/finally`, call `disposeAllTrackedTrees()` in `finally`

By the time the `finally` runs, every comparator / facts harvester has finished walking the nodes they needed, so the dispose is safe.

## Test results

- All **389 contract-verifier tests** pass (`pnpm vitest run tests/contract-verifier/`).
- No `RuntimeError: memory access out of bounds` anywhere.
- Full-suite: 4,211 / 4,216 pass. The 5 remaining failures are sandbox `git commit` GPG-signing failures (`signing server returned status 400`) entirely unrelated to this diff.

## What this doesn't address (intentionally, separate PRs)

- **Memory pressure during the run** is still O(file-count) — all trees live until `verify()` ends. For repos with extreme file counts this could still matter. A future refactor could collect-and-release per-extractor pass since some return types (`ExtractedEnum` / `ExtractedConstant` / `ExtractedEffect`) only retain `filePath + line numbers` and never touch nodes; that requires auditing every extractor's return type and is real work. The shared-registry fix is enough to unblock the campaigns now.
- **Manual payload campaign-close PR** — once this lands on main, I'll open the clean close PR for payload (just `campaigns.yaml` flip + `0.6.4 → 0.6.5` bump in the 4 canonical locations, no code). That's what closed PR #531 should have been.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_