### PR TITLE
spec-consolidator: let .truecourseignore re-include override SKIP_DIRS

### DIFF
--- a/packages/shared/src/fs/tcignore.ts
+++ b/packages/shared/src/fs/tcignore.ts
@@ -23,6 +23,18 @@ export interface TcIgnore {
   root: string;
   /** True when `absPath` (a file or directory) is excluded. */
   ignores(absPath: string): boolean;
+  /**
+   * True when `absPath` is *explicitly re-included* by a negation rule
+   * (a `!pattern` line) — as opposed to merely not matching any rule.
+   *
+   * This is the signal that distinguishes "the scope deliberately opted
+   * into this path" from "no opinion". Directory walkers use it to let an
+   * explicit re-include override a hardcoded skip list: an allow-list
+   * ignore (`*.md` + `!docs/.../build/**`) re-includes the `.md` files
+   * inside a `build/` tree, so a probe of a markdown descendant reports
+   * `true` here even though the bare directory matches no rule.
+   */
+  reincludes(absPath: string): boolean;
 }
 
 /**
@@ -62,6 +74,11 @@ export function loadTcIgnore(startDir: string): TcIgnore {
       // Empty (the root itself) or escaping the root → out of scope.
       if (rel === '' || rel.startsWith('..')) return false;
       return ig.ignores(rel);
+    },
+    reincludes(absPath: string): boolean {
+      const rel = path.relative(root, path.resolve(absPath)).split(path.sep).join('/');
+      if (rel === '' || rel.startsWith('..')) return false;
+      return ig.test(rel).unignored;
     },
   };
 }

--- a/packages/spec-consolidator/src/discovery.ts
+++ b/packages/spec-consolidator/src/discovery.ts
@@ -12,7 +12,10 @@
  *
  * Exclusions:
  *   - Build/tooling dirs (node_modules, dist, .next, build, .turbo,
- *     .git) — never user content.
+ *     .git) — never user content. A repo whose docs genuinely live
+ *     under such a name (e.g. dagster's `docs/docs/guides/build/`) can
+ *     override the skip with an explicit `.truecourseignore` re-include
+ *     (`!.../build/**`); the dotfile skip below is not overridable.
  *   - `.truecourse/` — the consolidator's own outputs live here. If
  *     we re-discovered them, every run would compound on its previous
  *     output and the canonical spec would echo into itself.
@@ -57,6 +60,13 @@ const SKIP_DIRS = new Set([
   'coverage',
 ]);
 
+// Synthetic markdown child used to ask `.truecourseignore` whether a
+// `SKIP_DIRS` directory has been explicitly re-included. An allow-list
+// ignore (`*.md` + `!path/build/**`) re-includes the markdown *under* a
+// dir, never the bare dir, so we test a `.md` descendant: `unignored`
+// comes back true only when a `!`-rule deliberately opted the tree in.
+const SKIP_DIR_PROBE = '__tc_skipdir_probe__.md';
+
 const PREVIEW_LINE_LIMIT = 200;
 
 export interface DiscoveryOptions {
@@ -98,9 +108,23 @@ export function discoverDocs(rootDir: string, opts: DiscoveryOptions = {}): DocC
     entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 
     for (const entry of entries) {
-      if (SKIP_DIRS.has(entry.name)) continue;
-      if (entry.name.startsWith('.') && entry.name !== '.') continue;
       const full = path.join(dir, entry.name);
+      // Build/tooling dirs are skipped by default — but an explicit
+      // `.truecourseignore` re-include (`!some/dir/build/**`) overrides the
+      // skip, so a doc tree that legitimately lives under a dir named
+      // `build`/`dist` is still discovered when the scope opts into it.
+      // The allow-list re-includes `.md` files, not the bare directory, so
+      // probe a markdown descendant rather than the directory itself.
+      if (
+        SKIP_DIRS.has(entry.name) &&
+        !(entry.isDirectory() && tcIgnore.reincludes(path.join(full, SKIP_DIR_PROBE)))
+      ) {
+        continue;
+      }
+      // Dotfiles stay unconditionally skipped — this guards the
+      // consolidator's own `.truecourse/` outputs from re-discovery even if
+      // an ignore file re-includes them above.
+      if (entry.name.startsWith('.') && entry.name !== '.') continue;
       if (tcIgnore.ignores(full)) continue;
       if (entry.isDirectory()) {
         visit(full);

--- a/tests/shared/tcignore.test.ts
+++ b/tests/shared/tcignore.test.ts
@@ -53,6 +53,31 @@ describe('loadTcIgnore', () => {
   });
 });
 
+describe('TcIgnore.reincludes', () => {
+  it('is true only for paths explicitly re-included by a negation rule', () => {
+    fs.writeFileSync(path.join(root, '.truecourseignore'), '*.md\n!docs/build/**\n');
+    const ig = loadTcIgnore(root);
+    // Re-included subtree (and nested descendants via `**`).
+    expect(ig.reincludes(path.join(root, 'docs/build/x.md'))).toBe(true);
+    expect(ig.reincludes(path.join(root, 'docs/build/assets/y.md'))).toBe(true);
+    // Ignored-but-not-re-included (a plain `*.md` match) → false.
+    expect(ig.reincludes(path.join(root, 'docs/other.md'))).toBe(false);
+    // A path no rule mentions at all → false (no opinion ≠ re-included).
+    expect(ig.reincludes(path.join(root, 'src/app.ts'))).toBe(false);
+  });
+
+  it('returns false when there is no .truecourseignore', () => {
+    const ig = loadTcIgnore(root);
+    expect(ig.reincludes(path.join(root, 'docs/build/x.md'))).toBe(false);
+  });
+
+  it('never re-includes paths outside the repo root', () => {
+    fs.writeFileSync(path.join(root, '.truecourseignore'), '!**\n');
+    const ig = loadTcIgnore(root);
+    expect(ig.reincludes(path.join(path.dirname(root), 'sibling.md'))).toBe(false);
+  });
+});
+
 describe('findRepoRoot', () => {
   it('stops at the directory holding .truecourseignore', () => {
     fs.writeFileSync(path.join(root, '.truecourseignore'), 'x\n');

--- a/tests/spec-consolidator/discovery.test.ts
+++ b/tests/spec-consolidator/discovery.test.ts
@@ -193,6 +193,50 @@ describe('discoverDocs — walker', () => {
     expect(paths).not.toContain('.cache/leaked.md');
   });
 
+  it('descends into a SKIP_DIRS dir (build) when .truecourseignore re-includes it', () => {
+    // dagster keeps its primary docs under docs/docs/guides/build/ — a
+    // directory name that collides with the build-output skip list. An
+    // allow-list .truecourseignore (the shape the generate routine writes)
+    // must override the hardcoded skip for that opted-in subtree.
+    place('.truecourseignore', '*.md\n!docs/guides/build/**\n');
+    place('docs/guides/build/assets/materialization.md', '# assets');
+    place('docs/guides/build/external-resources.md', '# resources');
+    place('docs/other.md', '# not in scope');
+
+    const paths = discoverDocs(root, { skipGit: true }).map((d) => d.path);
+    expect(paths).toContain('docs/guides/build/assets/materialization.md');
+    expect(paths).toContain('docs/guides/build/external-resources.md');
+    // Allow-list semantics: a .md outside the re-included subtree is excluded.
+    expect(paths).not.toContain('docs/other.md');
+  });
+
+  it('still skips a build dir that is NOT re-included, even with a .truecourseignore present', () => {
+    // The override is scoped to the re-included subtree only — an
+    // unrelated build/ tree (and node_modules) stays pruned so the skip
+    // list keeps doing its job.
+    place('.truecourseignore', '*.md\n!docs/guides/build/**\n');
+    place('docs/guides/build/kept.md', '# in scope');
+    place('build/leaked.md', '# top-level build output — must stay skipped');
+    place('node_modules/pkg/build/leaked.md', '# dependency build — must stay skipped');
+
+    const paths = discoverDocs(root, { skipGit: true }).map((d) => d.path);
+    expect(paths).toContain('docs/guides/build/kept.md');
+    expect(paths).not.toContain('build/leaked.md');
+    expect(paths).not.toContain('node_modules/pkg/build/leaked.md');
+  });
+
+  it('a re-include cannot resurrect .truecourse/ (dotfile skip is not overridable)', () => {
+    // Even an explicit re-include of the consolidator's own output dir
+    // must not reopen the feedback loop — the dotfile guard wins.
+    place('.truecourseignore', '*.md\n!.truecourse/**\n!docs/**\n');
+    place('.truecourse/specs/overview.md', '# canonical — must not echo');
+    place('docs/source.md', '# original');
+
+    const paths = discoverDocs(root, { skipGit: true }).map((d) => d.path);
+    expect(paths).toContain('docs/source.md');
+    expect(paths).not.toContain('.truecourse/specs/overview.md');
+  });
+
   it('reading .truecourse/ would echo on every run — exclude is critical', () => {
     // Simulate a state where the consolidator already ran. If we
     // re-discovered its outputs, every run would compound on its own


### PR DESCRIPTION
## Why

Doc discovery pruned any directory named `build` (and the other build-tooling `SKIP_DIRS`) **before** consulting `.truecourseignore`. So a repo whose docs legitimately live under such a name — e.g. dagster's `docs/docs/guides/build/assets/…` — could never be scanned: the `!docs/docs/guides/build/**` re-include the generate routine writes was checked too late to take effect.

Surfaced by the `drift-fp-generate` routine on the dagster campaign (`dagster-io/dagster @ a902ba3`): the doc-scan completed but missed **93 of 373** docs — the entire `guides/build` subtree (assets / external-resources / ops / automation), which was the campaign's primary intended contract surface. The partial scan would have seeded a campaign on a corpus missing its whole reason for existing, so the routine correctly stopped and filed this for a scoped engine fix (same shape as #518 / #555 / #533).

## What

Make the hardcoded skip yield to an **explicit opt-in**. A `SKIP_DIRS` directory is still pruned by default; it descends when `.truecourseignore` explicitly re-includes content beneath it.

- New `TcIgnore.reincludes(path)` on `@truecourse/shared`, backed by the `ignore` package's `test().unignored` — the only signal that distinguishes "deliberately re-included by a `!`-rule" from "no rule matched". (A plain `.ignores()` boolean can't tell those apart.)
- `discovery.ts` consults it before pruning. Because the allow-list re-includes `.md` files (`!dir/**`) and not the bare directory, the walker probes a synthetic markdown descendant.
- **The dotfile skip stays unconditional** — `.truecourse/` can never be re-discovered even if an ignore file re-includes it. The feedback-loop guard (consolidator's own outputs echoing into the canonical spec) is preserved.

A naïve "just delete `'build'` from SKIP_DIRS" wouldn't work: real build-output trees (`packages/*/build/`, `node_modules/*/build/`) often contain generated `.md` (typedoc, storybook) — walking them would tank every campaign's scan. This change keeps the default behavior intact while letting a campaign's `doc_scope` opt back in.

## Verification

- **Full `pnpm build`** — every consumer of the changed interface typechecks ✓
- **185 tests** across `spec-consolidator/` + `shared/tcignore` + `contract-verifier/tcignore-walker` + `analyzer/file-discovery` ✓, including 6 new ones:
  - descends into a re-included `build/` tree
  - still skips a non-re-included top-level `build/` and `node_modules/*/build/`
  - cannot resurrect `.truecourse/` (dotfile guard wins over an explicit re-include)
  - `reincludes` unit coverage: true only for paths a negation rule deliberately opts in; false for `.md` paths a plain `*.md` rule excludes; false for paths no rule mentions
- **End-to-end repro** of dagster's real layout (the `.truecourseignore` the generate routine writes verbatim):

  ```
  total discovered            : 78
  guides/build docs (was 0)   : 23
  deployment docs             : 19
  integrations/libraries docs : 36
  leaked build-output excluded: true   (python_modules/.../build, node_modules/.../build)
  out-of-scope guide excluded : true   (docs/docs/guides/other/)
  ```

  The "was 0" line is the bug. After the fix the in-scope `guides/build` docs are discovered, while real build output and out-of-scope guides stay correctly excluded.

## After merge

A fresh `drift-fp-generate` run picks dagster back up (branch still absent ⇒ still pending) and produces the real corpus instead of the gutted 280-doc partial. Independent of #565 — different packages, no overlap, can merge in either order.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_