### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/empty-object-type.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/empty-object-type.ts
@@ -25,7 +25,7 @@ export const emptyObjectTypeVisitor: CodeRuleVisitor = {
 
     if (node.type === 'type_annotation') {
       const emptyObj = checkForEmptyObject(node)
-      if (emptyObj) {
+      if (emptyObj && !isReactPropsParameter(node, filePath)) {
         return makeViolation(
           this.ruleKey, emptyObj, filePath, 'high',
           'Empty object type {}',
@@ -54,4 +54,17 @@ export const emptyObjectTypeVisitor: CodeRuleVisitor = {
 
     return null
   },
+}
+
+// `function Component(props: {})` in a React (.tsx/.jsx) file is the idiomatic
+// "this component takes no props" annotation. The framework builds the props
+// bag, so the `{}`-matches-everything footgun does not apply here — flagging it
+// is noise. Scoped to a parameter literally named `props` in a JSX file so
+// genuine `{}` misuse on other parameters / variables / return types still fires.
+function isReactPropsParameter(typeAnnotation: import('web-tree-sitter').Node, filePath: string): boolean {
+  if (!/\.(tsx|jsx)$/i.test(filePath)) return false
+  const param = typeAnnotation.parent
+  if (param?.type !== 'required_parameter' && param?.type !== 'optional_parameter') return false
+  const pattern = param.childForFieldName('pattern')
+  return pattern?.text === 'props'
 }

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/empty-pattern.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/empty-pattern.ts
@@ -10,6 +10,15 @@ export const emptyPatternVisitor: CodeRuleVisitor = {
     // Flag if the pattern has no named children (no bindings)
     const bindings = node.namedChildren.filter((c) => c.type !== 'comment')
     if (bindings.length === 0) {
+      // An empty object pattern `{}` used as a function parameter is a deliberate
+      // "ignore this argument" placeholder for a fixed callback signature —
+      // React `forwardRef((  {}, ref) => …)` render functions, test-runner
+      // fixtures (`async ({}: Ctx, use) => …`), etc. The positional slot is
+      // dictated by the framework, so it can't be removed. This mirrors ESLint's
+      // `no-empty-pattern` `allowObjectPatternsAsParameters` option. Empty
+      // patterns in variable declarations (`const {} = foo()`) and empty array
+      // patterns still bind nothing by mistake and keep firing.
+      if (node.type === 'object_pattern' && isFunctionParameter(node)) return null
       const kind = node.type === 'object_pattern' ? '{}' : '[]'
       return makeViolation(
         this.ruleKey, node, filePath, 'medium',
@@ -21,4 +30,17 @@ export const emptyPatternVisitor: CodeRuleVisitor = {
     }
     return null
   },
+}
+
+// True when `node` sits in a function's parameter list — either directly inside
+// `formal_parameters` or wrapped in a `required_parameter` / `optional_parameter`
+// (the typed form, e.g. `{}: Ctx`).
+function isFunctionParameter(node: import('web-tree-sitter').Node): boolean {
+  const parent = node.parent
+  if (!parent) return false
+  if (parent.type === 'formal_parameters') return true
+  if (parent.type === 'required_parameter' || parent.type === 'optional_parameter') {
+    return parent.parent?.type === 'formal_parameters'
+  }
+  return false
 }

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/default-parameter-position.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/default-parameter-position.ts
@@ -30,6 +30,15 @@ export const defaultParameterPositionVisitor: CodeRuleVisitor = {
         // Skip when the non-default param after a default is optional (valid TS pattern)
         const isOptional = param.type === 'optional_parameter' || param.text.includes('?')
         if (isOptional) continue
+        // Skip when the trailing required param is a destructuring pattern. Fixed-arity
+        // callback signatures (framework run/handler functions) routinely take a leading
+        // arg with a default followed by a destructured context object the caller always
+        // supplies — e.g. `(payload = {}, { ctx }) => …`. The default there is a runtime
+        // safety net, not a misplaced default, so flagging it is a false positive.
+        const patternNode = param.childForFieldName('pattern') ?? param.namedChildren[0]
+        const isDestructured = param.type === 'object_pattern' || param.type === 'array_pattern'
+          || patternNode?.type === 'object_pattern' || patternNode?.type === 'array_pattern'
+        if (isDestructured) continue
         const nameNode = param.childForFieldName('pattern') ?? param.childForFieldName('name') ?? param.namedChildren[0]
         const name = nameNode?.text ?? 'parameter'
         return makeViolation(

--- a/packages/analyzer/src/rules/performance/visitors/javascript/sync-fs-in-request-handler.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/sync-fs-in-request-handler.ts
@@ -39,6 +39,11 @@ export const syncFsInRequestHandlerVisitor: CodeRuleVisitor = {
     const lowerPath = filePath.toLowerCase()
     if (lowerPath.includes('/scripts/') || lowerPath.includes('/bin/') || lowerPath.includes('/cli/')) return null
     if (SEED_FILE_PATH_PATTERN.test(filePath)) return null
+    // A file with a shebang (`#!/usr/bin/env node`) is an executable script run
+    // directly, not a server module on a request path — dev tooling, one-off
+    // utilities, leak detectors, etc. Sync FS there blocks the script's own
+    // process, never a shared event loop, so flagging it is noise.
+    if (sourceCode.startsWith('#!')) return null
 
     if (!isInsideAsyncFunctionOrHandler(node)) return null
 

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/catch-without-error-type.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/catch-without-error-type.ts
@@ -43,6 +43,14 @@ export const catchWithoutErrorTypeVisitor: CodeRuleVisitor = {
     // them is noise.
     if (!hasBranchingConstruct(body)) return null
 
+    // Skip when the body narrows the error through a user-defined type guard,
+    // e.g. `if (!isExecaChildProcess(error)) throw error`. `instanceof`/`typeof`
+    // are not the only ways to discriminate an error — predicate functions
+    // (`isXxx` / `hasXxx` / `assertXxx`) applied to the caught binding are the
+    // idiomatic TS type-guard pattern and narrow it just as effectively.
+    const paramName = param.type === 'identifier' ? param.text : null
+    if (paramName && narrowsViaTypeGuard(body, paramName)) return null
+
     return makeViolation(
       this.ruleKey, node, filePath, 'medium',
       'Catch without error type discrimination',
@@ -51,6 +59,39 @@ export const catchWithoutErrorTypeVisitor: CodeRuleVisitor = {
       'Use instanceof checks or type guards in the catch block to handle specific error types.',
     )
   },
+}
+
+// True when `body` contains a type-guard-style call (`isXxx`/`hasXxx`/`assertXxx`)
+// that receives the caught error binding as an argument — the user-defined
+// equivalent of an `instanceof` narrowing.
+const TYPE_GUARD_NAME = /^(is|has|assert)[A-Z]/
+function narrowsViaTypeGuard(node: SyntaxNode, paramName: string): boolean {
+  if (node.type === 'call_expression') {
+    const fn = node.childForFieldName('function')
+    let calleeName: string | null = null
+    if (fn?.type === 'identifier') calleeName = fn.text
+    else if (fn?.type === 'member_expression') calleeName = fn.childForFieldName('property')?.text ?? null
+    if (calleeName && TYPE_GUARD_NAME.test(calleeName)) {
+      const args = node.childForFieldName('arguments')
+      if (args && referencesBinding(args, paramName)) return true
+    }
+  }
+  for (let i = 0; i < node.childCount; i++) {
+    const ch = node.child(i)
+    if (ch && narrowsViaTypeGuard(ch, paramName)) return true
+  }
+  return false
+}
+
+// True when `node` contains an identifier matching `name` (the bare binding or
+// the object root of a member access like `name.cause`).
+function referencesBinding(node: SyntaxNode, name: string): boolean {
+  if (node.type === 'identifier' && node.text === name) return true
+  for (let i = 0; i < node.childCount; i++) {
+    const ch = node.child(i)
+    if (ch && referencesBinding(ch, name)) return true
+  }
+  return false
 }
 
 function hasBranchingConstruct(node: SyntaxNode): boolean {

--- a/tests/fixtures/sample-js-project-negative/catch-without-error-type.ts
+++ b/tests/fixtures/sample-js-project-negative/catch-without-error-type.ts
@@ -1,0 +1,21 @@
+// A multi-statement catch block that branches on unrelated state (a retry
+// counter) and never inspects the error's type. Different failures (a transient
+// network error vs. a permanent validation error) need different handling, but
+// here they are all treated the same — the discrimination gap the rule flags.
+
+declare function attempt(): Promise<void>;
+declare const log: { error: (msg: string, err: unknown) => void };
+
+export async function withRetry(maxRetries: number): Promise<void> {
+  let remaining = maxRetries;
+  try {
+    await attempt();
+  } catch (error) {
+    // VIOLATION: reliability/deterministic/catch-without-error-type
+    if (remaining > 0) {
+      remaining -= 1;
+      await attempt();
+    }
+    log.error('giving up', error);
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/default-parameter-position.ts
+++ b/tests/fixtures/sample-js-project-negative/default-parameter-position.ts
@@ -1,0 +1,9 @@
+// A required, named parameter that appears after a parameter with a default
+// value. Callers can never benefit from the default without also passing the
+// trailing argument, so the default is effectively dead — this is the real bug
+// the rule is meant to catch.
+
+// VIOLATION: code-quality/deterministic/default-parameter-position
+export function applyDiscount(rate = 0.1, amount: number): number {
+  return amount - amount * rate;
+}

--- a/tests/fixtures/sample-js-project-negative/empty-object-type.ts
+++ b/tests/fixtures/sample-js-project-negative/empty-object-type.ts
@@ -1,0 +1,9 @@
+// Annotating a value as `{}` is almost always a mistake: the `{}` type matches
+// everything except `null`/`undefined`, so the compiler will not catch passing
+// a number or string where a real object was intended. This is the footgun the
+// rule is meant to flag.
+
+// VIOLATION: bugs/deterministic/empty-object-type
+export function mergeSettings(overrides: {}): Record<string, unknown> {
+  return { ...overrides };
+}

--- a/tests/fixtures/sample-js-project-negative/empty-pattern.ts
+++ b/tests/fixtures/sample-js-project-negative/empty-pattern.ts
@@ -1,0 +1,12 @@
+// An empty object pattern on the left of a variable declaration binds nothing —
+// the developer almost certainly meant to destructure a specific field (or to
+// drop the declaration entirely). This dead binding is the real bug the rule
+// is meant to catch.
+
+declare function loadConfig(): { host: string; port: number };
+
+export function readHost(): string {
+  // VIOLATION: bugs/deterministic/empty-pattern
+  const {} = loadConfig();
+  return 'localhost';
+}

--- a/tests/fixtures/sample-js-project-negative/sync-fs-in-request-handler.ts
+++ b/tests/fixtures/sample-js-project-negative/sync-fs-in-request-handler.ts
@@ -1,0 +1,11 @@
+// A synchronous filesystem read inside an ordinary async handler module (no
+// shebang, not a script directory). This blocks the shared event loop on every
+// invocation — the real performance bug the rule is meant to catch.
+
+import { readFileSync } from 'fs';
+
+export async function loadReport(reportPath: string): Promise<string> {
+  // VIOLATION: performance/deterministic/sync-fs-in-request-handler
+  const contents = readFileSync(reportPath, 'utf-8');
+  return contents.trim();
+}

--- a/tests/fixtures/sample-js-project-positive/catch-without-error-type-custom-guard.ts
+++ b/tests/fixtures/sample-js-project-positive/catch-without-error-type-custom-guard.ts
@@ -1,0 +1,29 @@
+// A catch block that narrows the error through a user-defined type guard
+// (`isSubprocessError(error)`) is correctly discriminating the error type —
+// `instanceof` / `typeof` are not the only ways to do so. The handler rethrows
+// anything that is not the expected shape and only formats the known case, so
+// flagging it for "no type discrimination" is a false positive.
+
+interface SubprocessError {
+  exitCode: number;
+  stderr: string;
+}
+
+declare function isSubprocessError(value: unknown): value is SubprocessError;
+declare function runCommand(args: readonly string[]): Promise<void>;
+declare const log: { error: (msg: string, meta: unknown) => void };
+
+export async function execute(args: readonly string[]): Promise<void> {
+  try {
+    await runCommand(args);
+  } catch (error) {
+    if (!isSubprocessError(error)) {
+      throw error;
+    }
+
+    log.error('command failed', {
+      exitCode: error.exitCode,
+      stderr: error.stderr,
+    });
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/default-parameter-position-destructured-callback.ts
+++ b/tests/fixtures/sample-js-project-positive/default-parameter-position-destructured-callback.ts
@@ -1,0 +1,30 @@
+// Fixed-arity callback signatures often take a leading argument with a default
+// followed by a destructured context object the runtime always supplies. The
+// default on the first parameter is a runtime safety net, not a misplaced
+// default — the second argument can never be omitted, so the usual
+// "default parameter not last" concern does not apply.
+
+interface JobPayload {
+  mode?: string;
+  attempts?: number;
+}
+
+interface RunContext {
+  signal: AbortSignal;
+}
+
+declare function defineJob(config: {
+  id: string;
+  run: (payload: JobPayload, ctx: RunContext) => Promise<string>;
+}): { id: string };
+
+declare function loadProfile(mode: string, signal: AbortSignal): Promise<string>;
+
+export const batchJob = defineJob({
+  id: 'process-batch',
+  run: async (payload: JobPayload = {}, { signal }) => {
+    const mode = payload.mode ?? 'standard';
+    if (signal.aborted) return 'aborted';
+    return await loadProfile(mode, signal);
+  },
+});

--- a/tests/fixtures/sample-js-project-positive/empty-object-type-react-props.tsx
+++ b/tests/fixtures/sample-js-project-positive/empty-object-type-react-props.tsx
@@ -1,0 +1,9 @@
+// A React component that takes no props can annotate its props parameter as
+// `{}`. The framework constructs the props bag, so the "`{}` matches everything
+// non-nullish" footgun does not apply — this is the idiomatic "no props"
+// annotation, not a type bug.
+
+export function WelcomeBanner(props: {}): JSX.Element {
+  const provided = Object.keys(props).length;
+  return <div>Welcome ({provided})</div>;
+}

--- a/tests/fixtures/sample-js-project-positive/empty-pattern-callback-parameter.ts
+++ b/tests/fixtures/sample-js-project-positive/empty-pattern-callback-parameter.ts
@@ -1,0 +1,24 @@
+// An empty object pattern `{}` used as a function parameter is a deliberate
+// placeholder for a fixed callback signature, not a binding mistake. Two common
+// shapes: a render callback whose component takes no props but still receives a
+// `ref` argument, and a test-runner fixture whose first argument is a typed
+// context object the body does not need. The positional slot is dictated by the
+// framework, so the empty pattern cannot be removed.
+
+interface FixtureContext {
+  seed: number;
+}
+
+type RenderFn = (props: Record<string, never>, ref: { current: unknown }) => string;
+type UseFn = () => Promise<void>;
+
+declare function registerRenderer(render: RenderFn): void;
+declare function defineFixture(
+  setup: (ctx: FixtureContext, use: UseFn) => Promise<void>,
+): void;
+
+registerRenderer(({}, ref) => String(ref.current));
+
+defineFixture(async ({}: FixtureContext, use) => {
+  await use();
+});

--- a/tests/fixtures/sample-js-project-positive/sync-fs-in-request-handler-shebang-script.ts
+++ b/tests/fixtures/sample-js-project-positive/sync-fs-in-request-handler-shebang-script.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+// A file with a shebang is an executable script run directly (`node file`),
+// not a server module on a request path. Synchronous filesystem calls in this
+// dev-tooling utility block only the script's own short-lived process, never a
+// shared event loop, so they are not the hazard this rule targets.
+
+import { existsSync, mkdirSync } from 'fs';
+
+declare function persistManifest(dir: string): Promise<void>;
+
+export async function ensureSnapshotDir(outputDir: string): Promise<void> {
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+  await persistManifest(outputDir);
+}


### PR DESCRIPTION
Batch of 5 analyzer false-positive fixes discovered against
[`triggerdotdev/trigger.dev`](https://github.com/triggerdotdev/trigger.dev)
at `2dd9f37b4045d2a414c0a300995d068f28926d50`. Each fix paraphrases the upstream
FP into the positive fixture (asserts zero violations), adds a true-bug case to
the negative fixture, and narrows the rule's visitor.

Closes #392
Closes #393
Closes #394
Closes #395
Closes #396

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/default-parameter-position` | #392 | `default-parameter-position-destructured-callback.ts` | `default-parameter-position.ts` |
| `performance/deterministic/sync-fs-in-request-handler` | #393 | `sync-fs-in-request-handler-shebang-script.ts` | `sync-fs-in-request-handler.ts` |
| `bugs/deterministic/empty-object-type` | #394 | `empty-object-type-react-props.tsx` | `empty-object-type.ts` |
| `reliability/deterministic/catch-without-error-type` | #395 | `catch-without-error-type-custom-guard.ts` | `catch-without-error-type.ts` |
| `bugs/deterministic/empty-pattern` | #396 | `empty-pattern-callback-parameter.ts` | `empty-pattern.ts` |

## code-quality/deterministic/default-parameter-position

OSS source: [`references/realtime-streams/src/trigger/streams.ts#L49`](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/references/realtime-streams/src/trigger/streams.ts#L49)

Positive fixture (new file):
```diff
+ // Fixed-arity callback signatures often take a leading argument with a default
+ // followed by a destructured context object the runtime always supplies. The
+ // default on the first parameter is a runtime safety net, not a misplaced
+ // default — the second argument can never be omitted, so the usual
+ // "default parameter not last" concern does not apply.
+
+ interface JobPayload {
+   mode?: string;
+   attempts?: number;
+ }
+
+ interface RunContext {
+   signal: AbortSignal;
+ }
+
+ declare function defineJob(config: {
+   id: string;
+   run: (payload: JobPayload, ctx: RunContext) => Promise<string>;
+ }): { id: string };
+
+ declare function loadProfile(mode: string, signal: AbortSignal): Promise<string>;
+
+ export const batchJob = defineJob({
+   id: 'process-batch',
+   run: async (payload: JobPayload = {}, { signal }) => {
+     const mode = payload.mode ?? 'standard';
+     if (signal.aborted) return 'aborted';
+     return await loadProfile(mode, signal);
+   },
+ });
```

Negative fixture (new file):
```diff
+ // A required, named parameter that appears after a parameter with a default
+ // value. Callers can never benefit from the default without also passing the
+ // trailing argument, so the default is effectively dead — this is the real bug
+ // the rule is meant to catch.
+
+ // VIOLATION: code-quality/deterministic/default-parameter-position
+ export function applyDiscount(rate = 0.1, amount: number): number {
+   return amount - amount * rate;
+ }
```

Visitor change: the rule no longer flags a required parameter that follows a
default when that trailing parameter is a destructuring pattern (object/array).
Fixed-arity callback signatures (framework `run`/handler functions) routinely
take a leading argument with a default followed by a destructured context object
the caller always supplies — e.g. `(payload = {}, { ctx }) => …`. The default
there is a runtime safety net, not a misplaced default. Plain named trailing
parameters (`(rate = 0.1, amount)`) still fire.

## performance/deterministic/sync-fs-in-request-handler

OSS source: [`apps/webapp/memory-leak-detector.js#L95`](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/memory-leak-detector.js#L95)

Positive fixture (new file):
```diff
+ #!/usr/bin/env node
+ // A file with a shebang is an executable script run directly (`node file`),
+ // not a server module on a request path. Synchronous filesystem calls in this
+ // dev-tooling utility block only the script's own short-lived process, never a
+ // shared event loop, so they are not the hazard this rule targets.
+
+ import { existsSync, mkdirSync } from 'fs';
+
+ declare function persistManifest(dir: string): Promise<void>;
+
+ export async function ensureSnapshotDir(outputDir: string): Promise<void> {
+   if (!existsSync(outputDir)) {
+     mkdirSync(outputDir, { recursive: true });
+   }
+   await persistManifest(outputDir);
+ }
```

Negative fixture (new file):
```diff
+ // A synchronous filesystem read inside an ordinary async handler module (no
+ // shebang, not a script directory). This blocks the shared event loop on every
+ // invocation — the real performance bug the rule is meant to catch.
+
+ import { readFileSync } from 'fs';
+
+ export async function loadReport(reportPath: string): Promise<string> {
+   // VIOLATION: performance/deterministic/sync-fs-in-request-handler
+   const contents = readFileSync(reportPath, 'utf-8');
+   return contents.trim();
+ }
```

Visitor change: in addition to the existing `/scripts/`, `/bin/`, `/cli/` and
seed-file skips, the rule now skips any file that begins with a shebang
(`#!/usr/bin/env node`). Such a file is an executable script run directly — dev
tooling, one-off utilities, leak detectors — whose sync FS blocks only the
script's own process, never a shared request event loop. Ordinary async handler
modules (no shebang) still fire.

## bugs/deterministic/empty-object-type

OSS source: [`packages/cli-v3/e2e/fixtures/monorepo-react-email/packages/email/src/emails.tsx#L4`](``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/e2e/fixtures/monorepo-react-email/packages/email/src/emails.tsx#L4)``

Positive fixture (new file):
```diff
+ // A React component that takes no props can annotate its props parameter as
+ // `{}`. The framework constructs the props bag, so the "`{}` matches everything
+ // non-nullish" footgun does not apply — this is the idiomatic "no props"
+ // annotation, not a type bug.
+
+ export function WelcomeBanner(props: {}): JSX.Element {
+   const provided = Object.keys(props).length;
+   return <div>Welcome ({provided})</div>;
+ }
```

Negative fixture (new file):
```diff
+ // Annotating a value as `{}` is almost always a mistake: the `{}` type matches
+ // everything except `null`/`undefined`, so the compiler will not catch passing
+ // a number or string where a real object was intended. This is the footgun the
+ // rule is meant to flag.
+
+ // VIOLATION: bugs/deterministic/empty-object-type
+ export function mergeSettings(overrides: {}): Record<string, unknown> {
+   return { ...overrides };
+ }
```

Visitor change: the rule no longer flags an `{}` type annotation on a parameter
literally named `props` in a React file (`.tsx`/`.jsx`). `function Component(props: {})`
is the idiomatic "this component takes no props" annotation; the framework builds
the props bag, so the `{}`-matches-everything footgun is irrelevant. Genuine `{}`
misuse on any other parameter, variable, return type, or type alias still fires.

## reliability/deterministic/catch-without-error-type

OSS source: [`apps/docker-provider/src/index.ts#L142`](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/docker-provider/src/index.ts#L142)

Positive fixture (new file):
```diff
+ // A catch block that narrows the error through a user-defined type guard
+ // (`isSubprocessError(error)`) is correctly discriminating the error type —
+ // `instanceof` / `typeof` are not the only ways to do so. The handler rethrows
+ // anything that is not the expected shape and only formats the known case, so
+ // flagging it for "no type discrimination" is a false positive.
+
+ interface SubprocessError {
+   exitCode: number;
+   stderr: string;
+ }
+
+ declare function isSubprocessError(value: unknown): value is SubprocessError;
+ declare function runCommand(args: readonly string[]): Promise<void>;
+ declare const log: { error: (msg: string, meta: unknown) => void };
+
+ export async function execute(args: readonly string[]): Promise<void> {
+   try {
+     await runCommand(args);
+   } catch (error) {
+     if (!isSubprocessError(error)) {
+       throw error;
+     }
+
+     log.error('command failed', {
+       exitCode: error.exitCode,
+       stderr: error.stderr,
+     });
+   }
+ }
```

Negative fixture (new file):
```diff
+ // A multi-statement catch block that branches on unrelated state (a retry
+ // counter) and never inspects the error's type. Different failures (a transient
+ // network error vs. a permanent validation error) need different handling, but
+ // here they are all treated the same — the discrimination gap the rule flags.
+
+ declare function attempt(): Promise<void>;
+ declare const log: { error: (msg: string, err: unknown) => void };
+
+ export async function withRetry(maxRetries: number): Promise<void> {
+   let remaining = maxRetries;
+   try {
+     await attempt();
+   } catch (error) {
+     // VIOLATION: reliability/deterministic/catch-without-error-type
+     if (remaining > 0) {
+       remaining -= 1;
+       await attempt();
+     }
+     log.error('giving up', error);
+   }
+ }
```

Visitor change: the rule now treats a user-defined type-guard call applied to the
caught binding as a valid narrowing, alongside the existing `instanceof`/`typeof`
checks. A predicate function whose name matches `is…`/`has…`/`assert…` and that
receives the caught error (e.g. `if (!isSubprocessError(error)) throw error`) is
the idiomatic TS type-guard pattern and discriminates the error just as
effectively. Catch blocks that branch without ever inspecting the error type
still fire.

## bugs/deterministic/empty-pattern

OSS sources:
- [`apps/webapp/app/routes/confirm-basic-details.tsx#L198`](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/confirm-basic-details.tsx#L198)
- [`internal-packages/run-engine/src/engine/tests/utils/engineTest.ts#L39`](``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/run-engine/src/engine/tests/utils/engineTest.ts#L39)``

Positive fixture (new file):
```diff
+ // An empty object pattern `{}` used as a function parameter is a deliberate
+ // placeholder for a fixed callback signature, not a binding mistake. Two common
+ // shapes: a render callback whose component takes no props but still receives a
+ // `ref` argument, and a test-runner fixture whose first argument is a typed
+ // context object the body does not need. The positional slot is dictated by the
+ // framework, so the empty pattern cannot be removed.
+
+ interface FixtureContext {
+   seed: number;
+ }
+
+ type RenderFn = (props: Record<string, never>, ref: { current: unknown }) => string;
+ type UseFn = () => Promise<void>;
+
+ declare function registerRenderer(render: RenderFn): void;
+ declare function defineFixture(
+   setup: (ctx: FixtureContext, use: UseFn) => Promise<void>,
+ ): void;
+
+ registerRenderer(({}, ref) => String(ref.current));
+
+ defineFixture(async ({}: FixtureContext, use) => {
+   await use();
+ });
```

Negative fixture (new file):
```diff
+ // An empty object pattern on the left of a variable declaration binds nothing —
+ // the developer almost certainly meant to destructure a specific field (or to
+ // drop the declaration entirely). This dead binding is the real bug the rule
+ // is meant to catch.
+
+ declare function loadConfig(): { host: string; port: number };
+
+ export function readHost(): string {
+   // VIOLATION: bugs/deterministic/empty-pattern
+   const {} = loadConfig();
+   return 'localhost';
+ }
```

Visitor change: the rule no longer flags an empty **object** pattern `{}` used as
a function parameter — mirroring ESLint `no-empty-pattern`'s
`allowObjectPatternsAsParameters` option. Such a pattern is a deliberate
"ignore this argument" placeholder for a fixed callback signature (React
`forwardRef(({}, ref) => …)` render functions, test-runner fixtures
`async ({}: Ctx, use) => …`), where the positional slot is dictated by the
framework. Empty patterns in variable declarations (`const {} = foo()`) and empty
array patterns still bind nothing by mistake and keep firing.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a
freshly-built `pnpm build:dist` (the exact artifact `publish.yml` ships), before
vs. after this batch's visitor edits.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/default-parameter-position` | 6 | 5 | -1 |
| `performance/deterministic/sync-fs-in-request-handler` | 24 | 18 | -6 |
| `bugs/deterministic/empty-object-type` | 1 | 0 | -1 |
| `reliability/deterministic/catch-without-error-type` | 35 | 20 | -15 |
| `bugs/deterministic/empty-pattern` | 2 | 0 | -2 |
| **Total (these 5 rules)** | 68 | 43 | -25 |
| **All-rules total on target** | 35041 | 35016 | -25 |

Every rule's count is flat or down (a negative delta is progress); no rule
increased, confirming detection of true bugs is preserved.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJCdeqGuRqj8FqWGRGCHHy)_