### PR TITLE
fix(drift-fp): resolve 2 drift FPs from dagster-io/dagster

### DIFF
--- a/packages/contract-verifier/src/comparator/enum.ts
+++ b/packages/contract-verifier/src/comparator/enum.ts
@@ -51,6 +51,12 @@ export function compareEnum(input: EnumCompareInput): ContractDrift[] {
   // overlap) — so a partial copy of an enum (e.g. a server-side subset) can't
   // contribute spurious `missing-value` drifts alongside the canonical match.
   const matched = matchByName(contract, codeEnums, ref.identity);
+  // A value-only match (no name link) is a weaker signal than a name match: the
+  // overlap could be a deliberate subset constant (a "finished"/"terminal"
+  // status family) rather than a renamed copy of the enum. We track this so the
+  // main-set diff can withhold `missing-value` for value-only matches that are
+  // strict subsets of the spec — see below.
+  const valueOnlyMatch = matched.byName.length === 0;
   const nameMatches =
     matched.byName.length > 0 ? matched.byName : bestValueMatch(contract, matched.byValue);
   if (nameMatches.length === 0) {
@@ -96,7 +102,16 @@ export function compareEnum(input: EnumCompareInput): ContractDrift[] {
       const g = byName.get(key)!;
       for (const v of m.values) g.values.add(normalizeValue(v));
     }
+    const specNormSet = new Set(contract.values.map(normalizeValue));
     for (const g of byName.values()) {
+      // Wrong-symbol-collision guard: a value-only match (no name evidence) whose
+      // value set is a STRICT subset of the spec is most likely a deliberate
+      // subset constant (e.g. `FINISHED_STATUSES` = the terminal slice of a run-
+      // status family) rather than a renamed copy of the full enum. The
+      // "missing" complement is then just the part the subset legitimately
+      // omits, not a divergence — so withhold `missing-value` for it. Name
+      // matches and non-subset value matches still report missing normally.
+      if (valueOnlyMatch && isStrictSubset(g.values, specNormSet)) continue;
       const missing = contract.values.filter(
         (v) => !g.values.has(normalizeValue(v)) && !cloudOnlyValues.has(normalizeValue(v)),
       );
@@ -282,6 +297,15 @@ function isSynthesizedEnumShape(shape: ExtractedEnum['shape']): boolean {
 /** Strip non-alphanumeric separators and lowercase so SET_NULL ≡ SET NULL ≡ set-null. */
 function normalizeValue(v: string): string {
   return v.replace(/[^A-Za-z0-9]/g, '').toLowerCase();
+}
+
+/** True when every (normalized) value in `codeValues` is in `specNorm` AND
+ *  `codeValues` is smaller — i.e. the code set is a proper subset of the spec
+ *  value set. Both inputs are already normalized. */
+function isStrictSubset(codeValues: Set<string>, specNorm: Set<string>): boolean {
+  if (codeValues.size === 0 || codeValues.size >= specNorm.size) return false;
+  for (const v of codeValues) if (!specNorm.has(v)) return false;
+  return true;
 }
 
 function valueSetOverlap(a: string[], b: string[]): number {

--- a/packages/contract-verifier/src/extractor/index.ts
+++ b/packages/contract-verifier/src/extractor/index.ts
@@ -10,7 +10,10 @@ import type { Tree } from 'web-tree-sitter';
 import { initParsers, parseFile } from '@truecourse/analyzer';
 import { loadTcIgnore } from '@truecourse/shared';
 import { extractOperationsFromFile, extractPluginStyleRoutesFromFile, type ExtractedOperation } from './operation.js';
-import { extractFastApiOperationsFromFile } from './operation-fastapi.js';
+import {
+  extractFastApiOperationsFromFile,
+  extractStarletteRoutesFromFile,
+} from './operation-fastapi.js';
 import { eachParsedSource } from './source-walker.js';
 import { extractFileBasedRoutesFromDir } from './file-based-routes.js';
 import {
@@ -143,7 +146,11 @@ export async function extractOperationsFromDir(rootDir: string): Promise<Extract
   // (`APIRouter(prefix=…)`), so no cross-file mount graph is needed.
   await eachParsedSource(rootDir, (s) => {
     if (s.lang !== 'python') return;
-    for (const op of extractFastApiOperationsFromFile(s.filePath, s.source, s.tree)) {
+    const pythonOps = [
+      ...extractFastApiOperationsFromFile(s.filePath, s.source, s.tree),
+      ...extractStarletteRoutesFromFile(s.filePath, s.source, s.tree),
+    ];
+    for (const op of pythonOps) {
       if (!seen.has(op.identity)) {
         expressOps.push(op);
         seen.add(op.identity);

--- a/packages/contract-verifier/src/extractor/operation-fastapi.ts
+++ b/packages/contract-verifier/src/extractor/operation-fastapi.ts
@@ -32,6 +32,114 @@ interface RouterInfo {
   hasAuthDep: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Starlette route extraction
+//
+// Some Python servers (Starlette directly, and frameworks built on it) declare
+// routes as a `Route(path, endpoint, methods=[...])` list passed to a
+// `Starlette(routes=[...])` app or `Mount`, rather than via `@router.<method>`
+// decorators. The FastAPI extractor above only lifts decorator-style routes,
+// so these endpoints read as `implementation.missing` even though they ship.
+//
+// We lift every `Route("/path", endpoint, methods=[...])` call we can find:
+//   - method(s) come from the `methods=[...]` kwarg; absent → GET (Starlette's
+//     default for a Route).
+//   - Starlette path converters (`{name:int}`, `{name:path}`) are normalized to
+//     the spec-side `{name}` form so identities line up.
+//   - a trailing catch-all segment (`/{name:path}`, which matches the rest of
+//     the URL including slashes) additionally yields the static-prefix identity
+//     (`/report_asset_materialization/`), because the documented endpoint for
+//     such routes is that prefix with the key appended as a path tail. Both
+//     identities are emitted; extra code-side identities that match no spec are
+//     harmless.
+// ---------------------------------------------------------------------------
+
+export function extractStarletteRoutesFromFile(
+  filePath: string,
+  source: string,
+  tree: Tree,
+): ExtractedOperation[] {
+  const out: ExtractedOperation[] = [];
+
+  walk(tree.rootNode, (node) => {
+    if (node.type !== 'call') return;
+    const fn = node.childForFieldName('function');
+    // Starlette `Route(...)` — plain identifier callee.
+    if (fn?.type !== 'identifier' || source.slice(fn.startIndex, fn.endIndex) !== 'Route') return;
+    const args = node.childForFieldName('arguments');
+    if (!args) return;
+
+    // First positional arg must be a string path; second positional arg is the
+    // endpoint callable. This signature is what distinguishes a Starlette
+    // `Route` from any other call that happens to be named `Route`.
+    const first = args.namedChild(0);
+    if (first?.type !== 'string') return;
+    const rawPath = pyStr(first, source);
+    if (!rawPath.startsWith('/')) return;
+    const second = args.namedChild(1);
+    if (!second || second.type === 'keyword_argument') return;
+
+    const methods = readStarletteMethods(args, source);
+    const identities = starletteIdentitiesForPath(rawPath);
+    const line = node.startPosition.row + 1;
+
+    for (const method of methods) {
+      for (const path of identities) {
+        out.push({
+          identity: `${method} ${path}`,
+          contract: {
+            protocol: 'http',
+            method,
+            path,
+            responses: [],
+            tags: [],
+          } satisfies OperationContract,
+          filePath,
+          declarationLine: line,
+          observed: { queryParams: [], numericClamps: [], hasClampCall: false },
+        });
+      }
+    }
+  });
+
+  return out;
+}
+
+/** Methods from a `methods=[...]` kwarg; defaults to `['GET']` when absent. */
+function readStarletteMethods(args: SyntaxNode, source: string): string[] {
+  for (let i = 0; i < args.namedChildCount; i++) {
+    const a = args.namedChild(i);
+    if (a?.type !== 'keyword_argument') continue;
+    const name = a.childForFieldName('name');
+    if (!name || source.slice(name.startIndex, name.endIndex) !== 'methods') continue;
+    const value = a.childForFieldName('value');
+    if (value?.type !== 'list') return ['GET'];
+    const methods: string[] = [];
+    for (let j = 0; j < value.namedChildCount; j++) {
+      const el = value.namedChild(j);
+      if (el?.type === 'string') methods.push(pyStr(el, source).toUpperCase());
+    }
+    return methods.length > 0 ? methods : ['GET'];
+  }
+  return ['GET'];
+}
+
+/**
+ * Normalize a Starlette path to the identity the spec side uses.
+ * When the final segment is a catch-all (`{name:path}`, which matches the rest
+ * of the URL including slashes), the documented endpoint is the static prefix
+ * with the key appended as a path tail — so the identity is that prefix
+ * (`/report_asset_materialization/`). Otherwise the converter is stripped to the
+ * spec-side `{name}` form (`{run_id:str}` → `{run_id}`).
+ */
+function starletteIdentitiesForPath(rawPath: string): string[] {
+  const catchAll = rawPath.match(/^(\/.*\/)\{\w+:path\}$/);
+  if (catchAll) {
+    return [catchAll[1].replace(/\{(\w+):[^}]+\}/g, '{$1}')];
+  }
+  return [rawPath.replace(/\{(\w+):[^}]+\}/g, '{$1}')];
+}
+
 export function extractFastApiOperationsFromFile(
   filePath: string,
   source: string,

--- a/tests/fixtures/sample-python-project-il/code/app/routers/imports.py
+++ b/tests/fixtures/sample-python-project-il/code/app/routers/imports.py
@@ -1,0 +1,29 @@
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+from app.services.imports_service import catalog_feed_import_endpoint
+
+
+# FP-GUARD: operation/implementation-missing — must NOT drift
+# The bulk catalog-feed import is mounted as a Starlette sub-app using the
+# Route([...]) list form instead of a FastAPI decorator.  The feed key is
+# supplied as a trailing catch-all path segment (`{feed_key:path}`), so the
+# documented endpoint is the static prefix `/imports/catalog_feed/`.  The
+# verifier must lift this list-style route, normalise the catch-all tail, and
+# recognise the POST endpoint as implemented.
+routes = [
+    Route(
+        "/imports/catalog_feed/{feed_key:path}",
+        catalog_feed_import_endpoint,
+        methods=["POST"],
+    ),
+]
+
+
+# Inventory reconciliation runs entirely inside the nightly batch worker and is
+# never exposed over HTTP, so the REST endpoint the spec documents has no
+# Starlette route here — a genuine missing implementation.
+# IL-DRIFT: Operation:POST /imports/inventory_sync/ / implementation.missing
+
+
+imports_app = Starlette(routes=routes)

--- a/tests/fixtures/sample-python-project-il/code/app/services/imports_service.py
+++ b/tests/fixtures/sample-python-project-il/code/app/services/imports_service.py
@@ -1,0 +1,14 @@
+"""Endpoint backing the Starlette-mounted bulk catalog-feed import.
+
+The handler reads the catch-all feed key off the request path, streams the
+upload into the import pipeline, and returns a JSON acknowledgement.
+"""
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+
+async def catalog_feed_import_endpoint(request: Request) -> JSONResponse:
+    feed_key = request.path_params["feed_key"]
+    body = await request.body()
+    return JSONResponse({"feed_key": feed_key, "accepted_bytes": len(body)})

--- a/tests/fixtures/sample-python-project-il/code/app/services/job_notifier.py
+++ b/tests/fixtures/sample-python-project-il/code/app/services/job_notifier.py
@@ -1,0 +1,29 @@
+"""Outbound job-event notifier.
+
+A third-party notifier integration (configured out-of-repo) documents the job
+events it can fire on; this module only decides which job statuses count as
+"finished" so a single terminal notification is sent per run.
+"""
+
+
+# FP-GUARD: enum/missing-value — must NOT drift
+# `FINISHED_JOB_STATUSES` is the deliberate terminal slice of the run-status
+# family — it omits the in-flight RUNNING status by design.  The notifier
+# integration's spec enum (succeeded/failed/canceled/running) has no code-side
+# enum of its own and is value-matched to this finished subset; RUNNING's
+# absence from a *finished* set is expected, not a missing implementation, so it
+# must NOT drift.
+FINISHED_JOB_STATUSES = {"SUCCEEDED", "FAILED", "CANCELED"}
+
+
+def is_finished(status: str) -> bool:
+    return status in FINISHED_JOB_STATUSES
+
+
+# Regression guard against over-suppression: `VALID_WORKER_PHASES` value-matches
+# the spec's `scheduler.run-phases` enum but is NOT a subset of it — it both
+# omits `PAUSED` and introduces `HALTED`.  That genuine divergence must still
+# drift, for both the missing and the extra value.
+# IL-DRIFT: Enum:scheduler.run-phases / enum.scheduler.run-phases.missing-value.PAUSED
+# IL-DRIFT: Enum:scheduler.run-phases / enum.scheduler.run-phases.extra-value.HALTED
+VALID_WORKER_PHASES = ["PENDING", "ACTIVE", "HALTED", "DONE"]

--- a/tests/fixtures/sample-python-project-il/reference/contracts/imports/operations/post-imports-catalog_feed.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/imports/operations/post-imports-catalog_feed.tc
@@ -1,0 +1,4 @@
+operation POST "/imports/catalog_feed/" {
+  origin "reference/specs/modules/catalog/imports.md" "POST /imports/catalog_feed/" 1..12
+  response 200 on success
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/imports/operations/post-imports-inventory_sync.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/imports/operations/post-imports-inventory_sync.tc
@@ -1,0 +1,4 @@
+operation POST "/imports/inventory_sync/" {
+  origin "reference/specs/modules/catalog/imports.md" "POST /imports/inventory_sync/" 13..24
+  response 200 on success
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/jobs/notifier-job-events.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/jobs/notifier-job-events.tc
@@ -1,0 +1,4 @@
+enum notifier.job-events {
+  origin "reference/specs/modules/jobs/notifier.md" "Supported job events" 1..1
+  values [SUCCEEDED, FAILED, CANCELED, RUNNING]
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/jobs/scheduler-run-phases.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/jobs/scheduler-run-phases.tc
@@ -1,0 +1,4 @@
+enum scheduler.run-phases {
+  origin "reference/specs/modules/jobs/scheduler.md" "Run phases" 1..1
+  values [PENDING, ACTIVE, PAUSED, DONE]
+}


### PR DESCRIPTION
Closes #574
Closes #575

Batch fix for false-positive drifts surfaced by the deterministic `verify` against the frozen `dagster-io/dagster` contracts (storage branch `claude/drift-fp-store/dagster-io-dagster`, target ref `d05d8a4b60da5036ae1facc03b59477b506fe949`). Each fix lands in `packages/contract-verifier/src/` with a paraphrased FP-guard case (must NOT drift) and a true-drift regression case (must STILL drift) added to the Python IL fixture.

## Fixes

| drift_kind | issue | fp-guard fixture | regression fixture |
|---|---|---|---|
| operation/implementation-missing | #574 | `sample-python-project-il/code/app/routers/imports.py` (+ `services/imports_service.py`, `reference/contracts/imports/operations/post-imports-catalog_feed.tc`) | marker in `imports.py` + `reference/contracts/imports/operations/post-imports-inventory_sync.tc` |
| enum/missing-value | #575 | `sample-python-project-il/code/app/services/job_notifier.py` (`FINISHED_JOB_STATUSES`) + `reference/contracts/jobs/notifier-job-events.tc` | markers in `job_notifier.py` (`VALID_WORKER_PHASES`) + `reference/contracts/jobs/scheduler-run-phases.tc` |

## operation/implementation-missing (#574)

OSS source: [`webserver.py:335`](``https://github.com/dagster-io/dagster/blob/d05d8a4b60da5036ae1facc03b59477b506fe949/python_modules/dagster-webserver/dagster_webserver/webserver.py#L335``) (handler at [`external_assets.py:52`](``https://github.com/dagster-io/dagster/blob/d05d8a4b60da5036ae1facc03b59477b506fe949/python_modules/dagster-webserver/dagster_webserver/external_assets.py#L52))``
Cited contract: `report_asset_materialization/operations/post-reportassetmaterialization.tc` (`operation POST "/report_asset_materialization/"`)

The dagster webserver registers a Starlette route — `Route("/report_asset_materialization/{asset_key:path}", endpoint, methods=["POST"])` — as an entry in a `Route([...])` list. The Python operation extractor only lifted FastAPI decorator routes (`@router.post(...)`), so this list-style route read as `implementation.missing` even though the endpoint ships.

**Fix** (`extractor/operation-fastapi.ts` + `extractor/index.ts`): added a Starlette route extractor that lifts every `Route(path, endpoint, methods=[...])` call (defaulting to GET when `methods` is absent), normalizes Starlette path converters (`{run_id:str}` → `{run_id}`), and maps a trailing `:path` catch-all (`/{asset_key:path}`, which matches the rest of the URL) to the documented static-prefix identity (`/report_asset_materialization/`). Wired into the existing Python extraction pass alongside `extractFastApiOperationsFromFile`.

FP-guard fixture (`code/app/routers/imports.py`):
```python
routes = [
    Route(
        "/imports/catalog_feed/{feed_key:path}",
        catalog_feed_import_endpoint,
        methods=["POST"],
    ),
]
```
```
# reference/contracts/imports/operations/post-imports-catalog_feed.tc
operation POST "/imports/catalog_feed/" {
  origin "reference/specs/modules/catalog/imports.md" "POST /imports/catalog_feed/" 1..12
  response 200 on success
}
```
Regression fixture (no Starlette route → still drifts):
```python
# IL-DRIFT: Operation:POST /imports/inventory_sync/ / implementation.missing
```
```
# reference/contracts/imports/operations/post-imports-inventory_sync.tc
operation POST "/imports/inventory_sync/" { ... response 200 on success }
```

**fix_summary:** Added a Starlette `Route(...)` list-entry extractor to the Python operation extractor so list-style routes are lifted like FastAPI decorator routes. It defaults methods to GET, strips Starlette path converters to the spec `{name}` form, and treats a trailing `:path` catch-all as the documented static-prefix endpoint so the POST route binds to its contract.

## enum/missing-value (#575)

OSS sources (all four sample collisions): [`dagster_run.py:104`](``https://github.com/dagster-io/dagster/blob/d05d8a4b60da5036ae1facc03b59477b506fe949/python_modules/dagster/dagster/_core/storage/dagster_run.py#L104),`` [`pipeline.py:125`](``https://github.com/dagster-io/dagster/blob/d05d8a4b60da5036ae1facc03b59477b506fe949/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py#L125),`` [`test_sensor_run.py:1120`](``https://github.com/dagster-io/dagster/blob/d05d8a4b60da5036ae1facc03b59477b506fe949/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py#L1120),`` [`test_runs_feed.py:1268`](``https://github.com/dagster-io/dagster/blob/d05d8a4b60da5036ae1facc03b59477b506fe949/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py#L1268)``
Cited contract: `dagster-apprise/dagster-apprise.events.tc` (`values [SUCCESS, FAILURE, CANCELED, RUNNING]`)

The spec enum `dagster-apprise.events` has no code-side enum of its own (the dagster-apprise integration isn't in the repo). The comparator's value-overlap fallback bound it to finished/terminal status subset constants (`FINISHED_STATUSES`, `COMPLETED_STATUSES`, … all `[SUCCESS, FAILURE, CANCELED]`), then reported `RUNNING` as `missing-value` — but a *finished* subset omits the in-flight `RUNNING` by design. That is a wrong-symbol collision, not a divergence.

**Fix** (`comparator/enum.ts`): when the spec enum matches only by value (no name link) and the matched code constant is a **strict subset** of the spec value set, withhold `missing-value` for it — without name evidence, a proper-subset value match is indistinguishable from a deliberate subset constant. Name matches and non-subset value matches are unaffected.

FP-guard fixture (`code/app/services/job_notifier.py`):
```python
# FINISHED_JOB_STATUSES is the deliberate terminal slice — it omits RUNNING by design.
FINISHED_JOB_STATUSES = {"SUCCEEDED", "FAILED", "CANCELED"}
```
```
# reference/contracts/jobs/notifier-job-events.tc
enum notifier.job-events { ... values [SUCCEEDED, FAILED, CANCELED, RUNNING] }
```
Regression fixture (value-match that is NOT a subset → both missing and extra still drift):
```python
# IL-DRIFT: Enum:scheduler.run-phases / enum.scheduler.run-phases.missing-value.PAUSED
# IL-DRIFT: Enum:scheduler.run-phases / enum.scheduler.run-phases.extra-value.HALTED
VALID_WORKER_PHASES = ["PENDING", "ACTIVE", "HALTED", "DONE"]
```
```
# reference/contracts/jobs/scheduler-run-phases.tc
enum scheduler.run-phases { ... values [PENDING, ACTIVE, PAUSED, DONE] }
```

**fix_summary:** The enum comparator now suppresses `missing-value` when the only match is value-only (no name link) and the matched code constant is a strict subset of the spec — a finished/terminal status subset no longer produces spurious "missing" drifts for the non-terminal values it legitimately omits. The regression guard (`VALID_WORKER_PHASES`, a same-size value match that swaps one value) confirms genuine divergences still drift for both the missing and the extra value.

## Skipped this batch

- **#576 enum/no-code-counterpart** — refactor-required. The 6 FPs span three shapes (a renamed-enum *subset* of `DagsterEventType`; class families spread across separate packages — `run-launchers`/`run-coordinators`/`compute-log-managers`/`instance-storage-backends`; and a function family — `asset-decorators`). Binding the class/function families needs a codebase-wide symbol registry aggregated cross-file (a new code-fact channel), which is a refactor crossing module boundaries. Detailed evidence posted on the issue; labeled `drift-fp-blocked`.

## Drift-count delta (vs `d05d8a4b60da5036ae1facc03b59477b506fe949` on dagster-io/dagster, pinned contracts)

Measured with `node dist/cli.mjs verify --no-stash --code-dir .` against the frozen contracts, before vs. after these fixes:

| Drift-kind | Before | After | Delta |
|---|---:|---:|---:|
| operation/implementation-missing | 1 | 0 | -1 |
| enum/missing-value | 4 | 0 | -4 |
| enum/no-code-counterpart (blocked, #576) | 13 | 13 | 0 |
| **Total (these 2 fixed kinds)** | 5 | 0 | -5 |
| **All-kinds total on target** | 18 | 13 | -5 |

Both fixed kinds went to 0 and no new drifts appeared. Full `pnpm test` is green except for 5 pre-existing, environment-only failures (`verify-store.test.ts`, `spec-routes.test.ts`) that fail identically on a clean `origin/main` checkout in this sandbox because the git commit-signing server returns HTTP 400 — unrelated to these changes.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_016wqeW8M3P6DNvEJHqQAVba)_