### PR TITLE
contract-extractor: ground immutability + constant extraction in explicit spec text

### DIFF
--- a/packages/contract-extractor/src/prompt.ts
+++ b/packages/contract-extractor/src/prompt.ts
@@ -662,6 +662,27 @@ not narrow the set.
 substitute for \`immutable\`. If a derived/server-computed field is also frozen
 after creation, emit BOTH \`computed-at\` AND \`immutable\`.
 
+**NEVER infer \`immutable\` from what a field IS — only from what the spec SAYS
+about changing it.** The following do NOT imply immutability, alone or combined:
+
+- The field is required (\`Required? yes\` in a field table).
+- The field is an identifier (\`id\`, \`uuid\`, "identifier of this X").
+- The field is a timestamp ("when the event happened", \`occurred\`, \`createdAt\`).
+- The field is client-provided or server-assigned (provenance is not mutability).
+
+Counter-example — a field table like:
+
+| Name     | Type   | Required? | Description                              |
+| -------- | ------ | --------- | ---------------------------------------- |
+| occurred | String | yes       | When the event happened                  |
+| id       | String | yes       | Client-provided identifier of this event |
+
+asserts NOTHING about mutability. Both fields get plain \`field occurred: string {}\`
+/ \`field id: string {}\` — no \`immutable\`, even though an id "sounds" immutable.
+Emitting un-stated \`immutable\` creates a false drift against every codebase whose
+model simply doesn't freeze the field. If the spec is silent on mutability, the
+contract is silent on mutability.
+
 # Enum extraction — required whenever spec defines an enum
 
 Whenever the spec text contains any of:
@@ -1012,6 +1033,42 @@ constant whose \`expected-value\` block has one line per row.
 Don't emit constants whose value is a function call, expression, or
 external reference — only literal values (strings, numbers, booleans,
 arrays of literals, flat object literals of literals).
+
+**Don't extract constants from customization examples.** A constant asserts
+"the code MUST hold this value". A doc that shows users how to CUSTOMIZE or
+OVERRIDE something is asserting the opposite — "you can put whatever value
+you want here" — and its example values are illustrations, not obligations.
+Skip a candidate value when EITHER signal is present:
+
+1. **Context signal**: the page title or enclosing section heading describes
+   a customization/override mechanism — "Customize …", "Override …",
+   "… template", "… variables", "Configure your own …", "Example
+   configuration".
+2. **Shape signal**: the value sits inside a JSON-schema-style variables
+   block, i.e. an object of the form
+   \`"<name>": { "title": …, "description": …, "default": <value>, "type": … }\`.
+   That quadruple is a schema DECLARING an overridable variable; the
+   \`"default"\` there is a starting point the user is expected to change.
+
+Counter-example — a page titled "Customize Base Job Templates" containing:
+
+\`\`\`json
+"cpu_request": {
+  "title": "CPU Request",
+  "description": "CPU allocation to request for this pod",
+  "default": "100m",
+  "type": "string"
+}
+\`\`\`
+
+emits NO constant. Both signals fire: the page is a customization guide, and
+the value is a variables-schema \`default\`. Extracting
+\`constant cpu_request { expected-value "100m" }\` would demand every codebase
+hard-code the example — a guaranteed false drift.
+
+By contrast, prose like "the scheduler polls every 15 seconds" or "the API
+version is \`v2\`" in a behavioral spec section IS an assertion about the
+system — extract those normally.
 
 # ArchitectureDecision — extract when the spec/ADR fixes a platform choice
 


### PR DESCRIPTION
## Why

The prefect campaign stalled (#554) with 65 FPs. Diagnosis showed **31 of them are contract-generation bugs**, not verifier bugs — same class as the directus `OperationType` under-extraction that PR #518 fixed. Per the project's no-workarounds rule, this fixes the generator instead of hand-editing the bad contracts on the storage branch.

### Bug 1 — invented immutability (#552, 27 FPs)

`event.tc` marks `Event.id` and `Event.occurred` as `immutable`. The source — `docs/v3/concepts/events.mdx` — is this table:

```
| Name     | Type   | Required? | Description                              |
| occurred | String | yes       | When the event happened                  |
| id       | String | yes       | Client-provided identifier of this event |
```

The word "immutable" appears **nowhere on the page**. The prompt's existing rule already lists the only valid trigger phrases ("immutable", "never changes after creation", …) — the LLM inferred immutability from field *semantics* anyway (identifier-sounding, timestamp-sounding, `Required: yes`). The rule had no explicit anti-inference clause and no counter-example, and these prompts' load-bearing parts are the examples.

### Bug 2 — example values extracted as obligations (#553, 4 FPs)

`cpu_limit` / `cpu_request` / `memory_limit` / `memory_request` were emitted as constants with `expected-value "1000m"` / `"100m"` / `"1Gi"` / `"256Mi"`. The source page is literally titled **"Customize Base Job Templates"** and the values sit inside a JSON variables schema:

```json
"cpu_request": {
  "title": "CPU Request",
  "description": "CPU allocation to request for this pod",
  "default": "100m",
  "type": "string"
}
```

That's a schema *declaring an overridable variable* — the `"default"` is a starting point the user is expected to change. But the NamedConstant trigger list ("X defaults to `<value>`", "identifier paired with a value in a config block") matches this shape exactly, and nothing excluded customization contexts.

## What

Two additions to `SYSTEM_PROMPT` in `packages/contract-extractor/src/prompt.ts`, each with a counter-example lifted from the real failure (anonymized to the doc *shape*, not naming prefect):

1. **Mutability rules** gain a "NEVER infer `immutable` from what a field IS — only from what the spec SAYS about changing it" block. Required / identifier / timestamp / client-provided do not imply immutability. Spec silent on mutability → contract silent on mutability. Includes the field-table counter-example.

2. **NamedConstant rules** gain a "Don't extract constants from customization examples" block with two skip signals — **context** (page/section heading says Customize / Override / template / variables) and **shape** (JSON-schema-style `{title, description, default, type}` variables block) — plus a contrast case showing that prose assertions ("the API version is `v2`") still extract normally.

## Cache invalidation (intentional)

Both edits are inside `SYSTEM_PROMPT`, which is sha256-fingerprinted into the slice cache key (`cache.ts:34-35`, checked at `cache.ts:70`). All cached extractions invalidate, so the prefect regeneration provably re-runs every slice under the new rules — same mechanism that made the directus regeneration work after PR #518.

## Validation

- 46/46 contract-extractor tests pass.
- The real validation is the regeneration: after merge, delete `claude/drift-fp-store/PrefectHQ-prefect`, reset prefect to `pending`, Run-now `drift-fp-generate`. Expected outcome on re-verify: the 27 `entity/field-mutability` FPs and 4 `named-constant/value-mismatch` FPs disappear (65 → ~34 FPs), leaving only the four verifier-limitation issues (#548–#551) as genuine engineering work.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_