### PR TITLE
fix(drift-fp): resolve 1 drift FP from PrefectHQ/prefect

### DIFF
--- a/packages/contract-verifier/src/verify.ts
+++ b/packages/contract-verifier/src/verify.ts
@@ -120,6 +120,11 @@ export async function verify(opts: VerifyOptions): Promise<VerifyResult> {
       // a code-side implementation yet — suppress the drift.
       if (st === 'planned' || st === 'deferred' || st === 'out-of-scope') continue;
 
+      // Operations whose identity is an absolute URL (e.g., "GET https://api.example.com/...")
+      // describe endpoints on external services. The codebase under verification will never
+      // implement them, so an implementation.missing drift here is always a false positive.
+      if (/^[A-Z]+ https?:\/\//.test(artifact.ref.identity)) continue;
+
       drifts.push({
         id: cryptoRandomId(),
         type: 'contract-drift',

--- a/tests/contract-verifier/operation-lifter.test.ts
+++ b/tests/contract-verifier/operation-lifter.test.ts
@@ -72,7 +72,7 @@ describe('Contract Operation lifter', () => {
   it('every Operation in the corpus has a lifted contract', () => {
     const r = loadAll();
     const ops = [...r.index.values()].filter((a) => a.ref.type === 'Operation');
-    expect(ops.length).toBe(20);
+    expect(ops.length).toBe(22);
     for (const op of ops) {
       expect(op.contract, `Operation:${op.ref.identity} missing contract`).toBeDefined();
     }

--- a/tests/fixtures/sample-js-project-il/code/src/processors/webhook/index.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/processors/webhook/index.ts
@@ -1,1 +1,6 @@
+// FP-GUARD: operation/implementation-missing — must NOT drift
+// Outbound delivery calls the partner notification API at
+// https://api.partner.io/notifications/{id}. That URL is declared in
+// the spec but lives on an external service — this module enqueues
+// delivery payloads; it does not implement the remote endpoint.
 export default { id: 'transform', handle: (_payload: unknown) => null };

--- a/tests/fixtures/sample-js-project-il/code/src/services/sync-pipeline.service.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/services/sync-pipeline.service.ts
@@ -33,3 +33,8 @@ export function createRun(id: string): PipelineRun {
 export function finishRun(run: PipelineRun): PipelineRun {
   return { ...run, state: 'inactive', finishedAt: new Date() };
 }
+
+// The spec declares a POST /api/sync/push endpoint for triggering push
+// deliveries; the implementation is incomplete — no route handler is
+// registered for it yet.
+// IL-DRIFT: Operation:POST /api/sync/push / implementation.missing

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-external-url-fp-guard.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-external-url-fp-guard.tc
@@ -1,0 +1,5 @@
+operation GET "https://api.partner.io/notifications/{id}" {
+  origin "reference/specs/shared/endpoints.md" "External Partner Delivery Endpoint" 1..3
+  response 200 on success {}
+  response 404 on not_found {}
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-relative-regression.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-relative-regression.tc
@@ -1,0 +1,4 @@
+operation POST "/api/sync/push" {
+  origin "reference/specs/modules/orders/endpoints.md" "POST /api/sync/push" 1..3
+  response 202 on success {}
+}


### PR DESCRIPTION
Closes #560

## Fixes

| drift_kind | issue | fp-guard fixture | regression fixture |
|---|---|---|---|
| operation/implementation-missing | #560 | `tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-external-url-fp-guard.tc` | `tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-relative-regression.tc` |

## operation/implementation-missing

**OSS source URLs:**
- https://github.com/PrefectHQ/prefect/blob/d858cb6725864c9a993be6a6633009b03b5e6f5e/docs/v3/concepts/webhooks.mdx

**Cited contract path:** `docs/drift-fp-automation/contracts/PrefectHQ-prefect/contracts/https:/operations/get-https-api.prefect.cloud-hooks-opaque-id.tc`

The spec's `webhooks.mdx` describes `https://api.prefect.cloud/hooks/{opaque-id}` as the Prefect Cloud hosted webhook receiver. The contract-extractor correctly lifted this as an `Operation` contract. However, `verify.ts` looks up each spec operation identity in a code-side index keyed by `METHOD path` — and code-side routes are always relative paths (e.g., `/hooks/{id}`). An absolute URL identity like `GET https://api.prefect.cloud/hooks/{opaque-id}` can never match, so `implementation.missing` fires for every such contract, always a false positive.

**FP-guard fixture diff (code + .tc):**

```diff
--- /dev/null
+++ tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-external-url-fp-guard.tc
@@ -0,0 +1,5 @@
+operation GET "https://api.partner.io/notifications/{id}" {
+  origin "reference/specs/shared/endpoints.md" "External Partner Delivery Endpoint" 1..3
+  response 200 on success {}
+  response 404 on not_found {}
+}
```

```diff
--- tests/fixtures/sample-js-project-il/code/src/processors/webhook/index.ts
+++ tests/fixtures/sample-js-project-il/code/src/processors/webhook/index.ts
@@ -1,1 +1,6 @@
+// FP-GUARD: operation/implementation-missing — must NOT drift
+// Outbound delivery calls the partner notification API at
+// https://api.partner.io/notifications/{id}. That URL is declared in
+// the spec but lives on an external service — this module enqueues
+// delivery payloads; it does not implement the remote endpoint.
 export default { id: 'transform', handle: (_payload: unknown) => null };
```

**Regression fixture diff (code + .tc):**

```diff
--- /dev/null
+++ tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-relative-regression.tc
@@ -0,0 +1,4 @@
+operation POST "/api/sync/push" {
+  origin "reference/specs/modules/orders/endpoints.md" "POST /api/sync/push" 1..3
+  response 202 on success {}
+}
```

```diff
--- tests/fixtures/sample-js-project-il/code/src/services/sync-pipeline.service.ts
+++ tests/fixtures/sample-js-project-il/code/src/services/sync-pipeline.service.ts
@@ -34,3 +34,7 @@
+
+// The spec declares a POST /api/sync/push endpoint for triggering push
+// deliveries; the implementation is incomplete — no route handler is
+// registered for it yet.
+// IL-DRIFT: Operation:POST /api/sync/push / implementation.missing
```

**Fix summary:** In `packages/contract-verifier/src/verify.ts`, added a guard before the `implementation.missing` emission: if `artifact.ref.identity` matches `/^[A-Z]+ https?:\/\//`, skip the check. Absolute URL identities describe endpoints on external services (e.g., a hosted Cloud API) that the OSS codebase under verification never implements. The code-side route index uses relative paths exclusively, so the match can never succeed — emitting the drift is always a false positive.

## Drift-count delta (vs d858cb67 on PrefectHQ/prefect, pinned contracts)

| Drift-kind | Before | After | Delta |
|---|---:|---:|---:|
| operation/implementation-missing | 2 | 0 | **-2** |
| **Total (these 1 kinds)** | 2 | 0 | **-2** |
| **All-kinds total on target** | 10 | 8 | **-2** |

After fix: fp=0, all 8 remaining drifts are `[info]` severity no-code-counterpart items (human-accepted borderline, excluded from fp ratio per the TP/FP rubric).

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_016B92rSWFLB4KXjNRAceRwn)_