### PR TITLE
fix(drift-fp): resolve 1 drift FP from dagster-io/dagster

### DIFF
--- a/packages/contract-verifier/src/verify.ts
+++ b/packages/contract-verifier/src/verify.ts
@@ -153,6 +153,18 @@ export async function verify(opts: VerifyOptions): Promise<VerifyResult> {
       // implement them, so an implementation.missing drift here is always a false positive.
       if (/^[A-Z]+ https?:\/\//.test(artifact.ref.identity)) continue;
 
+      // Same root cause, post-relativization: when a spec lifts an absolute
+      // cloud-control-plane URL into a path identity, the host is dropped but a
+      // leading deployment-scope placeholder segment survives — e.g.
+      // "POST /[deployment]/report_asset_materialization/". The square-bracket
+      // segment is doc-placeholder notation; Express/FastAPI route declarations
+      // express path params as ":id"/"{id}", never "[id]", so a leading "/[…]/"
+      // segment marks a per-deployment hosted route served by the managed
+      // control plane, not by the OSS code under verification. Treat it as
+      // out-of-scope (the same family as the absolute-URL guard above), not an
+      // implementation.missing false positive.
+      if (/^[A-Z]+ \/\[[^\]/]+\]\//.test(artifact.ref.identity)) continue;
+
       drifts.push({
         id: cryptoRandomId(),
         type: 'contract-drift',

--- a/tests/contract-verifier/operation-lifter.test.ts
+++ b/tests/contract-verifier/operation-lifter.test.ts
@@ -72,7 +72,7 @@ describe('Contract Operation lifter', () => {
   it('every Operation in the corpus has a lifted contract', () => {
     const r = loadAll();
     const ops = [...r.index.values()].filter((a) => a.ref.type === 'Operation');
-    expect(ops.length).toBe(22);
+    expect(ops.length).toBe(24);
     for (const op of ops) {
       expect(op.contract, `Operation:${op.ref.identity} missing contract`).toBeDefined();
     }

--- a/tests/fixtures/sample-js-project-il/code/src/services/catalog-snapshot.service.ts
+++ b/tests/fixtures/sample-js-project-il/code/src/services/catalog-snapshot.service.ts
@@ -1,0 +1,29 @@
+// Catalog snapshot publishing — assembles an immutable snapshot of the
+// current catalog so downstream consumers can pin a known-good version.
+// The snapshot bytes are built locally here; the REST surface that exposes
+// them is split between the OSS build and the hosted control plane.
+
+export interface CatalogSnapshot {
+  id: string;
+  itemCount: number;
+  createdAt: Date;
+}
+
+export function buildCatalogSnapshot(items: readonly unknown[]): CatalogSnapshot {
+  return { id: `snap_${Date.now()}`, itemCount: items.length, createdAt: new Date() };
+}
+
+// FP-GUARD: operation/implementation-missing — must NOT drift
+// The hosted control plane exposes a per-workspace publish endpoint,
+// POST /[workspace]/publish_snapshot. That bracketed `[workspace]` segment
+// is a relativized cloud-deployment URL — the spec lifted it from an
+// absolute control-plane URL that carried the deployment scope in the path,
+// dropping the host but keeping the `[workspace]` placeholder. The OSS build
+// never serves a per-deployment route (those are routed by the hosted plane),
+// so the verifier must treat this identity as out-of-scope rather than emit
+// an implementation.missing drift.
+
+// The bare OSS publish endpoint, POST /publish_snapshot, is documented in the
+// spec but no route handler is registered for it in this build yet — a
+// genuine missing implementation the verifier must still report.
+// IL-DRIFT: Operation:POST /publish_snapshot / implementation.missing

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-cloud-deployment-prefix-fp-guard.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-cloud-deployment-prefix-fp-guard.tc
@@ -1,0 +1,4 @@
+operation POST "/[workspace]/publish_snapshot" {
+  origin "reference/specs/shared/endpoints.md" "Hosted control-plane snapshot endpoint (per-workspace)" 1..3
+  response 200 on success {}
+}

--- a/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-bare-publish-regression.tc
+++ b/tests/fixtures/sample-js-project-il/reference/contracts/fp-guards/operation-implementation-missing-bare-publish-regression.tc
@@ -1,0 +1,4 @@
+operation POST "/publish_snapshot" {
+  origin "reference/specs/modules/catalog/endpoints.md" "POST /publish_snapshot" 1..3
+  response 202 on success {}
+}


### PR DESCRIPTION
Resolves the open `drift-fp-fix` queue for the dagster-io/dagster campaign (1 issue this batch).

Closes #587

## Fixes

| drift_kind | issue | fp-guard fixture | regression fixture |
|---|---|---|---|
| `operation/implementation-missing` | #587 | `sample-js-project-il/.../fp-guards/operation-cloud-deployment-prefix-fp-guard.tc` + `code/src/services/catalog-snapshot.service.ts` (FP-GUARD narrative) | `sample-js-project-il/.../fp-guards/operation-implementation-missing-bare-publish-regression.tc` + `catalog-snapshot.service.ts` (IL-DRIFT marker) |

## operation/implementation-missing

**OSS source:** [`python_modules/dagster-webserver/dagster_webserver/webserver.py#L335`](``https://github.com/dagster-io/dagster/blob/c6778b93e76a1b2a24256fe6d6a0fe29dc5a91be/python_modules/dagster-webserver/dagster_webserver/webserver.py#L335``) — `Route("/report_asset_materialization/{asset_key:path}", methods=["POST"])`.

**Cited contract:** `contracts/[deployment]/operations/post-deployment-reportassetmaterialization.tc` (`operation POST "/[deployment]/report_asset_materialization/"`).

The contract operation `POST /[deployment]/report_asset_materialization/` was lifted from the **Dagster+ tab** of `docs/docs/guides/build/assets/external-assets.md`, whose `curl` example targets the absolute Cloud URL `https://[ORG].dagster.cloud/[DEPLOYMENT]/report_asset_materialization/`. The generator relativized that into a path identity, dropping the `dagster.cloud` host but keeping the `[deployment]` deployment-scope placeholder. That endpoint is served by the hosted Dagster+ control plane, **not** the OSS code under verification. The equivalent OSS endpoint **is** implemented (webserver.py:335) and is matched cleanly by the sibling OSS contract `POST /report_asset_materialization/` — so reporting the relativized variant "missing" is a verifier FP.

This is the same family as prefect PR #561 ("absolute external Cloud URLs can never match relative code routes"). The existing guard in `verify.ts` only fires on a full `https://` identity; after relativization the host is gone, so it misses. The fix adds a sibling guard:

```diff
       // Operations whose identity is an absolute URL (e.g., "GET https://api.example.com/...")
       // ... so an implementation.missing drift here is always a false positive.
       if (/^[A-Z]+ https?:\/\//.test(artifact.ref.identity)) continue;
+
+      // Same root cause, post-relativization: when a spec lifts an absolute
+      // cloud-control-plane URL into a path identity, the host is dropped but a
+      // leading deployment-scope placeholder segment survives — e.g.
+      // "POST /[deployment]/report_asset_materialization/". The square-bracket
+      // segment is doc-placeholder notation; Express/FastAPI route declarations
+      // express path params as ":id"/"{id}", never "[id]", so a leading "/[…]/"
+      // segment marks a per-deployment hosted route served by the managed
+      // control plane, not by the OSS code under verification. Treat it as
+      // out-of-scope (the same family as the absolute-URL guard above), not an
+      // implementation.missing false positive.
+      if (/^[A-Z]+ \/\[[^\]/]+\]\//.test(artifact.ref.identity)) continue;
```

**FP-guard fixture** (must NOT drift) — `operation-cloud-deployment-prefix-fp-guard.tc`:

```diff
+operation POST "/[workspace]/publish_snapshot" {
+  origin "reference/specs/shared/endpoints.md" "Hosted control-plane snapshot endpoint (per-workspace)" 1..3
+  response 200 on success {}
+}
```

with a FP-GUARD narrative (no marker) in `code/src/services/catalog-snapshot.service.ts`:

```diff
+// FP-GUARD: operation/implementation-missing — must NOT drift
+// The hosted control plane exposes a per-workspace publish endpoint,
+// POST /[workspace]/publish_snapshot. That bracketed `[workspace]` segment
+// is a relativized cloud-deployment URL — the spec lifted it from an
+// absolute control-plane URL that carried the deployment scope in the path,
+// dropping the host but keeping the `[workspace]` placeholder. The OSS build
+// never serves a per-deployment route (those are routed by the hosted plane),
+// so the verifier must treat this identity as out-of-scope rather than emit
+// an implementation.missing drift.
```

**Regression fixture** (still MUST drift) — `operation-implementation-missing-bare-publish-regression.tc`:

```diff
+operation POST "/publish_snapshot" {
+  origin "reference/specs/modules/catalog/endpoints.md" "POST /publish_snapshot" 1..3
+  response 202 on success {}
+}
```

with the IL-DRIFT marker in the same file:

```diff
+// The bare OSS publish endpoint, POST /publish_snapshot, is documented in the
+// spec but no route handler is registered for it in this build yet — a
+// genuine missing implementation the verifier must still report.
+// IL-DRIFT: Operation:POST /publish_snapshot / implementation.missing
```

The two fixtures share an endpoint name (`publish_snapshot`) and differ only by the leading `[workspace]` segment, so they pin the guard precisely on the bracketed prefix: the hosted variant is suppressed, the bare OSS variant still drifts. (`tests/contract-verifier/operation-lifter.test.ts` corpus count bumped 22 → 24 for the two new authored operation contracts.)

**fix_summary:** Extended the operation `implementation.missing` out-of-scope guard in `verify.ts` so that, in addition to full absolute-URL identities, it also skips operations whose path identity begins with a bracketed deployment-scope placeholder segment (`/[…]/`). These are relativized cloud-control-plane URLs that the OSS codebase never serves; square-bracket path segments are doc-placeholder notation never produced by Express/FastAPI route declarations. The bare OSS sibling endpoint still matches its code route and still drifts when genuinely missing.

## Drift-count delta (vs c6778b93e76a1b2a24256fe6d6a0fe29dc5a91be on dagster-io/dagster, pinned contracts)

| Drift-kind | Before | After | Delta |
|---|---:|---:|---:|
| `operation/implementation-missing`        | 1 | 0 | -1 |
| **Total (these 1 kinds)**                 | 1 | 0 | -1 |
| **All-kinds total on target**             | 2 | 1 | -1 |

Measured with `node dist/cli.mjs verify --no-stash --code-dir .` from a fresh `pnpm build:dist`, against the frozen contracts on `claude/drift-fp-store/dagster-io-dagster`. The 1 remaining drift is the `auth-requirement/unprotected` item on `/report_asset_materialization/`, documented in `campaigns.yaml` as a contract-quality artifact (the OSS route is correctly reported unprotected) — not a verifier FP, out of scope for this PR.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUkYdiPhedFh2uwT71jpmE)_