### PR TITLE
chore(drift-fp): close payloadcms/payload campaign, bump to v0.6.5

### DIFF
--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -100,10 +100,13 @@ campaigns:
       - docs/rich-text           # 11 — rich-text editor features + node types
       - docs/custom-components   # 8 — extension points + lifecycle hooks
     priority: 4
-    status: discovering
-    baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
-    final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
-    notes: ["Probe 2026-06-06: 147 .md + 154 .mdx in-repo. docs/fields and docs/plugins describe field-type enums + plugin config constants — same drift-fp surface as strapi (collections / content-manager) but a different codebase. Tests whether strapi-era comparator fixes generalize across TS CMS implementations."]
+    status: done
+    baseline: { verified_at: "2026-06-07", target_ref: "a6e494ed6b8488e186e7e1b02d3bb0a9309c0bbd", total_drifts: 3, tp: 0, fp: 0, info: 3, fp_rate: 0 }
+    final:    { verified_at: "2026-06-08", target_ref: "a6e494ed6b8488e186e7e1b02d3bb0a9309c0bbd", total_drifts: 3, tp: 0, fp: 0, info: 3, fp_rate: 0, tp_rate: 1.0 }
+    notes:
+      - "Probe 2026-06-06: 147 .md + 154 .mdx in-repo. docs/fields and docs/plugins describe field-type enums + plugin config constants — same drift-fp surface as strapi (collections / content-manager) but a different codebase. Tests whether strapi-era comparator fixes generalize across TS CMS implementations."
+      - "Closed at fp=0 on first verify run. 3 drifts, all named-constant/no-code-counterpart [info]: overrideLock.default (documented API default stored as a parameter default, not a named constant), widget.maxWidth.default + widget.minWidth.default (optional API property defaults, also not named constants). 17 contracts total — 9 UnenforceableObligation (can't drift by design), 3 NamedConstant (these 3 info drifts), 2 AuthRequirement, 2 Entity, 1 Enum, all clean. WidgetWidth enum and entity/auth contracts verified cleanly."
+      - "Surfaced the WASM tree-sitter heap exhaustion bug on a 4493-file TS monorepo (PR #531 was the routine's wrong-shape attempt at fixing it inline + bundling with close; PR #532 was a tests-pass-but-still-crashes deferred-disposal; PR #533 was the real fix — eager handler-fact extraction + per-file tree disposal). Verified end-to-end on this branch: 69s wall-clock, exit 0, zero Aborted(), drift set unchanged."
 
   # ---- Python — prefect (orchestration, state-machine-heavy enums) ----
   - target_repo: PrefectHQ/prefect

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -63,7 +63,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.6.4")
+  .version("0.6.5")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## What

The clean campaign-close PR for **payloadcms/payload**. `campaigns.yaml` flip + version bump only, **no code** — what closed PR #531 should have been. The WASM fix that #531 bundled inline (and got wrong) landed properly in PR #533.

## Numbers

payloadcms/payload reached `fp == 0` on first verify run. 17 contracts loaded from the storage branch; 9 are `UnenforceableObligation` (can't drift by design). Of the 8 enforceable contracts, 3 produced drifts and all 3 are `named-constant/no-code-counterpart [info]`:

| Drift | Cause |
|---|---|
| `constant.overrideLock.default` | Documented API default stored as a parameter default, not a named constant |
| `constant.widget.maxWidth.default` | Optional API property default, not a named constant |
| `constant.widget.minWidth.default` | Same |

Same classification pattern as feast (all info, constants documented narratively rather than as named symbols).

| | Baseline | Final |
|---|---|---|
| total_drifts | 3 | 3 |
| fp | 0 | 0 |
| info | 3 | 3 |
| fp_rate | 0 | 0 |
| tp_rate | — | 1.0 |
| verified_at | 2026-06-07 | 2026-06-08 |

`verified_at` the pinned `target_ref a6e494ed6b8488e186e7e1b02d3bb0a9309c0bbd` against `node dist/cli.mjs` built from current main (post-PR #533, eager handler-fact extraction).

## Version

`0.6.4 → 0.6.5` in all four canonical locations:

- `tools/cli/package.json`
- `packages/core/package.json`
- `apps/dashboard/server/package.json`
- `tools/cli/src/index.ts` (`.version("0.6.5")`)

## On merge

`drift-fp-campaign-close` fires — closes the payload storage PR, files the `[drift-fp-campaign-close] tag v0.6.5 ready to push` issue (Telegram alert). `drift-fp-generate` fires in parallel and picks up **prefect** (next `pending`, no storage branch). The chain rolls.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_