### PR TITLE
chore(drift-fp): start discovery for PrefectHQ/prefect

### DIFF
--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -117,7 +117,7 @@ campaigns:
       - docs/v3/advanced         # 29 — advanced behavior: retries, caching, transactions
       - docs/v3/api-ref/rest-api # REST API operation reference (server/flow-runs, server/deployments, …)
     priority: 5
-    status: pending
+    status: discovering
     baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes:


### PR DESCRIPTION
Starting a drift discovery run for **PrefectHQ/prefect** against the regenerated pinned contracts on storage branch `claude/drift-fp-store/PrefectHQ-prefect` (storage PR #557).

This is the legitimate first discovery run after the campaign was reset to `pending` on 2026-06-09 (PR #555 fixed two contract-extractor bugs and the old storage branch was deleted to force regeneration with the fixed prompt).

Plan (per the `drift-fp-discover` routine):
- Build truecourse from local source (`pnpm build:dist`).
- Clone PrefectHQ/prefect at `target_ref` `d858cb6725864c9a993be6a6633009b03b5e6f5e`, `code_dir: "."`.
- Run deterministic `verify` against the pinned contracts.
- Triage drifts by drift-kind (TP / FP / borderline), file one `[drift-fp-fix]` issue per drift-kind with ≥1 clear FP.
- Fill `baseline.*` in `campaigns.yaml`.

The campaign is now marked `status: discovering`. Verify results, filed issues, and the baseline will follow as commits/comments on this PR.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBqtZEyVwjLNRzJybQAxwk)_