### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/element-overwrite.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/element-overwrite.ts
@@ -68,7 +68,12 @@ export const elementOverwriteVisitor: CodeRuleVisitor = {
         // the property is the React `.current` accessor.
         const isRefCurrent =
           left.type === 'member_expression' && indexOrProp.text === 'current'
-        if (!wasRead && !(isRefCurrent && hasAwait)) {
+        // Read-modify-write: `x = x.concat(...)` then `x = Array.from(new Set(x))`.
+        // The second assignment's RHS reads the value the first produced, so the
+        // first write is consumed — not a dead store.
+        const right = expr.childForFieldName('right')
+        const readsSelfInRhs = right ? right.text.includes(left.text) : false
+        if (!wasRead && !readsSelfInRhs && !(isRefCurrent && hasAwait)) {
           return makeViolation(
             this.ruleKey, expr, filePath, 'high',
             'Element overwritten before read',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/deep-callback-nesting.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/deep-callback-nesting.ts
@@ -16,6 +16,22 @@ function isDirectCallbackArg(fn: SyntaxNode): SyntaxNode | null {
   return p?.type === 'arguments' ? p : null
 }
 
+/**
+ * A trivial callback is not "callback hell": a concise expression-bodied arrow
+ * (`xs.map((x) => x.id)`, `arr.map((p) => ({ ...p }))`) or an empty callback
+ * (`fs.unlink(p, () => {})`). These are one-liners / no-ops, not the sequential
+ * nested control flow the rule targets, so they should never be the flagged
+ * innermost callback.
+ */
+function isTrivialCallback(fn: SyntaxNode): boolean {
+  const body = fn.childForFieldName('body')
+  if (!body) return false
+  // Expression-bodied arrow (no statement block) — a concise transform.
+  if (body.type !== 'statement_block') return true
+  // Empty block body — a no-op callback.
+  return body.namedChildren.length === 0
+}
+
 function findEnclosingFn(start: SyntaxNode | null): SyntaxNode | null {
   let n = start
   while (n) {
@@ -31,6 +47,10 @@ export const deepCallbackNestingVisitor: CodeRuleVisitor = {
   languages: ['typescript', 'tsx', 'javascript'],
   nodeTypes: ['function_expression', 'arrow_function'],
   visit(node, filePath, sourceCode) {
+    // A trivial leaf callback (concise transform or no-op) is not the deepest
+    // level of real callback nesting — don't flag it.
+    if (isTrivialCallback(node)) return null
+
     let depth = 0
     let current: SyntaxNode = node
 

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/prefer-this-return-type.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/prefer-this-return-type.ts
@@ -47,6 +47,27 @@ export const preferThisReturnTypeVisitor: CodeRuleVisitor = {
 
     // Check if the return type annotation is exactly the class name
     if (typeText === className) {
+      // Only flag methods that actually return `this`. A method that returns a
+      // freshly-constructed instance (a child, a clone, ...) genuinely returns a
+      // different object, so declaring the concrete class is correct — not a
+      // candidate for a `this` return type.
+      const body = node.childForFieldName('body')
+      if (!body) return null
+      const returns = collectMethodReturns(body)
+      if (returns.length === 0) return null
+      let returnsThis = false
+      for (const ret of returns) {
+        const arg = ret.namedChildren[0]
+        if (arg && arg.type === 'this') {
+          returnsThis = true
+        } else {
+          // Returns something other than `this` (a new instance, a property, a
+          // bare `return`) — the class-name return type is appropriate.
+          return null
+        }
+      }
+      if (!returnsThis) return null
+
       return makeViolation(
         this.ruleKey,
         returnTypeNode,
@@ -61,6 +82,38 @@ export const preferThisReturnTypeVisitor: CodeRuleVisitor = {
 
     return null
   },
+}
+
+/**
+ * Collect every `return_statement` that belongs to this method body, without
+ * descending into nested function-like scopes (arrow functions, inner function
+ * declarations, etc.) whose returns belong to a different callable.
+ */
+function collectMethodReturns(body: SyntaxNode): SyntaxNode[] {
+  const returns: SyntaxNode[] = []
+  const NESTED_SCOPES = new Set([
+    'function_declaration',
+    'function_expression',
+    'function',
+    'arrow_function',
+    'generator_function',
+    'generator_function_declaration',
+    'method_definition',
+    'class_declaration',
+    'class',
+  ])
+  const walk = (n: SyntaxNode): void => {
+    for (const child of n.namedChildren) {
+      if (child.type === 'return_statement') {
+        returns.push(child)
+      }
+      if (!NESTED_SCOPES.has(child.type)) {
+        walk(child)
+      }
+    }
+  }
+  walk(body)
+  return returns
 }
 
 function findEnclosingClass(node: SyntaxNode): SyntaxNode | null {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/public-static-readonly.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/public-static-readonly.ts
@@ -13,8 +13,13 @@ export const publicStaticReadonlyVisitor: CodeRuleVisitor = {
       const isPublic = !member.children.some((c) => c.type === 'accessibility_modifier'
         && (c.text === 'private' || c.text === 'protected'))
       const isReadonly = member.children.some((c) => c.type === 'readonly')
+      // Only constants (fields with an initializer) should be `readonly`. A
+      // declaration with no initializer (`static onError: Handler;`,
+      // `static __cache: ATN;`) is a mutable slot assigned elsewhere — making it
+      // readonly is impossible, so it isn't a candidate.
+      const hasInitializer = member.childForFieldName('value') != null
 
-      if (isStatic && isPublic && !isReadonly) {
+      if (isStatic && isPublic && !isReadonly && hasInitializer) {
         const nameNode = member.childForFieldName('name')
         const name = nameNode?.text ?? 'field'
         return makeViolation(

--- a/packages/analyzer/src/rules/performance/visitors/javascript/spread-in-reduce.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/spread-in-reduce.ts
@@ -2,11 +2,40 @@ import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
-function containsSpread(node: SyntaxNode): boolean {
-  if (node.type === 'spread_element') return true
+/**
+ * The O(n^2) anti-pattern is spreading the ACCUMULATOR itself on each
+ * iteration (`acc.reduce((acc, x) => ({ ...acc, ...x }), {})`) — every pass
+ * copies the whole accumulator. Spreading some other, fixed-size value while
+ * mutating the accumulator in place (`acc[x.id] = { ...x.state, ... }; return acc`)
+ * is linear and must not be flagged.
+ */
+function getAccumulatorName(callback: SyntaxNode): string | null {
+  if (
+    callback.type !== 'arrow_function' &&
+    callback.type !== 'function_expression' &&
+    callback.type !== 'function'
+  ) {
+    return null
+  }
+  const params = callback.childForFieldName('parameters')
+  if (!params) return null
+  const first = params.namedChildren.find((c) => c.type !== 'comment')
+  if (!first) return null
+  if (first.type === 'identifier') return first.text
+  // TS wraps the binding in required_parameter / optional_parameter.
+  const pattern = first.childForFieldName('pattern')
+  if (pattern && pattern.type === 'identifier') return pattern.text
+  return null
+}
+
+function spreadsIdentifier(node: SyntaxNode, name: string): boolean {
+  if (node.type === 'spread_element') {
+    const arg = node.namedChildren[0]
+    if (arg && arg.type === 'identifier' && arg.text === name) return true
+  }
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i)
-    if (child && containsSpread(child)) return true
+    if (child && spreadsIdentifier(child, name)) return true
   }
   return false
 }
@@ -28,8 +57,11 @@ export const spreadInReduceVisitor: CodeRuleVisitor = {
     const callback = args.namedChildren[0]
     if (!callback) return null
 
-    // Check if callback body contains spread_element
-    if (containsSpread(callback)) {
+    const accName = getAccumulatorName(callback)
+    if (!accName) return null
+
+    // Only flag when the accumulator itself is spread (the actual O(n^2) shape).
+    if (spreadsIdentifier(callback, accName)) {
       return makeViolation(
         this.ruleKey, node, filePath, 'medium',
         'Spread operator in reduce callback',

--- a/tests/fixtures/sample-js-project-negative/deep-callback-nesting.ts
+++ b/tests/fixtures/sample-js-project-negative/deep-callback-nesting.ts
@@ -1,0 +1,26 @@
+// Genuine callback hell: four levels of nested, block-bodied callbacks doing
+// sequential work. This is the pattern the rule is meant to catch.
+
+function readSettings(cb: (value: number) => void): void {
+  cb(1)
+}
+
+function fetchRows(seed: number, cb: (rows: number[]) => void): void {
+  cb([seed, seed + 1])
+}
+
+export function startPipeline(
+  events: { on: (name: string, handler: () => void) => void },
+  sink: number[],
+): void {
+  events.on('start', () => {
+    setTimeout(() => {
+      readSettings((seed) => {
+        // VIOLATION: code-quality/deterministic/deep-callback-nesting
+        fetchRows(seed, (rows) => {
+          sink.push(rows.length)
+        })
+      })
+    }, 25)
+  })
+}

--- a/tests/fixtures/sample-js-project-negative/element-overwrite.ts
+++ b/tests/fixtures/sample-js-project-negative/element-overwrite.ts
@@ -1,0 +1,17 @@
+// A genuine dead store: the second assignment overwrites the property without
+// ever reading the value the first assignment produced.
+
+interface Settings {
+  retries: number
+}
+
+function computeDefault(): number {
+  return 3
+}
+
+export function configure(settings: Settings): Settings {
+  settings.retries = computeDefault()
+  // VIOLATION: bugs/deterministic/element-overwrite
+  settings.retries = 5
+  return settings
+}

--- a/tests/fixtures/sample-js-project-negative/prefer-this-return-type.ts
+++ b/tests/fixtures/sample-js-project-negative/prefer-this-return-type.ts
@@ -1,0 +1,17 @@
+// A fluent builder whose method returns `this` for chaining but declares the
+// concrete class as the return type. Subclasses lose chaining because the type
+// narrows to the parent — the return type should be `this`.
+
+export class FilterBuilder {
+  private readonly conditions: string[] = []
+
+  // VIOLATION: code-quality/deterministic/prefer-this-return-type
+  where(condition: string): FilterBuilder {
+    this.conditions.push(condition)
+    return this
+  }
+
+  build(): string {
+    return this.conditions.join(' AND ')
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/public-static-readonly.ts
+++ b/tests/fixtures/sample-js-project-negative/public-static-readonly.ts
@@ -1,0 +1,11 @@
+// A public static field initialized with a constant value should be `readonly`
+// so it cannot be reassigned elsewhere.
+
+export class HttpClient {
+  // VIOLATION: code-quality/deterministic/public-static-readonly
+  static DEFAULT_TIMEOUT_MS = 5000
+
+  timeout(): number {
+    return HttpClient.DEFAULT_TIMEOUT_MS
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/spread-in-reduce.ts
+++ b/tests/fixtures/sample-js-project-negative/spread-in-reduce.ts
@@ -1,0 +1,15 @@
+// Spreading the accumulator on every iteration copies the whole accumulator
+// each pass — the O(n^2) anti-pattern this rule catches.
+
+interface Entry {
+  key: string
+  value: number
+}
+
+export function combine(entries: readonly Entry[]): Record<string, number> {
+  // VIOLATION: performance/deterministic/spread-in-reduce
+  return entries.reduce(
+    (acc, entry) => ({ ...acc, [entry.key]: entry.value }),
+    {} as Record<string, number>,
+  )
+}

--- a/tests/fixtures/sample-js-project-positive/deep-callback-nesting.ts
+++ b/tests/fixtures/sample-js-project-positive/deep-callback-nesting.ts
@@ -1,0 +1,54 @@
+// Trivial leaf callbacks nested inside other callbacks — concise `.map`
+// transforms and no-op cleanups — are not callback hell and must not be
+// flagged, even when several callback layers sit above them.
+
+interface Row {
+  id: string
+  price: number
+}
+
+function withSpan(fn: (span: { payload: unknown }) => void): void {
+  fn({ payload: null })
+}
+
+export function buildReport(
+  source: { on: (name: string, handler: () => void) => void },
+  rows: readonly Row[],
+): void {
+  source.on('refresh', () => {
+    queueMicrotask(() => {
+      withSpan((span) => {
+        span.payload = {
+          // Concise expression-bodied transforms — not nesting depth.
+          prices: rows.map((r) => ({ ...r, price: Number(r.price) })),
+          ids: rows.map((r) => r.id),
+        }
+      })
+    })
+  })
+}
+
+function defer(fn: () => void): void {
+  fn()
+}
+
+function flush(fn: () => void): void {
+  fn()
+}
+
+function removeTemp(fn: () => void): void {
+  fn()
+}
+
+export function cleanupLater(
+  watcher: { on: (name: string, handler: () => void) => void },
+): void {
+  watcher.on('done', () => {
+    defer(() => {
+      flush(() => {
+        // No-op cleanup callback nested deeply — still not callback hell.
+        removeTemp(() => {})
+      })
+    })
+  })
+}

--- a/tests/fixtures/sample-js-project-positive/element-overwrite.ts
+++ b/tests/fixtures/sample-js-project-positive/element-overwrite.ts
@@ -1,0 +1,20 @@
+// A read-modify-write where the second assignment's RHS reads the value the
+// first assignment produced is NOT a dead store — the first write is consumed
+// (a common dedup-by-reassign pattern).
+
+interface Manifest {
+  packages?: string[]
+  conditions?: string[]
+}
+
+export function mergeLayer(manifest: Manifest, extra: readonly string[]): Manifest {
+  manifest.packages ??= []
+  manifest.packages = manifest.packages.concat(extra)
+  manifest.packages = Array.from(new Set(manifest.packages))
+
+  manifest.conditions ??= []
+  manifest.conditions = manifest.conditions.concat(extra)
+  manifest.conditions = Array.from(new Set(manifest.conditions))
+
+  return manifest
+}

--- a/tests/fixtures/sample-js-project-positive/prefer-this-return-type.ts
+++ b/tests/fixtures/sample-js-project-positive/prefer-this-return-type.ts
@@ -1,0 +1,22 @@
+// A method whose declared return type is the class name but which returns a
+// brand-new instance (not `this`) is NOT a candidate for a `this` return type —
+// declaring the concrete class is correct. These must not be flagged.
+
+export class TreeNode {
+  constructor(private readonly label: string) {}
+
+  // Builds a separate child node — the result is a distinct object, so the
+  // return type is the class, not `this`.
+  withChild(suffix: string): TreeNode {
+    return new TreeNode(`${this.label}/${suffix}`)
+  }
+}
+
+export class RangeCursor {
+  constructor(private readonly path: string) {}
+
+  // Returns a clone scoped to a segment — a new object, never `this`.
+  forSegment(index: number): RangeCursor {
+    return new RangeCursor(`${this.path}/segment_${index}`)
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/public-static-readonly.ts
+++ b/tests/fixtures/sample-js-project-positive/public-static-readonly.ts
@@ -1,0 +1,20 @@
+// Static public fields declared without an initializer are mutable slots
+// (assignment points for consumers, lazily-populated caches), not constants —
+// they cannot be `readonly` and must not be flagged.
+
+export class Registry {
+  constructor(readonly id: string = 'default') {}
+
+  // Assignment point for consumers — declared without an initializer.
+  static onError: (message: string, detail?: unknown) => void
+
+  // Lazily-populated singleton slot, assigned the first time the getter runs.
+  static cached: Registry | undefined
+
+  static get current(): Registry {
+    if (!Registry.cached) {
+      Registry.cached = new Registry()
+    }
+    return Registry.cached
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/spread-in-reduce.ts
+++ b/tests/fixtures/sample-js-project-positive/spread-in-reduce.ts
@@ -1,0 +1,26 @@
+// Spreading a fixed-size value (`nodeState`) while mutating the accumulator in
+// place is linear — not the O(n^2) spread-the-accumulator anti-pattern — and
+// must not be flagged.
+
+interface NodeState {
+  selected: boolean
+  expanded: boolean
+}
+
+interface TreeNode {
+  id: string
+}
+
+export function buildState(
+  nodes: readonly TreeNode[],
+  base: Record<string, NodeState>,
+): Record<string, NodeState> {
+  return nodes.reduce(
+    (acc, node) => {
+      const nodeState = base[node.id] ?? { selected: false, expanded: true }
+      acc[node.id] = { ...nodeState, expanded: false }
+      return acc
+    },
+    {} as Record<string, NodeState>,
+  )
+}


### PR DESCRIPTION
Resolves 5 false positives surfaced by analyzing [`triggerdotdev/trigger.dev`](https://github.com/triggerdotdev/trigger.dev) @ `2dd9f37b4045d2a414c0a300995d068f28926d50`. Each fix is paired with a paraphrased positive fixture (must NOT fire) and a true-bug negative fixture (must still fire).

Closes #387
Closes #388
Closes #389
Closes #390
Closes #391

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/prefer-this-return-type` | #387 | `sample-js-project-positive/prefer-this-return-type.ts` | `sample-js-project-negative/prefer-this-return-type.ts` |
| `code-quality/deterministic/deep-callback-nesting` | #388 | `sample-js-project-positive/deep-callback-nesting.ts` | `sample-js-project-negative/deep-callback-nesting.ts` |
| `bugs/deterministic/element-overwrite` | #389 | `sample-js-project-positive/element-overwrite.ts` | `sample-js-project-negative/element-overwrite.ts` |
| `performance/deterministic/spread-in-reduce` | #390 | `sample-js-project-positive/spread-in-reduce.ts` | `sample-js-project-negative/spread-in-reduce.ts` |
| `code-quality/deterministic/public-static-readonly` | #391 | `sample-js-project-positive/public-static-readonly.ts` | `sample-js-project-negative/public-static-readonly.ts` |

## code-quality/deterministic/prefer-this-return-type

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/query/printer_context.ts#L222
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/query/timings.ts#L46

Positive fixture (new file):
```ts
export class TreeNode {
  constructor(private readonly label: string) {}

  withChild(suffix: string): TreeNode {
    return new TreeNode(`${this.label}/${suffix}`)
  }
}

export class RangeCursor {
  constructor(private readonly path: string) {}

  forSegment(index: number): RangeCursor {
    return new RangeCursor(`${this.path}/segment_${index}`)
  }
}
```

Negative fixture (new file):
```ts
export class FilterBuilder {
  private readonly conditions: string[] = []

  // VIOLATION: code-quality/deterministic/prefer-this-return-type
  where(condition: string): FilterBuilder {
    this.conditions.push(condition)
    return this
  }

  build(): string {
    return this.conditions.join(' AND ')
  }
}
```

**Visitor change:** The rule flagged any method whose declared return type equals the enclosing class name, without checking what the method returns. Added `collectMethodReturns` to gather the method's own `return` statements (not descending into nested function scopes) and now only fire when every return returns `this` and at least one does. Methods that return a freshly-constructed instance (a child, a clone) are no longer flagged.

## code-quality/deterministic/deep-callback-nesting

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/admin.llm-models._index.tsx#L62
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/marqs/index.server.ts#L951
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts#L1494
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/memory-leak-detector.js#L195

Positive fixture (new file):
```ts
export function buildReport(
  source: { on: (name: string, handler: () => void) => void },
  rows: readonly Row[],
): void {
  source.on('refresh', () => {
    queueMicrotask(() => {
      withSpan((span) => {
        span.payload = {
          prices: rows.map((r) => ({ ...r, price: Number(r.price) })),
          ids: rows.map((r) => r.id),
        }
      })
    })
  })
}
// ...plus a parallel case with a nested no-op `removeTemp(() => {})` cleanup.
```

Negative fixture (new file):
```ts
export function startPipeline(
  events: { on: (name: string, handler: () => void) => void },
  sink: number[],
): void {
  events.on('start', () => {
    setTimeout(() => {
      readSettings((seed) => {
        // VIOLATION: code-quality/deterministic/deep-callback-nesting
        fetchRows(seed, (rows) => {
          sink.push(rows.length)
        })
      })
    }, 25)
  })
}
```

**Visitor change:** Added `isTrivialCallback` and bail out when the flagged (innermost) callback is a concise expression-bodied arrow (`xs.map((x) => x.id)`) or an empty `() => {}`. These one-liners / no-ops are not the deepest level of real callback nesting, so a chain whose leaf is a trivial transform is no longer reported; genuinely deep block-bodied chains still fire.

## bugs/deterministic/element-overwrite

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/build/extensions.ts#L209
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/build/extensions.ts#L216

Positive fixture (new file):
```ts
export function mergeLayer(manifest: Manifest, extra: readonly string[]): Manifest {
  manifest.packages ??= []
  manifest.packages = manifest.packages.concat(extra)
  manifest.packages = Array.from(new Set(manifest.packages))
  // ...same dedup-by-reassign for manifest.conditions
  return manifest
}
```

Negative fixture (new file):
```ts
export function configure(settings: Settings): Settings {
  settings.retries = computeDefault()
  // VIOLATION: bugs/deterministic/element-overwrite
  settings.retries = 5
  return settings
}
```

**Visitor change:** The "was it read between the two assignments?" check ignored the second assignment's own right-hand side, so a read-modify-write like `x = x.concat(...)` immediately followed by `x = Array.from(new Set(x))` was misreported as a dead store. Now, before reporting, the rule checks whether the second assignment's RHS references the assigned lvalue; if so, the first write is consumed and no violation is raised.

## performance/deterministic/spread-in-reduce

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/primitives/TreeView/utils.ts#L69

Positive fixture (new file):
```ts
export function buildState(
  nodes: readonly TreeNode[],
  base: Record<string, NodeState>,
): Record<string, NodeState> {
  return nodes.reduce(
    (acc, node) => {
      const nodeState = base[node.id] ?? { selected: false, expanded: true }
      acc[node.id] = { ...nodeState, expanded: false }
      return acc
    },
    {} as Record<string, NodeState>,
  )
}
```

Negative fixture (new file):
```ts
export function combine(entries: readonly Entry[]): Record<string, number> {
  // VIOLATION: performance/deterministic/spread-in-reduce
  return entries.reduce(
    (acc, entry) => ({ ...acc, [entry.key]: entry.value }),
    {} as Record<string, number>,
  )
}
```

**Visitor change:** The rule fired on any spread anywhere in a reduce callback. The O(n^2) anti-pattern is specifically spreading the *accumulator* each iteration. The rule now resolves the callback's accumulator parameter name and only fires when that identifier is itself spread (`{ ...acc, ... }`). Spreading a fixed-size object while mutating the accumulator in place (`acc[k] = { ...nodeState }; return acc`) is linear and no longer flagged. This also incidentally cleared a second non-sampled FP of the same shape.

## code-quality/deterministic/public-static-readonly

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/grammar/TSQLLexer.ts#L1720
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/grammar/TSQLParser.ts#L7650
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/core/src/logger.ts#L27

Positive fixture (new file):
```ts
export class Registry {
  constructor(readonly id: string = 'default') {}

  static onError: (message: string, detail?: unknown) => void
  static cached: Registry | undefined

  static get current(): Registry {
    if (!Registry.cached) {
      Registry.cached = new Registry()
    }
    return Registry.cached
  }
}
```

Negative fixture (new file):
```ts
export class HttpClient {
  // VIOLATION: code-quality/deterministic/public-static-readonly
  static DEFAULT_TIMEOUT_MS = 5000

  timeout(): number {
    return HttpClient.DEFAULT_TIMEOUT_MS
  }
}
```

**Visitor change:** The rule flagged every non-readonly public static field, including type-only declarations with no initializer. A field with no initializer (`static onError: Handler;`, `static __ATN: ATN;`) is a mutable slot assigned elsewhere and cannot be made `readonly`. The rule now only fires when the field has an initializer (a constant value).

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

Measured by running `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` against a freshly-built `dist` (the exact artifact `publish.yml` ships) before and after this batch's visitor changes.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/prefer-this-return-type` | 4 | 2 | -2 |
| `code-quality/deterministic/deep-callback-nesting` | 65 | 58 | -7 |
| `bugs/deterministic/element-overwrite` | 2 | 0 | -2 |
| `performance/deterministic/spread-in-reduce` | 5 | 3 | -2 |
| `code-quality/deterministic/public-static-readonly` | 9 | 6 | -3 |
| **Total (these 5 rules)** | 85 | 69 | -16 |
| **All-rules total on target** | 35057 | 35041 | -16 |

All deltas are negative (FP reductions) with no collateral increases elsewhere — the all-rules total dropped by exactly the same 16.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBqjxqa6omqR8o9pcoMFwV)_