### PR TITLE
feat(contract-verifier): C# matchers for the 5 missing code-derivable kinds

### DIFF
--- a/packages/contract-verifier/src/extractor/effect/cs-effects.ts
+++ b/packages/contract-verifier/src/extractor/effect/cs-effects.ts
@@ -1,0 +1,71 @@
+/**
+ * C# effect extractor — the C# twin of the JS/Python `matchEffects` scanner.
+ * Enumerates every event-emission call site, spec-free. C# event buses come in
+ * two idioms:
+ *
+ *   - string-named:  `_eventBus.Emit("order.confirmed")`  → event = the string
+ *   - typed message: `_mediator.Publish(new OrderPlaced())` (MediatR / MassTransit)
+ *                    → event = the message TYPE name (`OrderPlaced`)
+ *
+ * Only emission-ish methods count (`Publish`, `Emit`, `Raise`, `Dispatch`, +
+ * `*Async`); `Send` is excluded (MediatR command semantics, not an event). The
+ * channel is the receiver (`_mediator`, `_eventBus`), defaulting to `event-bus`.
+ * A dynamic event (neither a string literal nor a `new T(...)`) is skipped — it
+ * can't be named here.
+ */
+
+import type { Node as SyntaxNode } from 'web-tree-sitter';
+import type { ParsedSource } from '../source-walker.js';
+import type { ExtractedEffect } from './types.js';
+import { walkCs, sliceNode, csStringText } from '../shared/cs-nodes.js';
+
+const EMIT_METHODS = /^(Publish|Emit|Raise|Dispatch|RaiseEvent)(Async)?$/;
+
+export function matchCsEffects(s: ParsedSource): ExtractedEffect[] {
+  const out: ExtractedEffect[] = [];
+  walkCs(s.tree.rootNode, (node) => {
+    if (node.type !== 'invocation_expression') return;
+    const fn = node.childForFieldName('function');
+    if (fn?.type !== 'member_access_expression') return;
+    const name = fn.childForFieldName('name');
+    if (!name || !EMIT_METHODS.test(sliceNode(name, s.source))) return;
+
+    const arg = firstArgExpr(node);
+    if (!arg) return;
+    const event = eventName(arg, s.source);
+    if (!event) return;
+
+    const recv = fn.childForFieldName('expression');
+    const channel = recv ? sliceNode(recv, s.source) : 'event-bus';
+    out.push({
+      event,
+      channel: channel || 'event-bus',
+      source: { filePath: s.filePath, lineStart: node.startPosition.row + 1, lineEnd: node.endPosition.row + 1 },
+    });
+  });
+  return out;
+}
+
+/** Event name: a string-literal argument's text, or the message TYPE name of a
+ *  `new OrderPlaced()` / `new Events.OrderShipped()` argument. */
+function eventName(arg: SyntaxNode, source: string): string | null {
+  if (arg.type.endsWith('string_literal')) return csStringText(arg, source) || null;
+  if (arg.type === 'object_creation_expression') {
+    const type = arg.childForFieldName('type');
+    if (!type) return null;
+    if (type.type === 'identifier') return sliceNode(type, source);
+    // `Events.OrderShipped` → the last segment.
+    if (type.type === 'qualified_name') {
+      const last = type.childForFieldName('name');
+      return last ? sliceNode(last, source) : null;
+    }
+  }
+  return null;
+}
+
+function firstArgExpr(call: SyntaxNode): SyntaxNode | null {
+  const args = call.childForFieldName('arguments');
+  const arg = args?.namedChild(0);
+  if (!arg) return null;
+  return arg.type === 'argument' ? arg.namedChild(0) : arg;
+}

--- a/packages/contract-verifier/src/extractor/effect/index.ts
+++ b/packages/contract-verifier/src/extractor/effect/index.ts
@@ -12,6 +12,7 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter';
 import { makeDirExtractor, jsMatchers, type ParsedSource } from '../source-walker.js';
 import type { ExtractedEffect } from './types.js';
+import { matchCsEffects } from './cs-effects.js';
 
 export type { ExtractedEffect } from './types.js';
 
