### PR TITLE
contract-extractor: don't emit enums for code-symbol lists

### DIFF
--- a/packages/contract-extractor/src/prompt.ts
+++ b/packages/contract-extractor/src/prompt.ts
@@ -705,6 +705,27 @@ data document. If \`Entity:Customer\` references \`Enum:LoyaltyTier\` and the sa
 slice contains "LoyaltyTier values: standard, silver, gold", emit BOTH the entity
 fragment AND the enum fragment.
 
+**An enum is a closed set of DATA VALUES the code compares against** (the
+string/number literals a field is set to or checked against) — NOT a catalog of
+code symbols a caller picks between. Before emitting, check what the listed items
+ARE. Emit nothing when the list is:
+
+- **Implementation / plugin classes** — e.g. "run launchers: \`DefaultRunLauncher\`,
+  \`DockerRunLauncher\`, \`K8sRunLauncher\`", storage backends, compute-log managers.
+  These are swappable extension points (a user can add their own); the items are
+  class names, not a closed value set.
+- **API functions, decorators, or methods** — e.g. "asset decorators: \`asset\`,
+  \`multi_asset\`, \`graph_asset\`". These are symbols a user calls, not values.
+- **An incidental excerpt** — a few items quoted inside a troubleshooting,
+  example, or how-to passage ("relevant event types: …") rather than a
+  definitional "the valid values of X are …". A subset mentioned in passing is
+  not an enum definition.
+
+Discriminator: if the items are **names of code symbols** (classes / functions a
+caller selects), do NOT emit an enum. Only emit when the items are **literal data
+values** the code stores or compares against (config keys, status strings, tag
+keys, numeric codes).
+
 **Never reference an enum without defining it.** Every \`Enum:X\` identifier you
 emit (in \`field: Enum:X\` or \`states Enum:X\`) MUST have a matching \`enum X { … }\`
 artifact somewhere in the same slice (or you must assume another slice provides


### PR DESCRIPTION
## Why

The dagster campaign got stuck (#579) on 6 `enum/*.no-code-counterpart` drifts that aren't verifier bugs — they're **bad contracts**. The generator's enum-extraction rule (`prompt.ts:686`) fires on any bare list (`X: a | b | c`) with **no guard on what the items are**, so documentation that lists implementation classes or API functions became closed `enum` contracts the code never defines.

The actual frozen dagster contracts show it plainly:

```
enum dagster.run-launchers   { values [DefaultRunLauncher, DockerRunLauncher, K8sRunLauncher] }  ← class names
enum dagster.asset-decorators { values [asset, multi_asset, graph_asset, graph_multi_asset] }     ← function names
enum dagster.step-event-types { origin "…/troubleshooting/…" values [STEP_START, …] }             ← incidental excerpt
```

`run-launchers` / `compute-log-managers` / `instance-storage-backends` / `run-coordinators` are **plugin extension points** (a user writes their own — there is no closed set); `asset-decorators` is a **list of API functions**; `step-event-types` is a **few values quoted in a troubleshooting doc**, not a definition. Forcing these into `enum` contracts asserts a closed value set the code deliberately doesn't make.

This is the same class as prefect #552/#553 and directus #516 — fixed **upstream in generation** (#555, #518), never in the verifier. Teaching the verifier to reverse-engineer "a family of plugin classes across packages" into a synthesized enum would be the *workaround*: it manufactures a closed set to satisfy a contract that should never have been closed.

## What

Add a negative grounding rule with one discriminator: **an enum is a closed set of DATA VALUES the code compares against** (status strings, config keys, tag keys, numeric codes), **not a catalog of code symbols a caller picks between**. Skip:

- implementation / plugin class lists (run launchers, storage backends, compute-log managers),
- API function / decorator / method lists (asset decorators),
- incidental excerpts (a few values quoted in a troubleshooting/example passage).

That same data-value-vs-symbol-name discriminator is also *why this rule is safe*: the dagster cases whose items are real data strings (`automatic-run-tags`, `standard-metadata-keys`, `workspace-load-methods`) stay enums — they're handled on the verifier side by #`claude/fix-py-constant-cluster-extraction`.

## Validation — honest scope

Prompt-only change. The contract-extractor cache is keyed on the system-prompt hash, so this forces re-extraction on the next dagster regenerate. **It cannot be proven by a local deterministic test** — confirmation requires a regen run (the cloud `drift-fp-generate` routine). Builds clean; no snapshot test asserts this prompt text.

## After merge

Delete the dagster storage branch → re-run `drift-fp-generate`. The 6 plugin/API-list enums won't be created; the regenerated corpus carries only genuine data-value enums.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_