### PR TITLE
drift-fp: notify on stuck-tracker state change, not just creation

### DIFF
--- a/.github/workflows/notify-routine-activity.yml
+++ b/.github/workflows/notify-routine-activity.yml
@@ -16,7 +16,15 @@ on:
   pull_request:
     types: [opened]
   issues:
-    types: [opened]
+    # `opened` covers first-time issue creation. `reopened` lets the
+    # drift-fp-next-fix queue-empty path notify on a material state
+    # change of an existing [drift-fp-campaign-stuck] tracker — the
+    # routine closes + reopens the tracker (with a "State change since
+    # last run" delta header) instead of spawning a new issue every run.
+    # Silent re-runs (no state change) edit the body in place and don't
+    # trigger this workflow. See drift-fp-next-fix.md
+    # "Notify-on-change protocol".
+    types: [opened, reopened]
 
 permissions:
   issues: read

--- a/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
@@ -332,10 +332,27 @@ Enter when the **pickable** queue is empty AND `successes == 0` (includes all-re
    first**: for each drift-kind still showing FPs, skip if an open `drift-fp-fix` issue
    (any label, including `drift-fp-blocked`) already exists; else file one (discovery shape).
    - Filed ≥1 new issue → continue into the per-issue loop this session.
-   - Filed 0 (every FP-kind already tracked, all blocked) → file/update a single
-     `[drift-fp-campaign-stuck] <owner>/<repo>` tracking issue (current `fp` count + `fp_rate`,
-     the close gate `fp == 0`, checklist of open `drift-fp-blocked` issues, `cc @mushgev`), then
-     end. Never dead-end silently.
+   - Filed 0 (every FP-kind already tracked, all blocked) → maintain a single
+     `[drift-fp-campaign-stuck] <owner>/<repo>` tracking issue with the current state.
+     Body carries: current `fp` count + `fp_rate`, the close gate `fp == 0`, a checklist
+     of open `drift-fp-blocked` issues. End with `cc @mushgev`.
+
+     **Notify-on-change protocol** — the Telegram alert (`notify-campaign-alert`) only
+     fires on `issues.opened` / `issues.reopened`, not on edits/comments. So:
+
+     - **No existing tracker** → open a new one. Telegram fires on `opened`. ✓
+     - **Existing tracker, state unchanged** — `fp` count is the same AND the set of
+       blocked-issue numbers in the body's checklist is identical (treat as a set, order
+       doesn't matter) — **edit the body in place** (refresh the timestamp, leave the
+       state as-is). Stay silent; the human has no new information to act on.
+     - **Existing tracker, state changed** — either `fp` count differs OR the
+       blocked-issue set differs — **close the tracker, then reopen it** via the GitHub
+       API, with the body rewritten to the new state AND a "## State change since last
+       run" header at the top summarising the delta (e.g.
+       `fp 65 → 8`, `blocked-issues +#557, -#552`). Telegram fires on `reopened`. ✓
+
+     This makes the human pinged exactly when there is news, never on silent re-runs.
+     Never dead-end silently.
 
 If the queue empties **after** ≥1 success, ship the batch PR instead — don't run this path in a
 session that already produced fixes.


### PR DESCRIPTION
## Why

When prefect's regenerated baseline came in at **65 FPs → 8 FPs** (a material result of PR #555 + the regeneration), the autonomous routine ran, correctly entered the queue-empty path, *commented* on the existing `[drift-fp-campaign-stuck]` tracker (#554)… and no Telegram alert fired. The human (you) was flying blind on the most important state change in the campaign.

Root cause: `notify-campaign-alert` in `notify-routine-activity.yml` triggers on `issues.opened` only. The routine's prompt said "file *or update*" the tracker. The "update" path edits the existing issue — no `opened` event — no Telegram.

## Fix (two surfaces, both small)

**Workflow** (`notify-routine-activity.yml`): add `reopened` to the `issues:` trigger types. The existing `if:` predicates already gate on `[drift-fp-campaign-stuck]` / `[drift-fp-campaign-close]` / etc. title prefixes, so unrelated reopens by humans don't spuriously fire.

**Prompt** (`drift-fp-next-fix.md`, queue-empty path step 6): replace "file/update" with a **Notify-on-change protocol**:

| State | Action | Telegram |
|---|---|---|
| No tracker exists | Open a new one | Fires on `opened` ✓ |
| Tracker exists, state unchanged (same `fp` count + same set of blocked-issue numbers) | Edit body in place (refresh timestamp) | Silent |
| Tracker exists, state changed (`fp` differs OR blocked-issue set differs) | Close + reopen via API, with a "## State change since last run" delta header | Fires on `reopened` ✓ |

"Change" is defined precisely. Both inputs are facts the routine already computes — no new state to maintain.

## Net

Human gets pinged exactly when there's news to act on. Silent re-runs of an unchanged stuck campaign stay silent. The exact gap that hid the 65→8 result going forward becomes a Telegram ping.

## Companion items (separately)

- #550 / #551 should be closed — no longer reproduce post-regeneration (per the routine's spot-check).
- `pnpm build:dist` ordering bug (the routine flagged: `scripts/build.ts` doesn't build the contract packages before `@truecourse/core`'s tsc on fresh checkouts) — separate small PR.
- The 4 remaining Python-extractor patterns in #548/#549 — engineering decision, not in this PR.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_