### PR TITLE
fix(deploy): prod deploy job skipped — remove broken env-var guard

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -2,8 +2,8 @@ name: Deploy (prod)
 
 # Merge to main → build, push, and create-or-update the Prod Container App.
 # Same self-discovering pattern as dev; resolves to the `prod` Environment's
-# variables. Requires the prod RG provisioned + the prod Environment configured
-# (see infra/azure/README.md) — until then this job has no AZURE_RG and is skipped.
+# variables (AZURE_RG, APP_NAME). Provision the prod RG + configure the prod
+# Environment first (see infra/azure/README.md).
 on:
   push:
     branches: [main]
@@ -20,7 +20,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: prod
-    if: ${{ vars.AZURE_RG != '' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/tests/cli/analyze-csharp.test.ts
+++ b/tests/cli/analyze-csharp.test.ts
@@ -83,7 +83,7 @@ describe('CLI analyze pipeline (e2e, C#)', () => {
     const result = await analyzeInProcess(project, { enableLlmRulesOverride: false });
     expect(result.analysisId).toBeTruthy();
 
-    const latest = readLatest(workDir);
+    const latest = await readLatest(workDir);
     expect(latest).not.toBeNull();
     expect(latest!.analysis.status).toBe('completed');
 

--- a/tests/cli/analyze-csharp.test.ts
+++ b/tests/cli/analyze-csharp.test.ts
@@ -68,13 +68,13 @@ describe('CLI analyze pipeline (e2e, C#)', () => {
     execSync('git add -A', { cwd: workDir, env });
     execSync('git -c commit.gpgsign=false commit -q -m init', { cwd: workDir, env });
 
-    project = registerProject(workDir);
-    updateProjectConfig(workDir, { enableLlmRules: false });
+    project = await registerProject(workDir);
+    await updateProjectConfig(workDir, { enableLlmRules: false });
     clearLatestCache();
   }, 30_000);
 
-  afterAll(() => {
-    if (project) unregisterProject(project.slug);
+  afterAll(async () => {
+    if (project) await unregisterProject(project.slug);
     if (workDir) fs.rmSync(workDir, { recursive: true, force: true });
     clearLatestCache();
   });


### PR DESCRIPTION
deploy-prod's job-level `if: vars.AZURE_RG != ''` never sees environment-scoped variables, so it always skipped. Removed the guard; deploy-prod now runs and reads the prod Environment vars in steps (like deploy-dev). Merging this fires the first prod deploy.