### PR TITLE
contract-verifier: resolve Python f-string constants + cluster by value prefix

### DIFF
--- a/packages/contract-verifier/src/comparator/enum.ts
+++ b/packages/contract-verifier/src/comparator/enum.ts
@@ -290,7 +290,8 @@ function isSynthesizedEnumShape(shape: ExtractedEnum['shape']): boolean {
   return (
     shape === 'sibling-id-literal' ||
     shape === 'py-instance-registry' ||
-    shape === 'py-discriminated-union'
+    shape === 'py-discriminated-union' ||
+    shape === 'py-constant-cluster'
   );
 }
 

--- a/packages/contract-verifier/src/extractor/constant/py-constants.ts
+++ b/packages/contract-verifier/src/extractor/constant/py-constants.ts
@@ -18,6 +18,7 @@
 
 import type { Node as SyntaxNode, Tree } from 'web-tree-sitter';
 import type { ExtractedConstant } from './types.js';
+import { collectStringConstantTable, stringValue } from '../py-string-resolver.js';
 
 const UNPARSEABLE = Symbol('unparseable');
 
@@ -28,6 +29,12 @@ export function extractPyConstantsFromFile(
 ): ExtractedConstant[] {
   const out: ExtractedConstant[] = [];
 
+  // Module-level string-constant table used to resolve f-strings like
+  // `SCHEDULE_NAME_TAG = f"{SYSTEM_TAG_PREFIX}/schedule_name"`. Built once per
+  // file; passed through `parseLiteral` so any string-typed literal (including
+  // dict values + Field defaults) gets the same resolution.
+  const stringTable = collectStringConstantTable(tree.rootNode, source);
+
   // Pass A: Pydantic settings-class fields. A class whose `model_config`
   // declares an env scope (`build_settings_config(("server",))` or
   // `SettingsConfigDict(env_prefix="...")`) exposes each `field = Field(default=v)`
@@ -36,7 +43,7 @@ export function extractPyConstantsFromFile(
   // identity via a value-gated suffix match (shape `settings-field`).
   walk(tree.rootNode, (node) => {
     if (node.type === 'class_definition') {
-      out.push(...extractSettingsFields(node, source, filePath));
+      out.push(...extractSettingsFields(node, source, filePath, stringTable));
     }
     return true;
   });
@@ -52,7 +59,7 @@ export function extractPyConstantsFromFile(
     const pos = { filePath, lineStart: node.startPosition.row + 1, lineEnd: node.endPosition.row + 1 };
 
     // Case 1: plain literal RHS (existing behavior for both bare and typed assignments)
-    const value = parseLiteral(right, source);
+    const value = parseLiteral(right, source, stringTable);
     if (value !== UNPARSEABLE) {
       out.push({ name, value, shape: 'const-literal', source: pos });
       return true;
@@ -80,9 +87,9 @@ export function extractPyConstantsFromFile(
       if (!kwName || !kwVal) continue;
       const kw = source.slice(kwName.startIndex, kwName.endIndex);
       if (kw === 'default' && defaultVal === UNPARSEABLE) {
-        defaultVal = parseLiteral(kwVal, source);
+        defaultVal = parseLiteral(kwVal, source, stringTable);
       } else if (kw === 'validation_alias') {
-        aliasStrings.push(...extractAliasChoiceStrings(kwVal, source));
+        aliasStrings.push(...extractAliasChoiceStrings(kwVal, source, stringTable));
       }
     }
 
@@ -119,11 +126,12 @@ function extractSettingsFields(
   classNode: SyntaxNode,
   source: string,
   filePath: string,
+  stringTable: Map<string, SyntaxNode>,
 ): ExtractedConstant[] {
   const body = classNode.childForFieldName('body');
   if (!body) return [];
 
-  const scope = deriveSettingsScope(body, source);
+  const scope = deriveSettingsScope(body, source, stringTable);
   if (scope === null) return [];
 
   const out: ExtractedConstant[] = [];
@@ -141,7 +149,7 @@ function extractSettingsFields(
 
     const right = assign.childForFieldName('right');
     if (!right) continue;
-    const value = fieldDefaultValue(right, source);
+    const value = fieldDefaultValue(right, source, stringTable);
     if (value === UNPARSEABLE) continue;
 
     const name = `${scope}_${fieldName}`.toUpperCase();
@@ -158,7 +166,11 @@ function extractSettingsFields(
 /** The scope string for a settings class, or null if the class is not a
  *  recognizable settings class. `("worker","webserver")` → `"worker_webserver"`;
  *  `env_prefix="SERVER_"` → `"server"`. */
-function deriveSettingsScope(body: SyntaxNode, source: string): string | null {
+function deriveSettingsScope(
+  body: SyntaxNode,
+  source: string,
+  stringTable: Map<string, SyntaxNode>,
+): string | null {
   for (let i = 0; i < body.namedChildCount; i++) {
     const stmt = body.namedChild(i);
     if (stmt?.type !== 'expression_statement') continue;
@@ -179,7 +191,7 @@ function deriveSettingsScope(body: SyntaxNode, source: string): string | null {
       const kw = arg.childForFieldName('name');
       const val = arg.childForFieldName('value');
       if (kw && val && source.slice(kw.startIndex, kw.endIndex) === 'env_prefix' && val.type === 'string') {
-        const prefix = stringValue(val, source);
+        const prefix = stringValue(val, source, stringTable);
         if (prefix) return prefix.replace(/_+$/, '').toLowerCase();
       }
     }
@@ -192,7 +204,7 @@ function deriveSettingsScope(body: SyntaxNode, source: string): string | null {
       for (let k = 0; k < arg.namedChildCount; k++) {
         const el = arg.namedChild(k);
         if (el?.type === 'string') {
-          const v = stringValue(el, source);
+          const v = stringValue(el, source, stringTable);
           if (v) parts.push(v);
         }
       }
@@ -205,8 +217,12 @@ function deriveSettingsScope(body: SyntaxNode, source: string): string | null {
 /** Value of a settings field's RHS: a bare literal, or the `default=` of a
  *  `Field(...)` / `Field(default_factory=...)` call. Returns UNPARSEABLE when
  *  there's no static literal default. */
-function fieldDefaultValue(right: SyntaxNode, source: string): unknown {
-  const direct = parseLiteral(right, source);
+function fieldDefaultValue(
+  right: SyntaxNode,
+  source: string,
+  stringTable: Map<string, SyntaxNode>,
+): unknown {
+  const direct = parseLiteral(right, source, stringTable);
   if (direct !== UNPARSEABLE) return direct;
   if (right.type !== 'call') return UNPARSEABLE;
   const fn = right.childForFieldName('function');
@@ -219,16 +235,20 @@ function fieldDefaultValue(right: SyntaxNode, source: string): unknown {
     const kw = arg.childForFieldName('name');
     const val = arg.childForFieldName('value');
     if (kw && val && source.slice(kw.startIndex, kw.endIndex) === 'default') {
-      return parseLiteral(val, source);
+      return parseLiteral(val, source, stringTable);
     }
   }
   return UNPARSEABLE;
 }
 
-function parseLiteral(node: SyntaxNode, source: string): unknown {
+function parseLiteral(
+  node: SyntaxNode,
+  source: string,
+  stringTable?: Map<string, SyntaxNode>,
+): unknown {
   switch (node.type) {
     case 'string': {
-      const v = stringValue(node, source);
+      const v = stringValue(node, source, stringTable);
       return v === null ? UNPARSEABLE : v;
     }
     case 'integer':
@@ -251,7 +271,7 @@ function parseLiteral(node: SyntaxNode, source: string): unknown {
       for (let i = 0; i < node.namedChildCount; i++) {
         const c = node.namedChild(i);
         if (!c) continue;
-        const v = parseLiteral(c, source);
+        const v = parseLiteral(c, source, stringTable);
         if (v === UNPARSEABLE) return UNPARSEABLE;
         items.push(v);
       }
@@ -266,10 +286,10 @@ function parseLiteral(node: SyntaxNode, source: string): unknown {
         const valNode = pair.childForFieldName('value');
         if (!keyNode || !valNode) continue;
         let key: string | null = null;
-        if (keyNode.type === 'string') key = stringValue(keyNode, source);
+        if (keyNode.type === 'string') key = stringValue(keyNode, source, stringTable);
         else if (keyNode.type === 'identifier') key = source.slice(keyNode.startIndex, keyNode.endIndex);
         if (key === null) return UNPARSEABLE;
-        const v = parseLiteral(valNode, source);
+        const v = parseLiteral(valNode, source, stringTable);
         if (v === UNPARSEABLE) return UNPARSEABLE;
         obj[key] = v;
       }
@@ -283,7 +303,11 @@ function parseLiteral(node: SyntaxNode, source: string): unknown {
 
 // Extracts plain string literals from AliasChoices(AliasPath("x"), "alias1", "alias2").
 // AliasPath calls are skipped — only flat string aliases are returned.
-function extractAliasChoiceStrings(node: SyntaxNode, source: string): string[] {
+function extractAliasChoiceStrings(
+  node: SyntaxNode,
+  source: string,
+  stringTable: Map<string, SyntaxNode>,
+): string[] {
   if (node.type !== 'call') return [];
   const fn = node.childForFieldName('function');
   if (!fn) return [];
@@ -295,29 +319,11 @@ function extractAliasChoiceStrings(node: SyntaxNode, source: string): string[] {
   for (let i = 0; i < args.namedChildCount; i++) {
     const c = args.namedChild(i);
     if (c?.type === 'string') {
-      const v = stringValue(c, source);
+      const v = stringValue(c, source, stringTable);
       if (v !== null) result.push(v);
     }
   }
   return result;
-}
-
-function stringValue(node: SyntaxNode, source: string): string | null {
-  let content = '';
-  let sawContent = false;
-  for (let i = 0; i < node.namedChildCount; i++) {
-    const c = node.namedChild(i);
-    if (c?.type === 'string_content') {
-      content += source.slice(c.startIndex, c.endIndex);
-      sawContent = true;
-    } else if (c?.type === 'interpolation') {
-      return null;
-    }
-  }
-  if (sawContent) return content;
-  const raw = source.slice(node.startIndex, node.endIndex);
-  const m = raw.match(/^[a-zA-Z]*('''|"""|'|")([\s\S]*)\1$/);
-  return m ? m[2] : null;
 }
 
 function walk(node: SyntaxNode, visit: (n: SyntaxNode) => boolean | void): void {

--- a/packages/contract-verifier/src/extractor/enum/py-enums.ts
+++ b/packages/contract-verifier/src/extractor/enum/py-enums.ts
@@ -16,6 +16,7 @@
 
 import type { Node as SyntaxNode, Tree } from 'web-tree-sitter';
 import type { ExtractedEnum, EnumShape } from './types.js';
+import { collectStringConstantTable, stringValue } from '../py-string-resolver.js';
 
 const ENUM_CONVENTION_NAME = /^(?:VALID|ALLOWED|KNOWN|ENUM)_/i;
 const ENUM_CONVENTION_SUFFIX = /_(?:VALUES|SET|CLASSIFICATIONS|STATUSES|KINDS|TYPES|OPTIONS|CHOICES)$/i;
@@ -26,6 +27,7 @@ export function extractPyEnumsFromFile(
   tree: Tree,
 ): ExtractedEnum[] {
   const out: ExtractedEnum[] = [];
+  const stringTable = collectStringConstantTable(tree.rootNode, source);
   walk(tree.rootNode, (node) => {
     if (node.type === 'class_definition') {
       const decl = extractEnumClass(node, filePath, source);
@@ -41,6 +43,7 @@ export function extractPyEnumsFromFile(
   });
   out.push(...synthesizeInstanceRegistryEnum(tree.rootNode, filePath, source));
   out.push(...synthesizeDiscriminatedUnionEnum(tree.rootNode, filePath, source));
+  out.push(...synthesizeConstantClusterEnums(tree.rootNode, filePath, source, stringTable));
   return out;
 }
 
@@ -206,6 +209,125 @@ function collectTypeIdentifiers(node: SyntaxNode, out: string[], source: string)
 // those names as values, so the comparator binds it (by value-set) to a spec
 // enum like `CachePolicies`.
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Module-level constant cluster → enum
+//
+// Documented value sets are often realized as a cluster of UPPER_SNAKE_CASE
+// module-level string constants sharing a common value prefix — frequently
+// built via f-strings off a single PREFIX constant:
+//
+//   SYSTEM_TAG_PREFIX = "dagster"
+//   SCHEDULE_NAME_TAG = f"{SYSTEM_TAG_PREFIX}/schedule_name"
+//   PARTITION_NAME_TAG = f"{SYSTEM_TAG_PREFIX}/partition"
+//   ...
+//
+// The shared value prefix is the signal — it identifies the constants as a
+// single namespace of allowed values, not a coincidental co-location. We pull
+// the longest common value prefix (length ≥ MIN_PREFIX), require at least
+// MIN_CLUSTER_MEMBERS string constants under that prefix, and emit one enum
+// with the resolved string values. The synthesized name keeps the prefix so a
+// later value-overlap match (Jaccard ≥ 0.6) binds it to a spec enum like
+// `dagster.automatic-run-tags`. Shape `py-constant-cluster` is heuristic, so
+// the comparator treats it like other synthesized shapes — name+overlap
+// matching is fine, but `extra-value` is suppressed against it.
+// ---------------------------------------------------------------------------
+
+const MIN_PREFIX = 6;
+const MIN_CLUSTER_MEMBERS = 3;
+const MAX_CLUSTER_MEMBERS = 200;
+
+function synthesizeConstantClusterEnums(
+  root: SyntaxNode,
+  filePath: string,
+  source: string,
+  stringTable: Map<string, SyntaxNode>,
+): ExtractedEnum[] {
+  // Collect (name → resolved string value) for every module-level string
+  // constant. The table already canonicalises f-strings via the shared
+  // resolver, so we can read each entry as a plain literal here.
+  const named: Array<{ name: string; value: string }> = [];
+  for (const [name, node] of stringTable) {
+    const v = stringValue(node, source, stringTable);
+    if (v === null) continue;
+    named.push({ name, value: v });
+  }
+  if (named.length < MIN_CLUSTER_MEMBERS) return [];
+
+  // Partition by longest-shared value prefix of length ≥ MIN_PREFIX.
+  // Sort by value first so members of the same prefix are contiguous, then
+  // collapse the longest-common-prefix run into a cluster. A trivial prefix
+  // (the empty string, or a too-short fragment) yields no cluster.
+  named.sort((a, b) => (a.value < b.value ? -1 : a.value > b.value ? 1 : 0));
+
+  const clusters: Array<{ prefix: string; members: typeof named }> = [];
+  let i = 0;
+  while (i < named.length) {
+    let j = i + 1;
+    let prefix = named[i].value;
+    while (j < named.length) {
+      const next = commonPrefix(prefix, named[j].value);
+      if (next.length < MIN_PREFIX) break;
+      prefix = next;
+      j++;
+    }
+    if (j - i >= MIN_CLUSTER_MEMBERS && j - i <= MAX_CLUSTER_MEMBERS && prefix.length >= MIN_PREFIX) {
+      clusters.push({ prefix, members: named.slice(i, j) });
+    }
+    i = j === i + 1 ? i + 1 : j;
+  }
+
+  // Refuse a cluster whose values aren't a real namespace — `"hello world A"`
+  // and `"hello world B"` would share an 11-char prefix without being a value
+  // family. Require either a delimiter (`/`, `-`, `_`, `.`, `:`) at the
+  // boundary, or that every value's tail past the shared prefix is a clean
+  // identifier-shaped token. Either way the prefix has to look like a real
+  // namespace boundary, not a coincidental substring overlap.
+  //
+  // Drop "no-tail" members first: when one constant's value IS the shared
+  // prefix (e.g. `SYSTEM_TAG_PREFIX = "dagster"` paired with
+  // `SCHEDULE_NAME_TAG = f"{SYSTEM_TAG_PREFIX}/schedule_name"`), that constant
+  // is the *building block*, not a member of the value set. Re-derive the
+  // common prefix from the remaining members so the namespace boundary
+  // (`"dagster/"`) lands correctly, then guard.
+  const out: ExtractedEnum[] = [];
+  for (const cluster of clusters) {
+    const realMembers = cluster.members.filter((m) => m.value.length > cluster.prefix.length);
+    if (realMembers.length < MIN_CLUSTER_MEMBERS) continue;
+    let prefix = realMembers[0].value;
+    for (let k = 1; k < realMembers.length; k++) {
+      prefix = commonPrefix(prefix, realMembers[k].value);
+      if (prefix.length < MIN_PREFIX) break;
+    }
+    if (prefix.length < MIN_PREFIX) continue;
+    const trailingDelim = /[/\-_.:]$/.test(prefix);
+    const allCleanTails =
+      trailingDelim ||
+      realMembers.every((m) => /^[A-Za-z0-9_\-./:]+$/.test(m.value.slice(prefix.length)));
+    if (!allCleanTails) continue;
+    const trimmedName = prefix.replace(/[^A-Za-z0-9]+$/, '') || prefix;
+    const firstNode = stringTable.get(realMembers[0].name);
+    const lastNode = stringTable.get(realMembers[realMembers.length - 1].name);
+    out.push({
+      name: trimmedName,
+      values: [...new Set(realMembers.map((m) => m.value))].sort(),
+      shape: 'py-constant-cluster',
+      source: {
+        filePath,
+        lineStart: firstNode ? firstNode.startPosition.row + 1 : 1,
+        lineEnd: lastNode ? lastNode.endPosition.row + 1 : 1,
+      },
+    });
+  }
+  return out;
+}
+
+function commonPrefix(a: string, b: string): string {
+  const len = Math.min(a.length, b.length);
+  let i = 0;
+  while (i < len && a.charCodeAt(i) === b.charCodeAt(i)) i++;
+  return a.slice(0, i);
+}
 
 function synthesizeInstanceRegistryEnum(
   root: SyntaxNode,
@@ -520,27 +642,6 @@ function collectStringChildren(node: SyntaxNode, source: string): string[] {
     if (v !== null) out.push(v);
   }
   return out;
-}
-
-/** Pull the literal text of a Python `string` node (handles prefixes
- *  like f"" / r"" and triple quotes by reading the string_content). */
-function stringValue(node: SyntaxNode, source: string): string | null {
-  let content = '';
-  let sawContent = false;
-  for (let i = 0; i < node.namedChildCount; i++) {
-    const c = node.namedChild(i);
-    if (c?.type === 'string_content') {
-      content += source.slice(c.startIndex, c.endIndex);
-      sawContent = true;
-    } else if (c?.type === 'interpolation' || c?.type === 'format_specifier') {
-      return null; // f-string with interpolation isn't a literal value
-    }
-  }
-  if (sawContent) return content;
-  // Empty string ("") has no string_content child.
-  const raw = source.slice(node.startIndex, node.endIndex);
-  const m = raw.match(/^[a-zA-Z]*('''|"""|'|")([\s\S]*)\1$/);
-  return m ? m[2] : null;
 }
 
 function textOfField(node: SyntaxNode, field: string, source: string): string {

--- a/packages/contract-verifier/src/extractor/enum/types.ts
+++ b/packages/contract-verifier/src/extractor/enum/types.ts
@@ -22,6 +22,7 @@ export type EnumShape =
   | 'py-list'            // VALID_X = ['a', 'b'] (with conventional name)
   | 'py-instance-registry'    // NAME = Subclass()  ×N of a common base → enum of NAMEs
   | 'py-discriminated-union'  // Union[A, B, …] of models each with type: Literal["x"]
+  | 'py-constant-cluster'     // ≥3 module-level string constants sharing a value prefix
   | 'py-set-difference';      // NAME = set(X) - Y — transient; resolved in enum/index.ts
 
 export interface ExtractedEnum {

--- a/packages/contract-verifier/src/extractor/py-string-resolver.ts
+++ b/packages/contract-verifier/src/extractor/py-string-resolver.ts
@@ -1,0 +1,115 @@
+/**
+ * Python module-level string-constant resolver. Shared by the enum + constant
+ * extractors so an f-string built from other module-level constants resolves to
+ * a real literal value.
+ *
+ * Why it matters: dagster's documented tag keys live in code as
+ *   SYSTEM_TAG_PREFIX = "dagster"
+ *   SCHEDULE_NAME_TAG = f"{SYSTEM_TAG_PREFIX}/schedule_name"
+ *   ...
+ * Without resolution, every `*_TAG` constant looks unparseable (f-string with
+ * interpolation) and never matches a spec enum like `dagster.automatic-run-tags`.
+ * The resolver keeps the existing per-call API of `stringValue(node, source)`
+ * while letting callers thread in a name→value-node table to substitute
+ * identifier-shaped interpolations.
+ *
+ * Scope is deliberately narrow:
+ *   - Resolves only `{identifier}` interpolations (no attribute access, no
+ *     arithmetic, no method calls).
+ *   - Operates on module-level assignments collected up-front by
+ *     `collectStringConstantTable` — class-scoped or nested-function constants
+ *     are not in the table, so a stray same-named local doesn't shadow.
+ *   - Bounded depth (4) guards against cyclic references.
+ */
+
+import type { Node as SyntaxNode } from 'web-tree-sitter';
+
+const MAX_DEPTH = 4;
+
+/**
+ * Collect a module-level table of `name → string-RHS AST node` for assignments
+ * of the form
+ *   NAME = "..."        (plain literal)
+ *   NAME = f"...{X}..." (f-string — resolved lazily by `stringValue`)
+ *
+ * Only top-level assignments are included. A second assignment to the same
+ * name keeps the first (matches Python's "first definition wins" for the kind
+ * of module-level config constants this targets).
+ */
+export function collectStringConstantTable(
+  rootNode: SyntaxNode,
+  source: string,
+): Map<string, SyntaxNode> {
+  const table = new Map<string, SyntaxNode>();
+  // Module body is the rootNode itself; iterate its immediate children only.
+  for (let i = 0; i < rootNode.namedChildCount; i++) {
+    const stmt = rootNode.namedChild(i);
+    // Top-level assignments are wrapped in `expression_statement`.
+    if (stmt?.type !== 'expression_statement') continue;
+    const assign = stmt.namedChild(0);
+    if (assign?.type !== 'assignment') continue;
+    const left = assign.childForFieldName('left');
+    if (left?.type !== 'identifier') continue;
+    const right = assign.childForFieldName('right');
+    if (right?.type !== 'string') continue;
+    const name = source.slice(left.startIndex, left.endIndex);
+    if (table.has(name)) continue;
+    table.set(name, right);
+  }
+  return table;
+}
+
+/**
+ * Read a Python string-node's literal value. Handles plain strings, triple
+ * quotes, and f-strings whose `{identifier}` interpolations resolve through
+ * `table`. Returns null when any part can't be reduced to a static string.
+ */
+export function stringValue(
+  node: SyntaxNode,
+  source: string,
+  table?: Map<string, SyntaxNode>,
+): string | null {
+  return resolve(node, source, table, 0);
+}
+
+function resolve(
+  node: SyntaxNode,
+  source: string,
+  table: Map<string, SyntaxNode> | undefined,
+  depth: number,
+): string | null {
+  if (node.type !== 'string') return null;
+  if (depth > MAX_DEPTH) return null;
+
+  let content = '';
+  let sawContent = false;
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const c = node.namedChild(i);
+    if (!c) continue;
+    if (c.type === 'string_content') {
+      content += source.slice(c.startIndex, c.endIndex);
+      sawContent = true;
+      continue;
+    }
+    if (c.type === 'interpolation') {
+      // Format specifiers (`{x:>3}` / `{x!r}`) signal non-string formatting;
+      // can't reduce to a literal value.
+      if (c.namedChildren.some((g) => g?.type === 'format_specifier')) return null;
+      const expr = c.namedChild(0);
+      if (expr?.type !== 'identifier' || !table) return null;
+      const referent = table.get(source.slice(expr.startIndex, expr.endIndex));
+      if (!referent) return null;
+      const resolved = resolve(referent, source, table, depth + 1);
+      if (resolved === null) return null;
+      content += resolved;
+      sawContent = true;
+      continue;
+    }
+    if (c.type === 'format_specifier') return null;
+  }
+  if (sawContent) return content;
+  // Empty string ("") has no string_content child.
+  const raw = source.slice(node.startIndex, node.endIndex);
+  const m = raw.match(/^[a-zA-Z]*('''|"""|'|")([\s\S]*)\1$/);
+  return m ? m[2] : null;
+}

--- a/tests/fixtures/sample-python-project-il/code/app/tag_keys.py
+++ b/tests/fixtures/sample-python-project-il/code/app/tag_keys.py
@@ -1,0 +1,42 @@
+"""
+FP-guard for `py-constant-cluster` shape (synthesized enum from a value-prefix
+cluster of module-level string constants).
+
+Pattern naturalised from real OSS — Dagster's `_core/storage/tags.py` builds
+each documented automatic-run-tag from one shared prefix constant via f-string:
+
+    SYSTEM_TAG_PREFIX = "dagster"
+    SCHEDULE_NAME_TAG = f"{SYSTEM_TAG_PREFIX}/schedule_name"
+    ...
+
+A spec enum then lists the *values* (not the constant names). Without f-string
+resolution + cluster synthesis those values look absent from the code and the
+verifier fires `no-code-counterpart`. With both the extractor synthesizes one
+enum `(value-prefix)` whose values match the contract — no drift.
+"""
+
+# Shared namespace prefix — every constant below builds off it.
+SYSTEM_TAG_PREFIX = "sample-app"
+
+# Tag keys — each f-string MUST resolve through the prefix table to a literal
+# value at extraction time. The cluster synthesis groups them by shared value
+# prefix (`sample-app/`).
+SCHEDULE_NAME_TAG = f"{SYSTEM_TAG_PREFIX}/schedule_name"
+PARTITION_NAME_TAG = f"{SYSTEM_TAG_PREFIX}/partition"
+USER_TAG = f"{SYSTEM_TAG_PREFIX}/user"
+CODE_LOCATION_TAG = f"{SYSTEM_TAG_PREFIX}/code_location"
+PARENT_RUN_ID_TAG = f"{SYSTEM_TAG_PREFIX}/parent_run_id"
+SENSOR_NAME_TAG = f"{SYSTEM_TAG_PREFIX}/sensor_name"
+
+
+def all_tag_keys() -> tuple[str, ...]:
+    """Used in production to enumerate every reserved tag — keeps the
+    constants referenced so a future linter doesn't strip them."""
+    return (
+        SCHEDULE_NAME_TAG,
+        PARTITION_NAME_TAG,
+        USER_TAG,
+        CODE_LOCATION_TAG,
+        PARENT_RUN_ID_TAG,
+        SENSOR_NAME_TAG,
+    )

--- a/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/code-location-tag/codelocationtag.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/code-location-tag/codelocationtag.tc
@@ -1,0 +1,7 @@
+constant CODE_LOCATION_TAG {
+  // inferred — policy constant defined in code but documented in no spec
+  inferred-from "app/tag_keys.py" 27..27
+  confidence high
+  type string
+  expected-value "sample-app/code_location"
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/parent-run-id-tag/parentrunidtag.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/parent-run-id-tag/parentrunidtag.tc
@@ -1,0 +1,7 @@
+constant PARENT_RUN_ID_TAG {
+  // inferred — policy constant defined in code but documented in no spec
+  inferred-from "app/tag_keys.py" 28..28
+  confidence high
+  type string
+  expected-value "sample-app/parent_run_id"
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/partition-name-tag/partitionnametag.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/partition-name-tag/partitionnametag.tc
@@ -1,0 +1,7 @@
+constant PARTITION_NAME_TAG {
+  // inferred — policy constant defined in code but documented in no spec
+  inferred-from "app/tag_keys.py" 25..25
+  confidence high
+  type string
+  expected-value "sample-app/partition"
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/schedule-name-tag/schedulenametag.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/schedule-name-tag/schedulenametag.tc
@@ -1,0 +1,7 @@
+constant SCHEDULE_NAME_TAG {
+  // inferred — policy constant defined in code but documented in no spec
+  inferred-from "app/tag_keys.py" 24..24
+  confidence high
+  type string
+  expected-value "sample-app/schedule_name"
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/sensor-name-tag/sensornametag.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/sensor-name-tag/sensornametag.tc
@@ -1,0 +1,7 @@
+constant SENSOR_NAME_TAG {
+  // inferred — policy constant defined in code but documented in no spec
+  inferred-from "app/tag_keys.py" 29..29
+  confidence high
+  type string
+  expected-value "sample-app/sensor_name"
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/system-tag-prefix/systemtagprefix.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/system-tag-prefix/systemtagprefix.tc
@@ -1,0 +1,7 @@
+constant SYSTEM_TAG_PREFIX {
+  // inferred — policy constant defined in code but documented in no spec
+  inferred-from "app/tag_keys.py" 19..19
+  confidence high
+  type string
+  expected-value "sample-app"
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/user-tag/usertag.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/user-tag/usertag.tc
@@ -1,0 +1,7 @@
+constant USER_TAG {
+  // inferred — policy constant defined in code but documented in no spec
+  inferred-from "app/tag_keys.py" 26..26
+  confidence high
+  type string
+  expected-value "sample-app/user"
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/catalog/automatic-tag-keys.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/catalog/automatic-tag-keys.tc
@@ -1,0 +1,11 @@
+enum AutomaticTagKey {
+  origin "reference/specs/modules/catalog/automatic-tags.md" "Automatic tag keys" 1..10
+  values [
+    "sample-app/schedule_name",
+    "sample-app/partition",
+    "sample-app/user",
+    "sample-app/code_location",
+    "sample-app/parent_run_id",
+    "sample-app/sensor_name",
+  ]
+}


### PR DESCRIPTION
## Why

The other half of the dagster stuck campaign (#576/#579). Three drifts are **real verifier false-positives** (ruled FP — the values genuinely exist in code): documented value sets realized as a cluster of `UPPER_SNAKE` module-level string constants built off one shared prefix via f-strings —

```python
SYSTEM_TAG_PREFIX = "dagster"
SCHEDULE_NAME_TAG = f"{SYSTEM_TAG_PREFIX}/schedule_name"
PARTITION_NAME_TAG = f"{SYSTEM_TAG_PREFIX}/partition"
...
```

Two failures compounded: (1) the f-string interpolation made every `*_TAG` unparseable (`stringValue` returned null on interpolation), and (2) even with values in hand, scattered individual constants were never offered to the comparator as a value set. So each documented tag/metadata value surfaced as a spurious `enum/no-code-counterpart`.

Unlike the 6 in #581 (plugin/API *symbol names* → bad contracts, fixed in the generator), these are genuine **data-value sets** the verifier should bind.

## What

Two scoped extractor changes:

- **`extractor/py-string-resolver.ts`** (new, shared by py-enums + py-constants) — builds a module-level `name → string-RHS` table and resolves `{identifier}` f-string interpolations by recursing through it. Depth-bounded; rejects format specifiers and non-identifier interpolations (no arithmetic / attribute access / calls). py-constants now resolves f-string-built constants and settings-field defaults too.

- **`py-constant-cluster` enum shape** (new) — synthesizes one enum per cluster of ≥3 string constants sharing a value prefix ≥6 chars. Drops the prefix constant itself before deriving the boundary, re-derives the common prefix from the remaining members, and requires a namespace-boundary delimiter (or clean identifier tails) so coincidental substring overlap doesn't cluster. Marked synthesized → comparator suppresses `extra-value` against it (heuristic superset, same rationale as `py-instance-registry`).

## Validation — proven locally

- **391/391** contract-verifier; **4241/4246** full suite (the 5 failures are the pre-existing sandbox `git commit` GPG-signing failures, identical on main).
- **Naturalistic IL fixture + contract** (`tag_keys.py` + `automatic-tag-keys.tc`) guard the pattern: a regression in either the resolver or the clusterer fires an unexpected `no-code-counterpart` and fails the marker test. The 7 resolved constants flow into the `infer` golden corpus (committed).
- **End-to-end repro** of a synthetic dagster tags namespace (9-member f-string cluster + a closed-set contract): **0 drifts** — the verifier binds the synthesized cluster.

## Honest residual

The cluster shape resolves the **2** dagster cases whose values share a clear namespace prefix (`automatic-run-tags`, `standard-metadata-keys`). The third borderline, `workspace-load-methods` (`python_file` / `python_module` / `grpc_server`), has **no shared prefix**, so it won't bind via this path. If it still fires after regen, it's a separate small follow-up (a `Literal[...]`/config-key channel), not covered here.

Independent of #581 — different package, no overlap. Both feed one dagster regeneration; the data-value enums stay enums (per #581) and then bind here.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_