### PR TITLE
contract-extractor: scope tier-conditional auth to the tier's path variant

### DIFF
--- a/packages/contract-extractor/src/prompt.ts
+++ b/packages/contract-extractor/src/prompt.ts
@@ -728,6 +728,49 @@ Concretely: if the slice heading path includes words like "overview", "stack",
 sentences with no exceptions listed, prefer \`UnenforceableObligation\` for that
 statement rather than a duplicate \`auth-requirement\`.
 
+# Auth-requirement: tier/deployment-conditional auth gates the path, not the obligation
+
+When a spec gates an auth requirement on an **environment/tier/deployment context**
+— typical wording: "X authentication is required when using <Hosted/Cloud/Plus>",
+"OSS does not require authentication", "Self-hosted instances may run without an
+API key" — and provides path examples for each variant, the auth requirement
+**applies only to the variant whose path uniquely identifies that tier**, not to
+the bare path that the other tier also serves. Scope the \`selector path-glob\` to
+that variant's path; do NOT use the unconditional/bare path, because that path
+matches the tier the spec said does NOT require auth, producing an artifact that
+asserts authentication on a route the spec explicitly leaves unauthenticated.
+
+Concrete example. The spec for an asset-materialization endpoint says:
+
+  "Authentication headers aren't required if using <Product> OSS"
+  → \`http://localhost:3000/report_asset_materialization/\`
+  "Authentication headers are required if using <Product> Cloud"
+  → \`https://[ORG].<product>.cloud/[DEPLOYMENT]/report_asset_materialization/\`
+
+Two paths describe the SAME endpoint name; only the Cloud path carries a
+deployment-scope segment. Encode this as:
+
+  auth-requirement auth.apikey.report-asset-materialization {
+    origin "<source>" "<section>" <lines>
+    scheme ApiKey
+    // Scope to the Cloud variant — the OSS path serves the same endpoint
+    // unauthenticated, which the spec explicitly states.
+    selector path-glob "/[deployment]/report_asset_materialization/"
+    on-violation { status 401  error-code unauthenticated }
+  }
+
+If both variants share the same bare path (the spec doesn't give a separate
+path-form for the gated tier), the auth obligation isn't structurally encodable
+as a single path-globbed \`auth-requirement\` — emit an \`UnenforceableObligation\`
+carrying the conditional ("ApiKey required on the <tier> deployment"), and do
+NOT emit a bare-path \`auth-requirement\`. A bare-path requirement would assert
+authentication on the tier the spec said does NOT require it.
+
+Discriminator: this rule fires only when the spec **names two tiers** and gives
+each its own path. If the spec uniformly says "all routes require auth," the
+default unconditional \`auth-requirement\` rule above applies — do not invoke this
+exception.
+
 # Parameterized paths that are pattern descriptions, not real endpoints
 
 Sometimes a spec section uses a parameterized path (e.g., \`GET /api/v1/reports/{slug}\`)


### PR DESCRIPTION
## Why

Same family as #581/#582 (which tightened enum + plugin/decorator grounding) but for the AuthRequirement extraction rule. Surfaced by the dagster campaign-stuck tracker (#600).

The spec for dagster's asset-materialization endpoint says:

> "Authentication headers aren't required if using Dagster OSS" → `http://localhost:3000/report_asset_materialization/`
> "Authentication headers are required if using Dagster+" → `https://[ORG].dagster.cloud/[DEPLOYMENT]/report_asset_materialization/`

Two paths describe the same endpoint name; only the Cloud variant carries a deployment-scope segment. The generator currently:
1. Relativizes the absolute Cloud URL into a bare path (`/report_asset_materialization/`).
2. Writes a single `auth-requirement` with `selector path-glob "/report_asset_materialization/"`.

That selector also matches the **OSS** route, which the spec explicitly states is **un**authenticated. The verifier correctly walks dagster, finds the OSS route unprotected, and emits an `unprotected` drift — not a verifier bug, a bad contract.

This will recur for any product with hosted/OSS or per-tenant tiers (likely SST, sentry, payload-cloud, etc.).

## What

Adds a new section to the AuthRequirement extraction rules with a sharp discriminator and explicit guidance:

> When a spec gates auth on a tier/deployment context **and** gives each tier its own path variant, scope `selector path-glob` to the **gated tier's** path variant — not the bare path the unauthenticated tier also serves. If the spec gives no separate path form for the gated tier, emit an `UnenforceableObligation` carrying the conditional, not a bare-path `auth-requirement`. **Never emit a bare-path auth-requirement that would assert authentication on the tier the spec said does NOT require it.**

The discriminator ("spec names two tiers AND gives each its own path") keeps the rule narrow — the unconditional "all routes require auth" path is unaffected.

## Validation — honest scope

Prompt-only change. The contract-extractor cache is keyed on the system-prompt hash so this forces re-extraction on the next regeneration. **Cannot be proven by a local deterministic test** — confirmation requires a regen run (`drift-fp-generate`). Builds clean; no snapshot test asserts this prompt text.

## After merge — dagster campaign

Same playbook as #555/#581:

1. Reset dagster `status: pending` + delete the storage branch `claude/drift-fp-store/dagster-io-dagster` (forces regeneration with the fixed prompt).
2. Re-run `drift-fp-generate` manually.
3. The regenerated `auth.apikey.report-asset-materialization` should scope to `/[deployment]/report_asset_materialization/`. The OSS route then correctly falls out of auth scope, the verifier reports 0 drifts, and the routine opens the campaign-close PR on its own.

I can prep the dagster reset PR + close #600 as superseded once this merges.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_