### PR TITLE
contract-verifier: 4 Python extractor coverage gaps (prefect 8 FPs → 0)

### DIFF
--- a/packages/contract-verifier/src/comparator/enum.ts
+++ b/packages/contract-verifier/src/comparator/enum.ts
@@ -46,7 +46,13 @@ export function compareEnum(input: EnumCompareInput): ContractDrift[] {
   const drifts: ContractDrift[] = [];
 
   // ---- Main value set ----
-  const nameMatches = matchByName(contract, codeEnums, ref.identity);
+  // A name match is authoritative. Only when NO enum matches by name do we fall
+  // back to value-set matches, and then to the single most-complete one (highest
+  // overlap) — so a partial copy of an enum (e.g. a server-side subset) can't
+  // contribute spurious `missing-value` drifts alongside the canonical match.
+  const matched = matchByName(contract, codeEnums, ref.identity);
+  const nameMatches =
+    matched.byName.length > 0 ? matched.byName : bestValueMatch(contract, matched.byValue);
   if (nameMatches.length === 0) {
     drifts.push({
       id: randomUUID(),
@@ -62,14 +68,35 @@ export function compareEnum(input: EnumCompareInput): ContractDrift[] {
       codeSide: '<no match>',
     });
   } else {
+    const specNorm = new Map(contract.values.map((v) => [normalizeValue(v), v]));
+    // Merge matches that are the SAME enum (same normalized name) — e.g. a client
+    // and server copy of one action union, one a subset of the other — by unioning
+    // their value sets, so a value present in either copy counts as present.
+    // Distinct-named matches (a fuzzy value-set match against a DIFFERENT entity's
+    // enum) stay separate, so a value genuinely missing from the named enum still
+    // drifts. Each name-group is diffed independently; a value fires `missing` if
+    // absent from any group's union.
+    const byName = new Map<string, { values: Set<string>; repr: ExtractedEnum }>();
     for (const m of nameMatches) {
-      const specNorm = new Map(contract.values.map((v) => [normalizeValue(v), v]));
-      const codeNorm = new Map(m.values.map((v) => [normalizeValue(v), v]));
-      const missing = contract.values.filter((v) => !codeNorm.has(normalizeValue(v)));
-      const extra = m.values.filter((v) => !specNorm.has(normalizeValue(v)));
+      const key = normalizeName(m.name);
+      if (!byName.has(key)) byName.set(key, { values: new Set(), repr: m });
+      const g = byName.get(key)!;
+      for (const v of m.values) g.values.add(normalizeValue(v));
+    }
+    for (const g of byName.values()) {
+      const missing = contract.values.filter((v) => !g.values.has(normalizeValue(v)));
       for (const v of missing) {
-        drifts.push(mkValueDrift(ref, 'missing-value', v, m, contract.values));
+        drifts.push(mkValueDrift(ref, 'missing-value', v, g.repr, contract.values));
       }
+    }
+    // `extra-value` (code has a value the spec omits) is only meaningful for an
+    // EXACT declared value set. Synthesized code enums (sibling-id-literal,
+    // py-instance-registry, py-discriminated-union) are heuristic supersets that
+    // sweep in internal/alias/composed members a docs enum legitimately omits,
+    // so skip extra-value for them. Real declared enums still report extras.
+    for (const m of nameMatches) {
+      if (isSynthesizedEnumShape(m.shape)) continue;
+      const extra = m.values.filter((v) => !specNorm.has(normalizeValue(v)));
       for (const v of extra) {
         drifts.push(mkValueDrift(ref, 'extra-value', v, m, contract.values));
       }
@@ -78,7 +105,7 @@ export function compareEnum(input: EnumCompareInput): ContractDrift[] {
 
   // ---- Trigger subsets ----
   for (const subset of contract.triggerSubsets ?? []) {
-    const subsetMatches = matchSubsetByName(subset.name, codeEnums);
+    const subsetMatches = matchSubsetByName(subset.name, subset.values, codeEnums);
     if (subsetMatches.length === 0) {
       drifts.push({
         id: randomUUID(),
@@ -130,17 +157,27 @@ function normalizeName(s: string): string {
   return n;
 }
 
+/** Matches split by HOW they matched: `byName` (exact or substring name link)
+ *  vs `byValue` (pure value-set similarity, no name link). A name match is
+ *  authoritative; value matches are fallbacks used only when no name match
+ *  exists. See compareEnum. */
+interface EnumMatches {
+  byName: ExtractedEnum[];
+  byValue: ExtractedEnum[];
+}
+
 function matchByName(
   contract: EnumContract,
   codeEnums: ExtractedEnum[],
   specName: string,
-): ExtractedEnum[] {
+): EnumMatches {
   const target = normalizeName(specName);
-  const out: ExtractedEnum[] = [];
+  const byName: ExtractedEnum[] = [];
+  const byValue: ExtractedEnum[] = [];
   for (const e of codeEnums) {
     const codeName = normalizeName(e.name);
     if (codeName === target) {
-      out.push(e);
+      byName.push(e);
       continue;
     }
     // Substring name + value-set overlap.
@@ -163,7 +200,7 @@ function matchByName(
         }
       }
       if (valueSetOverlap(contract.values, e.values) >= 0.5) {
-        out.push(e);
+        byName.push(e);
         continue;
       }
     }
@@ -178,7 +215,7 @@ function matchByName(
       const overlap = valueSetOverlap(contract.values, e.values);
       const sizeDiff = Math.abs(contract.values.length - e.values.length);
       if (overlap >= 0.6 && sizeDiff <= 2) {
-        out.push(e);
+        byValue.push(e);
       }
     } else if (minLen >= 2) {
       // For small (2-value) enum sets, require an exact value-set match (Jaccard = 1,
@@ -189,11 +226,32 @@ function matchByName(
       const overlap = valueSetOverlap(contract.values, e.values);
       const sizeDiff = Math.abs(contract.values.length - e.values.length);
       if (overlap === 1.0 && sizeDiff === 0) {
-        out.push(e);
+        byValue.push(e);
       }
     }
   }
-  return out;
+  return { byName, byValue };
+}
+
+/** Of several value-set matches, keep only the most complete (highest overlap
+ *  with the contract). Ties keep all — they have identical value coverage so
+ *  the missing/extra diff is the same regardless of which is the representative. */
+function bestValueMatch(contract: EnumContract, byValue: ExtractedEnum[]): ExtractedEnum[] {
+  if (byValue.length <= 1) return byValue;
+  let best = -1;
+  for (const e of byValue) best = Math.max(best, valueSetOverlap(contract.values, e.values));
+  return byValue.filter((e) => valueSetOverlap(contract.values, e.values) === best);
+}
+
+/** Code enums we SYNTHESIZE from non-declarative shapes (rather than lift from a
+ *  literal value list). These are heuristic supersets, so `extra-value` against
+ *  them is unreliable — see compareEnum. */
+function isSynthesizedEnumShape(shape: ExtractedEnum['shape']): boolean {
+  return (
+    shape === 'sibling-id-literal' ||
+    shape === 'py-instance-registry' ||
+    shape === 'py-discriminated-union'
+  );
 }
 
 /** Strip non-alphanumeric separators and lowercase so SET_NULL ≡ SET NULL ≡ set-null. */
@@ -211,10 +269,27 @@ function valueSetOverlap(a: string[], b: string[]): number {
 
 function matchSubsetByName(
   subsetName: string,
+  subsetValues: string[],
   codeEnums: ExtractedEnum[],
 ): ExtractedEnum[] {
   const target = normalizeName(subsetName);
-  return codeEnums.filter((e) => normalizeName(e.name) === target);
+  const out: ExtractedEnum[] = [];
+  for (const e of codeEnums) {
+    const codeName = normalizeName(e.name);
+    if (codeName === target) {
+      out.push(e);
+      continue;
+    }
+    // A subset is often exposed as a named set whose identifier embeds the
+    // subset word (`terminal` → `TERMINAL_STATES` → normalized `terminalstates`).
+    // Accept a substring name link, but GATE on value-set overlap so a near-name
+    // (`terminal` is a substring of `nonterminalstates`) can't cross-match a set
+    // with a disjoint value set.
+    if (codeName.includes(target) || target.includes(codeName)) {
+      if (valueSetOverlap(subsetValues, e.values) >= 0.5) out.push(e);
+    }
+  }
+  return out;
 }
 
 function countOverlap<T>(a: T[], b: T[]): number {

--- a/packages/contract-verifier/src/comparator/named-constant.ts
+++ b/packages/contract-verifier/src/comparator/named-constant.ts
@@ -64,6 +64,26 @@ export function compareNamedConstant(input: NamedConstantCompareInput): Contract
     });
   }
 
+  // Settings-field suffix match. A Pydantic settings field is emitted under its
+  // env scope WITHOUT the project prefix (`SERVER_ANALYTICS_ENABLED`), while the
+  // spec names it with the prefix (`PREFECT_SERVER_ANALYTICS_ENABLED`). Bind them
+  // when the spec name ENDS WITH the code name and the values are equal. The
+  // value gate + the suffix being multi-segment (the code name still carries the
+  // scope, e.g. `serveranalyticsenabled`) keeps this from matching unrelated
+  // single-word constants. Scoped to `settings-field` shape only — no effect on
+  // any other constant kind or campaign.
+  if (matches.length === 0) {
+    matches = codeConstants.filter((c) => {
+      if (c.shape !== 'settings-field') return false;
+      const codeName = normalizeName(c.name);
+      if (codeName.length < 8 || !target.endsWith(codeName)) return false;
+      return (
+        contract.expectedValue === undefined ||
+        deepEqual(contract.expectedValue, c.value, /*allowExtraCodeKeys*/ true)
+      );
+    });
+  }
+
   if (matches.length === 0) {
     return [{
       id: randomUUID(),

--- a/packages/contract-verifier/src/extractor/constant/py-constants.ts
+++ b/packages/contract-verifier/src/extractor/constant/py-constants.ts
@@ -27,6 +27,21 @@ export function extractPyConstantsFromFile(
   tree: Tree,
 ): ExtractedConstant[] {
   const out: ExtractedConstant[] = [];
+
+  // Pass A: Pydantic settings-class fields. A class whose `model_config`
+  // declares an env scope (`build_settings_config(("server",))` or
+  // `SettingsConfigDict(env_prefix="...")`) exposes each `field = Field(default=v)`
+  // under an env-var name `<SCOPE>_<FIELD>`. We emit the scoped name WITHOUT a
+  // project prefix (PREFECT_/DAGSTER_/APP_…); the comparator binds it to a spec
+  // identity via a value-gated suffix match (shape `settings-field`).
+  walk(tree.rootNode, (node) => {
+    if (node.type === 'class_definition') {
+      out.push(...extractSettingsFields(node, source, filePath));
+    }
+    return true;
+  });
+
+  // Pass B: flat module-level / nested literal + Field(validation_alias) constants.
   walk(tree.rootNode, (node) => {
     if (node.type !== 'assignment') return true;
     const left = node.childForFieldName('left');
@@ -79,6 +94,135 @@ export function extractPyConstantsFromFile(
     return true;
   });
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Pydantic settings-class field extraction (Pass A)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract `<SCOPE>_<FIELD>` constants from a Pydantic settings class.
+ *
+ * Recognizes a class body containing a `model_config = <call>(...)` whose
+ * call either:
+ *   - passes an explicit `env_prefix="SERVER_"` kwarg, or
+ *   - passes a positional tuple of string scope parts, e.g.
+ *     `build_settings_config(("worker", "webserver"))`.
+ *
+ * For each field assignment in the body of the form
+ *   `name: Type = Field(default=<literal>, ...)`  or  `name: Type = <literal>`
+ * emits a constant named `<SCOPE_JOINED>_<NAME>` (uppercased) with the literal
+ * value. The project prefix (PREFECT_/DAGSTER_/…) is intentionally NOT prepended
+ * — the comparator's value-gated suffix match supplies it.
+ */
+function extractSettingsFields(
+  classNode: SyntaxNode,
+  source: string,
+  filePath: string,
+): ExtractedConstant[] {
+  const body = classNode.childForFieldName('body');
+  if (!body) return [];
+
+  const scope = deriveSettingsScope(body, source);
+  if (scope === null) return [];
+
+  const out: ExtractedConstant[] = [];
+  for (let i = 0; i < body.namedChildCount; i++) {
+    const stmt = body.namedChild(i);
+    if (stmt?.type !== 'expression_statement') continue;
+    const assign = stmt.namedChild(0);
+    if (assign?.type !== 'assignment') continue;
+    // Must be an annotated field: `name: Type = value`.
+    if (!assign.childForFieldName('type')) continue;
+    const left = assign.childForFieldName('left');
+    if (left?.type !== 'identifier') continue;
+    const fieldName = source.slice(left.startIndex, left.endIndex);
+    if (fieldName === 'model_config') continue;
+
+    const right = assign.childForFieldName('right');
+    if (!right) continue;
+    const value = fieldDefaultValue(right, source);
+    if (value === UNPARSEABLE) continue;
+
+    const name = `${scope}_${fieldName}`.toUpperCase();
+    out.push({
+      name,
+      value,
+      shape: 'settings-field',
+      source: { filePath, lineStart: assign.startPosition.row + 1, lineEnd: assign.endPosition.row + 1 },
+    });
+  }
+  return out;
+}
+
+/** The scope string for a settings class, or null if the class is not a
+ *  recognizable settings class. `("worker","webserver")` → `"worker_webserver"`;
+ *  `env_prefix="SERVER_"` → `"server"`. */
+function deriveSettingsScope(body: SyntaxNode, source: string): string | null {
+  for (let i = 0; i < body.namedChildCount; i++) {
+    const stmt = body.namedChild(i);
+    if (stmt?.type !== 'expression_statement') continue;
+    const assign = stmt.namedChild(0);
+    if (assign?.type !== 'assignment') continue;
+    const left = assign.childForFieldName('left');
+    if (left?.type !== 'identifier') continue;
+    if (source.slice(left.startIndex, left.endIndex) !== 'model_config') continue;
+    const right = assign.childForFieldName('right');
+    if (right?.type !== 'call') continue;
+    const args = right.childForFieldName('arguments');
+    if (!args) continue;
+
+    // Form 1: explicit env_prefix="SCOPE_" kwarg.
+    for (let j = 0; j < args.namedChildCount; j++) {
+      const arg = args.namedChild(j);
+      if (arg?.type !== 'keyword_argument') continue;
+      const kw = arg.childForFieldName('name');
+      const val = arg.childForFieldName('value');
+      if (kw && val && source.slice(kw.startIndex, kw.endIndex) === 'env_prefix' && val.type === 'string') {
+        const prefix = stringValue(val, source);
+        if (prefix) return prefix.replace(/_+$/, '').toLowerCase();
+      }
+    }
+
+    // Form 2: positional tuple of string parts, e.g. ("worker", "webserver").
+    for (let j = 0; j < args.namedChildCount; j++) {
+      const arg = args.namedChild(j);
+      if (arg?.type !== 'tuple') continue;
+      const parts: string[] = [];
+      for (let k = 0; k < arg.namedChildCount; k++) {
+        const el = arg.namedChild(k);
+        if (el?.type === 'string') {
+          const v = stringValue(el, source);
+          if (v) parts.push(v);
+        }
+      }
+      if (parts.length > 0) return parts.join('_').toLowerCase();
+    }
+  }
+  return null;
+}
+
+/** Value of a settings field's RHS: a bare literal, or the `default=` of a
+ *  `Field(...)` / `Field(default_factory=...)` call. Returns UNPARSEABLE when
+ *  there's no static literal default. */
+function fieldDefaultValue(right: SyntaxNode, source: string): unknown {
+  const direct = parseLiteral(right, source);
+  if (direct !== UNPARSEABLE) return direct;
+  if (right.type !== 'call') return UNPARSEABLE;
+  const fn = right.childForFieldName('function');
+  if (!fn || !source.slice(fn.startIndex, fn.endIndex).endsWith('Field')) return UNPARSEABLE;
+  const args = right.childForFieldName('arguments');
+  if (!args) return UNPARSEABLE;
+  for (let i = 0; i < args.namedChildCount; i++) {
+    const arg = args.namedChild(i);
+    if (arg?.type !== 'keyword_argument') continue;
+    const kw = arg.childForFieldName('name');
+    const val = arg.childForFieldName('value');
+    if (kw && val && source.slice(kw.startIndex, kw.endIndex) === 'default') {
+      return parseLiteral(val, source);
+    }
+  }
+  return UNPARSEABLE;
 }
 
 function parseLiteral(node: SyntaxNode, source: string): unknown {

--- a/packages/contract-verifier/src/extractor/constant/types.ts
+++ b/packages/contract-verifier/src/extractor/constant/types.ts
@@ -10,7 +10,11 @@ export type ConstantShape =
   | 'const-literal'   // const X = <literal>
   | 'object-property' // const X = { key: <literal>, ... }  — one record per property
   | 'default-arg'     // function f(name = <literal>)
-  | 'window-global';  // window.X access — value is undefined; matched by last-segment fallback
+  | 'window-global'   // window.X access — value is undefined; matched by last-segment fallback
+  | 'settings-field'; // Pydantic settings field `f: T = Field(default=v)` in a class whose
+                      //   config declares an env scope. Emitted under `<SCOPE>_<FIELD>`
+                      //   (no project prefix); comparator matches it by value-gated suffix
+                      //   so a spec name like `PREFECT_SERVER_PORT` binds to code `SERVER_PORT`.
 
 export interface ExtractedConstant {
   name: string;

--- a/packages/contract-verifier/src/extractor/enum/index.ts
+++ b/packages/contract-verifier/src/extractor/enum/index.ts
@@ -58,9 +58,30 @@ export async function extractEnumsFromDir(rootDir: string): Promise<ExtractedEnu
     });
   }
 
+  // Resolve `py-set-difference` placeholders (NAME = set(base) - minus) against
+  // the full extracted enum set — base and minus may live in different files.
+  const norm = (s: string) => s.replace(/[^A-Za-z0-9]/g, '').toLowerCase();
+  const valuesByName = new Map<string, string[]>();
+  for (const e of raw) {
+    if (e.shape !== 'py-set-difference') valuesByName.set(norm(e.name), e.values);
+  }
+  for (const e of raw) {
+    if (e.shape !== 'py-set-difference' || !e.unresolved) continue;
+    const baseVals = valuesByName.get(norm(e.unresolved.base));
+    const minusVals = valuesByName.get(norm(e.unresolved.minus));
+    if (baseVals && minusVals) {
+      const minusSet = new Set(minusVals.map((v) => v.replace(/[^A-Za-z0-9]/g, '').toLowerCase()));
+      e.values = [...new Set(baseVals.filter((v) => !minusSet.has(v.replace(/[^A-Za-z0-9]/g, '').toLowerCase())))].sort();
+      e.shape = 'py-set';
+      delete e.unresolved;
+    }
+  }
+  // Drop any placeholder that couldn't be resolved.
+  const resolved = raw.filter((e) => e.shape !== 'py-set-difference');
+
   // Dedup by (name, value-set).
   const seen = new Map<string, ExtractedEnum>();
-  for (const e of raw) {
+  for (const e of resolved) {
     const key = `${e.name}|${e.values.join(',')}`;
     if (!seen.has(key)) seen.set(key, e);
   }

--- a/packages/contract-verifier/src/extractor/enum/py-enums.ts
+++ b/packages/contract-verifier/src/extractor/enum/py-enums.ts
@@ -39,6 +39,286 @@ export function extractPyEnumsFromFile(
     }
     return true;
   });
+  out.push(...synthesizeInstanceRegistryEnum(tree.rootNode, filePath, source));
+  out.push(...synthesizeDiscriminatedUnionEnum(tree.rootNode, filePath, source));
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union of Pydantic models → enum
+//
+// A closed categorical set is often modeled as a tagged union of model classes,
+// each carrying a string `Literal` discriminator:
+//
+//   class RunDeployment(Action):
+//       type: Literal["run-deployment"] = "run-deployment"
+//   ...
+//   ActionTypes: TypeAlias = Union[DoNothing, RunDeployment, ...]
+//
+// The "enum" is the set of discriminator strings. We map each member class to
+// its discriminator, then synthesize one ExtractedEnum (named after the union
+// alias) with those strings as values — so the comparator binds it (by value
+// set) to a spec enum like `AutomationActionType`.
+// ---------------------------------------------------------------------------
+
+function synthesizeDiscriminatedUnionEnum(
+  root: SyntaxNode,
+  filePath: string,
+  source: string,
+): ExtractedEnum[] {
+  // 1. className → discriminator literal, for every class declaring
+  //    `type: Literal["x"]` (decorated classes included).
+  const discriminatorOf = new Map<string, string>();
+  walk(root, (node) => {
+    if (node.type !== 'class_definition') return true;
+    const className = textOfField(node, 'name', source);
+    const body = node.childForFieldName('body');
+    if (!className || !body) return true;
+    for (let i = 0; i < body.namedChildCount; i++) {
+      const stmt = body.namedChild(i);
+      if (stmt?.type !== 'expression_statement') continue;
+      const assign = stmt.namedChild(0);
+      if (assign?.type !== 'assignment') continue;
+      const left = assign.childForFieldName('left');
+      const typeAnn = assign.childForFieldName('type');
+      if (left?.type !== 'identifier' || !typeAnn) continue;
+      if (source.slice(left.startIndex, left.endIndex) !== 'type') continue;
+      const lit = literalStringOfAnnotation(typeAnn, source);
+      if (lit !== null) discriminatorOf.set(className, lit);
+    }
+    return true;
+  });
+  if (discriminatorOf.size === 0) return [];
+
+  // 2. Union aliases: `NAME[: TypeAlias] = Union[...]` or `NAME = A | B | C`.
+  const out: ExtractedEnum[] = [];
+  for (let i = 0; i < root.namedChildCount; i++) {
+    const stmt = root.namedChild(i);
+    if (stmt?.type !== 'expression_statement') continue;
+    const assign = stmt.namedChild(0);
+    if (assign?.type !== 'assignment') continue;
+    const left = assign.childForFieldName('left');
+    if (left?.type !== 'identifier') continue;
+    const aliasName = source.slice(left.startIndex, left.endIndex);
+    const right = assign.childForFieldName('right');
+    if (!right) continue;
+
+    const memberClasses = unionMemberIdentifiers(right, source);
+    if (memberClasses.length === 0) continue;
+    const values = memberClasses
+      .map((m) => discriminatorOf.get(m))
+      .filter((v): v is string => v !== undefined);
+    if (values.length < 3) continue;
+    out.push(mkEnum(aliasName, values, 'py-discriminated-union', root, filePath));
+  }
+  return out;
+}
+
+/** The single string in a `Literal["x"]` annotation, else null. The annotation
+ *  arrives as a `type` wrapper around a `generic_type`/`subscript` whose base is
+ *  `Literal` and whose parameter is the string (possibly nested under a
+ *  type_parameter/type_list node), so we unwrap then collect strings deeply. */
+function literalStringOfAnnotation(ann: SyntaxNode, source: string): string | null {
+  let node: SyntaxNode | null = ann;
+  if (node.type === 'type') node = node.namedChild(0);
+  if (!node || (node.type !== 'generic_type' && node.type !== 'subscript')) return null;
+  const base = node.namedChild(0);
+  if (!base || !source.slice(base.startIndex, base.endIndex).endsWith('Literal')) return null;
+  const strings = collectStringsDeep(node, source);
+  return strings.length === 1 ? strings[0] : null;
+}
+
+/** All string-literal values anywhere under `node` (handles type_parameter /
+ *  type_list wrappers inside a generic_type). */
+function collectStringsDeep(node: SyntaxNode, source: string): string[] {
+  const out: string[] = [];
+  const visit = (n: SyntaxNode): void => {
+    if (n.type === 'string') {
+      const v = stringValue(n, source);
+      if (v !== null) out.push(v);
+      return;
+    }
+    for (let i = 0; i < n.namedChildCount; i++) {
+      const c = n.namedChild(i);
+      if (c) visit(c);
+    }
+  };
+  visit(node);
+  return out;
+}
+
+/** Member class identifiers of a union RHS: `Union[A, B, C]` (subscript) or
+ *  `A | B | C` (chained binary `|`). */
+function unionMemberIdentifiers(node: SyntaxNode, source: string): string[] {
+  // Form 1: Union[...] subscript.
+  if (node.type === 'subscript') {
+    const value = node.childForFieldName('value');
+    if (value && source.slice(value.startIndex, value.endIndex).endsWith('Union')) {
+      const out: string[] = [];
+      for (let i = 0; i < node.namedChildCount; i++) {
+        const c = node.namedChild(i);
+        if (c && c !== value) collectTypeIdentifiers(c, out, source);
+      }
+      return out;
+    }
+    return [];
+  }
+  // Form 2: A | B | C — binary_operator chain with `|`.
+  if (node.type === 'binary_operator') {
+    const text = source.slice(node.startIndex, node.endIndex);
+    if (text.includes('|')) {
+      const out: string[] = [];
+      collectTypeIdentifiers(node, out, source);
+      return out;
+    }
+  }
+  return [];
+}
+
+/** Collect bare type-name identifiers under a union type node (skips
+ *  subscript brackets, the `Union`/`|` operators themselves). */
+function collectTypeIdentifiers(node: SyntaxNode, out: string[], source: string): void {
+  if (node.type === 'identifier') {
+    out.push(source.slice(node.startIndex, node.endIndex));
+    return;
+  }
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const c = node.namedChild(i);
+    if (c) collectTypeIdentifiers(c, out, source);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level instance registry → enum
+//
+// Some codebases model a closed set of categorical values not as an Enum but as
+// module-level constants, each an instance of a subclass of a common base:
+//
+//   class CachePolicy: ...            # base
+//   class Inputs(CachePolicy): ...
+//   class TaskSource(CachePolicy): ...
+//   INPUTS = Inputs()
+//   TASK_SOURCE = TaskSource()
+//   DEFAULT = INPUTS + TASK_SOURCE    # composed from other members
+//
+// The categorical "enum" is the set of CONSTANT NAMES (INPUTS, TASK_SOURCE,
+// DEFAULT, …). We synthesize one ExtractedEnum named after the base class with
+// those names as values, so the comparator binds it (by value-set) to a spec
+// enum like `CachePolicies`.
+// ---------------------------------------------------------------------------
+
+function synthesizeInstanceRegistryEnum(
+  root: SyntaxNode,
+  filePath: string,
+  source: string,
+): ExtractedEnum[] {
+  // 1. class → direct base name (first superclass identifier). Classes may be
+  //    `@decorator`-wrapped (`@dataclass class X(Base)`), in which case
+  //    tree-sitter nests the `class_definition` inside a `decorated_definition`.
+  const baseOf = new Map<string, string>();
+  for (let i = 0; i < root.namedChildCount; i++) {
+    const child = root.namedChild(i);
+    const node =
+      child?.type === 'class_definition'
+        ? child
+        : child?.type === 'decorated_definition'
+          ? child.childForFieldName('definition')
+          : null;
+    if (node?.type !== 'class_definition') continue;
+    const name = textOfField(node, 'name', source);
+    const supers = node.childForFieldName('superclasses');
+    if (!name || !supers) continue;
+    const first = supers.namedChild(0);
+    if (first?.type === 'identifier') baseOf.set(name, source.slice(first.startIndex, first.endIndex));
+  }
+  // Categorical base = a class that is the direct base of ≥2 classes in the file.
+  const subclassCount = new Map<string, number>();
+  for (const base of baseOf.values()) subclassCount.set(base, (subclassCount.get(base) ?? 0) + 1);
+  const categoricalBases = new Set([...subclassCount].filter(([, n]) => n >= 2).map(([b]) => b));
+  if (categoricalBases.size === 0) return [];
+
+  // Resolve a class name to its categorical base (walk the in-file chain).
+  const resolveBase = (cls: string): string | null => {
+    let cur = cls;
+    for (let hops = 0; hops < 8; hops++) {
+      if (categoricalBases.has(cur)) return cur;
+      const next = baseOf.get(cur);
+      if (!next) return null;
+      cur = next;
+    }
+    return null;
+  };
+
+  // 2. Module-level UPPER_SNAKE assignments. First collect constructor-based
+  //    members (NAME = Ctor(...)); then a second pass folds in composed members
+  //    (NAME = A + B …) whose operands are already members of one base group.
+  const group = new Map<string, string[]>(); // base → member names
+  const memberBase = new Map<string, string>(); // member name → its base
+  const deferred: Array<{ name: string; rhs: SyntaxNode }> = [];
+
+  for (let i = 0; i < root.namedChildCount; i++) {
+    const stmt = root.namedChild(i);
+    if (stmt?.type !== 'expression_statement') continue;
+    const assign = stmt.namedChild(0);
+    if (assign?.type !== 'assignment') continue;
+    if (assign.childForFieldName('type')) continue; // typed (annotated) — not a plain const
+    const left = assign.childForFieldName('left');
+    if (left?.type !== 'identifier') continue;
+    const name = source.slice(left.startIndex, left.endIndex);
+    if (!/^[A-Z][A-Z0-9_]*$/.test(name)) continue;
+    const right = assign.childForFieldName('right');
+    if (!right) continue;
+
+    if (right.type === 'call') {
+      const fn = right.childForFieldName('function');
+      if (fn?.type !== 'identifier') continue;
+      const ctor = source.slice(fn.startIndex, fn.endIndex);
+      const base = resolveBase(ctor);
+      if (base) {
+        if (!group.has(base)) group.set(base, []);
+        group.get(base)!.push(name);
+        memberBase.set(name, base);
+      }
+    } else {
+      deferred.push({ name, rhs: right });
+    }
+  }
+
+  // Second pass: composed expressions whose leaf identifiers are all members of
+  // the same base group.
+  for (const { name, rhs } of deferred) {
+    const ids = collectIdentifiers(rhs, source);
+    if (ids.length === 0) continue;
+    const bases = new Set(ids.map((id) => memberBase.get(id)).filter((b): b is string => !!b));
+    if (bases.size === 1) {
+      const base = [...bases][0];
+      group.get(base)!.push(name);
+      memberBase.set(name, base);
+    }
+  }
+
+  const out: ExtractedEnum[] = [];
+  for (const [base, members] of group) {
+    if (members.length < 3) continue;
+    out.push(mkEnum(base, members, 'py-instance-registry', root, filePath));
+  }
+  return out;
+}
+
+/** Leaf identifier names referenced anywhere under `node`. */
+function collectIdentifiers(node: SyntaxNode, source: string): string[] {
+  const out: string[] = [];
+  const visit = (n: SyntaxNode): void => {
+    if (n.type === 'identifier') {
+      out.push(source.slice(n.startIndex, n.endIndex));
+      return;
+    }
+    for (let i = 0; i < n.namedChildCount; i++) {
+      const c = n.namedChild(i);
+      if (c) visit(c);
+    }
+  };
+  visit(node);
   return out;
 }
 
@@ -118,6 +398,30 @@ function extractAssignmentEnum(node: SyntaxNode, filePath: string, source: strin
     return null;
   }
 
+  // Set/list of enum-member references: { StateType.COMPLETED, StateType.FAILED }
+  // → values are the member last-segments (COMPLETED, FAILED). The all-attribute-
+  //   element shape is the signal (a named subset of an enum), so NO name
+  //   convention is required — checked before nameLooksLikeEnumConst below.
+  if (right.type === 'set' || right.type === 'list') {
+    const attrs = attributeSetValues(right, source);
+    if (attrs) {
+      return mkEnum(name, attrs, right.type === 'set' ? 'py-set' : 'py-list', node, filePath);
+    }
+  }
+
+  // Set difference: NAME = list(set(X) - Y) | set(X) - Y → a transient placeholder
+  // resolved in enum/index.ts against the extracted X (base) and Y (minus) enums.
+  const diff = parseSetDifference(right, source);
+  if (diff) {
+    return {
+      name,
+      values: [],
+      shape: 'py-set-difference',
+      source: { filePath, lineStart: node.startPosition.row + 1, lineEnd: node.endPosition.row + 1 },
+      unresolved: diff,
+    };
+  }
+
   if (!nameLooksLikeEnumConst(name)) return null;
 
   // 3. {"a", "b"}  /  5. ["a", "b"]
@@ -145,6 +449,59 @@ function extractAssignmentEnum(node: SyntaxNode, filePath: string, source: strin
 
 function nameLooksLikeEnumConst(name: string): boolean {
   return ENUM_CONVENTION_NAME.test(name) || ENUM_CONVENTION_SUFFIX.test(name);
+}
+
+/** If EVERY element of a set/list node is an attribute access (`X.MEMBER`),
+ *  return the member last-segments; else null. (A named subset of enum members.) */
+function attributeSetValues(node: SyntaxNode, source: string): string[] | null {
+  const out: string[] = [];
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const c = node.namedChild(i);
+    if (!c) continue;
+    if (c.type !== 'attribute') return null;
+    const attr = c.childForFieldName('attribute');
+    if (!attr) return null;
+    out.push(source.slice(attr.startIndex, attr.endIndex));
+  }
+  return out.length >= 2 ? out : null;
+}
+
+/** Parse `set(X) - Y`, `list(set(X) - Y)`, `X - Y` into operand enum names.
+ *  `set(StateType) - states.TERMINAL_STATES` → { base: 'StateType', minus: 'TERMINAL_STATES' }. */
+function parseSetDifference(node: SyntaxNode, source: string): { base: string; minus: string } | null {
+  let n = node;
+  // Unwrap an outer list()/set()/frozenset()/tuple() wrapper.
+  if (n.type === 'call') {
+    const fn = n.childForFieldName('function');
+    const fnName = fn ? source.slice(fn.startIndex, fn.endIndex) : '';
+    if (/^(list|set|frozenset|tuple)$/.test(fnName)) {
+      const inner = n.childForFieldName('arguments')?.namedChild(0);
+      if (inner) n = inner;
+    }
+  }
+  if (n.type !== 'binary_operator') return null;
+  if (!source.slice(n.startIndex, n.endIndex).includes('-')) return null;
+  const left = n.childForFieldName('left');
+  const right = n.childForFieldName('right');
+  if (!left || !right) return null;
+  const base = enumOperandName(left, source);
+  const minus = enumOperandName(right, source);
+  return base && minus ? { base, minus } : null;
+}
+
+/** Resolve a set-difference operand to an enum name: `set(X)`→X, `pkg.X`→X, `X`→X. */
+function enumOperandName(node: SyntaxNode, source: string): string | null {
+  let n = node;
+  if (n.type === 'call') {
+    const inner = n.childForFieldName('arguments')?.namedChild(0);
+    if (inner) n = inner;
+  }
+  if (n.type === 'identifier') return source.slice(n.startIndex, n.endIndex);
+  if (n.type === 'attribute') {
+    const a = n.childForFieldName('attribute');
+    if (a) return source.slice(a.startIndex, a.endIndex);
+  }
+  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/contract-verifier/src/extractor/enum/types.ts
+++ b/packages/contract-verifier/src/extractor/enum/types.ts
@@ -19,7 +19,10 @@ export type EnumShape =
   | 'py-enum'            // class X(str, Enum): A = 'a'
   | 'py-literal'         // X = Literal['a', 'b']
   | 'py-set'             // X_SET = {'a', 'b'} / frozenset({...})
-  | 'py-list';           // VALID_X = ['a', 'b'] (with conventional name)
+  | 'py-list'            // VALID_X = ['a', 'b'] (with conventional name)
+  | 'py-instance-registry'    // NAME = Subclass()  ×N of a common base → enum of NAMEs
+  | 'py-discriminated-union'  // Union[A, B, …] of models each with type: Literal["x"]
+  | 'py-set-difference';      // NAME = set(X) - Y — transient; resolved in enum/index.ts
 
 export interface ExtractedEnum {
   /** Identifier in code — type name, const name, or property key. */
@@ -28,4 +31,7 @@ export interface ExtractedEnum {
   values: string[];
   shape: EnumShape;
   source: SourceLocation;
+  /** Only on a transient `py-set-difference`: the operand enum names to resolve
+   *  (`set(<base>) - <minus>`). Cleared once enum/index.ts computes the diff. */
+  unresolved?: { base: string; minus: string };
 }

--- a/tests/fixtures/sample-python-project-il/code/app/config.py
+++ b/tests/fixtures/sample-python-project-il/code/app/config.py
@@ -37,3 +37,19 @@ class JobSettings(BaseSettings):
             "app_workers_concurrency_limit",
         ),
     )
+
+
+from pydantic_settings import SettingsConfigDict
+
+
+class WebhookSettings(BaseSettings):
+    """Webhook delivery settings, scoped to the APP_WEBHOOK_ env namespace."""
+
+    model_config = SettingsConfigDict(env_prefix="APP_WEBHOOK_")
+
+    # FP-GUARD: named-constant/no-code-counterpart — must NOT drift
+    # The spec names this APP_WEBHOOK_TIMEOUT_SECONDS. There is no bare module
+    # constant or validation_alias of that name; the verifier must derive the
+    # env-var name from the class's env_prefix + field name and bind by value.
+    timeout_seconds: int = Field(default=30, description="Per-delivery timeout.")
+    verify_tls: bool = Field(default=True, description="Verify TLS on delivery.")

--- a/tests/fixtures/sample-python-project-il/code/app/events/webhook_actions.py
+++ b/tests/fixtures/sample-python-project-il/code/app/events/webhook_actions.py
@@ -1,0 +1,25 @@
+"""Webhook automation actions — a discriminated union of Pydantic models."""
+
+from typing import Literal, Union
+
+from pydantic import BaseModel
+
+
+# FP-GUARD: enum/no-code-counterpart — must NOT drift
+# Each action carries a string `type` discriminator; the union below ties them
+# together. The verifier must synthesize a `WebhookActionTypes` enum from the
+# discriminator literals so the spec's WebhookActionType enum has a counterpart.
+class SendEmail(BaseModel):
+    type: Literal["send-email"] = "send-email"
+
+class PostMessage(BaseModel):
+    type: Literal["post-message"] = "post-message"
+
+class OpenTicket(BaseModel):
+    type: Literal["open-ticket"] = "open-ticket"
+
+class RunScript(BaseModel):
+    type: Literal["run-script"] = "run-script"
+
+
+WebhookActionTypes = Union[SendEmail, PostMessage, OpenTicket, RunScript]

--- a/tests/fixtures/sample-python-project-il/code/app/models.py
+++ b/tests/fixtures/sample-python-project-il/code/app/models.py
@@ -62,3 +62,36 @@ class TxIsolation(AutoEnum):
 class JobPriority(str, Enum):
     HIGH = "HIGH"
     NORMAL = "NORMAL"
+
+
+# FP-GUARD: enum/no-code-counterpart — must NOT drift
+# Pricing strategies are modeled as module-level singletons, each an instance
+# of a subclass of a common base (not an Enum). The verifier must synthesize a
+# `PricingStrategy` enum from the constant NAMES so the spec's PricingStrategies
+# enum has a code counterpart. STANDARD is composed from other strategies.
+class PricingStrategy:
+    """Base class for all pricing strategies."""
+
+class FlatRate(PricingStrategy): ...
+class Tiered(PricingStrategy): ...
+class Promotional(PricingStrategy): ...
+
+FLAT_RATE = FlatRate()
+TIERED = Tiered()
+PROMOTIONAL = Promotional()
+STANDARD = FLAT_RATE  # alias-composed member
+
+
+# FP-GUARD: enum/no-code-counterpart — must NOT drift
+# Fulfilment stage subsets exposed as named sets of enum-member references
+# (not string literals). The spec models `picked`/`packed` as trigger subsets of
+# FulfilmentStage; the verifier must lift the member last-segments and resolve
+# the set-difference for OUTSTANDING_STAGES.
+class FulfilmentStage(AutoEnum):
+    PICKED = AutoEnum.auto()
+    PACKED = AutoEnum.auto()
+    SHIPPED = AutoEnum.auto()
+    DELIVERED = AutoEnum.auto()
+
+COMPLETED_STAGES: set[FulfilmentStage] = {FulfilmentStage.SHIPPED, FulfilmentStage.DELIVERED}
+OUTSTANDING_STAGES = list(set(FulfilmentStage) - COMPLETED_STAGES)

--- a/tests/fixtures/sample-python-project-il/reference/contracts/catalog/pricing-strategy.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/catalog/pricing-strategy.tc
@@ -1,0 +1,4 @@
+enum PricingStrategies {
+  origin "reference/specs/modules/catalog/pricing.md" "Pricing strategies" 1..8
+  values [FLAT_RATE, TIERED, PROMOTIONAL, STANDARD]
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/catalog/webhook-action-type.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/catalog/webhook-action-type.tc
@@ -1,0 +1,4 @@
+enum WebhookActionType {
+  origin "reference/specs/modules/catalog/webhooks.md" "Webhook action types" 1..10
+  values [send-email, post-message, open-ticket, run-script]
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/catalog/webhook-timeout.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/catalog/webhook-timeout.tc
@@ -1,0 +1,5 @@
+constant APP_WEBHOOK_TIMEOUT_SECONDS {
+  origin "reference/specs/modules/catalog/webhooks.md" "Webhook timeout" 12..14
+  type number
+  expected-value 30
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/orders/fulfilment-stage.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/orders/fulfilment-stage.tc
@@ -1,0 +1,6 @@
+enum FulfilmentStage {
+  origin "reference/specs/modules/orders/fulfilment.md" "Fulfilment stages" 1..12
+  values [PICKED, PACKED, SHIPPED, DELIVERED]
+  trigger-subset completed [SHIPPED, DELIVERED]
+  trigger-subset outstanding [PICKED, PACKED]
+}


### PR DESCRIPTION
> **Supersedes #564** — identical commit, renamed onto `claude/drift-fp-fix/batch-*` so that **merging this fires the `drift-fp-next-fix` routine** (branch prefix `claude/drift-fp-fix/` → re-builds dist with these fixes, re-verifies prefect against its frozen contracts, sees `fp==0`, opens the campaign-close PR automatically). #564 sat on a non-triggering branch.

## Closes

- **Closes #548** — enum/no-code-counterpart FPs (`CachePolicies`, `FlowRunStateType` terminal/non-terminal, `AutomationActionType`). The extractor now lifts all four Python shapes. Residual `AutomationActionType.subset.cloud-only` is a **contract-quality** item (no code-side set to bind), not an extractor gap; `AutomationActionType.send-email-notification` is a **genuine TP** (Cloud-only). Neither is an FP.
- **Closes #549** — named-constant/no-code-counterpart FPs: `PREFECT_SERVER_ANALYTICS_ENABLED` + `PREFECT_WORKER_WEBSERVER_PORT` now bind to their nested Pydantic settings fields. Residual `ConcurrencySlotLeaseDuration` (`"5 minutes"` vs code `300`) is a **contract-wording** issue, not a verifier bug.
- **Closes #554** — the `[drift-fp-campaign-stuck]` tracker. Both live blockers it lists (#548, #549) are fixed here, so the stuck condition is cleared. (Its stale sub-items #550 / #551 — auth-requirement / operation.503 that no longer reproduce at `d858cb6` — are **separate** issues; close those by hand if still desired.)
- #552, #553 already closed (contract-quality, not verifier bugs).

## TL;DR — verified before asking to merge

Resolves the **6 verifier false-positive coverage gaps** the prefect campaign surfaced (#548, #549). Validated end-to-end:

| Check | Result |
|---|---|
| **prefect verify** | **8 no-code-counterpart FPs → 0 FPs** (3 honest drifts remain) |
| **strapi / feast / directus / payload** | **byte-identical drift sets vs main** (clean-main baseline diff, contracts held constant — zero regression) |
| contract-verifier suite | **391 / 391 pass** |
| full suite | 4,235 pass; the 5 failures are the pre-existing sandbox `git commit` GPG-signing failures, identical on main |

These are real engine bugs the autonomous routine is correctly guard-railed from doing (they need cross-class AST resolution + a comparator change), so they were done interactively.

## The 4 patterns

Each is a Python shape the extractor couldn't lift, so a documented enum/constant looked absent when it exists in code.

**A — module-level instance registry → enum** (`py-enums.ts`)
`NAME = Subclass()` ×N of a common base (+ composed `DEFAULT = A + B`) → synthesize an enum of the constant NAMES. Fixes `CachePolicies`.

**B — named set/list of enum members → subset** (`py-enums.ts` + `enum/index.ts` + `comparator/enum.ts`)
`{ StateType.COMPLETED, … }` lifts member last-segments; `NAME = list(set(X) - Y)` resolves the cross-file set difference. `matchSubsetByName` relaxed from exact-name to substring **gated by value-overlap**. Fixes `FlowRunStateType` terminal/non-terminal.

**C — discriminated union of Pydantic models → enum** (`py-enums.ts`)
`class X: type: Literal["x"]` + `Union[X, Y, …]` → enum of discriminator strings. Fixes `AutomationActionType` — now correctly yields **one genuine TP** (`send-email-notification` is Cloud-only, truly absent from OSS — the tool working, not an FP).

**D — nested Pydantic settings field → env-var constant** (`py-constants.ts` + `comparator/named-constant.ts`)
A settings class whose `model_config` declares an env scope exposes each `Field(default=v)` under `_`; matched to the spec name by a **value-gated suffix match** (the project prefix `PREFECT_`/`DAGSTER_` is what the suffix skips — no hardcoding). Fixes `PREFECT_SERVER_ANALYTICS_ENABLED` + `PREFECT_WORKER_WEBSERVER_PORT`.

## Shared comparator hardening (output-identical to main on all closed campaigns)

- `matchByName` splits **byName vs byValue**: a name match is authoritative; value matches are a fallback and only the most-complete one is used — so a partial copy of an enum (e.g. a server-side subset) can't add spurious `missing-value` drifts.
- Same-name matches are **unioned** for the missing-value diff (client + server copy of one union → a value counts present if either has it).
- `extra-value` suppressed for synthesized shapes (heuristic supersets sweep in internal/alias/composed members a docs enum legitimately omits).

## Fixtures

Naturalistic FP-guards for all 4 patterns in the Python fixture (`models.py`, `config.py`, `events/webhook_actions.py`) + matching contracts. Each guards the fix: if a pattern regresses, its synthesized enum vanishes → unexpected `no-code-counterpart` → marker test fails.

## Not fixed (honest residuals — NOT verifier bugs)

- `AutomationActionType.subset.cloud-only` — docs describe a grouping with **no code-side set**; fabricating one would be a hack.
- `ConcurrencySlotLeaseDuration` — contract value `"5 minutes"` (string) vs code `300` (seconds): a contract-wording issue, fixable in the generator, not the verifier.

So prefect lands at **3 honest drifts (1 TP + 2 contract-quality), fp = 0** — not a dishonest 0.

## After merge

`drift-fp-next-fix` fires automatically and re-verifies prefect from the freshly-built dist; at fp=0 it opens the campaign-close PR. The same fixes de-risk dagster (next campaign, also Python).

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_