@@ -81,6 +82,7 @@ function matchEffects(s: ParsedSource): ExtractedEffect[] {
 const extract = makeDirExtractor<ExtractedEffect>({
   ...jsMatchers(matchEffects),
   python: matchEffects,
+  csharp: matchCsEffects,
 });
 
 export async function extractEffectsFromDir(rootDir: string): Promise<ExtractedEffect[]> {

--- a/packages/contract-verifier/src/extractor/fallback/cs-fallbacks.ts
+++ b/packages/contract-verifier/src/extractor/fallback/cs-fallbacks.ts
@@ -1,0 +1,231 @@
+/**
+ * C# fallback extractor — the language-general twin of `ts-fallbacks.ts` /
+ * `py-fallbacks.ts`. Recognizes the same "null/absent → default" RUNTIME
+ * coalescing shape, in C# syntax. C# has no `undefined`, so every null-coalescing
+ * / null-guard form fires on `null` (trigger `null`); a defaulted parameter fires
+ * on an absent argument (trigger `absent`). Four structural patterns, none
+ * specific to any feature, framework, or ORM:
+ *
+ *   1. Null-coalescing:        `x ?? DEFAULT`          (also `var v = x ?? DEFAULT`)
+ *   2. Coalescing assignment:  `x ??= DEFAULT`
+ *   3. Default parameter:      `void F(string currency = "USD")`
+ *   4. Guarded assignment:     `if (x == null) x = DEFAULT;`  / `if (x is null) …`
+ *
+ * From each it derives a FallbackContract:
+ *   - target       = the coalesced field/input (`x`, `obj.Field` → field `Field`)
+ *   - trigger      = `null` (coalescing/guards) | `absent` (default parameter)
+ *   - defaultValue = the substituted literal/identifier (LiteralValue)
+ *
+ * A site whose default is a complex expression (call, object/collection
+ * initializer, another `??`) is skipped — the extractor never invents a scalar
+ * default from a non-scalar coalescing.
+ */
+
+import type { Node as SyntaxNode, Tree } from 'web-tree-sitter';
+import type { FallbackContract, LiteralValue } from '../../types/index.js';
+import type { ExtractedFallback } from './types.js';
+import { walkCs, sliceNode, csStringText } from '../shared/cs-nodes.js';
+
+export function extractCsFallbacksFromFile(
+  filePath: string,
+  source: string,
+  tree: Tree,
+): ExtractedFallback[] {
+  const out: ExtractedFallback[] = [];
+  walkCs(tree.rootNode, (node) => {
+    let fb: ExtractedFallback | null = null;
+    if (node.type === 'binary_expression') fb = fromCoalesce(node, source, filePath);
+    else if (node.type === 'assignment_expression') fb = fromCoalesceAssign(node, source, filePath);
+    else if (node.type === 'parameter') fb = fromDefaultParam(node, source, filePath);
+    else if (node.type === 'if_statement') fb = fromGuardedAssign(node, source, filePath);
+    if (fb) out.push(fb);
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Null-coalescing — `x ?? DEFAULT`
+// ---------------------------------------------------------------------------
+
+function fromCoalesce(node: SyntaxNode, source: string, filePath: string): ExtractedFallback | null {
+  if (opText(node, source) !== '??') return null;
+  const left = node.childForFieldName('left');
+  const right = node.childForFieldName('right');
+  if (!left || !right) return null;
+  const field = targetField(left, source);
+  if (!field) return null;
+  const value = scalarLiteral(right, source);
+  if (!value) return null;
+  // C# `??` fires only on null.
+  return build(field, 'null', value, node, filePath);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Coalescing assignment — `x ??= DEFAULT`
+// ---------------------------------------------------------------------------
+
+function fromCoalesceAssign(node: SyntaxNode, source: string, filePath: string): ExtractedFallback | null {
+  if (opText(node, source) !== '??=') return null;
+  const left = node.childForFieldName('left');
+  const right = node.childForFieldName('right');
+  if (!left || !right) return null;
+  const field = targetField(left, source);
+  if (!field) return null;
+  const value = scalarLiteral(right, source);
+  if (!value) return null;
+  return build(field, 'null', value, node, filePath);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Default parameter — `void F(string currency = "USD")`
+// ---------------------------------------------------------------------------
+
+function fromDefaultParam(node: SyntaxNode, source: string, filePath: string): ExtractedFallback | null {
+  const name = node.childForFieldName('name');
+  const type = node.childForFieldName('type');
+  if (!name || name.type !== 'identifier') return null;
+  // The default value is the named child that is neither the `type` nor the
+  // `name` field (C# attaches it directly to the parameter, no wrapper node).
+  let value: SyntaxNode | null = null;
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const c = node.namedChild(i);
+    if (!c || c.id === name.id || (type && c.id === type.id)) continue;
+    value = c;
+  }
+  if (!value) return null;
+  const lit = scalarLiteral(value, source);
+  if (!lit) return null;
+  // A defaulted parameter fires when the argument is absent.
+  return build(sliceNode(name, source), 'absent', lit, node, filePath);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Guarded assignment — `if (x == null) x = DEFAULT;` / `if (x is null) …`
+// ---------------------------------------------------------------------------
+
+function fromGuardedAssign(ifNode: SyntaxNode, source: string, filePath: string): ExtractedFallback | null {
+  const cond = ifNode.childForFieldName('condition');
+  const conseq = ifNode.childForFieldName('consequence');
+  if (!cond || !conseq) return null;
+
+  const target = matchNullGuard(cond, source);
+  if (!target) return null;
+
+  const assign = findAssignmentTo(conseq, target, source);
+  if (!assign) return null;
+  const lit = scalarLiteral(assign, source);
+  if (!lit) return null;
+
+  // C# null guards (`== null`, `is null`) fire only on null.
+  return build(target, 'null', lit, ifNode, filePath);
+}
+
+/** Recognize `<target> == null` or `<target> is null`; return the target's
+ *  root field. C# has no `undefined`, so both are pure null checks. */
+function matchNullGuard(node: SyntaxNode, source: string): string | null {
+  if (node.type === 'binary_expression') {
+    if (opText(node, source) !== '==') return null;
+    const left = node.childForFieldName('left');
+    const right = node.childForFieldName('right');
+    if (!left || !right) return null;
+    for (const [tgt, lit] of [[left, right], [right, left]] as Array<[SyntaxNode, SyntaxNode]>) {
+      if (lit.type !== 'null_literal') continue;
+      const field = targetField(tgt, source);
+      if (field) return field;
+    }
+    return null;
+  }
+  if (node.type === 'is_pattern_expression') {
+    const expr = node.childForFieldName('expression');
+    const pattern = node.childForFieldName('pattern');
+    if (!expr || !pattern) return null;
+    // `x is null` — the pattern is a `constant_pattern` wrapping `null_literal`.
+    const hasNull = pattern.type === 'constant_pattern' && pattern.namedChild(0)?.type === 'null_literal';
+    if (!hasNull) return null;
+    return targetField(expr, source);
+  }
+  return null;
+}
+
+/** Find `<target> = <value>` in the consequence and return the value node, so a
+ *  guard-then-default pair is structurally linked (same target). */
+function findAssignmentTo(conseq: SyntaxNode, target: string, source: string): SyntaxNode | null {
+  let value: SyntaxNode | null = null;
+  walkCs(conseq, (n) => {
+    if (value || n.type !== 'assignment_expression') return;
+    if (opText(n, source) !== '=') return;
+    const lhs = n.childForFieldName('left');
+    const rhs = n.childForFieldName('right');
+    if (lhs && rhs && targetField(lhs, source) === target) value = rhs;
+  });
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function build(
+  field: string,
+  trigger: FallbackContract['trigger'],
+  defaultValue: LiteralValue,
+  node: SyntaxNode,
+  filePath: string,
+): ExtractedFallback {
+  return {
+    identity: `${field}.fallback`,
+    contract: { target: { field }, trigger, defaultValue },
+    source: { filePath, lineStart: node.startPosition.row + 1, lineEnd: node.endPosition.row + 1 },
+  };
+}
+
+/** Operator text of a binary/assignment expression — the `operator` field when
+ *  present, else the slice between the left and right operands. */
+function opText(node: SyntaxNode, source: string): string | null {
+  const op = node.childForFieldName('operator');
+  if (op) return sliceNode(op, source);
+  const left = node.childForFieldName('left');
+  const right = node.childForFieldName('right');
+  if (left && right) return source.slice(left.endIndex, right.startIndex).trim();
+  return null;
+}
+
+/** Root field of a target: `x` → `x`; `obj.Field` → `Field`. */
+function targetField(node: SyntaxNode, source: string): string | null {
+  if (node.type === 'identifier') return sliceNode(node, source);
+  if (node.type === 'member_access_expression') {
+    const name = node.childForFieldName('name');
+    if (name) return sliceNode(name, source);
+  }
+  return null;
+}
+
+/**
+ * A scalar default value — string, number, bool, null, or a bare identifier
+ * (a named constant / enum member). Anything else (call, initializer, nested
+ * coalescing) is not a value fallback and returns null so the site is skipped.
+ */
+function scalarLiteral(node: SyntaxNode, source: string): LiteralValue | null {
+  switch (node.type) {
+    case 'string_literal':
+    case 'verbatim_string_literal':
+    case 'raw_string_literal':
+      return { kind: 'string', value: csStringText(node, source) ?? '' };
+    case 'integer_literal': {
+      const n = parseInt(sliceNode(node, source).replace(/[_lLuU]/g, ''), 10);
+      return Number.isNaN(n) ? null : { kind: 'number', value: n };
+    }
+    case 'real_literal': {
+      const n = parseFloat(sliceNode(node, source).replace(/[_fFdDmM]/g, ''));
+      return Number.isNaN(n) ? null : { kind: 'number', value: n };
+    }
+    case 'boolean_literal':
+      return { kind: 'boolean', value: sliceNode(node, source) === 'true' };
+    case 'null_literal':
+      return { kind: 'null' };
+    case 'identifier':
+      return { kind: 'identifier', ref: sliceNode(node, source) };
+    default:
+      return null;
+  }
+}

--- a/packages/contract-verifier/src/extractor/fallback/index.ts
+++ b/packages/contract-verifier/src/extractor/fallback/index.ts
@@ -12,12 +12,14 @@ import { eachParsedSource, jsMatchers, type LanguageMatchers } from '../source-w
 import type { ExtractedFallback } from './types.js';
 import { extractFallbacksFromFile } from './ts-fallbacks.js';
 import { extractPyFallbacksFromFile } from './py-fallbacks.js';
+import { extractCsFallbacksFromFile } from './cs-fallbacks.js';
 
 export type { ExtractedFallback } from './types.js';
 
 const MATCHERS: LanguageMatchers<ExtractedFallback> = {
   ...jsMatchers((s) => extractFallbacksFromFile(s.filePath, s.source, s.tree)),
   python: (s) => extractPyFallbacksFromFile(s.filePath, s.source, s.tree),
+  csharp: (s) => extractCsFallbacksFromFile(s.filePath, s.source, s.tree),
 };
 
 export async function extractFallbacksFromDir(rootDir: string): Promise<ExtractedFallback[]> {

--- a/packages/contract-verifier/src/extractor/field-exposure/cs-fields.ts
+++ b/packages/contract-verifier/src/extractor/field-exposure/cs-fields.ts
@@ -1,0 +1,159 @@
+/**
+ * C# field-exposure extractor — the language-general twin of `ts-fields.ts` /
+ * `py-fields.ts`. Recognizes the same "field exposed on a read path" shape, in
+ * C# syntax. Two structural channels, neither specific to any feature or ORM:
+ *
+ *   1. query-select — an EF Core projection: `db.Orders.Select(o => new { o.Id,
+ *      o.Status, Total = o.TotalCents })`. Each member of the projected
+ *      anonymous object is an exposed field.
+ *
+ *   2. api-response — a response body object passed to an ASP.NET result helper:
+ *      `return Ok(new { o.Id, o.Status })` / `Json(new OrderDto { Id = o.Id })`.
+ *      Each member of the serialized object is an exposed field.
+ *
+ * From each it derives a FieldExposureContract:
+ *   - target     = the exposed field (`{ field }`; the code site carries no entity
+ *                  binding, so the comparator matches by field name)
+ *   - exposedVia = ['query-select'] or ['api-response']
+ *
+ * Only a projection / response SITE counts — a bare `new { … }` built for
+ * internal use is not an exposure.
+ */
+
+import type { Node as SyntaxNode, Tree } from 'web-tree-sitter';
+import type { FieldExposureContract, SourceLocation } from '../../types/index.js';
+import type { ExtractedFieldExposure } from './types.js';
+import { walkCs, sliceNode } from '../shared/cs-nodes.js';
+
+type Channel = FieldExposureContract['exposedVia'][number];
+
+/** ASP.NET result helpers whose body argument is a serialized response shape. */
+const RESPONSE_METHODS = new Set([
+  'Ok', 'Json', 'Created', 'CreatedAtAction', 'CreatedAtRoute', 'Accepted', 'AcceptedAtAction',
+]);
+
+export function extractCsFieldExposuresFromFile(
+  filePath: string,
+  source: string,
+  tree: Tree,
+): ExtractedFieldExposure[] {
+  const out: ExtractedFieldExposure[] = [];
+  walkCs(tree.rootNode, (node) => {
+    if (node.type !== 'invocation_expression') return;
+    const method = methodName(node, source);
+    if (!method) return;
+
+    if (method === 'Select') {
+      const obj = selectProjection(node);
+      if (obj) for (const f of objectMembers(obj, source)) out.push(build(f, 'query-select', obj, filePath));
+    } else if (RESPONSE_METHODS.has(method)) {
+      const obj = firstObjectArg(node);
+      if (obj) for (const f of objectMembers(obj, source)) out.push(build(f, 'api-response', obj, filePath));
+    }
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Call shape
+// ---------------------------------------------------------------------------
+
+/** Method name of an invocation: a bare `Ok(...)` → `Ok`; `x.Select(...)` →
+ *  the member name `Select`. */
+function methodName(call: SyntaxNode, source: string): string | null {
+  const fn = call.childForFieldName('function');
+  if (!fn) return null;
+  if (fn.type === 'identifier') return sliceNode(fn, source);
+  if (fn.type === 'member_access_expression') {
+    const name = fn.childForFieldName('name');
+    return name ? sliceNode(name, source) : null;
+  }
+  return null;
+}
+
+/** The anonymous/object body of a `Select(o => new { … })` lambda projection. */
+function selectProjection(call: SyntaxNode): SyntaxNode | null {
+  const args = call.childForFieldName('arguments');
+  if (!args) return null;
+  for (let i = 0; i < args.namedChildCount; i++) {
+    const arg = args.namedChild(i);
+    const lambda = arg?.type === 'argument' ? arg.namedChild(0) : arg;
+    if (lambda?.type !== 'lambda_expression') continue;
+    const body = lambda.childForFieldName('body');
+    if (body && isObjectShape(body)) return body;
+  }
+  return null;
+}
+
+/** The first object-shape argument of a response call (`Ok(new { … })`). */
+function firstObjectArg(call: SyntaxNode): SyntaxNode | null {
+  const args = call.childForFieldName('arguments');
+  if (!args) return null;
+  for (let i = 0; i < args.namedChildCount; i++) {
+    const arg = args.namedChild(i);
+    const val = arg?.type === 'argument' ? arg.namedChild(0) : arg;
+    if (val && isObjectShape(val)) return val;
+  }
+  return null;
+}
+
+function isObjectShape(node: SyntaxNode): boolean {
+  return node.type === 'anonymous_object_creation_expression' || node.type === 'object_creation_expression';
+}
+
+// ---------------------------------------------------------------------------
+// Member names of an object shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Field names exposed by an object shape:
+ *   - `anonymous_object_creation_expression`: shorthand `o.Field` → `Field`;
+ *     explicit `Alias = expr` → `Alias` (the `=` token marks the name/value split).
+ *   - `object_creation_expression` (named DTO): each `Id = expr` initializer
+ *     assignment → the left identifier.
+ */
+function objectMembers(obj: SyntaxNode, source: string): string[] {
+  if (obj.type === 'object_creation_expression') {
+    const init = obj.childForFieldName('initializer');
+    if (!init) return [];
+    const out: string[] = [];
+    for (let i = 0; i < init.namedChildCount; i++) {
+      const c = init.namedChild(i);
+      if (c?.type !== 'assignment_expression') continue;
+      const left = c.childForFieldName('left');
+      if (left?.type === 'identifier') out.push(sliceNode(left, source));
+    }
+    return out;
+  }
+  // anonymous object: walk ALL children (incl `=` / `,` tokens) so an explicit
+  // `Alias = value` is distinguished from a shorthand `o.Field`.
+  const out: string[] = [];
+  for (let i = 0; i < obj.childCount; i++) {
+    const c = obj.child(i);
+    if (!c) continue;
+    const prevIsEq = sliceNode(obj.child(i - 1) ?? c, source) === '=' && i > 0;
+    if (c.type === 'identifier') {
+      if (prevIsEq) continue; // a bare-identifier VALUE of an explicit member
+      out.push(sliceNode(c, source)); // explicit name, or `new { localVar }` shorthand
+    } else if (c.type === 'member_access_expression') {
+      if (prevIsEq) continue; // the VALUE of an explicit member (`Alias = o.Field`)
+      const name = c.childForFieldName('name');
+      if (name) out.push(sliceNode(name, source)); // shorthand `o.Field` → `Field`
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+
+function build(field: string, channel: Channel, node: SyntaxNode, filePath: string): ExtractedFieldExposure {
+  return {
+    identity: `${field}.exposure`,
+    contract: { target: { field }, exposedVia: [channel] },
+    source: location(node, filePath),
+  };
+}
+
+function location(node: SyntaxNode, filePath: string): SourceLocation {
+  return { filePath, lineStart: node.startPosition.row + 1, lineEnd: node.endPosition.row + 1 };
+}

--- a/packages/contract-verifier/src/extractor/field-exposure/index.ts
+++ b/packages/contract-verifier/src/extractor/field-exposure/index.ts
@@ -15,6 +15,7 @@ import type { ExtractedFieldExposure } from './types.js';
 import type { FieldExposureContract } from '../../types/index.js';
 import { extractFieldExposuresFromFile } from './ts-fields.js';
 import { extractPyFieldExposuresFromFile } from './py-fields.js';
+import { extractCsFieldExposuresFromFile } from './cs-fields.js';
 
 export type { ExtractedFieldExposure } from './types.js';
 
@@ -23,6 +24,7 @@ type Channel = FieldExposureContract['exposedVia'][number];
 const MATCHERS: LanguageMatchers<ExtractedFieldExposure> = {
   ...jsMatchers((s) => extractFieldExposuresFromFile(s.filePath, s.source, s.tree)),
   python: (s) => extractPyFieldExposuresFromFile(s.filePath, s.source, s.tree),
+  csharp: (s) => extractCsFieldExposuresFromFile(s.filePath, s.source, s.tree),
 };
 
 export async function extractFieldExposuresFromDir(

--- a/packages/contract-verifier/src/extractor/persistence-strategy/cs-metadata-keys.ts
+++ b/packages/contract-verifier/src/extractor/persistence-strategy/cs-metadata-keys.ts
@@ -1,0 +1,79 @@
+/**
+ * C# metadata-blob key scanner — the language-general twin of
+ * `ts-metadata-keys.ts` / `py-metadata-keys.ts`. Finds keys read/written on a
+ * conventionally-named JSON/dictionary "blob" — the shapes that say "this value
+ * lives inside a `Metadata` bag, not in its own column":
+ *
+ *   o.Metadata.RequiresReason         (member access — JObject/dynamic style)
+ *   o.Metadata["cancellationReason"]  (indexer — Dictionary<string, object> style)
+ *   metadata["refundPolicy"] = x      (indexer write)
+ *
+ * Blob identifier names (`metadata`, `meta`, case-insensitive — C# properties are
+ * PascalCase) are intentionally narrow, so a normal `config.Timeout` access is
+ * never mistaken for metadata storage. The scan never decides the strategy
+ * itself — the dispatcher reconciles these key hits against the schema columns.
+ */
+
+import type { Node as SyntaxNode, Tree } from 'web-tree-sitter';
+import type { SourceLocation } from '../../types/index.js';
+import type { MetadataKeyHit } from './ts-metadata-keys.js';
+import { walkCs, sliceNode, csStringText } from '../shared/cs-nodes.js';
+
+const BLOB_NAMES = new Set(['metadata', 'meta']);
+
+export function extractCsMetadataKeysFromFile(
+  filePath: string,
+  source: string,
+  tree: Tree,
+): MetadataKeyHit[] {
+  const out: MetadataKeyHit[] = [];
+  const push = (key: string, node: SyntaxNode): void => {
+    if (!key) return;
+    out.push({ key, source: location(node, filePath) });
+  };
+
+  walkCs(tree.rootNode, (node) => {
+    // <blob>.KEY  (e.g. o.Metadata.RequiresReason / metadata.RequiresReason)
+    if (node.type === 'member_access_expression') {
+      const object = node.childForFieldName('expression');
+      const name = node.childForFieldName('name');
+      if (object && name && isBlobNode(object, source)) push(sliceNode(name, source), node);
+      return;
+    }
+    // <blob>["KEY"]  (indexer read or write)
+    if (node.type === 'element_access_expression') {
+      const object = node.childForFieldName('expression');
+      if (!object || !isBlobNode(object, source)) return;
+      const subscript = node.childForFieldName('subscript');
+      const key = subscript ? stringSubscript(subscript, source) : null;
+      if (key !== null) push(key, node);
+    }
+  });
+
+  return out;
+}
+
+/** A blob identifier (`metadata`/`meta`), or a member access ending in one
+ *  (`o.Metadata`, `row.Meta`). Case-insensitive — C# props are PascalCase. */
+function isBlobNode(node: SyntaxNode, source: string): boolean {
+  if (node.type === 'identifier') return BLOB_NAMES.has(sliceNode(node, source).toLowerCase());
+  if (node.type === 'member_access_expression') {
+    const name = node.childForFieldName('name');
+    return !!name && BLOB_NAMES.has(sliceNode(name, source).toLowerCase());
+  }
+  return false;
+}
+
+/** The string key of a `["..."]` subscript (`bracketed_argument_list`), or null. */
+function stringSubscript(subscript: SyntaxNode, source: string): string | null {
+  for (let i = 0; i < subscript.namedChildCount; i++) {
+    const arg = subscript.namedChild(i);
+    const val = arg?.type === 'argument' ? arg.namedChild(0) : arg;
+    if (val && val.type.endsWith('string_literal')) return csStringText(val, source) ?? '';
+  }
+  return null;
+}
+
+function location(node: SyntaxNode, filePath: string): SourceLocation {
+  return { filePath, lineStart: node.startPosition.row + 1, lineEnd: node.endPosition.row + 1 };
+}

--- a/packages/contract-verifier/src/extractor/persistence-strategy/index.ts
+++ b/packages/contract-verifier/src/extractor/persistence-strategy/index.ts
@@ -24,6 +24,7 @@ import { extractEntitiesFromDir } from '../entity-schema/index.js';
 import { eachParsedSource, jsMatchers, type LanguageMatchers } from '../source-walker.js';
 import { extractMetadataKeysFromFile, type MetadataKeyHit } from './ts-metadata-keys.js';
 import { extractPyMetadataKeysFromFile } from './py-metadata-keys.js';
+import { extractCsMetadataKeysFromFile } from './cs-metadata-keys.js';
 import type { ExtractedPersistenceStrategy } from './types.js';
 
 export type { ExtractedPersistenceStrategy, PersistenceStrategyChoice } from './types.js';
@@ -31,6 +32,7 @@ export type { ExtractedPersistenceStrategy, PersistenceStrategyChoice } from './
 const MATCHERS: LanguageMatchers<MetadataKeyHit> = {
   ...jsMatchers((s) => extractMetadataKeysFromFile(s.filePath, s.tree)),
   python: (s) => extractPyMetadataKeysFromFile(s.filePath, s.source, s.tree),
+  csharp: (s) => extractCsMetadataKeysFromFile(s.filePath, s.source, s.tree),
 };
 
 export async function extractPersistenceStrategiesFromDir(

--- a/packages/contract-verifier/src/extractor/validation-rule/cs-validation-rules.ts
+++ b/packages/contract-verifier/src/extractor/validation-rule/cs-validation-rules.ts
@@ -1,0 +1,353 @@
+/**
+ * C# validation-rule extractor — the language-general twin of
+ * `ts-validation-rules.ts` / `py-validation-rules.ts`. Recognizes the same
+ * "required-when" guard shape, in C# syntax:
+ *
+ *   if (eventType.RequiresReason && actor == "host" && string.IsNullOrEmpty(reason))
+ *       throw new ValidationException("reason_required");
+ *
+ * Structural pattern (framework/ORM-agnostic):
+ *
+ *   if ( <setting-predicate> [&& <actor-predicate>] && <target-missing> )
+ *       <throw | return-error>
+ *
+ * → ValidationRuleContract { target, when: Predicate, effect: 'required',
+ *   actor?, onViolation? }. A guard with no recognizable missing-check or no
+ * setting predicate is skipped.
+ */
+
+import type { Node as SyntaxNode, Tree } from 'web-tree-sitter';
+import type {
+  LiteralValue,
+  Predicate,
+  QualifiedColumn,
+  ValidationRuleContract,
+} from '../../types/index.js';
+import type { ExtractedValidationRule } from './types.js';
+import { walkCs, sliceNode, csStringText } from '../shared/cs-nodes.js';
+
+const MISSING_HELPERS = /^(IsNullOrEmpty|IsNullOrWhiteSpace)$/;
+
+export function extractCsValidationRulesFromFile(
+  filePath: string,
+  source: string,
+  tree: Tree,
+): ExtractedValidationRule[] {
+  const out: ExtractedValidationRule[] = [];
+  walkCs(tree.rootNode, (node) => {
+    if (node.type !== 'if_statement') return;
+    const rule = extractFromIf(node, source, filePath);
+    if (rule) out.push(rule);
+  });
+  return out;
+}
+
+function extractFromIf(ifNode: SyntaxNode, source: string, filePath: string): ExtractedValidationRule | null {
+  const condNode = ifNode.childForFieldName('condition');
+  const conseqNode = ifNode.childForFieldName('consequence');
+  if (!condNode || !conseqNode) return null;
+
+  const violation = findViolation(conseqNode, source);
+  if (!violation.enforces) return null;
+
+  const conjuncts = flattenAnd(condNode, source);
+
+  let when: Predicate | undefined;
+  let actor: string | undefined;
+  let target: string | undefined;
+
+  for (const c of conjuncts) {
+    const missing = matchMissing(c, source);
+    if (missing && !target) { target = missing; continue; }
+    const a = matchActor(c, source);
+    if (a && !actor) { actor = a; continue; }
+    const p = matchSettingPredicate(c, source);
+    if (p && !when) { when = p; continue; }
+  }
+
+  if (!target || !when) return null;
+
+  const contract: ValidationRuleContract = {
+    target,
+    when,
+    effect: 'required',
+    ...(actor ? { actor } : {}),
+    ...(violation.onViolation ? { onViolation: violation.onViolation } : {}),
+  };
+
+  const col = (when as { column?: QualifiedColumn }).column;
+  const settingName = col ? `${col.table ? col.table + '.' : ''}${col.column}` : 'condition';
+
+  return {
+    identity: `${settingName}.required-when.${target}`,
+    contract,
+    source: { filePath, lineStart: ifNode.startPosition.row + 1, lineEnd: ifNode.endPosition.row + 1 },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Condition matchers
+// ---------------------------------------------------------------------------
+
+/** Member-access compared to a literal → Predicate; bare member-access
+ *  truthiness → `eq <col> true`. */
+function matchSettingPredicate(node: SyntaxNode, source: string): Predicate | null {
+  if (node.type === 'binary_expression') {
+    const left = node.childForFieldName('left');
+    const right = node.childForFieldName('right');
+    if (!left || !right || left.type !== 'member_access_expression') return null;
+    const col = memberToColumn(left, source);
+    if (!col) return null;
+    const lit = literalFromNode(right, source);
+    if (!lit) return null;
+    const op = opText(node, source) ?? '';
+    const kind = compareKind(op, false) ?? compareKind(op, true);
+    return kind ? ({ kind, column: col, value: lit } as Predicate) : null;
+  }
+  if (node.type === 'member_access_expression') {
+    const col = memberToColumn(node, source);
+    if (col) return { kind: 'eq', column: col, value: { kind: 'boolean', value: true } };
+  }
+  return null;
+}
+
+/** Bare-identifier (or role-ish member) `== "literal"` actor check → the literal. */
+function matchActor(node: SyntaxNode, source: string): string | null {
+  if (node.type !== 'binary_expression') return null;
+  const op = opText(node, source);
+  if (op !== '==' && op !== '!=') return null;
+  const left = node.childForFieldName('left');
+  const right = node.childForFieldName('right');
+  if (!left || !right) return null;
+  for (const [idNode, litNode] of [[left, right], [right, left]] as Array<[SyntaxNode, SyntaxNode]>) {
+    if (!litNode.type.endsWith('string_literal')) continue;
+    if (idNode.type === 'identifier') return csStringText(litNode, source) ?? '';
+    if (idNode.type === 'member_access_expression') {
+      const prop = idNode.childForFieldName('name');
+      if (prop && /^(role|actor|userType|kind|type)$/i.test(sliceNode(prop, source))) {
+        return csStringText(litNode, source) ?? '';
+      }
+    }
+  }
+  return null;
+}
+
+/** Target-missing check → the missing field name. */
+function matchMissing(node: SyntaxNode, source: string): string | null {
+  // string.IsNullOrEmpty(x) / string.IsNullOrWhiteSpace(x)
+  if (node.type === 'invocation_expression') {
+    const fn = node.childForFieldName('function');
+    if (fn?.type !== 'member_access_expression') return null;
+    const name = fn.childForFieldName('name');
+    if (!name || !MISSING_HELPERS.test(sliceNode(name, source))) return null;
+    const arg = firstArgExpr(node);
+    return arg ? rootIdentifier(arg, source) : null;
+  }
+  // x == null / x.Length == 0
+  if (node.type === 'binary_expression') {
+    if (opText(node, source) !== '==') return null;
+    const left = node.childForFieldName('left');
+    const right = node.childForFieldName('right');
+    if (!left || !right) return null;
+    // x.Length == 0
+    if (
+      left.type === 'member_access_expression' &&
+      sliceNode(left.childForFieldName('name') ?? left, source) === 'Length' &&
+      right.type === 'integer_literal' && sliceNode(right, source) === '0'
+    ) {
+      const obj = left.childForFieldName('expression');
+      return obj ? rootIdentifier(obj, source) : null;
+    }
+    if (right.type === 'null_literal') return rootIdentifier(left, source);
+    if (left.type === 'null_literal') return rootIdentifier(right, source);
+    return null;
+  }
+  // x is null
+  if (node.type === 'is_pattern_expression') {
+    const expr = node.childForFieldName('expression');
+    const pattern = node.childForFieldName('pattern');
+    if (expr && pattern?.type === 'constant_pattern' && pattern.namedChild(0)?.type === 'null_literal') {
+      return rootIdentifier(expr, source);
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Violation (throw / return-error) detection
+// ---------------------------------------------------------------------------
+
+interface Violation {
+  enforces: boolean;
+  onViolation?: { status: number; errorCode: string };
+}
+
+function findViolation(conseq: SyntaxNode, source: string): Violation {
+  let result: Violation = { enforces: false };
+  walkCs(conseq, (n) => {
+    if (result.enforces) return;
+    if (n.type === 'throw_statement') {
+      const expr = n.namedChild(0);
+      const args = expr?.type === 'object_creation_expression' ? expr.childForFieldName('arguments') : null;
+      result = { enforces: true, onViolation: args ? statusAndCode(args, source) : undefined };
+    } else if (n.type === 'return_statement') {
+      const v = violationFromReturn(n, source);
+      if (v) result = { enforces: true, onViolation: v };
+    }
+  });
+  return result;
+}
+
+function violationFromReturn(returnNode: SyntaxNode, source: string): { status: number; errorCode: string } | null {
+  let status = 0;
+  let errorCode = '';
+  walkCs(returnNode, (n) => {
+    // `return BadRequest(new { error = "reason_required" })` / `StatusCode(400, …)`
+    if (n.type === 'assignment_expression') {
+      const left = n.childForFieldName('left');
+      const right = n.childForFieldName('right');
+      if (!left || !right) return;
+      const key = sliceNode(left, source);
+      if (/^(status|statusCode|httpStatus)$/i.test(key) && right.type === 'integer_literal') {
+        status = parseInt(sliceNode(right, source), 10);
+      } else if (/^(error|errorCode|code|message)$/i.test(key) && right.type.endsWith('string_literal') && !errorCode) {
+        errorCode = csStringText(right, source) ?? '';
+      }
+    }
+    if (n.type === 'invocation_expression') {
+      const fn = n.childForFieldName('function');
+      const name = fn?.type === 'identifier' ? sliceNode(fn, source)
+        : fn?.type === 'member_access_expression' ? sliceNode(fn.childForFieldName('name') ?? fn, source) : '';
+      if (name === 'StatusCode') {
+        const a = firstArgExpr(n);
+        if (a?.type === 'integer_literal') status = parseInt(sliceNode(a, source), 10);
+      } else if (/^BadRequest$/.test(name) && status === 0) {
+        status = 400;
+      }
+    }
+  });
+  if (status === 0 && errorCode === '') return null;
+  if (status !== 0 && status < 400) return null;
+  return { status: status || 400, errorCode };
+}
+
+/** First numeric arg → status; first string arg → errorCode. */
+function statusAndCode(args: SyntaxNode, source: string): { status: number; errorCode: string } | undefined {
+  let status = 0;
+  let errorCode = '';
+  for (let i = 0; i < args.namedChildCount; i++) {
+    const arg = args.namedChild(i);
+    const a = arg?.type === 'argument' ? arg.namedChild(0) : arg;
+    if (!a) continue;
+    if (a.type === 'integer_literal' && status === 0) status = parseInt(sliceNode(a, source), 10);
+    else if (a.type.endsWith('string_literal') && errorCode === '') errorCode = csStringText(a, source) ?? '';
+  }
+  if (status === 0 && errorCode === '') return undefined;
+  return { status: status || 400, errorCode };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Flatten left-associated `a && b && c` into [a, b, c]. */
+function flattenAnd(node: SyntaxNode, source: string): SyntaxNode[] {
+  if (node.type === 'binary_expression' && opText(node, source) === '&&') {
+    const left = node.childForFieldName('left');
+    const right = node.childForFieldName('right');
+    const out: SyntaxNode[] = [];
+    if (left) out.push(...flattenAnd(left, source));
+    if (right) out.push(...flattenAnd(right, source));
+    return out;
+  }
+  return [node];
+}
+
+function opText(node: SyntaxNode, source: string): string | null {
+  const op = node.childForFieldName('operator');
+  if (op) return sliceNode(op, source);
+  const left = node.childForFieldName('left');
+  const right = node.childForFieldName('right');
+  if (left && right) return source.slice(left.endIndex, right.startIndex).trim();
+  return null;
+}
+
+function firstArgExpr(call: SyntaxNode): SyntaxNode | null {
+  const args = call.childForFieldName('arguments');
+  const arg = args?.namedChild(0);
+  if (!arg) return null;
+  return arg.type === 'argument' ? arg.namedChild(0) : arg;
+}
+
+/** `eventType.RequiresReason` → { table: 'eventType', column: 'RequiresReason' }. */
+function memberToColumn(member: SyntaxNode, source: string): QualifiedColumn | null {
+  const name = member.childForFieldName('name');
+  if (!name) return null;
+  const column = sliceNode(name, source);
+  const obj = member.childForFieldName('expression');
+  const objPath = obj ? dottedPath(obj, source) : null;
+  return objPath ? { table: objPath, column } : { column };
+}
+
+function dottedPath(node: SyntaxNode, source: string): string | null {
+  if (node.type === 'identifier' || node.type === 'this_expression') return sliceNode(node, source);
+  if (node.type === 'member_access_expression') {
+    const obj = node.childForFieldName('expression');
+    const name = node.childForFieldName('name');
+    if (!name) return null;
+    const base = obj ? dottedPath(obj, source) : null;
+    return base ? `${base}.${sliceNode(name, source)}` : sliceNode(name, source);
+  }
+  return null;
+}
+
+/** Root field of an expression (`reason`, `input.Reason` → `reason`/`Reason`). */
+function rootIdentifier(node: SyntaxNode, source: string): string | null {
+  if (node.type === 'identifier') return sliceNode(node, source);
+  if (node.type === 'member_access_expression') {
+    const name = node.childForFieldName('name');
+    if (name) return sliceNode(name, source);
+    const obj = node.childForFieldName('expression');
+    return obj ? rootIdentifier(obj, source) : null;
+  }
+  if (node.type === 'invocation_expression') {
+    const fn = node.childForFieldName('function');
+    return fn ? rootIdentifier(fn, source) : null;
+  }
+  return null;
+}
+
+function compareKind(op: string, inverse: boolean): Extract<Predicate, { value: LiteralValue }>['kind'] | null {
+  if (inverse) return op === '!=' ? 'neq' : null;
+  switch (op) {
+    case '==': return 'eq';
+    case '>': return 'gt';
+    case '>=': return 'gte';
+    case '<': return 'lt';
+    case '<=': return 'lte';
+    default: return null;
+  }
+}
+
+function literalFromNode(node: SyntaxNode, source: string): LiteralValue | null {
+  switch (node.type) {
+    case 'string_literal':
+    case 'verbatim_string_literal':
+    case 'raw_string_literal':
+      return { kind: 'string', value: csStringText(node, source) ?? '' };
+    case 'integer_literal': {
+      const n = parseInt(sliceNode(node, source).replace(/[_lLuU]/g, ''), 10);
+      return Number.isNaN(n) ? null : { kind: 'number', value: n };
+    }
+    case 'real_literal': {
+      const n = parseFloat(sliceNode(node, source).replace(/[_fFdDmM]/g, ''));
+      return Number.isNaN(n) ? null : { kind: 'number', value: n };
+    }
+    case 'boolean_literal':
+      return { kind: 'boolean', value: sliceNode(node, source) === 'true' };
+    case 'null_literal':
+      return { kind: 'null' };
+    default:
+      return null;
+  }
+}

--- a/packages/contract-verifier/src/extractor/validation-rule/index.ts
+++ b/packages/contract-verifier/src/extractor/validation-rule/index.ts
@@ -12,12 +12,14 @@ import { eachParsedSource, jsMatchers, type LanguageMatchers } from '../source-w
 import type { ExtractedValidationRule } from './types.js';
 import { extractValidationRulesFromFile } from './ts-validation-rules.js';
 import { extractPyValidationRulesFromFile } from './py-validation-rules.js';
+import { extractCsValidationRulesFromFile } from './cs-validation-rules.js';
 
 export type { ExtractedValidationRule } from './types.js';
 
 const MATCHERS: LanguageMatchers<ExtractedValidationRule> = {
   ...jsMatchers((s) => extractValidationRulesFromFile(s.filePath, s.source, s.tree)),
   python: (s) => extractPyValidationRulesFromFile(s.filePath, s.source, s.tree),
+  csharp: (s) => extractCsValidationRulesFromFile(s.filePath, s.source, s.tree),
 };
 
 export async function extractValidationRulesFromDir(

--- a/tests/contract-verifier/effect-csharp-extractor.test.ts
+++ b/tests/contract-verifier/effect-csharp-extractor.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initParsers, parseFile } from '../../packages/analyzer/src/index.js';
+import { matchCsEffects } from '../../packages/contract-verifier/src/extractor/effect/cs-effects.js';
+import { extractEffectsFromDir } from '../../packages/contract-verifier/src/extractor/effect/index.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+beforeAll(async () => {
+  await initParsers();
+});
+
+function effects(source: string) {
+  const tree = parseFile('/x.cs', source, 'csharp');
+  const res = matchCsEffects({ filePath: '/x.cs', source, tree, lang: 'csharp' });
+  tree.delete();
+  return res;
+}
+
+// C# event buses come in two idioms — string-named (`bus.Emit("x")`) and typed
+// messages (`_mediator.Publish(new OrderPlaced())`). Both are real effect
+// emissions; the typed form names the event by its message TYPE.
+describe('Effect code extractor — C#', () => {
+  it('extracts a string-named bus emit', () => {
+    const e = effects(`public class S { public void M() { _eventBus.Emit("order.confirmed"); } }`);
+    expect(e).toHaveLength(1);
+    expect(e[0]).toMatchObject({ event: 'order.confirmed', channel: '_eventBus' });
+  });
+
+  it('extracts a MediatR typed Publish (event = message type name), unwrapping await', () => {
+    const e = effects(`public class S { public async Task M(Order o) { await _mediator.Publish(new OrderPlaced(o.Id)); } }`);
+    expect(e).toHaveLength(1);
+    expect(e[0]).toMatchObject({ event: 'OrderPlaced', channel: '_mediator' });
+  });
+
+  it('takes the last segment of a namespaced typed event', () => {
+    const e = effects(`public class S { public void M() { _bus.Publish(new Events.OrderShipped()); } }`);
+    expect(e[0]).toMatchObject({ event: 'OrderShipped', channel: '_bus' });
+  });
+
+  it('skips a dynamic emit (neither string nor `new T()`)', () => {
+    const e = effects(`public class S { public void M(object evt) { _bus.Publish(evt); } }`);
+    expect(e).toHaveLength(0);
+  });
+
+  it('ignores `Send` (MediatR command semantics, not an event)', () => {
+    const e = effects(`public class S { public void M() { _mediator.Send(new GetOrder()); } }`);
+    expect(e).toHaveLength(0);
+  });
+
+  it('extracts C# effects via the directory dispatcher', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cseff-'));
+    fs.writeFileSync(path.join(dir, 'svc.cs'), `public class S { public void M() { _bus.Publish(new OrderCancelled()); _bus.Emit("order.paid"); } }`);
+    const e = await extractEffectsFromDir(dir);
+    fs.rmSync(dir, { recursive: true, force: true });
+    expect(e.map((x) => x.event).sort()).toEqual(['OrderCancelled', 'order.paid']);
+  });
+});

--- a/tests/contract-verifier/fallback-extractor.test.ts
+++ b/tests/contract-verifier/fallback-extractor.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initParsers, parseFile } from '../../packages/analyzer/src/index.js';
 import { extractFallbacksFromFile } from '../../packages/contract-verifier/src/extractor/fallback/ts-fallbacks.js';
 import { extractPyFallbacksFromFile } from '../../packages/contract-verifier/src/extractor/fallback/py-fallbacks.js';
+import { extractCsFallbacksFromFile } from '../../packages/contract-verifier/src/extractor/fallback/cs-fallbacks.js';
 import { extractFallbacksFromDir } from '../../packages/contract-verifier/src/extractor/fallback/index.js';
 import type { ExtractedFallback } from '../../packages/contract-verifier/src/extractor/fallback/index.js';
 
@@ -209,6 +210,96 @@ def read_preferences(customer):
 
   it('skips a guarded branch that does not assign the guarded target', () => {
     const rules = extractPy(`def f(x, y):\n    if x is None:\n        y = 1`);
+    expect(rules).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C#: the same null/absent -> default coalescing, in C# syntax. C# has no
+// `undefined`, so `??`/`??=`/`== null`/`is null` are pure null checks; a
+// defaulted parameter fires on absence.
+// ---------------------------------------------------------------------------
+
+function extractCs(source: string, filePath = '/test/x.cs'): ExtractedFallback[] {
+  const tree = parseFile(filePath, source, 'csharp');
+  const rules = extractCsFallbacksFromFile(filePath, source, tree);
+  tree.delete();
+  return rules;
+}
+
+describe('Fallback code extractor — C#', () => {
+  it('derives every fallback from a realistic reservation-service method', () => {
+    const rules = extractCs(`
+public class ReservationService {
+  public Reservation Create(ReservationInput input, string locale = "en-US") {
+    var currency = input.Currency ?? "USD";
+    var partySize = input.PartySize ?? 2;
+    var timezone = input.Timezone ?? DefaultTimezone;
+    if (input.NotifyGuest == null) { input.NotifyGuest = true; }
+    return new Reservation();
+  }
+}`);
+    expect(rules.map((r) => r.contract.target.field).sort()).toEqual([
+      'Currency',
+      'NotifyGuest',
+      'PartySize',
+      'Timezone',
+      'locale',
+    ]);
+    // string `??` default — C# `??` fires on null only.
+    expect(byField(rules, 'Currency')!.contract).toEqual({
+      target: { field: 'Currency' },
+      trigger: 'null',
+      defaultValue: { kind: 'string', value: 'USD' },
+    });
+    // numeric `??` default
+    expect(byField(rules, 'PartySize')!.contract.defaultValue).toEqual({ kind: 'number', value: 2 });
+    // identifier `??` default (named constant)
+    expect(byField(rules, 'Timezone')!.contract.defaultValue).toEqual({
+      kind: 'identifier',
+      ref: 'DefaultTimezone',
+    });
+    // default-parameter fallback fires on absence
+    expect(byField(rules, 'locale')!.contract).toEqual({
+      target: { field: 'locale' },
+      trigger: 'absent',
+      defaultValue: { kind: 'string', value: 'en-US' },
+    });
+    // guarded-assignment boolean fallback (`== null`)
+    expect(byField(rules, 'NotifyGuest')!.contract).toEqual({
+      target: { field: 'NotifyGuest' },
+      trigger: 'null',
+      defaultValue: { kind: 'boolean', value: true },
+    });
+  });
+
+  it('recognizes a `??=` coalescing assignment', () => {
+    const rules = extractCs(`class C { void M(string region) { region ??= "us-east"; } }`);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].contract).toEqual({
+      target: { field: 'region' },
+      trigger: 'null',
+      defaultValue: { kind: 'string', value: 'us-east' },
+    });
+  });
+
+  it('recognizes an `is null` guard', () => {
+    const rules = extractCs(`class C { void M(Input input) { if (input.Tier is null) { input.Tier = "bronze"; } } }`);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].contract).toEqual({
+      target: { field: 'Tier' },
+      trigger: 'null',
+      defaultValue: { kind: 'string', value: 'bronze' },
+    });
+  });
+
+  it('skips a non-scalar `??` default (object initializer)', () => {
+    const rules = extractCs(`class C { void M(Opts o) { var x = o ?? new Options { Retries = 3 }; } }`);
+    expect(rules).toHaveLength(0);
+  });
+
+  it('skips a guarded branch that does not assign the guarded target', () => {
+    const rules = extractCs(`class C { void M(string x, string y) { if (x == null) { y = "1"; } } }`);
     expect(rules).toHaveLength(0);
   });
 });

--- a/tests/contract-verifier/field-exposure-extractor.test.ts
+++ b/tests/contract-verifier/field-exposure-extractor.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initParsers, parseFile } from '../../packages/analyzer/src/index.js';
 import { extractFieldExposuresFromFile } from '../../packages/contract-verifier/src/extractor/field-exposure/ts-fields.js';
 import { extractPyFieldExposuresFromFile } from '../../packages/contract-verifier/src/extractor/field-exposure/py-fields.js';
+import { extractCsFieldExposuresFromFile } from '../../packages/contract-verifier/src/extractor/field-exposure/cs-fields.js';
 import { extractFieldExposuresFromDir } from '../../packages/contract-verifier/src/extractor/field-exposure/index.js';
 import type { ExtractedFieldExposure } from '../../packages/contract-verifier/src/extractor/field-exposure/index.js';
 
@@ -158,6 +159,50 @@ describe('FieldExposure code extractor — Python', () => {
     // A dict that is neither returned nor passed to a response serializer is
     // not an exposure site.
     const recs = extractPy(`def read():\n    opts = {"retries": 3}\n    return opts.get("retries")`);
+    expect(recs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C#: the same exposure channels in C# syntax — EF Core `.Select(o => new {…})`
+// projections and ASP.NET `Ok(new {…})` / `Json(new Dto {…})` response shapes.
+// ---------------------------------------------------------------------------
+
+function extractCs(source: string, filePath = "/test/x.cs"): ExtractedFieldExposure[] {
+  const tree = parseFile(filePath, source, "csharp");
+  const recs = extractCsFieldExposuresFromFile(filePath, source, tree);
+  tree.delete();
+  return recs;
+}
+
+describe("FieldExposure code extractor — C#", () => {
+  it("derives query-select exposures from an EF Core projection", () => {
+    const recs = extractCs(`public class R { public object Get() { return db.Orders.Select(o => new { o.Id, o.Status, Total = o.TotalCents }).ToList(); } }`);
+    expect(recs.map((r) => r.contract.target.field).sort()).toEqual(["Id", "Status", "Total"]);
+    expect(byField(recs, "Status")!.contract).toEqual({ target: { field: "Status" }, exposedVia: ["query-select"] });
+  });
+
+  it("derives api-response exposures from an anonymous Ok(new {…}) body", () => {
+    const recs = extractCs(`public class C { public IActionResult Get(Order o) { return Ok(new { o.Id, o.Status }); } }`);
+    expect(recs.map((r) => r.contract.target.field).sort()).toEqual(["Id", "Status"]);
+    expect(byField(recs, "Id")!.contract.exposedVia).toEqual(["api-response"]);
+  });
+
+  it("derives api-response exposures from a named DTO initializer", () => {
+    const recs = extractCs(`public class C { public IActionResult Get(Order o) { return Json(new OrderDto { Id = o.Id, Status = o.Status }); } }`);
+    expect(recs.map((r) => r.contract.target.field).sort()).toEqual(["Id", "Status"]);
+  });
+
+  it("unions channels for a field selected AND returned (via the dispatcher)", async () => {
+    const dir = fs.mkdtempSync(path.join(require("node:os").tmpdir(), "csfe-"));
+    fs.writeFileSync(path.join(dir, "svc.cs"), `public class C { public IActionResult Get() { var q = db.Orders.Select(o => new { o.Status }).First(); return Ok(new { q.Status }); } }`);
+    const recs = await extractFieldExposuresFromDir(dir);
+    fs.rmSync(dir, { recursive: true, force: true });
+    expect(byField(recs, "Status")!.contract.exposedVia).toEqual(["query-select", "api-response"]);
+  });
+
+  it("ignores a bare `new {…}` not in a Select/response site", () => {
+    const recs = extractCs(`public class C { public void M(Order o) { var internalView = new { o.Secret }; } }`);
     expect(recs).toHaveLength(0);
   });
 });

--- a/tests/contract-verifier/persistence-strategy-extractor.test.ts
+++ b/tests/contract-verifier/persistence-strategy-extractor.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initParsers, parseFile } from '../../packages/analyzer/src/index.js';
 import { extractPersistenceStrategiesFromDir } from '../../packages/contract-verifier/src/extractor/persistence-strategy/index.js';
 import { extractPyMetadataKeysFromFile } from '../../packages/contract-verifier/src/extractor/persistence-strategy/py-metadata-keys.js';
+import { extractCsMetadataKeysFromFile } from '../../packages/contract-verifier/src/extractor/persistence-strategy/cs-metadata-keys.js';
 import type { ExtractedPersistenceStrategy } from '../../packages/contract-verifier/src/extractor/persistence-strategy/index.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -119,5 +120,53 @@ def read(customer):
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C#: metadata-blob key hits in C# syntax — member access on a `Metadata`
+// JObject/dynamic, and `Metadata["key"]` dictionary read/write. (The
+// dedicated-column-vs-metadata-json reconciliation is language-agnostic and
+// already covered by the dispatcher test above; here we assert the C# matcher
+// surfaces the right keys.)
+// ---------------------------------------------------------------------------
+
+function csKeys(source: string): string[] {
+  const tree = parseFile('/x.cs', source, 'csharp');
+  const hits = extractCsMetadataKeysFromFile('/x.cs', source, tree);
+  tree.delete();
+  return hits.map((h) => h.key).sort();
+}
+
+describe('persistence-strategy code extractor — C#', () => {
+  it('finds metadata keys via member access and indexer (read + write)', () => {
+    const keys = csKeys(`
+public class Repo {
+  public void Save(Order o, string reason) {
+    var a = o.Metadata.DisableGuests;
+    var b = o.Metadata["hideCalendarNotes"];
+    o.Metadata["refundPolicy"] = reason;
+  }
+}`);
+    expect(keys).toEqual(['DisableGuests', 'hideCalendarNotes', 'refundPolicy']);
+  });
+
+  it('recognizes a bare `metadata` blob identifier', () => {
+    const keys = csKeys(`public class R { public void M(string v) { metadata["cancellationReason"] = v; } }`);
+    expect(keys).toEqual(['cancellationReason']);
+  });
+
+  it('does not treat a normal (non-blob) member/indexer access as metadata', () => {
+    const keys = csKeys(`public class R { public void M(Config config, string[] items) { var x = config.Timeout; var y = items["0"]; } }`);
+    expect(keys).toEqual([]);
+  });
+
+  it('reconciles C# metadata keys to metadata-json end-to-end (no schema column)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cspers-'));
+    fs.writeFileSync(path.join(dir, 'repo.cs'), `public class R { public void M(Order o) { var a = o.Metadata["disableGuests"]; } }`);
+    const rows = await extractPersistenceStrategiesFromDir(dir);
+    fs.rmSync(dir, { recursive: true, force: true });
+    const m = byField(rows);
+    expect(m.get('disableGuests')?.chosen).toBe('metadata-json');
   });
 });

--- a/tests/contract-verifier/validation-rule-extractor.test.ts
+++ b/tests/contract-verifier/validation-rule-extractor.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initParsers, parseFile } from '../../packages/analyzer/src/index.js';
 import { extractValidationRulesFromFile } from '../../packages/contract-verifier/src/extractor/validation-rule/ts-validation-rules.js';
 import { extractPyValidationRulesFromFile } from '../../packages/contract-verifier/src/extractor/validation-rule/py-validation-rules.js';
+import { extractCsValidationRulesFromFile } from '../../packages/contract-verifier/src/extractor/validation-rule/cs-validation-rules.js';
 import { extractValidationRulesFromDir } from '../../packages/contract-verifier/src/extractor/validation-rule/index.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -213,6 +214,83 @@ def no_setting(reason):
     if not reason:
         raise Exception("reason_required")
 `);
+    expect(rules).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C#: the same required-when guard shape in C# syntax — a setting predicate
+// (member truthiness or `==`), an optional actor `== "literal"` check, a
+// `string.IsNullOrEmpty(x)` / `x == null` / `x is null` missing-check, and a
+// `throw new …Exception("code")` enforcement.
+// ---------------------------------------------------------------------------
+
+function extractCs(source: string, filePath = '/test/x.cs') {
+  const tree = parseFile(filePath, source, 'csharp');
+  const rules = extractCsValidationRulesFromFile(filePath, source, tree);
+  tree.delete();
+  return rules;
+}
+
+describe('ValidationRule code extractor — C#', () => {
+  it('derives a required-when contract from a realistic booking validator', () => {
+    const rules = extractCs(`
+public class BookingValidator {
+  public void Validate(EventType eventType, string actor, string cancellationReason) {
+    if (eventType.RequiresCancellationReason == "MANDATORY" && actor == "host" && string.IsNullOrEmpty(cancellationReason)) {
+      throw new ValidationException("cancellation_reason_required");
+    }
+  }
+}`);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].contract).toEqual({
+      target: 'cancellationReason',
+      when: {
+        kind: 'eq',
+        column: { table: 'eventType', column: 'RequiresCancellationReason' },
+        value: { kind: 'string', value: 'MANDATORY' },
+      },
+      actor: 'host',
+      effect: 'required',
+      onViolation: { status: 400, errorCode: 'cancellation_reason_required' },
+    });
+    expect(rules[0].identity).toBe(
+      'eventType.RequiresCancellationReason.required-when.cancellationReason',
+    );
+  });
+
+  it('recognizes a bare member-truthiness setting + `== null` missing-check, no actor', () => {
+    const rules = extractCs(`
+public class V {
+  public void Check(Settings settings, string note) {
+    if (settings.RequiresNote && note == null) { throw new BadRequestException("note_required"); }
+  }
+}`);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].contract).toEqual({
+      target: 'note',
+      when: { kind: 'eq', column: { table: 'settings', column: 'RequiresNote' }, value: { kind: 'boolean', value: true } },
+      effect: 'required',
+      onViolation: { status: 400, errorCode: 'note_required' },
+    });
+  });
+
+  it('recognizes an `is null` missing-check', () => {
+    const rules = extractCs(`
+public class V { public void C(Cfg cfg, string reason) {
+  if (cfg.NeedReason && reason is null) throw new ValidationException("reason_required");
+} }`);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].contract.target).toBe('reason');
+  });
+
+  it('skips a guard with no enforcement (no throw / error return)', () => {
+    const rules = extractCs(`public class V { public void C(Cfg cfg, string r) { if (cfg.Need && string.IsNullOrEmpty(r)) { r = "x"; } } }`);
+    expect(rules).toHaveLength(0);
+  });
+
+  it('skips a guard with no setting predicate', () => {
+    const rules = extractCs(`public class V { public void C(string r) { if (string.IsNullOrEmpty(r)) throw new ValidationException("r"); } }`);
     expect(rules).toHaveLength(0);
   });
 });

--- a/tests/fixtures/sample-csharp-project-il/code/Services/CustomerPreferencesService.cs
+++ b/tests/fixtures/sample-csharp-project-il/code/Services/CustomerPreferencesService.cs
@@ -1,0 +1,27 @@
+using SampleApi.Data.Entities;
+
+namespace SampleApi.Services;
+
+// Customer preferences read path. Exercises the runtime null/absent → default
+// coalescing (fallback) kind for C#: one matching site, one divergent site.
+public class CustomerPreferencesService
+{
+    private const string DefaultLoyaltyTier = "standard";
+
+    // MATCHING: the loyalty-tier fallback IS applied — `?? DefaultLoyaltyTier`
+    // coalesces a missing tier, exactly as `customer.loyalty-tier-default` states.
+    public string ResolveLoyaltyTier(Customer customer)
+    {
+        var loyaltyTier = customer.LoyaltyTier ?? DefaultLoyaltyTier;
+        return loyaltyTier;
+    }
+
+    // DIVERGENT: `customer.status-default` says a missing status falls back to a
+    // default, but Status is read straight through — the fallback is never applied.
+    public string ResolveStatus(Customer customer)
+    {
+        // IL-DRIFT: Fallback:customer.status-default / fallback.customer.status-default.not-applied
+        var status = customer.Status;
+        return status;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-il/code/Services/CustomerReadService.cs
+++ b/tests/fixtures/sample-csharp-project-il/code/Services/CustomerReadService.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using SampleApi.Data.Entities;
+
+namespace SampleApi.Services;
+
+// Customer read paths. Exercises field-exposure (EF Core projection),
+// validation-rule (required-when guard), and persistence-strategy (metadata
+// bag) for C#.
+public class CustomerReadService
+{
+    private readonly AppDb _db = null!;
+
+    // FIELD-EXPOSURE: the projection exposes LoyaltyTier + Status on the read
+    // path (matches `customer.loyalty-tier-exposed`). It OMITS StoreCredit, so
+    // `customer.store-credit-exposed` is never satisfied.
+    // IL-DRIFT: FieldExposure:customer.store-credit-exposed / field-exposure.customer.store-credit-exposed.not-exposed
+    public List<object> ProjectCustomers()
+    {
+        return _db.Customers.Select(c => new { c.LoyaltyTier, c.Status }).ToList<object>();
+    }
+
+    // VALIDATION-RULE (DIVERGENT): applies the status change with no
+    // suspensionReason check, so the required-when rule is never enforced.
+    // IL-DRIFT: ValidationRule:customer.suspension-reason-required-when-suspended / validation-rule.customer.suspension-reason-required-when-suspended.not-enforced
+    public void ApplyAccountStatus(Customer customer, string status, string actor)
+    {
+        customer.Status = status;
+    }
+
+    // PERSISTENCE-STRATEGY (MATCHING): marketingOptIn is read off the Metadata
+    // JSON bag, not a dedicated column — matches `persistence.marketingOptIn`.
+    public bool ReadMarketingPref(Customer customer)
+    {
+        var opt = customer.Metadata["marketingOptIn"];
+        return opt != null;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/loyalty-tier-exposure.tc
+++ b/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/loyalty-tier-exposure.tc
@@ -1,0 +1,10 @@
+// Read-path field exposure (MATCHING): a customer's loyaltyTier travels on the
+// read path — it is included in the EF Core projection in
+// CustomerReadService.ProjectCustomers (`.Select(c => new { c.LoyaltyTier, … })`).
+
+field-exposure customer.loyalty-tier-exposed {
+  origin "reference/specs/modules/customers/data.md" "Customer read projection" 43..48
+  field Entity:Customer.loyaltyTier
+  via query-select
+  in ProjectCustomers
+}

--- a/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/loyalty-tier-fallback.tc
+++ b/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/loyalty-tier-fallback.tc
@@ -1,0 +1,11 @@
+// Runtime null/absent → default coalescing (MATCHING): a customer with no
+// recorded loyalty tier is treated as `standard`. The C# read path applies the
+// fallback via `customer.LoyaltyTier ?? DefaultLoyaltyTier` in
+// CustomerPreferencesService.ResolveLoyaltyTier. C# `??` fires on null only.
+
+fallback customer.loyalty-tier-default {
+  origin "reference/specs/modules/customers/data.md" "Loyalty tier fallback" 25..29
+  target loyaltyTier
+  when null
+  default DefaultLoyaltyTier
+}

--- a/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/preference-storage.tc
+++ b/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/preference-storage.tc
@@ -1,0 +1,11 @@
+// Storage-strategy decision (MATCHING): the per-customer `marketingOptIn`
+// preference is kept inside the customer `Metadata` JSON bag rather than a
+// dedicated column — read through `customer.Metadata["marketingOptIn"]` in
+// CustomerReadService.ReadMarketingPref.
+
+architecture-decision persistence.marketingOptIn {
+  origin "reference/specs/modules/customers/data.md" "Preference storage" 31..35
+  category persistence-strategy
+  chosen metadata-json
+  reason "Read-mostly preference flag, never filtered in a hot path — not worth a dedicated column"
+}

--- a/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/status-fallback.tc
+++ b/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/status-fallback.tc
@@ -1,0 +1,11 @@
+// Runtime null/absent → default coalescing (DIVERGENT): a customer with no
+// recorded status SHOULD fall back to `DefaultStatus`, but ResolveStatus reads
+// `customer.Status` straight through with no coalescing — the fallback is never
+// applied.
+
+fallback customer.status-default {
+  origin "reference/specs/modules/customers/data.md" "Status fallback" 30..34
+  target status
+  when null
+  default DefaultStatus
+}

--- a/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/store-credit-exposure.tc
+++ b/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/store-credit-exposure.tc
@@ -1,0 +1,10 @@
+// Read-path field exposure (DIVERGENT): storeCredit must travel on the read
+// path (included in the projection), but ProjectCustomers' `.Select(...)` omits
+// it, so it is never selected and never reaches the consumer.
+
+field-exposure customer.store-credit-exposed {
+  origin "reference/specs/modules/customers/data.md" "Billing summary projection" 51..56
+  field Entity:Customer.storeCredit
+  via query-select
+  in ProjectCustomers
+}

--- a/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/suspension-reason-required.tc
+++ b/tests/fixtures/sample-csharp-project-il/reference/contracts/customers/suspension-reason-required.tc
@@ -1,0 +1,16 @@
+// Conditional field-requiredness (DIVERGENT): when an account is moved to
+// `suspended`, an admin must record a suspensionReason. The guard SHOULD live in
+// CustomerReadService.ApplyAccountStatus, but that code applies the status with
+// NO reason check, so the rule is not enforced.
+
+validation-rule customer.suspension-reason-required-when-suspended {
+  origin "reference/specs/modules/customers/data.md" "Account suspension" 31..37
+  target suspensionReason
+  when eq customer.accountStatus "suspended"
+  actor admin
+  effect required
+  on-violation {
+    status 400
+    error-code suspension_reason_required
+  }
+}


### PR DESCRIPTION
## Why
The C# PR (#547) added code-side extractors for the older kinds but missed the four code-derivable kinds from #589 — validation-rule, fallback, field-exposure, persistence-strategy — plus effect. Each kind dispatches per language via MATCHERS[lang]; with no `csharp:` entry, a .cs file produced zero facts, so infer never emitted those kinds and verify never detected their drift for C#.

## What
Adds 5 C# matchers + registers each `csharp:` in its dispatcher (infer + verify both inherit C# via the shared extractCodeContracts layer):
- fallback/cs-fallbacks — ?? / ??= / default param / ==null,is null guards
- field-exposure/cs-fields — EF Core .Select(new {…}) + Ok/Json(new {…})
- validation-rule/cs-validation-rules — required-when guard → throw
- persistence-strategy/cs-metadata-keys — Metadata.X / Metadata["X"] blob keys
- effect/cs-effects — string emits + MediatR typed Publish(new OrderPlaced())

## Verification
Fixture-first (real C# ASTs); C# cases in each -extractor.test.ts; sample-csharp-project-il IL-DRIFT corpus extended for the 4 verify kinds (matching FP-guard + divergent regression). Full contract-verifier suite green (584 tests); tsc clean. Additive only; comparators' normalize already bridges PascalCase C# ↔ camelCase/snake spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)