### PR TITLE
ci(landing): only deploy to Vercel when landing folder changes

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx turbo-ignore @truecourse/landing --fallback=HEAD^1",
   "rewrites": [
     {
       "source": "/((?!api/).*)",


### PR DESCRIPTION
## Problem

Every PR/push triggers a Vercel build + deployment for the landing site, even when the commit doesn't touch `apps/landing/`. The landing site is a standalone Vercel project (Root Directory `apps/landing`), so it shouldn't redeploy for changes elsewhere in the monorepo (`packages/`, `apps/dashboard`, `tools/`, etc.).

## Fix

Add an **Ignored Build Step** to `apps/landing/vercel.json`:

```json
"ignoreCommand": "npx turbo-ignore @truecourse/landing --fallback=HEAD^1"
```

Vercel runs `ignoreCommand` from the Root Directory and uses its exit code — **exit `1` → build proceeds, exit `0` → build canceled**. `turbo-ignore` (Vercel's recommended monorepo command) exits `0` when the `@truecourse/landing` workspace isn't affected by the commit range, so the deploy is skipped. It determines the range from `VERCEL_GIT_PREVIOUS_SHA`, falling back to `HEAD^1`.

Because `@truecourse/landing` has no internal workspace dependencies, "affected" is effectively "the landing folder changed" — with the desirable extra case that it also rebuilds if a dependency landing actually uses changes in the root lockfile. Using `turbo-ignore` (rather than a raw `git diff -- apps/landing`) also correctly handles multi-commit PRs where the tip commit doesn't touch landing but an earlier commit in the push did.

## Notes

- `ignoreCommand` cancels the build but still briefly enters the build step (canceled builds count toward Vercel quotas). Vercel's newer **Skip unaffected projects** toggle (Project → Settings → Build and Deployment → Root Directory) skips without consuming a build slot — worth enabling in the dashboard alongside this, but it's not committable to the repo.

## Testing

- Validated `apps/landing/vercel.json` is valid JSON.
- No behavior change to the site itself; only gates when Vercel runs the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)