### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/error-swallowed-in-callback.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/error-swallowed-in-callback.ts
@@ -55,7 +55,15 @@ export const errorSwallowedInCallbackVisitor: CodeRuleVisitor = {
     let isUsed = false
 
     function scanForUsage(n: import('web-tree-sitter').Node): void {
-      if (n.type === 'identifier' && n.text === errorName) {
+      // Plain references (`error`, `error.message`) are `identifier` nodes;
+      // object-shorthand uses (`logger.debug(msg, { error })`) are
+      // `shorthand_property_identifier` nodes. Both are real uses of the param.
+      if (
+        (n.type === 'identifier' ||
+          n.type === 'shorthand_property_identifier' ||
+          n.type === 'shorthand_property_identifier_pattern') &&
+        n.text === errorName
+      ) {
         // Make sure it's not the parameter definition itself
         if (n.parent?.type !== 'required_parameter' && n.parent?.id !== params?.id) {
           isUsed = true

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/duplicate-string.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/duplicate-string.ts
@@ -2,6 +2,30 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 
+// True when the string is rendered inside JSX markup — either a direct
+// attribute value or any string embedded in a JSX `{…}` expression container
+// (e.g. `className={cond ? "ml-auto" : ""}`, `style={{ height: "100vh" }}`,
+// `to={docsPath("guides/x")}`, `{value ?? "Not set"}`). These are presentation
+// strings (CSS values, Tailwind classes, UI labels), not domain constants worth
+// extracting. The walk stops at a function boundary so strings inside inline
+// event-handler callbacks are still considered imperative code.
+function isInsideJsxMarkup(n: SyntaxNode): boolean {
+  let cur: SyntaxNode | null = n.parent
+  while (cur) {
+    if (
+      cur.type === 'arrow_function' ||
+      cur.type === 'function' ||
+      cur.type === 'function_declaration' ||
+      cur.type === 'function_expression' ||
+      cur.type === 'method_definition'
+    ) return false
+    if (cur.type === 'jsx_expression' || cur.type === 'jsx_attribute') return true
+    if (cur.type === 'program') return false
+    cur = cur.parent
+  }
+  return false
+}
+
 export const duplicateStringVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/duplicate-string',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -32,8 +56,11 @@ export const duplicateStringVisitor: CodeRuleVisitor = {
           && (parent.parent?.type === 'call_expression' || parent.parent?.type === 'new_expression')
           && /^[A-Za-z_$][A-Za-z0-9_$-]*$/.test(inner)
           && (inner.match(/-/g)?.length ?? 0) <= 2) return
-        // Skip JSX attribute values (SVG props, className, Tailwind classes)
-        if (parent?.type === 'jsx_attribute') return
+        // Skip strings rendered inside JSX markup (attribute values and any
+        // string embedded in a JSX `{…}` expression — CSS values, Tailwind
+        // classes, conditional UI labels). Presentation strings, not domain
+        // constants worth extracting.
+        if (isInsideJsxMarkup(n)) return
         // Skip type annotations and type contexts
         if (parent?.type === 'type_annotation' || parent?.type === 'type_alias_declaration'
           || parent?.type === 'property_signature' || parent?.type === 'literal_type') return

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/react-hook-setter-in-body.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/react-hook-setter-in-body.ts
@@ -73,6 +73,11 @@ export const reactHookSetterInBodyVisitor: CodeRuleVisitor = {
     if (!fn.text.startsWith('set') || fn.text.length < 4) return null
     if (!/^set[A-Z]/.test(fn.text)) return null
 
+    // Only flag setters that actually run during a React component's render —
+    // a `set`-prefixed call inside a class method or a plain module function is
+    // not a hook setter and cannot cause a render loop.
+    if (!isComponentBody(node)) return null
+
     // Make sure it's not inside useEffect or event handler
     if (isInsideEventHandlerOrEffect(node)) return null
 

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/missing-finally-cleanup.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/missing-finally-cleanup.ts
@@ -21,8 +21,11 @@ export const missingFinallyCleanupVisitor: CodeRuleVisitor = {
     const bodyText = body.text
 
     for (const method of RESOURCE_OPEN_METHODS) {
-      // Use word boundary + call syntax to avoid matching substrings (e.g. "connection" matching "connect")
-      if (new RegExp(`\\b${method}\\s*\\(`).test(bodyText)) {
+      // Require a real identifier boundary before the method name so we match
+      // whole identifiers only. `\b` treats `$` as a boundary, which wrongly
+      // matches managed-client methods like Prisma's `$connect()` as the raw
+      // `connect()` resource-open. `$` is a JS identifier char, so exclude it.
+      if (new RegExp(`(?<![\\w$])${method}\\s*\\(`).test(bodyText)) {
         // Skip createServer with .listen() — server lifecycle, not resource leak
         if (method === 'createServer' && bodyText.includes('.listen')) continue
         // Skip 'connect' and 'open' when called as method on existing object (pool/managed resource)

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/process-exit-in-library.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/process-exit-in-library.ts
@@ -13,6 +13,14 @@ export const processExitInLibraryVisitor: CodeRuleVisitor = {
     const prop = fn.childForFieldName('property')
     if (obj?.text !== 'process' || prop?.text !== 'exit') return null
 
+    // Files with a Node entry-point guard (`require.main === module`) or an ESM
+    // `import.meta.main` check are runnable scripts, not library modules —
+    // process.exit is the conventional way they terminate, regardless of the
+    // file's name.
+    if (/require\.main\s*===?\s*module|module\s*===?\s*require\.main|import\.meta\.main/.test(sourceCode)) {
+      return null
+    }
+
     // Allow in files that look like entry points
     const lowerPath = filePath.toLowerCase()
     if (

--- a/tests/fixtures/sample-js-project-negative/duplicate-string-query-fragment.ts
+++ b/tests/fixtures/sample-js-project-negative/duplicate-string-query-fragment.ts
@@ -1,0 +1,18 @@
+// A genuine duplicate-string bug: the same query fragment is repeated across
+// three builders in one file. Extracting it to a named constant deduplicates
+// the query and keeps it consistent if the schema or filter changes.
+
+declare function runQuery(sql: string): Promise<unknown>;
+
+// VIOLATION: code-quality/deterministic/duplicate-string
+export function activeReport(): Promise<unknown> {
+  return runQuery("SELECT id, label FROM accounts WHERE archived = false");
+}
+
+export function activeExport(): Promise<unknown> {
+  return runQuery("SELECT id, label FROM accounts WHERE archived = false");
+}
+
+export function activeCount(): Promise<unknown> {
+  return runQuery("SELECT id, label FROM accounts WHERE archived = false");
+}

--- a/tests/fixtures/sample-js-project-negative/error-swallowed-in-callback.ts
+++ b/tests/fixtures/sample-js-project-negative/error-swallowed-in-callback.ts
@@ -1,0 +1,14 @@
+// The error-first callback receives `err` but never checks or uses it — the
+// data is processed while failures are silently swallowed.
+
+declare function writeOut(line: string): void;
+declare const emitter: {
+  on(event: string, handler: (err: Error, data: string) => void): void;
+};
+
+export function listen(): void {
+  // VIOLATION: bugs/deterministic/error-swallowed-in-callback
+  emitter.on("data", (err, data) => {
+    writeOut(data);
+  });
+}

--- a/tests/fixtures/sample-js-project-negative/missing-finally-cleanup.ts
+++ b/tests/fixtures/sample-js-project-negative/missing-finally-cleanup.ts
@@ -1,0 +1,17 @@
+// A raw connection is opened inside the try and never released. There is no
+// `finally`, and the throwing path performs no cleanup, so an exception after
+// the open leaks the connection.
+declare function createConnection(opts: { host: string; port: number }): {
+  readable: boolean;
+  destroy(): void;
+};
+
+export function probe(host: string, port: number): boolean {
+  // VIOLATION: reliability/deterministic/missing-finally-cleanup
+  try {
+    const socket = createConnection({ host, port });
+    return socket.readable;
+  } catch {
+    return false;
+  }
+}

--- a/tests/fixtures/sample-js-project-negative/process-exit-in-library.ts
+++ b/tests/fixtures/sample-js-project-negative/process-exit-in-library.ts
@@ -1,0 +1,11 @@
+// A reusable library function that terminates the whole process on bad input.
+// This kills the caller's process instead of letting it decide how to handle
+// the failure — library code should throw an error instead. There is no
+// entry-point guard, so this file is plain library code.
+export function requireConfig(raw: string | undefined): string {
+  if (!raw) {
+    // VIOLATION: reliability/deterministic/process-exit-in-library
+    process.exit(1);
+  }
+  return raw;
+}

--- a/tests/fixtures/sample-js-project-negative/react-hook-setter-in-body.tsx
+++ b/tests/fixtures/sample-js-project-negative/react-hook-setter-in-body.tsx
@@ -1,0 +1,11 @@
+import { useState } from "react";
+
+// Calling the state setter directly in the component's render body schedules a
+// re-render on every render, producing an infinite update loop. The setter must
+// be moved into an effect, an event handler, or a callback.
+export function CounterBadge(): JSX.Element {
+  const [count, setCount] = useState(0);
+  // VIOLATION: code-quality/deterministic/react-hook-setter-in-body
+  setCount(count + 1);
+  return <span>{count}</span>;
+}

--- a/tests/fixtures/sample-js-project-positive/duplicate-string-jsx-style-values.tsx
+++ b/tests/fixtures/sample-js-project-positive/duplicate-string-jsx-style-values.tsx
@@ -1,0 +1,22 @@
+// CSS fallback values supplied inside JSX `{…}` child expressions. A viewport
+// height and a background size are presentation literals, not domain constants
+// worth extracting to a named value — repeating them as layout fallbacks inside
+// JSX markup is idiomatic, so this must not be flagged as a duplicate string.
+
+interface RowProps {
+  readonly height: string | null;
+  readonly size: string | null;
+}
+
+export function Row({ height, size }: RowProps): JSX.Element {
+  return (
+    <ul>
+      <li>{height ?? "100vh"}</li>
+      <li>{height ?? "100vh"}</li>
+      <li>{height ?? "100vh"}</li>
+      <li>{size ?? "260px auto"}</li>
+      <li>{size ?? "260px auto"}</li>
+      <li>{size ?? "260px auto"}</li>
+    </ul>
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/error-swallowed-in-callback-shorthand-log.ts
+++ b/tests/fixtures/sample-js-project-positive/error-swallowed-in-callback-shorthand-log.ts
@@ -1,0 +1,15 @@
+// The error-first callback reports its error through an object-shorthand
+// property (`{ error }`) passed to the logger. That is a real use of the
+// parameter — the error is logged, not silently swallowed — so this must not
+// be flagged.
+
+declare function logEvent(message: string, context: Record<string, unknown>): void;
+declare const emitter: {
+  on(event: string, handler: (error: Error, meta: { url: string }) => void): void;
+};
+
+export function register(): void {
+  emitter.on("request", (error, meta) => {
+    logEvent("request failed", { error, url: meta.url });
+  });
+}

--- a/tests/fixtures/sample-js-project-positive/missing-finally-cleanup-managed-client.ts
+++ b/tests/fixtures/sample-js-project-positive/missing-finally-cleanup-managed-client.ts
@@ -1,0 +1,25 @@
+// `$connect` is a method on an already-constructed, managed client (the client
+// itself is created before the try), not a raw resource-open that leaks. On the
+// failure path the catch block disconnects and rethrows; on the success path the
+// caller is handed a `stop` function that disconnects later. Cleanup is fully
+// handled without a `finally`, so this must not be flagged.
+
+interface ManagedClient {
+  $connect(): Promise<void>;
+  $disconnect(): Promise<void>;
+}
+
+declare function createManagedClient(url: string): ManagedClient;
+
+export async function openSession(url: string): Promise<() => Promise<void>> {
+  const client = createManagedClient(url);
+  try {
+    await client.$connect();
+  } catch (err) {
+    await client.$disconnect();
+    throw err;
+  }
+  return async () => {
+    await client.$disconnect();
+  };
+}

--- a/tests/fixtures/sample-js-project-positive/process-exit-in-library-self-run-guard.js
+++ b/tests/fixtures/sample-js-project-positive/process-exit-in-library-self-run-guard.js
@@ -1,0 +1,17 @@
+// A standalone CLI script. The `require.main === module` guard marks this file
+// as a runnable entry point, so terminating the process with an exit code is
+// appropriate here — this is not a reusable library module, even though its
+// filename does not match the usual entry-point naming conventions, and the
+// exit call inside the helper is reached only when the script is run directly.
+
+const runChecks = (args) => {
+  if (args.length === 0) {
+    process.exit(1);
+  }
+  return args.length;
+};
+
+if (require.main === module) {
+  const argCount = runChecks(process.argv.slice(2));
+  process.exit(argCount > 0 ? 0 : 1);
+}

--- a/tests/fixtures/sample-js-project-positive/react-hook-setter-in-body-class-method.tsx
+++ b/tests/fixtures/sample-js-project-positive/react-hook-setter-in-body-class-method.tsx
@@ -1,0 +1,24 @@
+// `setRuntimeBaseUrl` is a module-level configuration function — its name
+// starts with "set" but it is not a React state setter. It is invoked from an
+// ordinary class method (`dispatch`), never inside a component's render body.
+// The "setter called during render" infinite-loop footgun cannot apply here,
+// so this must not be flagged.
+
+const runtimeConfig = { baseUrl: "" };
+
+function setRuntimeBaseUrl(url: string): void {
+  runtimeConfig.baseUrl = url;
+}
+
+export class MessageDispatcher {
+  #baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.#baseUrl = baseUrl;
+  }
+
+  dispatch(payload: string): string {
+    setRuntimeBaseUrl(this.#baseUrl);
+    return `${runtimeConfig.baseUrl}:${payload}`;
+  }
+}


### PR DESCRIPTION
Batched false-positive fixes discovered against `triggerdotdev/trigger.dev` @ `2dd9f37b4045d2a414c0a300995d068f28926d50`.

Closes #397
Closes #398
Closes #399
Closes #400
Closes #401

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/react-hook-setter-in-body` | #397 | `react-hook-setter-in-body-class-method.tsx` | `react-hook-setter-in-body.tsx` |
| `reliability/deterministic/missing-finally-cleanup` | #398 | `missing-finally-cleanup-managed-client.ts` | `missing-finally-cleanup.ts` |
| `code-quality/deterministic/duplicate-string` | #399 | `duplicate-string-jsx-style-values.tsx` | `duplicate-string-query-fragment.ts` |
| `reliability/deterministic/process-exit-in-library` | #400 | `process-exit-in-library-self-run-guard.js` | `process-exit-in-library.ts` |
| `bugs/deterministic/error-swallowed-in-callback` | #401 | `error-swallowed-in-callback-shorthand-log.ts` | `error-swallowed-in-callback.ts` |

## code-quality/deterministic/react-hook-setter-in-body

OSS source: https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/emails/src/index.tsx#L73

Positive fixture (`tests/fixtures/sample-js-project-positive/react-hook-setter-in-body-class-method.tsx`):
```diff
+// `setRuntimeBaseUrl` is a module-level configuration function — its name
+// starts with "set" but it is not a React state setter. It is invoked from an
+// ordinary class method (`dispatch`), never inside a component's render body.
+const runtimeConfig = { baseUrl: "" };
+function setRuntimeBaseUrl(url: string): void { runtimeConfig.baseUrl = url; }
+export class MessageDispatcher {
+  #baseUrl: string;
+  constructor(baseUrl: string) { this.#baseUrl = baseUrl; }
+  dispatch(payload: string): string {
+    setRuntimeBaseUrl(this.#baseUrl);
+    return `${runtimeConfig.baseUrl}:${payload}`;
+  }
+}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/react-hook-setter-in-body.tsx`):
```diff
+import { useState } from "react";
+export function CounterBadge(): JSX.Element {
+  const [count, setCount] = useState(0);
+  // VIOLATION: code-quality/deterministic/react-hook-setter-in-body
+  setCount(count + 1);
+  return <span>{count}</span>;
+}
```

Visitor summary: the visitor already defined an `isComponentBody` helper but never called it, so it flagged *any* `set`-prefixed call. It now returns early unless the call is inside a React component (a capitalized function), so `set`-prefixed module functions invoked from class methods are no longer flagged.

## reliability/deterministic/missing-finally-cleanup

OSS source: https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/testcontainers/src/webapp.ts#L196

Positive fixture (`tests/fixtures/sample-js-project-positive/missing-finally-cleanup-managed-client.ts`):
```diff
+interface ManagedClient { $connect(): Promise<void>; $disconnect(): Promise<void>; }
+declare function createManagedClient(url: string): ManagedClient;
+export async function openSession(url: string): Promise<() => Promise<void>> {
+  const client = createManagedClient(url);
+  try {
+    await client.$connect();
+  } catch (err) {
+    await client.$disconnect();
+    throw err;
+  }
+  return async () => { await client.$disconnect(); };
+}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/missing-finally-cleanup.ts`):
```diff
+declare function createConnection(opts: { host: string; port: number }): { readable: boolean; destroy(): void };
+export function probe(host: string, port: number): boolean {
+  // VIOLATION: reliability/deterministic/missing-finally-cleanup
+  try {
+    const socket = createConnection({ host, port });
+    return socket.readable;
+  } catch {
+    return false;
+  }
+}
```

Visitor summary: the resource-open detection used `\bconnect\s*\(`, but `\b` treats `$` as a word boundary, so Prisma's managed-client method `$connect()` matched the raw `connect()` resource-open. The regex now uses a `(?<[\w$])` lookbehind so `$`-prefixed managed-client methods are not treated as raw opens; the existing `.connect()` method skip already covered the rest.

## code-quality/deterministic/duplicate-string

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/BackgroundWrapper.tsx#L14
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/BlankStatePanels.tsx#L266
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/SetupCommands.tsx#L86
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/admin/FlagControls.tsx#L22
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/admin/debugRun.tsx#L241

Positive fixture (`tests/fixtures/sample-js-project-positive/duplicate-string-jsx-style-values.tsx`):
```diff
+interface RowProps { readonly height: string | null; readonly size: string | null; }
+export function Row({ height, size }: RowProps): JSX.Element {
+  return (
+    <ul>
+      <li>{height ?? "100vh"}</li>
+      <li>{height ?? "100vh"}</li>
+      <li>{height ?? "100vh"}</li>
+      <li>{size ?? "260px auto"}</li>
+      <li>{size ?? "260px auto"}</li>
+      <li>{size ?? "260px auto"}</li>
+    </ul>
+  );
+}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/duplicate-string-query-fragment.ts`):
```diff
+declare function runQuery(sql: string): Promise<unknown>;
+// VIOLATION: code-quality/deterministic/duplicate-string
+export function activeReport(): Promise<unknown> {
+  return runQuery("SELECT id, label FROM accounts WHERE archived = false");
+}
+export function activeExport(): Promise<unknown> {
+  return runQuery("SELECT id, label FROM accounts WHERE archived = false");
+}
+export function activeCount(): Promise<unknown> {
+  return runQuery("SELECT id, label FROM accounts WHERE archived = false");
+}
```

Visitor summary: the rule already exempted strings whose direct parent is a `jsx_attribute`, but the FP strings were nested one level deeper inside JSX `{…}` expression containers (style values, `className` ternaries, `cn(...)` args, `to={docsPath(...)}`, `{x ?? "Not set"}`). A new `isInsideJsxMarkup` ancestor check extends the same intent to any string embedded in JSX markup, stopping at function boundaries so strings inside inline event-handler callbacks are still considered imperative code.

## reliability/deterministic/process-exit-in-library

OSS source: https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/memory-leak-detector.js#L950

Positive fixture (`tests/fixtures/sample-js-project-positive/process-exit-in-library-self-run-guard.js`):
```diff
+const runChecks = (args) => {
+  if (args.length === 0) { process.exit(1); }
+  return args.length;
+};
+if (require.main === module) {
+  const argCount = runChecks(process.argv.slice(2));
+  process.exit(argCount > 0 ? 0 : 1);
+}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/process-exit-in-library.ts`):
```diff
+export function requireConfig(raw: string | undefined): string {
+  if (!raw) {
+    // VIOLATION: reliability/deterministic/process-exit-in-library
+    process.exit(1);
+  }
+  return raw;
+}
```

Visitor summary: the rule only recognized entry points by file *path*. A file with a Node `require.main === module` (or ESM `import.meta.main`) guard is a runnable script regardless of its filename, so the visitor now treats any such file as an entry point and does not flag `process.exit()` in it.

## bugs/deterministic/error-swallowed-in-callback

OSS source: https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/entry.server.tsx#L211

Positive fixture (`tests/fixtures/sample-js-project-positive/error-swallowed-in-callback-shorthand-log.ts`):
```diff
+declare function logEvent(message: string, context: Record<string, unknown>): void;
+declare const emitter: { on(event: string, handler: (error: Error, meta: { url: string }) => void): void };
+export function register(): void {
+  emitter.on("request", (error, meta) => {
+    logEvent("request failed", { error, url: meta.url });
+  });
+}
```

Negative fixture (`tests/fixtures/sample-js-project-negative/error-swallowed-in-callback.ts`):
```diff
+declare function writeOut(line: string): void;
+declare const emitter: { on(event: string, handler: (err: Error, data: string) => void): void };
+export function listen(): void {
+  // VIOLATION: bugs/deterministic/error-swallowed-in-callback
+  emitter.on("data", (err, data) => {
+    writeOut(data);
+  });
+}
```

Visitor summary: the usage scan only matched `identifier` nodes, so an error parameter used solely via object shorthand (`logger.debug(msg, { error })`) was missed because shorthand produces a `shorthand_property_identifier` node. The scan now also counts `shorthand_property_identifier` / `shorthand_property_identifier_pattern` references as real uses.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a fresh `pnpm build:dist` — the exact artifact publish.yml ships.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/react-hook-setter-in-body` | 4 | 3 | -1 |
| `reliability/deterministic/missing-finally-cleanup` | 2 | 1 | -1 |
| `code-quality/deterministic/duplicate-string` | 196 | 173 | -23 |
| `reliability/deterministic/process-exit-in-library` | 41 | 38 | -3 |
| `bugs/deterministic/error-swallowed-in-callback` | 5 | 4 | -1 |
| **Total (these 5 rules)** | 248 | 219 | -29 |
| **All-rules total on target** | 35016 | 34987 | -29 |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_018xYo7A3dLQyX5oRz3sbvgN)_