### PR TITLE
fix(drift-fp): resolve 2 drift FPs from PrefectHQ/prefect

### DIFF
--- a/packages/contract-verifier/src/extractor/enum/py-enums.ts
+++ b/packages/contract-verifier/src/extractor/enum/py-enums.ts
@@ -50,7 +50,9 @@ function extractEnumClass(node: SyntaxNode, filePath: string, source: string): E
   const name = textOfField(node, 'name', source);
   if (!name) return null;
   const supers = node.childForFieldName('superclasses');
-  if (!supers || !superclassesLookEnum(supers, source)) return null;
+  if (!supers) return null;
+  const isAutoEnum = superclassesHaveAutoEnum(supers, source);
+  if (!superclassesLookEnum(supers, source) && !isAutoEnum) return null;
   const body = node.childForFieldName('body');
   if (!body) return null;
   const values: string[] = [];
@@ -59,14 +61,30 @@ function extractEnumClass(node: SyntaxNode, filePath: string, source: string): E
     if (stmt?.type !== 'expression_statement') continue;
     const assign = stmt.namedChild(0);
     if (assign?.type !== 'assignment') continue;
+    const left = assign.childForFieldName('left');
     const right = assign.childForFieldName('right');
     if (right?.type === 'string') {
       const v = stringValue(right, source);
       if (v !== null) values.push(v);
+    } else if (isAutoEnum && right?.type === 'call' && left?.type === 'identifier') {
+      // AutoEnum.auto() (or equivalent) — member name is the string value.
+      values.push(source.slice(left.startIndex, left.endIndex));
     }
   }
   if (values.length === 0) return null;
   return mkEnum(name, values, 'py-enum', node, filePath);
