### PR TITLE
fix(landing): scope Vercel deploy gate to landing's real inputs

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore @truecourse/landing --fallback=HEAD^1",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- apps/landing pnpm-lock.yaml",
   "rewrites": [
     {
       "source": "/((?!api/).*)",


### PR DESCRIPTION
## Problem

The Vercel deploy gate for `@truecourse/landing` was firing on PRs that never touched the marketing site (e.g. PR #599, which only changed `packages/contract-verifier` and `tests/`).

**Root cause:** `turbo-ignore @truecourse/landing --fallback=HEAD^1` relies on turbo's affected-package analysis. When a commit changes files at the repo root that fall **outside every pnpm workspace** — `tests/`, `docs/`, etc. — turbo can't attribute them to any package, so it conservatively marks the **entire monorepo** as affected. Landing (which has zero internal `@truecourse/*` dependencies) gets pulled in and deploys.

Reproduced locally:
```
--filter="@truecourse/landing...[HEAD^1]"  → 18 packages (all, incl. landing)
git diff HEAD^1                            → only tests/ + packages/contract-verifier
```

## Fix

Replace the turbo-ignore call with a git check scoped to landing's actual inputs:

```json
"ignoreCommand": "git diff --quiet HEAD^ HEAD -- apps/landing pnpm-lock.yaml"
```

Vercel skips the build when the command exits 0 (no changes to those paths) and builds when it exits non-zero. This is immune to turbo's root-file fallback and keeps the same single-commit granularity as the old `--fallback=HEAD^1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)