### PR TITLE
fix(drift-fp): resolve 1 drift FP from PrefectHQ/prefect

### DIFF
--- a/packages/contract-verifier/src/comparator/enum.ts
+++ b/packages/contract-verifier/src/comparator/enum.ts
@@ -69,6 +69,19 @@ export function compareEnum(input: EnumCompareInput): ContractDrift[] {
     });
   } else {
     const specNorm = new Map(contract.values.map((v) => [normalizeValue(v), v]));
+    // Values the contract marks as belonging to a `cloud-only` trigger-subset are
+    // environment-gated: documented for the hosted/cloud tier and expected to be
+    // ABSENT from a self-hosted/OSS code enum. Their omission from the main code
+    // enum is not a missing implementation, so exclude them from the main-set
+    // `missing-value` diff. (The `cloud-only` subset itself is still diffed below
+    // — an absent code counterpart surfaces as the subset's info-level
+    // no-code-counterpart, so the gating is still reported, just not as a
+    // high-severity missing-value on the self-hosted target.)
+    const cloudOnlyValues = new Set(
+      (contract.triggerSubsets ?? [])
+        .filter((s) => isEnvironmentGatedSubset(s.name))
+        .flatMap((s) => s.values.map(normalizeValue)),
+    );
     // Merge matches that are the SAME enum (same normalized name) — e.g. a client
     // and server copy of one action union, one a subset of the other — by unioning
     // their value sets, so a value present in either copy counts as present.
@@ -84,7 +97,9 @@ export function compareEnum(input: EnumCompareInput): ContractDrift[] {
       for (const v of m.values) g.values.add(normalizeValue(v));
     }
     for (const g of byName.values()) {
-      const missing = contract.values.filter((v) => !g.values.has(normalizeValue(v)));
+      const missing = contract.values.filter(
+        (v) => !g.values.has(normalizeValue(v)) && !cloudOnlyValues.has(normalizeValue(v)),
+      );
       for (const v of missing) {
         drifts.push(mkValueDrift(ref, 'missing-value', v, g.repr, contract.values));
       }
@@ -155,6 +170,16 @@ function normalizeName(s: string): string {
     }
   }
   return n;
+}
+
+/** A trigger-subset whose name marks its members as available only on the
+ *  hosted/cloud tier (`cloud-only`). Such values are documented for the managed
+ *  product and are expected to be absent from a self-hosted/OSS code enum, so
+ *  their omission is not a `missing-value` drift — see compareEnum. Kept tight
+ *  to the established `cloud-only` convention to avoid suppressing genuine
+ *  missing values that merely happen to live in some other named subset. */
+function isEnvironmentGatedSubset(name: string): boolean {
+  return normalizeName(name) === 'cloudonly';
 }
 
 /** Matches split by HOW they matched: `byName` (exact or substring name link)

--- a/tests/fixtures/sample-python-project-il/code/app/events/webhook_actions.py
+++ b/tests/fixtures/sample-python-project-il/code/app/events/webhook_actions.py
@@ -23,3 +23,56 @@ class RunScript(BaseModel):
 
 
 WebhookActionTypes = Union[SendEmail, PostMessage, OpenTicket, RunScript]
+
+
+# FP-GUARD: enum/missing-value — must NOT drift
+# Escalation actions are another discriminated union. Two of them — `page-oncall`
+# and `open-incident` — are only available on the managed/cloud tier; the spec
+# captures that via a `cloud-only` trigger-subset. This self-hosted build ships
+# `open-incident` but deliberately omits `page-oncall` (a cloud-gated capability
+# implemented only in the hosted backend). A value the spec marks cloud-only and
+# that is absent from the self-hosted union must NOT be reported as a missing
+# implementation — its omission is expected, not a divergence.
+class NotifyTeam(BaseModel):
+    type: Literal["notify-team"] = "notify-team"
+
+class ReassignTicket(BaseModel):
+    type: Literal["reassign-ticket"] = "reassign-ticket"
+
+class PostUpdate(BaseModel):
+    type: Literal["post-update"] = "post-update"
+
+class OpenIncident(BaseModel):  # cloud-only capability that this build does ship
+    type: Literal["open-incident"] = "open-incident"
+
+
+EscalationActionTypes = Union[NotifyTeam, ReassignTicket, PostUpdate, OpenIncident]
+
+# Cloud-only escalation capabilities the platform recognizes — used to hide
+# actions that are unavailable on self-hosted installs.
+CLOUD_ONLY_ESCALATION_TYPES = {"page-oncall", "open-incident"}
+
+
+# Integration channels — also a discriminated union, also carrying a `cloud-only`
+# trigger-subset (`datadog`/`pagerduty` are managed-tier only). Unlike the
+# escalation union above, this build is missing `email`, an ORDINARY (non-gated)
+# channel the spec requires — a genuine omission that must still drift even though
+# the enum has a cloud-only subset.
+# IL-DRIFT: Enum:IntegrationChannelType / enum.IntegrationChannelType.missing-value.email
+class WebhookChannel(BaseModel):
+    type: Literal["webhook"] = "webhook"
+
+class SlackChannel(BaseModel):
+    type: Literal["slack"] = "slack"
+
+class PagerDutyChannel(BaseModel):
+    type: Literal["pagerduty"] = "pagerduty"
+
+class DatadogChannel(BaseModel):
+    type: Literal["datadog"] = "datadog"
+
+
+IntegrationChannelTypes = Union[WebhookChannel, SlackChannel, PagerDutyChannel, DatadogChannel]
+
+# Cloud-only integration channels recognized by the platform.
+CLOUD_ONLY_CHANNEL_TYPES = {"datadog", "pagerduty"}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/catalog/escalation-action-type.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/catalog/escalation-action-type.tc
@@ -1,0 +1,5 @@
+enum EscalationActionType {
+  origin "reference/specs/modules/orders/escalations.md" "Escalation action types" 1..1
+  values [notify-team, reassign-ticket, post-update, page-oncall, open-incident]
+  trigger-subset cloud-only [page-oncall, open-incident]
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/catalog/integration-channel-type.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/catalog/integration-channel-type.tc
@@ -1,0 +1,5 @@
+enum IntegrationChannelType {
+  origin "reference/specs/modules/orders/integrations.md" "Integration channel types" 1..1
+  values [webhook, email, slack, pagerduty, datadog]
+  trigger-subset cloud-only [datadog, pagerduty]
+}


### PR DESCRIPTION
Closes #566

Batch from the `drift-fp-next-fix` queue-empty path: the pickable `drift-fp-fix` queue was empty, so a re-verify of `PrefectHQ/prefect@d858cb6` against the frozen contracts (storage branch `claude/drift-fp-store/PrefectHQ-prefect`) was run. It found 3 drifts — 1 false positive (`enum/missing-value`) and 2 `[info]` no-code-counterparts. The FP was filed as #566 and fixed in this session.

## Fixes

| drift_kind | issue | fp-guard fixture | regression fixture |
|---|---|---|---|
| `enum/missing-value` | #566 | `events/webhook_actions.py` (`EscalationActionType`) + `catalog/escalation-action-type.tc` | `events/webhook_actions.py` (`IntegrationChannelType`) + `catalog/integration-channel-type.tc` |

## enum/missing-value

**OSS source:** [`src/prefect/events/actions.py#L296`](https://github.com/PrefectHQ/prefect/blob/d858cb6725864c9a993be6a6633009b03b5e6f5e/src/prefect/events/actions.py#L296) (the `ActionTypes` union) — docs context: [`docs/v3/concepts/automations.mdx`](https://github.com/PrefectHQ/prefect/blob/d858cb6725864c9a993be6a6633009b03b5e6f5e/docs/v3/concepts/automations.mdx) ("The `send-email-notification` and `declare-incident` actions are only available in Prefect Cloud.").
**Cited contract:** `docs/drift-fp-automation/contracts/PrefectHQ-prefect/contracts/automationactiontype/automationactiontype.tc`

The contract declares `AutomationActionType` with all action values **and** a `trigger-subset cloud-only [send-email-notification, declare-incident]`. The OSS `ActionTypes` union includes the also-cloud-only `DeclareIncident` (under a `# Prefect Cloud only` comment) but has **no** `SendEmailNotification` class — `send-email-notification` is implemented only in the proprietary Cloud backend. The verifier matched the synthesized code enum and fired a **high-severity `missing-value`** for `send-email-notification`, even though the contract itself flags it as cloud-gated. Its absence from the self-hosted/OSS code is expected, not a missing implementation → false positive.

**FP-guard fixture (must NOT drift):**
```python
# FP-GUARD: enum/missing-value — must NOT drift
class NotifyTeam(BaseModel):
    type: Literal["notify-team"] = "notify-team"
class ReassignTicket(BaseModel):
    type: Literal["reassign-ticket"] = "reassign-ticket"
class PostUpdate(BaseModel):
    type: Literal["post-update"] = "post-update"
class OpenIncident(BaseModel):  # cloud-only capability that this build does ship
    type: Literal["open-incident"] = "open-incident"

EscalationActionTypes = Union[NotifyTeam, ReassignTicket, PostUpdate, OpenIncident]
CLOUD_ONLY_ESCALATION_TYPES = {"page-oncall", "open-incident"}
```
```
enum EscalationActionType {
  origin "reference/specs/modules/orders/escalations.md" "Escalation action types" 1..1
  values [notify-team, reassign-ticket, post-update, page-oncall, open-incident]
  trigger-subset cloud-only [page-oncall, open-incident]
}
```
The union omits the cloud-only `page-oncall` (mirroring `send-email-notification`). Pre-fix this fired `enum.EscalationActionType.missing-value.page-oncall`; post-fix it is suppressed (zero drift — the `cloud-only` subset binds to `CLOUD_ONLY_ESCALATION_TYPES`).

**Regression fixture (must STILL drift):**
```python
# IL-DRIFT: Enum:IntegrationChannelType / enum.IntegrationChannelType.missing-value.email
class WebhookChannel(BaseModel):
    type: Literal["webhook"] = "webhook"
class SlackChannel(BaseModel):
    type: Literal["slack"] = "slack"
class PagerDutyChannel(BaseModel):
    type: Literal["pagerduty"] = "pagerduty"
class DatadogChannel(BaseModel):
    type: Literal["datadog"] = "datadog"

IntegrationChannelTypes = Union[WebhookChannel, SlackChannel, PagerDutyChannel, DatadogChannel]
CLOUD_ONLY_CHANNEL_TYPES = {"datadog", "pagerduty"}
```
```
enum IntegrationChannelType {
  origin "reference/specs/modules/orders/integrations.md" "Integration channel types" 1..1
  values [webhook, email, slack, pagerduty, datadog]
  trigger-subset cloud-only [datadog, pagerduty]
}
```
This enum **also** has a `cloud-only` subset, but the missing value (`email`) is an ordinary, non-gated channel — so it must still drift. This guards against over-suppression: the fix only excludes members of a `cloud-only` subset, not every value of an enum that happens to carry one.

**fix_summary:** In `comparator/enum.ts`, the main-set `missing-value` diff now skips values that the contract marks as members of a `cloud-only` trigger-subset (`isEnvironmentGatedSubset`, keyed tightly to the `cloud-only` convention). Such values are documented for the hosted tier and expected to be absent from self-hosted/OSS code, so their omission is not a high-severity missing implementation. The `cloud-only` subset is still diffed, so an absent code counterpart still surfaces as the subset's info-level `no-code-counterpart` — the gating is reported, just not as a false high drift.

## Drift-count delta (vs `d858cb6725864c9a993be6a6633009b03b5e6f5e` on PrefectHQ/prefect, pinned contracts)

| Drift-kind | Before | After | Delta |
|---|---:|---:|---:|
| `enum/missing-value`            | 1 | 0 | -1 |
| **Total (these 1 kinds)**       | 1 | 0 | -1 |
| **All-kinds total on target**   | 3 | 2 | -1 |

Measured with `node dist/cli.mjs verify --no-stash --code-dir .` from a fresh `pnpm build:dist`, against the frozen contracts. The 2 remaining drifts are both `[info]` no-code-counterparts (`enum.AutomationActionType.subset.cloud-only.no-code-counterpart`, `constant.ConcurrencySlotLeaseDuration.no-code-counterpart`) — no false-positive drifts remain on the target.

Full contract-verifier suite is green, including both IL marker tests (`verify-end-to-end` and `verify-python-end-to-end`). (Note: 5 unrelated tests in `verify-store.test.ts` / `spec-routes.test.ts` fail in this sandbox due to the git commit-signing server rejecting their ephemeral `gitInit` commits — an environment issue, not affected by this change.)

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsnuCY7jFQP76y3PPG1PJp)_