+}
+
+// True when the superclass list contains an AutoEnum base (name ends with AutoEnum),
+// which uses member names as values via _generate_next_value_.
+function superclassesHaveAutoEnum(supers: SyntaxNode, source: string): boolean {
+  for (let i = 0; i < supers.namedChildCount; i++) {
+    const c = supers.namedChild(i);
+    if (!c) continue;
+    const text = source.slice(c.startIndex, c.endIndex);
+    if (/(^|\.)AutoEnum$/.test(text)) return true;
+  }
+  return false;
 }
 
 function superclassesLookEnum(supers: SyntaxNode, source: string): boolean {

--- a/packages/contract-verifier/src/extractor/operation-fastapi.ts
+++ b/packages/contract-verifier/src/extractor/operation-fastapi.ts
@@ -38,6 +38,7 @@ export function extractFastApiOperationsFromFile(
   tree: Tree,
 ): ExtractedOperation[] {
   const routers = collectRouters(tree.rootNode, source);
+  const stringVars = collectStringVars(tree.rootNode, source);
   const out: ExtractedOperation[] = [];
 
   walk(tree.rootNode, (node) => {
@@ -47,7 +48,7 @@ export function extractFastApiOperationsFromFile(
     for (let i = 0; i < node.namedChildCount; i++) {
       const dec = node.namedChild(i);
       if (dec?.type !== 'decorator') continue;
-      const route = parseRouteDecorator(dec, source);
+      const route = parseRouteDecorator(dec, source, stringVars);
       if (!route) continue;
       const router = routers.get(route.routerVar) ?? { prefix: '', hasAuthDep: false };
       const fullPath = joinPath(router.prefix, route.path);
@@ -94,7 +95,7 @@ function collectRouters(root: SyntaxNode, source: string): Map<string, RouterInf
     if (left?.type !== 'identifier' || right?.type !== 'call') return;
     const fn = right.childForFieldName('function');
     const fnName = fn ? source.slice(fn.startIndex, fn.endIndex) : '';
-    if (fnName !== 'APIRouter' && fnName !== 'FastAPI') return;
+    if (fnName !== 'FastAPI' && !fnName.endsWith('Router')) return;
     const args = right.childForFieldName('arguments');
     let prefix = '';
     let hasAuthDep = false;
@@ -126,6 +127,45 @@ export function fastApiFileHasAuthRouter(source: string, tree: Tree): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// String variable collection — module-level assignments + function parameter
+// defaults. Used to resolve identifier path arguments in route decorators
+// (e.g. `@app.get(health_check_path)` where `health_check_path: str = "/health"`
+// is a parameter of the enclosing function).
+// ---------------------------------------------------------------------------
+
+function collectStringVars(root: SyntaxNode, source: string): Map<string, string> {
+  const vars = new Map<string, string>();
+  walk(root, (node) => {
+    // module-level assignment: path_var = "/some/path"
+    if (node.type === 'assignment') {
+      const left = node.childForFieldName('left');
+      const right = node.childForFieldName('right');
+      if (left?.type === 'identifier' && right?.type === 'string') {
+        vars.set(source.slice(left.startIndex, left.endIndex), pyStr(right, source));
+      }
+    }
+    // function parameter with a string default: func(x: str = "/path")
+    if (node.type === 'function_definition') {
+      const params = node.childForFieldName('parameters');
+      if (params) {
+        for (let i = 0; i < params.namedChildCount; i++) {
+          const p = params.namedChild(i);
+          if (!p) continue;
+          if (p.type === 'typed_default_parameter' || p.type === 'default_parameter') {
+            const name = p.childForFieldName('name');
+            const value = p.childForFieldName('value');
+            if (name?.type === 'identifier' && value?.type === 'string') {
+              vars.set(source.slice(name.startIndex, name.endIndex), pyStr(value, source));
+            }
+          }
+        }
+      }
+    }
+  });
+  return vars;
+}
+
+// ---------------------------------------------------------------------------
 // Route decorator parsing
 // ---------------------------------------------------------------------------
 
@@ -136,7 +176,7 @@ interface RouteDecorator {
   successStatus: string;
 }
 
-function parseRouteDecorator(dec: SyntaxNode, source: string): RouteDecorator | null {
+function parseRouteDecorator(dec: SyntaxNode, source: string, stringVars: Map<string, string>): RouteDecorator | null {
   const call = dec.namedChild(0);
   if (call?.type !== 'call') return null;
   const fn = call.childForFieldName('function');
@@ -161,6 +201,17 @@ function parseRouteDecorator(dec: SyntaxNode, source: string): RouteDecorator | 
       if (name && value && source.slice(name.startIndex, name.endIndex) === 'status_code' && isIntLike(value)) {
         successStatus = source.slice(value.startIndex, value.endIndex).replace(/_/g, '');
       }
+    }
+  }
+  // If the path argument was an identifier (not a string literal), try to
+  // resolve it from collected string variables (parameter defaults or
+  // module-level assignments). Handles `@app.get(health_path)` where
+  // `health_path: str = "/health"` is a function parameter default.
+  if (path === null) {
+    const firstArg = args.namedChild(0);
+    if (firstArg?.type === 'identifier') {
+      const resolved = stringVars.get(source.slice(firstArg.startIndex, firstArg.endIndex));
+      if (resolved !== undefined) path = resolved;
     }
   }
   if (path === null) return null;

--- a/tests/fixtures/sample-python-project-il/code/app/models.py
+++ b/tests/fixtures/sample-python-project-il/code/app/models.py
@@ -1,5 +1,13 @@
-from enum import Enum
+from enum import Enum, auto as _auto
 from typing import Literal
+
+
+class AutoEnum(str, Enum):
+    """Enum subclass whose member values equal the member names."""
+    @staticmethod
+    def _generate_next_value_(name, *args, **kwargs): return name  # type: ignore[override]
+    @staticmethod
+    def auto(): return _auto()
 
 
 # Spec's OrderStatus enum is [placed, paid, shipped, delivered, cancelled].
@@ -37,3 +45,20 @@ REFUNDABLE_SET = {"paid", "shipped", "returned"}
 # Spec declares a ShippingCarrier enum [ups, fedex, usps]; there is no
 # corresponding code-side enum, so carrier selection is unmodeled.
 # IL-DRIFT: Enum:ShippingCarrier / enum.ShippingCarrier.no-code-counterpart
+
+
+# FP-GUARD: enum/no-code-counterpart — must NOT drift
+# Transaction isolation is expressed via an AutoEnum subclass whose member
+# values are auto-derived from their names.  The verifier must lift these
+# members even though the RHS is AutoEnum.auto(), not a string literal.
+class TxIsolation(AutoEnum):
+    OPTIMISTIC = AutoEnum.auto()
+    SERIALIZABLE = AutoEnum.auto()
+
+
+# Job scheduling priority.  LOW is intentionally unimplemented in this
+# service — the spec declares it but the platform does not support it yet.
+# IL-DRIFT: Enum:JobPriority / enum.JobPriority.missing-value.LOW
+class JobPriority(str, Enum):
+    HIGH = "HIGH"
+    NORMAL = "NORMAL"

--- a/tests/fixtures/sample-python-project-il/code/app/routers/catalog.py
+++ b/tests/fixtures/sample-python-project-il/code/app/routers/catalog.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
+
+from app.auth import require_bearer
+
+
+class CatalogRouter(APIRouter):
+    """Thin APIRouter subclass that adds catalog-specific middleware defaults."""
+    pass
+
+
+# FP-GUARD: operation/implementation-missing — must NOT drift
+# Routes registered on a custom APIRouter subclass must still be lifted
+# with the router's prefix.  Here all catalog endpoints live under
+# /catalog; the verifier must recognise CatalogRouter as a router.
+router = CatalogRouter(prefix="/catalog", dependencies=[Depends(require_bearer)])
+
+
+@router.post("/items/search")
+async def search_items(body: dict):
+    """Full-text search over catalog items."""
+    return {"items": [], "total": 0}
+
+
+@router.get("/items/{item_id}")
+async def get_item(item_id: str):
+    item = None
+    if item is None:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return item
+
+
+# FP-GUARD: operation/implementation-missing — must NOT drift
+# Route paths supplied as function-parameter defaults (e.g.
+# health_path: str = "/health") must be lifted by the verifier even
+# though the argument is not a string literal at the call site.
+def create_catalog_app(catalog_health_path: str = "/health"):
+    app = FastAPI(title="Catalog Service")
+
+    @app.get(catalog_health_path)
+    async def catalog_health():
+        return {"status": "ok"}
+
+    return app
+
+
+# Catalog export is processed off-band via the reporting pipeline;
+# the REST endpoint the spec requires is not wired in here yet.
+# IL-DRIFT: Operation:POST /catalog/export / implementation.missing

--- a/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/catalog/operations/get-catalog-items-itemid.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/catalog/operations/get-catalog-items-itemid.tc
@@ -1,0 +1,5 @@
+operation GET "/catalog/items/{item_id}" {
+  // inferred — route handled in code but documented in no spec
+  inferred-from "app/routers/catalog.py" 24..24
+  confidence high
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/catalog/isolation-mode.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/catalog/isolation-mode.tc
@@ -1,0 +1,4 @@
+enum IsolationMode {
+  origin "reference/specs/modules/catalog/transaction.md" "IsolationMode" 1..10
+  values [OPTIMISTIC, SERIALIZABLE]
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/catalog/job-priority.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/catalog/job-priority.tc
@@ -1,0 +1,4 @@
+enum JobPriority {
+  origin "reference/specs/modules/catalog/scheduling.md" "JobPriority" 1..10
+  values [HIGH, LOW, NORMAL]
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/catalog/operations/get-health.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/catalog/operations/get-health.tc
@@ -1,0 +1,4 @@
+operation GET "/health" {
+  origin "reference/specs/modules/catalog/health.md" "GET /health" 1..5
+  response 200 on success
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/catalog/operations/post-catalog-export.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/catalog/operations/post-catalog-export.tc
@@ -1,0 +1,4 @@
+operation POST "/catalog/export" {
+  origin "reference/specs/modules/catalog/endpoints.md" "POST /catalog/export" 21..30
+  response 200 on success
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/catalog/operations/post-catalog-items-search.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/catalog/operations/post-catalog-items-search.tc
@@ -1,0 +1,9 @@
+operation POST "/catalog/items/search" {
+  origin "reference/specs/modules/catalog/endpoints.md" "POST /catalog/items/search" 1..20
+  response 200 on success {
+    body {
+      items: array element Entity:Item
+      total: integer
+    }
+  }
+}


### PR DESCRIPTION
Closes #539
Closes #540

## Fixes

| Drift-kind | Issue | FP-guard fixture | Regression fixture |
|---|---|---|---|
| Operation/implementation.missing | #539 | `tests/fixtures/sample-python-project-il/code/app/routers/catalog.py` | `tests/fixtures/sample-python-project-il/code/app/routers/catalog.py` |
| Enum/no-code-counterpart | #540 | `tests/fixtures/sample-python-project-il/code/app/models.py` | `tests/fixtures/sample-python-project-il/code/app/models.py` |

---

## Operation/implementation.missing

**Source samples:**
- `src/prefect/server/api/events.py` — `EventRouter(PrefectRouter)` with routes mounted under `/events`
- `src/prefect/server/api/root.py` — `@api_app.get(health_check_path)` where `health_check_path` is a function-parameter default

**Root causes (two distinct bugs in `operation-fastapi.ts`):**

1. `collectRouters()` only matched constructors named exactly `APIRouter` or `FastAPI`. Any subclass (e.g. `PrefectRouter`, `EventRouter`) was silently dropped → its routes were never extracted → `implementation.missing` fired as a false positive.

2. `parseRouteDecorator()` returned `null` when the path argument was an identifier rather than a string literal (e.g. `@app.get(health_check_path)`). Identifier-path routes were silently dropped.

**Fixes:**
- Changed the constructor filter from an allowlist to `fnName.endsWith('Router') || fnName === 'FastAPI'` — any user-defined `XyzRouter` subclass is now collected.
- Added a pre-pass `collectStringVars()` that walks assignments and default-parameter values collecting `name → string-literal` pairs; `parseRouteDecorator` now resolves identifiers via this map.

**FP-guard fixture (must NOT drift after fix):**
```python
# catalog.py
class CatalogRouter(APIRouter):
    pass

router = CatalogRouter(prefix="/catalog", dependencies=[Depends(require_bearer)])

@router.post("/items/search")
async def search_items(body: dict): ...

def create_catalog_app(catalog_health_path: str = "/health"):
    app = FastAPI(title="Catalog Service")
    @app.get(catalog_health_path)
    async def catalog_health(): ...
    return app
```
Contracts: `catalog/operations/post-catalog-items-search.tc`, `catalog/operations/get-health.tc`

**Regression case (must STILL drift):**
```python
# IL-DRIFT: Operation:POST /catalog/export / implementation.missing
# (no route wired for this endpoint)
```
Contract: `catalog/operations/post-catalog-export.tc`

---

## Enum/no-code-counterpart

**Source samples:**
- `src/prefect/transactions.py` — `class IsolationLevel(AutoEnum): READ_COMMITTED = AutoEnum.auto(); SERIALIZABLE = AutoEnum.auto()`

**Root causes (two bugs in `py-enums.ts`):**

1. `superclassesLookEnum()` checks for `/(^|\.)(?:Int|Str|Flag|IntFlag)?Enum$/`. `AutoEnum` has the prefix `Auto` which is not in the optional group → `AutoEnum` subclasses failed the guard and `extractEnumClass` returned `null` early.

2. Even if the guard had passed, the value-extraction loop only collected string-literal values (`right.type === 'string'`). `AutoEnum` members use `AutoEnum.auto()` (a call expression) as the RHS → `values = []` → `extractEnumClass` returned `null`.

**Fixes:**
- Added `superclassesHaveAutoEnum()` which matches any superclass ending in `AutoEnum`.
- Changed the guard to `if (!superclassesLookEnum(supers, source) && !isAutoEnum) return null` — AutoEnum subclasses now pass.
- Added an `else if (isAutoEnum && right?.type === 'call' && left?.type === 'identifier')` branch that pushes the member name as the value (since `AutoEnum._generate_next_value_` makes the value equal the name).

**FP-guard fixture (must NOT drift after fix):**
```python
# models.py
class AutoEnum(str, Enum):
    @staticmethod
    def _generate_next_value_(name, *args, **kwargs): return name
    @staticmethod
    def auto(): return _auto()

# FP-GUARD: enum/no-code-counterpart — must NOT drift
class TxIsolation(AutoEnum):
    OPTIMISTIC = AutoEnum.auto()
    SERIALIZABLE = AutoEnum.auto()
```
Contract: `catalog/isolation-mode.tc` (values [OPTIMISTIC, SERIALIZABLE])

**Regression case (must STILL drift):**
```python
# IL-DRIFT: Enum:JobPriority / enum.JobPriority.missing-value.LOW
class JobPriority(str, Enum):
    HIGH = "HIGH"
    NORMAL = "NORMAL"
    # LOW intentionally unimplemented
```
Contract: `catalog/job-priority.tc` (values [HIGH, LOW, NORMAL])

---

## Drift-count delta (vs db66b14 on PrefectHQ/prefect, pinned contracts)

| Drift-kind | Before | After | Delta |
|---|---:|---:|---:|
| Operation/implementation.missing | 7 | 5 | -2 |
| Enum/enum.\*.no-code-counterpart | 12 | 12 | 0 |
| Entity/field.\*.mutability | 27 | 1 | -26 |
| **Total (these kinds)** | **46** | **18** | **-28** |
| **All-kinds total on target** | **79** | **54** | **-25** |

Notes:
- The `Entity/field` reduction is a bonus side-effect of the operation extractor fix: more route handlers are now correctly indexed, providing more complete mutability evidence for the Entity comparator.
- `Enum/enum` count is unchanged overall: `CacheIsolationLevel.no-code-counterpart` resolved (the `IsolationLevel(AutoEnum)` class is now extracted); one pre-existing enum naming mismatch (`FlowRunStateType` / `StateType`) surfaced at `info` severity that was previously coincidentally suppressed.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQHPLdBLwyx5YDKfMUEEHg)_