### PR TITLE
chore(drift-fp): start discovery for dagster-io/dagster

### DIFF
--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -136,7 +136,7 @@ campaigns:
       - docs/docs/deployment         # 19 — deployment behavior (kubernetes, dagster-plus)
       - docs/docs/integrations/libraries  # 36 — integration adapters (aws/gcp/snowflake/dbt/…)
     priority: 6
-    status: pending
+    status: discovering
     baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes: ["Probe 2026-06-06: rich in-repo docs at docs/docs/guides/build/assets (12), build/external-resources (11), deployment/dagster-plus/management (12), integrations/libraries/aws (12). Python monorepo (python_modules/dagster/, python_modules/libraries/*); narrow code_dir if generate runs hot, but start with `.` like the other monorepos."]


### PR DESCRIPTION
Starting a drift discovery run for **dagster-io/dagster** (campaign priority 6).

This PR marks the campaign `status: discovering` in `campaigns.yaml`. The deterministic `verify` will run against the pinned contracts on `claude/drift-fp-store/dagster-io-dagster` at `target_ref` `d05d8a4b60da5036ae1facc03b59477b506fe949` (code_dir `.`). I'll triage drifts, file one `[drift-fp-fix]` issue per drift-kind with false positives, and fill in the baseline on this PR.

- Storage PR: #572
- Contracts branch: `claude/drift-fp-store/dagster-io-dagster`

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHmAbioHmiynFS6UnWd6Be)_