### PR TITLE
fix(verify): stop the stash from sweeping away .truecourse/ contracts (#542)

### DIFF
--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.6.6",
+  "version": "0.6.6-next.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.6.6-next.0",
+  "version": "0.6.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.6.6-next.0",
+  "version": "0.6.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.6.6",
+  "version": "0.6.6-next.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/src/commands/analyze-core.ts
+++ b/packages/core/src/commands/analyze-core.ts
@@ -15,9 +15,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import path from 'node:path';
 import { log } from '../lib/logger.js';
-import { getGit } from '../lib/git.js';
+import { getGit, runWithStash } from '../lib/git.js';
 import { readProjectConfig } from '../config/project-config.js';
 import { touchProject } from '../config/registry.js';
 import type { RegistryEntry } from '../config/registry.js';
@@ -159,42 +158,32 @@ export async function analyzeCore(
 
     // ------------------------------------------------------------
     // Stash dirty working tree so the entire pipeline (parse + LLM scan +
-    // persist) sees the committed state. Diff mode never stashes — it
-    // analyzes the working tree by design.
+    // persist) sees the committed state. The shared helper scopes the stash
+    // to code only — it excludes TrueCourse's own `.truecourse/` working dir
+    // so generated artifacts and baselines survive. Diff mode (and skipGit)
+    // never stash — they analyze the working tree by design.
     // ------------------------------------------------------------
-    let didStash = false;
-    let stashGit: Awaited<ReturnType<typeof getGit>> | undefined;
-    if (!isDiff && !skipGit && !options.skipStash) {
-      try {
-        stashGit = await getGit(project.path);
-        const status = await stashGit.status();
-        if (!status.isClean()) {
-          const gitRoot = (await stashGit.revparse(['--show-toplevel'])).trim();
-          // Skip stashing when the repo path is a subdirectory of a larger
-          // repo (e.g., test fixtures inside the main repo). Stashing there
-          // would touch unrelated parent-repo files.
-          const isSubdirectory = path.resolve(project.path) !== path.resolve(gitRoot);
-          if (!isSubdirectory) {
-            options.tracker?.detail('parse', 'Stashing pending changes...');
-            options.onProgress?.({ detail: 'Stashing pending changes to analyze committed state...' });
-            const stashResult = await stashGit.stash([
-              'push',
-              '--include-untracked',
-              '-m',
-              'truecourse-analysis-stash',
-            ]);
-            // git stash push prints "No local changes to save" if nothing to stash
-            didStash = !stashResult.includes('No local changes');
-          }
-        }
-      } catch (error) {
-        log.warn(
-          `[Analyzer] Failed to stash changes, analyzing current state: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    }
-
-  try {
+    return await runWithStash(
+      project.path,
+      {
+        skipStash: isDiff || skipGit || (options.skipStash ?? false),
+        message: 'truecourse-analysis-stash',
+        onStashStart: () => {
+          options.tracker?.detail('parse', 'Stashing pending changes...');
+          options.onProgress?.({ detail: 'Stashing pending changes to analyze committed state...' });
+        },
+        onRestoreStart: () => {
+          options.tracker?.detail('parse', 'Restoring pending changes...');
+          options.onProgress?.({ detail: 'Restoring pending changes...' });
+        },
+        onStashError: (error) =>
+          log.warn(`[Analyzer] Failed to stash changes, analyzing current state: ${error.message}`),
+        onRestoreError: (error) =>
+          log.error(
+            `[Analyzer] Failed to restore stashed changes. Run "git stash pop" manually. ${error.message}`,
+          ),
+      },
+      async () => {
     // ------------------------------------------------------------
     // Parse the code
     // ------------------------------------------------------------
@@ -370,19 +359,8 @@ export async function analyzeCore(
       previousAnalysisId,
       analysisResult: result,
     };
-    } finally {
-      if (didStash && stashGit) {
-        options.tracker?.detail('parse', 'Restoring pending changes...');
-        options.onProgress?.({ detail: 'Restoring pending changes...' });
-        try {
-          await stashGit.stash(['pop']);
-        } catch (error) {
-          log.error(
-            `[Analyzer] Failed to restore stashed changes. Run "git stash pop" manually. ${error instanceof Error ? error.message : String(error)}`,
-          );
-        }
-      }
-    }
+      },
+    );
   } finally {
     releaseAnalyzeLock(project.path);
   }

--- a/packages/core/src/commands/spec-in-process.ts
+++ b/packages/core/src/commands/spec-in-process.ts
@@ -62,7 +62,7 @@ import {
 import fs from 'node:fs';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { getGit, isGitRepo } from '../lib/git.js';
+import { getGit, isGitRepo, runWithStash } from '../lib/git.js';
 import {
   writeVerifyRun,
   writeVerifyLatest,
@@ -869,8 +869,20 @@ export async function verifyInProcess(
     // one tracker call because the engine doesn't surface them yet.
     // Stash dirty changes first (unless opted out) so the baseline reflects
     // the committed state — same model as a full `analyze`.
-    result = await runWithStash(repoRoot, options.skipStash ?? false, tracker, () =>
-      verify({ contractsDir, codeDir }),
+    result = await runWithStash(
+      repoRoot,
+      {
+        skipStash: options.skipStash ?? false,
+        message: 'truecourse-verify-stash',
+        onStashStart: () => tracker?.detail?.('load', 'Stashing pending changes...'),
+        onRestoreStart: () => tracker?.detail?.('load', 'Restoring pending changes...'),
+        onRestoreError: (e) =>
+          // eslint-disable-next-line no-console
+          console.error(
+            `[Verify] Failed to restore stashed changes. Run "git stash pop" manually. ${e.message}`,
+          ),
+      },
+      () => verify({ contractsDir, codeDir }),
     );
   } catch (e) {
     tracker?.error('load', (e as Error).message);
@@ -971,52 +983,6 @@ async function gitMeta(repoRoot: string): Promise<{ branch: string | null; commi
     return { branch, commitHash };
   } catch {
     return { branch: null, commitHash: null };
-  }
-}
-
-/**
- * Run `fn` against the committed state by stashing the dirty working tree first
- * and popping after — mirroring `analyze-core`'s full-mode stash. No-ops when
- * `skipStash`, when the tree is clean, when the repo is a subdirectory of a
- * larger repo (stashing would touch parent-repo files), or when git is
- * unavailable.
- */
-async function runWithStash<T>(
-  repoRoot: string,
-  skipStash: boolean,
-  tracker: StepTracker | undefined,
-  fn: () => Promise<T>,
-): Promise<T> {
-  let didStash = false;
-  let stashGit: Awaited<ReturnType<typeof getGit>> | undefined;
-  if (!skipStash) {
-    try {
-      stashGit = await getGit(repoRoot);
-      const status = await stashGit.status();
-      if (!status.isClean()) {
-        const gitRoot = (await stashGit.revparse(['--show-toplevel'])).trim();
-        if (path.resolve(repoRoot) === path.resolve(gitRoot)) {
-          tracker?.detail?.('load', 'Stashing pending changes...');
-          const res = await stashGit.stash(['push', '--include-untracked', '-m', 'truecourse-verify-stash']);
-          didStash = !res.includes('No local changes');
-        }
-      }
-    } catch {
-      // Not a git repo / git unavailable — verify the current state as-is.
-    }
-  }
-  try {
-    return await fn();
-  } finally {
-    if (didStash && stashGit) {
-      tracker?.detail?.('load', 'Restoring pending changes...');
-      try {
-        await stashGit.stash(['pop']);
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(`[Verify] Failed to restore stashed changes. Run "git stash pop" manually. ${(e as Error).message}`);
-      }
-    }
   }
 }
 

--- a/packages/core/src/config/paths.ts
+++ b/packages/core/src/config/paths.ts
@@ -2,13 +2,34 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-const TRUECOURSE_DIR = '.truecourse';
+// Canonical name of the per-repo TrueCourse working directory. Exported as the
+// single source of truth so callers (e.g. the git stash helper, which must
+// never sweep this dir) reference the constant instead of a literal string.
+export const TRUECOURSE_DIR = '.truecourse';
+// Default `.truecourse/.gitignore`, mirroring the documented committable-vs-local
+// layout (see README "Setup"). Local-only state is ignored; the canonical spec
+// (`specs/`), the diff baselines (`LATEST.json`, `verifier/LATEST.json`) and
+// `config.json` stay committable so they travel with the repo.
+//
 // `LATEST.json` is intentionally tracked: it travels with the repo via git so
 // fresh clones and `git worktree add` checkouts inherit a baseline without
 // having to cold-start `truecourse analyze`. Convention: only commit it after
 // merging to main (post-merge analyze). Branch-local analyzes shouldn't
 // commit it, to avoid PR conflicts on a generated JSON.
-const GITIGNORE_CONTENTS = 'analyses/\nhistory.json\ndiff.json\nui-state.json\nlogs/\n.analyze.lock\n';
+const GITIGNORE_CONTENTS = [
+  'analyses/',
+  'history.json',
+  'diff.json',
+  'ui-state.json',
+  'logs/',
+  '.analyze.lock',
+  'contracts/',
+  'verifier/runs/',
+  'verifier/history.json',
+  'verifier/diff.json',
+  '.cache/',
+  '',
+].join('\n');
 
 // ---------------------------------------------------------------------------
 // Global paths (user-level)

--- a/packages/core/src/lib/analysis-store.ts
+++ b/packages/core/src/lib/analysis-store.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { atomicWriteJson } from './atomic-write.js';
+import { TRUECOURSE_DIR } from '../config/paths.js';
 import type {
   AnalysisSnapshot,
   DiffSnapshot,
@@ -22,7 +23,6 @@ import type {
 // Consumers pass `repoPath` (the repo root, not the `.truecourse` dir).
 // ---------------------------------------------------------------------------
 
-const TRUECOURSE_DIR = '.truecourse';
 const ANALYSES_DIR = 'analyses';
 const LATEST_FILE = 'LATEST.json';
 const HISTORY_FILE = 'history.json';

--- a/packages/core/src/lib/git.ts
+++ b/packages/core/src/lib/git.ts
@@ -7,8 +7,10 @@
  * Also provides `isGitRepo()` for cases where callers want to check without throwing.
  */
 
+import fs from 'node:fs';
 import { simpleGit, type SimpleGit } from 'simple-git';
 import { createAppError } from './errors.js';
+import { TRUECOURSE_DIR } from '../config/paths.js';
 
 /**
  * Single-sourced message for the "this isn't a git repo" guard. TrueCourse
@@ -42,4 +44,104 @@ export async function getGit(repoPath: string): Promise<SimpleGit> {
     throw createAppError(NOT_A_GIT_REPO_MESSAGE, 400);
   }
   return git;
+}
+
+export interface RunWithStashOptions {
+  /**
+   * When true, skip stashing entirely and run `fn` against the working tree
+   * as-is (e.g. `--no-stash`, diff mode, or a non-git context). The helper
+   * touches git only when this is false.
+   */
+  skipStash: boolean;
+  /** Stash message passed to `git stash push -m`. */
+  message: string;
+  /** Invoked right before the stash is pushed (surface "Stashing…" progress). */
+  onStashStart?: () => void;
+  /** Invoked right before the stash is popped (surface "Restoring…" progress). */
+  onRestoreStart?: () => void;
+  /**
+   * Invoked when the initial stash attempt throws (git unavailable, etc.). The
+   * run still proceeds against the current tree. Callers log in their own voice;
+   * omit to swallow silently.
+   */
+  onStashError?: (error: Error) => void;
+  /**
+   * Invoked when `git stash pop` fails in the `finally`. The stash entry is left
+   * for the user to recover manually. Callers log in their own voice.
+   */
+  onRestoreError?: (error: Error) => void;
+}
+
+/**
+ * Run `fn` against the committed state by stashing the dirty working tree first
+ * and popping it after — the shared implementation behind `analyze` and
+ * `verify`'s full-mode stash.
+ *
+ * Crucially, the stash **excludes TrueCourse's own `.truecourse/` directory**.
+ * That dir holds the tool's inputs (generated contracts) and committable state,
+ * not the code under analysis; sweeping it into the stash would delete the very
+ * artifacts `verify` then reads (issue #542). The stash is scoped to neutralize
+ * uncommitted *code* only.
+ *
+ * No-ops (runs `fn` directly) when `skipStash`, when the tree is clean, when the
+ * repo is a subdirectory of a larger repo (stashing would touch parent-repo
+ * files), or when git is unavailable.
+ */
+export async function runWithStash<T>(
+  repoRoot: string,
+  options: RunWithStashOptions,
+  fn: () => Promise<T>,
+): Promise<T> {
+  let didStash = false;
+  let stashGit: SimpleGit | undefined;
+
+  if (!options.skipStash) {
+    try {
+      stashGit = await getGit(repoRoot);
+      const status = await stashGit.status();
+      if (!status.isClean()) {
+        const gitRoot = (await stashGit.revparse(['--show-toplevel'])).trim();
+        // Skip stashing when the repo path is a subdirectory of a larger repo
+        // (e.g. test fixtures inside the main repo) — stashing there would
+        // touch unrelated parent-repo files. Compare *canonical* paths:
+        // `git --show-toplevel` returns the realpath, so a symlinked repoRoot
+        // (e.g. macOS /tmp → /private/tmp, or a symlinked $HOME) must be
+        // resolved too — otherwise we'd wrongly treat the real git root as a
+        // parent and silently skip the stash. When we do stash, simple-git's
+        // baseDir (repoRoot) makes the `.` pathspec resolve to the repo root.
+        if (fs.realpathSync(repoRoot) === fs.realpathSync(gitRoot)) {
+          options.onStashStart?.();
+          const res = await stashGit.stash([
+            'push',
+            '--include-untracked',
+            '-m',
+            options.message,
+            // Stash everything under the repo root EXCEPT `.truecourse/`, so the
+            // tool's own working dir (contracts, specs, baselines) survives.
+            '--',
+            '.',
+            `:(exclude,top)${TRUECOURSE_DIR}`,
+          ]);
+          // `git stash push` prints "No local changes to save" when the
+          // pathspec matched nothing dirty.
+          didStash = !res.includes('No local changes');
+        }
+      }
+    } catch (error) {
+      options.onStashError?.(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    if (didStash && stashGit) {
+      options.onRestoreStart?.();
+      try {
+        await stashGit.stash(['pop']);
+      } catch (error) {
+        options.onRestoreError?.(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+  }
 }

--- a/packages/core/src/lib/verify-store.ts
+++ b/packages/core/src/lib/verify-store.ts
@@ -17,6 +17,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { atomicWriteJson } from './atomic-write.js';
 import { buildAnalysisFilename } from './analysis-store.js';
+import { TRUECOURSE_DIR } from '../config/paths.js';
 import { summarizeDrifts } from '../types/verify-snapshot.js';
 import type {
   VerifyDiff,
@@ -26,7 +27,6 @@ import type {
   VerifyRunSnapshot,
 } from '../types/verify-snapshot.js';
 
-const TRUECOURSE_DIR = '.truecourse';
 const VERIFIER_DIR = 'verifier';
 const RUNS_DIR = 'runs';
 const LATEST_FILE = 'LATEST.json';

--- a/tests/core/paths.test.ts
+++ b/tests/core/paths.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ensureRepoTruecourseDir } from '../../packages/core/src/config/paths';
+
+// The scaffolded `.truecourse/.gitignore` must match the documented
+// committable-vs-local layout (README "Setup"). Getting this wrong both lets
+// users commit generated artifacts and — combined with the stash — used to
+// delete the contracts `verify` reads (issue #542).
+
+let repo: string;
+beforeEach(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-paths-'));
+});
+afterEach(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+describe('ensureRepoTruecourseDir .gitignore template', () => {
+  it('ignores generated/local state but keeps the spec and baselines committable', () => {
+    ensureRepoTruecourseDir(repo);
+    const lines = fs
+      .readFileSync(path.join(repo, '.truecourse', '.gitignore'), 'utf-8')
+      .split('\n')
+      .filter(Boolean);
+
+    // Local-only state (ignored).
+    for (const ignored of [
+      'analyses/',
+      'logs/',
+      '.analyze.lock',
+      'contracts/',
+      'verifier/runs/',
+      'verifier/history.json',
+      'verifier/diff.json',
+      '.cache/',
+    ]) {
+      expect(lines).toContain(ignored);
+    }
+
+    // Committable — must NOT be ignored (travels with the repo).
+    for (const committable of ['specs/', 'verifier/LATEST.json', 'LATEST.json', 'config.json']) {
+      expect(lines).not.toContain(committable);
+    }
+  });
+});

--- a/tests/core/run-with-stash.test.ts
+++ b/tests/core/run-with-stash.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { runWithStash } from '../../packages/core/src/lib/git';
+
+// `runWithStash` is the shared full-mode stash behind `analyze` and `verify`.
+// The defining property (issue #542): it stashes uncommitted *code* so the run
+// sees committed state, but it must NEVER sweep TrueCourse's own `.truecourse/`
+// working dir — that dir holds the contracts `verify` is about to read.
+
+let repo: string;
+beforeEach(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-run-with-stash-'));
+});
+afterEach(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+function gitInit(dir: string): void {
+  execSync('git init -q', { cwd: dir });
+  execSync('git config user.email t@t.co', { cwd: dir });
+  execSync('git config user.name test', { cwd: dir });
+}
+
+function commitFile(dir: string, name: string, contents: string): void {
+  fs.writeFileSync(path.join(dir, name), contents);
+  execSync(`git add ${name}`, { cwd: dir });
+  execSync(`git commit -q -m ${name}`, { cwd: dir });
+}
+
+describe('runWithStash', () => {
+  it('stashes dirty tracked code but never sweeps .truecourse/ (issue #542)', async () => {
+    gitInit(repo);
+    const tracked = path.join(repo, 'app.ts');
+    commitFile(repo, 'app.ts', 'export const x = 1;\n');
+    fs.writeFileSync(tracked, 'export const x = 2;\n'); // dirty tracked edit
+
+    // TrueCourse's own untracked working dir, exactly as `contracts generate`
+    // leaves it in a repo that hasn't committed `.truecourse/`.
+    const contract = path.join(repo, '.truecourse', 'contracts', 'op.tc');
+    fs.mkdirSync(path.dirname(contract), { recursive: true });
+    fs.writeFileSync(contract, 'operation X\n');
+
+    let codeDuringRun = '';
+    let contractPresentDuringRun = false;
+    await runWithStash(repo, { skipStash: false, message: 'tc-test' }, async () => {
+      codeDuringRun = fs.readFileSync(tracked, 'utf-8');
+      contractPresentDuringRun = fs.existsSync(contract);
+    });
+
+    // Inside the run: committed code is visible (dirty edit was stashed)…
+    expect(codeDuringRun).toBe('export const x = 1;\n');
+    // …but the contract survived (`.truecourse/` was excluded from the stash).
+    expect(contractPresentDuringRun).toBe(true);
+
+    // After the run: the dirty edit is restored, contract still present.
+    expect(fs.readFileSync(tracked, 'utf-8')).toBe('export const x = 2;\n');
+    expect(fs.existsSync(contract)).toBe(true);
+  });
+
+  it('skipStash: runs fn against the working tree as-is', async () => {
+    gitInit(repo);
+    const tracked = path.join(repo, 'app.ts');
+    commitFile(repo, 'app.ts', 'committed\n');
+    fs.writeFileSync(tracked, 'dirty\n');
+
+    let during = '';
+    await runWithStash(repo, { skipStash: true, message: 'x' }, async () => {
+      during = fs.readFileSync(tracked, 'utf-8');
+    });
+    expect(during).toBe('dirty\n'); // not stashed
+  });
+
+  it('clean tree: runs fn without stashing and returns its result', async () => {
+    gitInit(repo);
+    execSync('git commit -q --allow-empty -m init', { cwd: repo });
+    const result = await runWithStash(repo, { skipStash: false, message: 'x' }, async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('non-git dir: swallows the stash error and still runs fn', async () => {
+    // `repo` here is a plain tmp dir (no git init).
+    let ran = false;
+    let stashErr: Error | undefined;
+    await runWithStash(
+      repo,
+      { skipStash: false, message: 'x', onStashError: (e) => (stashErr = e) },
+      async () => {
+        ran = true;
+      },
+    );
+    expect(ran).toBe(true);
+    expect(stashErr).toBeInstanceOf(Error);
+  });
+});

--- a/tests/core/run-with-stash.test.ts
+++ b/tests/core/run-with-stash.test.ts
@@ -60,6 +60,38 @@ describe('runWithStash', () => {
     expect(fs.existsSync(contract)).toBe(true);
   });
 
+  it('resolves a symlinked repoRoot to its realpath so the stash still happens', async () => {
+    // Deterministic guard for the realpath comparison in runWithStash. `git
+    // --show-toplevel` returns the realpath, so a symlinked repoRoot (a
+    // symlinked $HOME, or macOS /tmp → /private/tmp) fails a lexical
+    // path.resolve compare → the repo looks like a subdir of a larger repo →
+    // the stash is silently skipped and the run sees the dirty tree (the
+    // #542-adjacent regression). Symlinking repoRoot explicitly pins this on
+    // every platform, not just macOS where os.tmpdir() happens to be symlinked.
+    const realDir = path.join(repo, 'real');
+    fs.mkdirSync(realDir);
+    gitInit(realDir);
+    const tracked = path.join(realDir, 'app.ts');
+    commitFile(realDir, 'app.ts', 'export const x = 1;\n');
+    fs.writeFileSync(tracked, 'export const x = 2;\n'); // dirty tracked edit
+
+    // A symlink pointing at the real repo, handed to runWithStash as repoRoot.
+    const linkDir = path.join(repo, 'link');
+    fs.symlinkSync(realDir, linkDir);
+
+    let codeDuringRun = '';
+    await runWithStash(linkDir, { skipStash: false, message: 'tc-test' }, async () => {
+      codeDuringRun = fs.readFileSync(path.join(linkDir, 'app.ts'), 'utf-8');
+    });
+
+    // The stash happened despite the symlinked path: committed state is visible.
+    // Under the old lexical compare, linkDir !== realpath(gitRoot) → stash
+    // skipped → this would be the dirty 'export const x = 2;'.
+    expect(codeDuringRun).toBe('export const x = 1;\n');
+    // …and the dirty edit is restored after the run.
+    expect(fs.readFileSync(tracked, 'utf-8')).toBe('export const x = 2;\n');
+  });
+
   it('skipStash: runs fn against the working tree as-is', async () => {
     gitInit(repo);
     const tracked = path.join(repo, 'app.ts');

--- a/tests/core/verify-store.test.ts
+++ b/tests/core/verify-store.test.ts
@@ -215,6 +215,29 @@ describe('full verify stashes the dirty tree (baseline = committed state)', () =
     // The dirty edit was stashed for the run, then popped back.
     expect(fs.readFileSync(tracked, 'utf-8')).toBe('uncommitted edit\n');
   });
+
+  it('does not stash away contracts under the repo .truecourse/ dir (issue #542)', async () => {
+    gitInit(repo);
+    // A committed code file so the tree has tracked history to stash against.
+    fs.writeFileSync(path.join(repo, 'app.ts'), 'committed\n');
+    execSync('git add app.ts', { cwd: repo });
+    execSync('git commit -q -m code', { cwd: repo });
+    fs.writeFileSync(path.join(repo, 'app.ts'), 'uncommitted edit\n'); // dirty → stash fires
+
+    // Generated contracts live UNTRACKED under .truecourse/contracts, exactly
+    // as `contracts generate` leaves them when .truecourse/ isn't committed.
+    const repoContracts = path.join(repo, '.truecourse', 'contracts');
+    fs.mkdirSync(repoContracts, { recursive: true });
+    fs.cpSync(CONTRACTS, repoContracts, { recursive: true });
+
+    // skipStash defaults false → full stash. Before the fix this threw
+    // `ENOENT scandir '.../.truecourse/contracts'` because the stash swept the
+    // contracts away before the verifier could read them.
+    const { verify } = await verifyInProcess(repo, { contractsDir: repoContracts, codeDir: CODE });
+
+    expect(verify.artifactCount).toBeGreaterThan(0); // contracts were actually read
+    expect(fs.existsSync(repoContracts)).toBe(true); // and survived the stash window
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.6.6-next.0",
+  "version": "0.6.7",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.6.6",
+  "version": "0.6.6-next.0",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -63,7 +63,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.6.6-next.0")
+  .version("0.6.7")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -63,7 +63,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.6.6")
+  .version("0.6.6-next.0")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program


### PR DESCRIPTION
## What & why

Fixes #542. `truecourse verify` failed with `ENOENT ... scandir '.../.truecourse/contracts'` **immediately after a successful `contracts generate`**, whenever the user picked "Stash and analyze committed state" at the stash prompt.

### Root cause

`verify` (and `analyze`) neutralize uncommitted **code** by running `git stash push --include-untracked` so the run reflects committed state. But `--include-untracked` sweeps up *every* untracked file — including TrueCourse's own `.truecourse/` working dir. `verify` reads `.truecourse/contracts/` **during** the stash window, so the contracts it had just generated were gone → ENOENT. The pre-stash existence check passed first, which made the failure look contradictory ("generate wrote the files, but verify says they're missing").

The stash logic was also **duplicated** in two near-identical copies (`analyze-core.ts` and `spec-in-process.ts`), both with the same latent bug. `analyze` didn't visibly crash only because its inputs are source code read during the window, while its `.truecourse/` outputs are written after the pop.

## Changes

- **Extract one shared `runWithStash` helper** into `packages/core/src/lib/git.ts`, used by both `analyze` and `verify` (removes the duplicate copies). It scopes the stash to code only:
  ```
  git stash push --include-untracked -m <msg> -- . :(exclude,top).truecourse
  ```
  so TrueCourse's own working dir (contracts, specs, baselines) is never swept away. Uses the exported `TRUECOURSE_DIR` constant — no hardcoded `.truecourse` string.
- **Harden the subdirectory guard to compare realpaths.** `git --show-toplevel` returns the realpath, so a symlinked repo path (macOS `/tmp → /private/tmp`, a symlinked `$HOME`) made the old lexical `path.resolve` comparison mismatch and **silently skip the stash entirely** — analyze/verify then ran against the dirty tree while believing they were on committed state. Now `fs.realpathSync(repoRoot) === fs.realpathSync(gitRoot)`.
- **Repair the stale `.truecourse/.gitignore` template** (`config/paths.ts`) to match the documented committable-vs-local layout: ignore `contracts/`, `verifier/runs/`, `verifier/history.json`, `verifier/diff.json`, `.cache/`; keep `specs/`, `LATEST.json`, `verifier/LATEST.json`, `config.json` committable. This is defense-in-depth + makes the README's "gitignored by default" claim true. (New repos only; existing repos are protected by the stash fix regardless.)

## Tests

- `tests/core/run-with-stash.test.ts` (new) — proves the helper stashes dirty tracked code (run sees committed state) **and** leaves `.truecourse/contracts/` on disk; plus `skipStash`, clean-tree, and non-git cases.
- `tests/core/verify-store.test.ts` — added a `verifyInProcess` regression with contracts under the repo's own untracked `.truecourse/contracts/` (the #542 repro): verify reads them with no ENOENT.
- `tests/core/paths.test.ts` (new) — asserts the gitignore template ignores generated/local state but keeps the spec and baselines committable.

Full suite: **133 files / 4191 tests passing**, `tsc --noEmit` clean.

## Manual verification

Reproduce the original report against the public **directus/directus** repo (https://github.com/directus/directus):

```bash
git clone https://github.com/directus/directus && cd directus
truecourse spec scan
truecourse contracts generate
truecourse verify   # choose "Stash and analyze committed state"
```

Before: `ENOENT ... scandir '.../.truecourse/contracts'`. After: verify reads the contracts and reports drifts (or "No drift detected"). `truecourse analyze` on a dirty tree is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
