### PR TITLE
ci(deploy): make dev/prod deploys opt-in, never auto

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,6 +1,9 @@
 name: Deploy (dev)
 
-# Every PR builds the image and create-or-updates the shared Dev Container App.
+# Opt-in: add the `deploy-dev` label to a PR to build its branch and
+# create-or-update the shared Dev Container App. Pushing new commits to a
+# still-labeled PR re-deploys; removing the label stops it. Nothing deploys
+# automatically on open/merge.
 # The foundation resources (ACR, Container Apps env, identity, Key Vault) are
 # discovered from the resource group at runtime, so the only variables you set are
 # the OIDC identity + AZURE_RG + APP_NAME. GitHub touches nothing in the runtime
@@ -8,6 +11,7 @@ name: Deploy (dev)
 on:
   pull_request:
     branches: [main]
+    types: [labeled, synchronize]
 
 permissions:
   id-token: write      # OIDC federated login to Azure (no stored secret)
@@ -20,6 +24,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: contains(github.event.pull_request.labels.*.name, 'deploy-dev')
     runs-on: ubuntu-latest
     environment: dev
     steps:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,12 +1,12 @@
 name: Deploy (prod)
 
-# Merge to main → build, push, and create-or-update the Prod Container App.
-# Same self-discovering pattern as dev; resolves to the `prod` Environment's
-# variables (AZURE_RG, APP_NAME). Provision the prod RG + configure the prod
-# Environment first (see infra/azure/README.md).
+# Manual only: Actions → Deploy (prod) → Run workflow (on main). Builds main's
+# current HEAD and create-or-updates the Prod Container App. Never deploys on
+# merge, and the main-only guard refuses any other branch. Resolves to the `prod`
+# Environment's variables (AZURE_RG, APP_NAME) + its required-reviewer gate.
+# Provision the prod RG + configure the prod Environment first (see infra/azure/README.md).
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: prod
     steps:

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -171,12 +171,22 @@ Create the `dev` and `prod` **Environments** (Settings → Environments) — the
 federated subjects above point at them. Add a required reviewer on `prod` for a
 manual gate before production rolls.
 
-> The workflow runs `containerapp.bicep` (create-or-update), so the **first PR
-> creates** the Container App and later PRs roll the image — the manual step 4
-> above is only needed if you'd rather create the app by hand.
+> The workflows run `containerapp.bicep` (create-or-update), so the **first
+> deploy creates** the Container App and later runs roll the image — the manual
+> step 4 above is only needed if you'd rather create the app by hand.
 
-After that: every PR deploys to **dev** (`deploy-dev.yml`), every merge to main
-deploys to **prod** (`deploy-prod.yml`).
+## Deploy triggers (both manual — nothing auto-deploys)
+
+Neither environment deploys on open or merge. You opt in each time:
+
+- **Dev (`deploy-dev.yml`)** — add the **`deploy-dev`** label to a PR. It builds
+  that PR's branch and rolls the shared Dev Container App. Pushing more commits
+  while the label is on re-deploys; remove the label to stop. (Create the label
+  once under the repo's Labels, or just type it when adding it to a PR.)
+- **Prod (`deploy-prod.yml`)** — **Actions → Deploy (prod) → Run workflow**, on
+  the **`main`** branch. It builds main's current HEAD; a `main`-only guard
+  refuses any other branch, and the `prod` Environment's required reviewer still
+  gates the rollout. Prod only ever ships merged code, never a PR branch.
 
 > If dev and prod live in **different subscriptions**, make `AZURE_SUBSCRIPTION_ID`
 > environment-scoped too.


### PR DESCRIPTION
## What

Stop auto-deploying. Neither environment deploys on PR open or merge — each is opt-in.

| Env | Before | After |
|---|---|---|
| **Dev** (`deploy-dev.yml`) | every PR | add the **`deploy-dev`** label → deploys that PR's branch; pushes while labeled re-deploy; remove the label to stop |
| **Prod** (`deploy-prod.yml`) | every merge to `main` | **manual** `workflow_dispatch` on `main` only (guarded to `refs/heads/main`); keeps the `prod` Environment required-reviewer gate |

Prod only ever ships **merged** code from `main`, never a PR branch.

## Notes

- The `workflow_dispatch` "Run workflow" button appears only once this is on `main`.
- Create a **`deploy-dev`** label in the repo (or type it when adding to a PR).
- `infra/azure/README.md` updated with the new triggers section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)