### PR TITLE
ci(notify): fix matrix-context use in job-level if (workflow load failure)

### DIFF
--- a/.github/workflows/notify-routine-activity.yml
+++ b/.github/workflows/notify-routine-activity.yml
@@ -67,26 +67,31 @@ jobs:
   # minutes, and sends ONE rollup message with the count.
   #
   # One matrixed job covers every scope+kind fix-label. The job `if`
-  # is evaluated per matrix value, so it fires only for the label the
-  # opened issue actually carries; each label gets its own concurrency
-  # group so the families never cancel each other. Add a new scope by
-  # appending its labels (e.g. `cs-fp-fix`, `cs-drift-fp-fix`).
+  # only filters on the event type — the `matrix` context is NOT
+  # available in job-level `if` (only in step-level `if`, `runs-on`,
+  # `concurrency`, `env`, `steps`), so referencing `matrix.label` at the
+  # job level rejects the whole workflow at load time. Instead, every
+  # matrix instance spawns on an `issues` event and the **steps** filter
+  # to the one whose label matches; the others no-op. Each label gets
+  # its own concurrency group so the families never cancel each other.
+  # Add a new scope by appending its labels (e.g. `cs-fp-fix`,
+  # `cs-drift-fp-fix`).
   notify-fix-burst:
     strategy:
       matrix:
         label: [fp-fix, cs-fp-fix, drift-fp-fix, cs-drift-fp-fix]
-    if: >
-      github.event_name == 'issues' &&
-      contains(github.event.issue.labels.*.name, matrix.label)
+    if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     concurrency:
       group: fix-burst-${{ matrix.label }}
       cancel-in-progress: true
     steps:
       - name: Wait for burst to settle
+        if: contains(github.event.issue.labels.*.name, matrix.label)
         run: sleep 60
 
       - name: Send rollup Telegram message
+        if: contains(github.event.issue.labels.*.name, matrix.label)
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}


### PR DESCRIPTION
## Why no Telegram alerts since #593

The `notify-fix-burst` job introduced in #593 collapsed two burst jobs into one matrixed job, but referenced `matrix.label` inside the **job-level `if:`** —

```yaml
notify-fix-burst:
  strategy:
    matrix:
      label: [fp-fix, cs-fp-fix, drift-fp-fix, cs-drift-fp-fix]
  if: >
    github.event_name == 'issues' &&
    contains(github.event.issue.labels.*.name, matrix.label)  # <- invalid
```

Per [GitHub's context-availability table](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability), the `matrix` context **is not available in `jobs.<job_id>.if`** (only in step-level `if`, `runs-on`, `concurrency`, `env`, `steps`, etc.). Expression resolution fails at workflow-load time → the **entire file is rejected** → **no jobs spawn**, including the otherwise-unrelated `notify-pr`. That's why Telegram alerts have been silent on every routine PR since #593 merged.

Evidence: every recent workflow run for `notify-routine-activity.yml` returns `total_jobs: 0` (e.g. run `27851141222` on PR #597's branch).

## Fix

Keep the event filter at the job level; move the label check to the **steps** where the `matrix` context is legal:

```yaml
notify-fix-burst:
  strategy:
    matrix:
      label: [fp-fix, cs-fp-fix, drift-fp-fix, cs-drift-fp-fix]
  if: github.event_name == 'issues'
  ...
  steps:
    - name: Wait for burst to settle
      if: contains(github.event.issue.labels.*.name, matrix.label)
      ...
    - name: Send rollup Telegram message
      if: contains(github.event.issue.labels.*.name, matrix.label)
      ...
```

Every matrix instance spawns on an `issues` event; only the step in the matching-label instance does work, the other three no-op. Concurrency groups stay per-label, so cancel-in-progress behavior is preserved.

## Validation

- YAML parses cleanly (`python3 -c 'yaml.safe_load(...)' → 3 jobs`).
- Matches GitHub's documented context rules — `matrix` is one of the contexts explicitly listed for step-level `if`.

## After merge

`notify-pr` fires again on the next `claude/*` PR; the fix-burst rollup fires on the next `*-fp-fix` issue. PR #597 (already open) won't retroactively get an alert, but every routine PR going forward will.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_