### PR TITLE
fix(build): build contract/spec packages before core in build:dist

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -53,10 +53,29 @@ console.log('Cleaning dist/...');
 fs.rmSync(DIST, { recursive: true, force: true });
 fs.mkdirSync(DIST, { recursive: true });
 
-// 1. Build shared + analyzer + core
+// 1. Build packages in dependency order:
+//      shared → analyzer
+//      spec-consolidator → contract-verifier → contract-extractor → core
+//
+// core's tsc imports the three contract/spec packages, so their .d.ts
+// files MUST exist before core compiles. The intra-package graph:
+//
+//   shared             ←  no truecourse deps
+//   analyzer           ←  shared
+//   spec-consolidator  ←  shared
+//   contract-verifier  ←  shared + analyzer
+//   contract-extractor ←  shared + contract-verifier + spec-consolidator
+//   core               ←  all of the above
+//
+// Sequential order below honors that graph. Prior to this, fresh-checkout
+// `pnpm build:dist` failed at core's tsc because the contract/spec
+// packages weren't built yet.
 console.log('\n=== Building packages ===');
 run('pnpm --filter @truecourse/shared build');
 run('pnpm --filter @truecourse/analyzer build');
+run('pnpm --filter @truecourse/spec-consolidator build');
+run('pnpm --filter @truecourse/contract-verifier build');
+run('pnpm --filter @truecourse/contract-extractor build');
 run('pnpm --filter @truecourse/core build');
 
 // 2. Build dashboard client (static export)


### PR DESCRIPTION
## Why

`scripts/build.ts` stage 1 built `shared → analyzer → core` directly, skipping the three workspace packages that `core`'s tsc imports (`@truecourse/contract-verifier`, `@truecourse/contract-extractor`, `@truecourse/spec-consolidator`). On a fresh checkout (no cached package builds), `pnpm build:dist` failed at `core`'s tsc with `error TS2307: Cannot find module '@truecourse/contract-verifier'`.

The drift-fp-next-fix routine documented hitting exactly this in its latest queue-empty post — it worked around it by running `pnpm build` (turbo, dep-ordered) before `pnpm build:dist`. Real bug. The "Build once: `pnpm install && pnpm build:dist`" step the next-fix prompt documents no longer worked as written on fresh checkouts.

## What

Insert the three missing package builds in the correct dependency order. Actual intra-package graph (from `import`/`export` statements in `src/`):

```
shared             ← no truecourse deps
analyzer           ← shared
spec-consolidator  ← shared
contract-verifier  ← shared, analyzer
contract-extractor ← shared, contract-verifier, spec-consolidator
core               ← all of the above
```

New stage-1 order in `scripts/build.ts`:

```ts
pnpm --filter @truecourse/shared            build
pnpm --filter @truecourse/analyzer          build
pnpm --filter @truecourse/spec-consolidator build  // NEW
pnpm --filter @truecourse/contract-verifier build  // NEW
pnpm --filter @truecourse/contract-extractor build // NEW
pnpm --filter @truecourse/core              build
```

## Subtlety worth noting

`contract-extractor`'s `claims-reader.ts` imports `@truecourse/spec-consolidator` — but the import is on a *multi-line continuation* (`} from '@truecourse/spec-consolidator';`), so a naive line-anchored `grep "^import"` misses it. My first attempt ordered the new builds wrong because of that. Confirmed by running clean and reading the actual error, then re-ordering.

## Validation

End-to-end on this branch:

```bash
rm -rf packages/*/dist dist
pnpm build:dist
# === Build complete ===
node dist/cli.mjs --version
# 0.6.6
```

Both succeed. No workaround needed.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_