### PR TITLE
fix(fp): resolve 4 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-duplicate-char-class.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-duplicate-char-class.ts
@@ -41,6 +41,19 @@ function tokenizeCharClass(content: string): string[] {
           i += 2
           continue
         }
+      } else if (next === 'p' || next === 'P') {
+        // \p{Name} / \P{Name} — Unicode property escape (u-flag mode).
+        // Consume the whole `\p{…}` as one atomic token so the letters
+        // inside the property name (e.g. the two `I`s in `\p{ASCII}`) aren't
+        // mistaken for repeated character-class members.
+        if (content[i + 2] === '{') {
+          const close = content.indexOf('}', i + 3)
+          if (close > 0) {
+            tokens.push(content.slice(i, close + 1))
+            i = close
+            continue
+          }
+        }
       }
       // Generic \X escape (\d, \w, \s, \., …)
       tokens.push(content.slice(i, i + 2))

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-empty-alternative.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/regex-empty-alternative.ts
@@ -2,13 +2,47 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { getRegexSource } from './_helpers.js'
 
+// Replace anything that can hold a `|` without it being an alternation
+// operator with a neutral placeholder, so the structural checks below only
+// see *real* alternation pipes and group parentheses. This neutralizes:
+//   - escaped characters (`\|`, `\(`, `\)`, …) → a literal, not an operator
+//   - character-class contents (`[a|b]`, `[)]`) → pipes/parens inside `[…]`
+//     are literals
+function stripRegexLiterals(src: string): string {
+  let out = ''
+  let inClass = false
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i]
+    if (ch === '\\' && i + 1 < src.length) {
+      // Escaped char — drop the escape and its target as a neutral literal.
+      if (!inClass) out += 'x'
+      i++
+      continue
+    }
+    if (inClass) {
+      if (ch === ']') {
+        inClass = false
+        out += 'c'
+      }
+      continue
+    }
+    if (ch === '[') {
+      inClass = true
+      continue
+    }
+    out += ch
+  }
+  return out
+}
+
 export const regexEmptyAlternativeVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/regex-empty-alternative',
   languages: ['typescript', 'tsx', 'javascript'],
   nodeTypes: ['regex', 'new_expression'],
   visit(node, filePath, sourceCode) {
-    const src = getRegexSource(node)
-    if (!src) return null
+    const rawSrc = getRegexSource(node)
+    if (!rawSrc) return null
+    const src = stripRegexLiterals(rawSrc)
 
     if (/\|\|/.test(src) || /^\|/.test(src) || /\|$/.test(src) || /\(\|/.test(src) || /\|\)/.test(src)) {
       return makeViolation(

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/unchecked-array-access.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/unchecked-array-access.ts
@@ -68,6 +68,12 @@ export const uncheckedArrayAccessVisitor: CodeRuleVisitor = {
     const statement = findContainingStatement(node)
     if (!statement || !statement.parent) return null
 
+    // When the access result is bound to a local (`const value = arr[i]`), a
+    // later guard usually checks that *result* variable (`if (!value)`), not
+    // the index. `process.env[name]` followed by `if (!value)` is the canonical
+    // shape. Capture the bound name so the sibling scan can honor such guards.
+    const resultVar = declaredResultName(statement, node)
+
     const siblings = statement.parent.namedChildren
     const stmtIndex = siblings.findIndex(n => n.id === statement.id)
 
@@ -83,6 +89,10 @@ export const uncheckedArrayAccessVisitor: CodeRuleVisitor = {
       }
       // Check for guards that reference the index variable: if (!result), if (x >= N) return, etc.
       if (sibText.includes('if') && sibText.includes(indexText)) {
+        return null
+      }
+      // Guard that checks the bound result variable, e.g. `if (!value) return …`.
+      if (resultVar && sibText.includes('if') && sibText.includes(resultVar)) {
         return null
       }
     }
@@ -139,6 +149,33 @@ export const uncheckedArrayAccessVisitor: CodeRuleVisitor = {
       'Add a bounds check (e.g., if (i < arr.length)) before accessing the array by index.',
     )
   },
+}
+
+/**
+ * If `statement` is a `const`/`let`/`var` declaration whose initializer
+ * contains `accessNode` (i.e. the subscript result is bound to a single
+ * named local), return that local's name. Returns null for destructuring
+ * patterns or when the access isn't part of an initializer.
+ */
+function declaredResultName(statement: SyntaxNode, accessNode: SyntaxNode): string | null {
+  if (statement.type !== 'lexical_declaration' && statement.type !== 'variable_declaration') {
+    return null
+  }
+  for (let i = 0; i < statement.namedChildCount; i++) {
+    const decl = statement.namedChild(i)
+    if (decl?.type !== 'variable_declarator') continue
+    const value = decl.childForFieldName('value')
+    const nameNode = decl.childForFieldName('name')
+    if (
+      value &&
+      nameNode?.type === 'identifier' &&
+      accessNode.startIndex >= value.startIndex &&
+      accessNode.endIndex <= value.endIndex
+    ) {
+      return nameNode.text
+    }
+  }
+  return null
 }
 
 /**

--- a/packages/analyzer/src/rules/reliability/visitors/python/shebang-error.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/python/shebang-error.ts
@@ -15,6 +15,17 @@ export const pythonShebangErrorVisitor: CodeRuleVisitor = {
     const segments = filePath.split('/')
     const fileName = segments[segments.length - 1] ?? ''
     const isMainFile = fileName === '__main__.py'
+    // A file is only "meant to be directly executed" (and therefore needs a
+    // shebang) when it is a __main__.py entrypoint or lives in a conventional
+    // executable-script directory (bin/, scripts/, …). A bare
+    // `if __name__ == "__main__":` guard is NOT sufficient on its own: many
+    // importable modules carry one for dual-use or ad-hoc debugging and are
+    // run via a runtime or `python path/to/file.py`, never as `./file.py`, so
+    // they require no shebang. Without this location gate the rule fires on
+    // every module with a guard, regardless of where it lives.
+    const dirName = (segments[segments.length - 2] ?? '').toLowerCase()
+    const SCRIPT_DIRS = new Set(['scripts', 'bin', 'tools', 'cli', 'cmd'])
+    if (!isMainFile && !SCRIPT_DIRS.has(dirName)) return null
     // Check for __main__ guard using the shared helper's AST check
     const hasMainGuard = !isMainFile && (() => {
       const module = node.type === 'module' ? node : null

--- a/tests/fixtures/sample-js-project-negative/regex-duplicate-char-class.ts
+++ b/tests/fixtures/sample-js-project-negative/regex-duplicate-char-class.ts
@@ -1,0 +1,10 @@
+// A character class that accidentally lists the same delimiter twice. The
+// author meant to match comma, semicolon, or whitespace, but typed the
+// semicolon twice — a redundant member that signals a copy-paste slip.
+
+// VIOLATION: code-quality/deterministic/regex-duplicate-char-class
+const delimiter = /[,;; ]/g;
+
+export function splitFields(input: string): string[] {
+  return input.split(delimiter).filter(Boolean);
+}

--- a/tests/fixtures/sample-js-project-negative/regex-empty-alternative.ts
+++ b/tests/fixtures/sample-js-project-negative/regex-empty-alternative.ts
@@ -1,0 +1,6 @@
+// A real empty alternative: the trailing `|` leaves a branch with nothing
+// after it, so the pattern also matches the empty string — almost always a
+// leftover from deleting the last option in the list.
+
+// VIOLATION: code-quality/deterministic/regex-empty-alternative
+export const danglingBranch = /red|green|/;

--- a/tests/fixtures/sample-js-project-negative/unchecked-array-access-bound-unguarded.ts
+++ b/tests/fixtures/sample-js-project-negative/unchecked-array-access-bound-unguarded.ts
@@ -1,0 +1,9 @@
+// Negative fixture: the access result is bound to a local, but nothing ever
+// guards it — no `if`, no length check, no fallback. A caller-supplied offset
+// is used directly, so the element may be undefined at runtime.
+
+export function fieldAt(parts: string[], offset: number): string {
+  // VIOLATION: reliability/deterministic/unchecked-array-access
+  const field = parts[offset];
+  return field.trim();
+}

--- a/tests/fixtures/sample-js-project-positive/regex-duplicate-char-class.ts
+++ b/tests/fixtures/sample-js-project-positive/regex-duplicate-char-class.ts
@@ -1,0 +1,18 @@
+// A character class whose only member is a single Unicode property escape
+// (`\p{ASCII}`). The repeated letters inside the property name (`ASCII` has
+// two `I`s) belong to one atomic `\p{…}` token — they are not separate
+// character-class members, so there is no duplicate to flag.
+
+const printableOnly = /^[\p{ASCII}]*$/u;
+
+// A second class mixing two distinct Unicode property escapes — still no
+// duplicate members once each `\p{…}` is treated as one token.
+const wordLike = /[\p{Letter}\p{Number}]+/u;
+
+export function isPrintable(value: string): boolean {
+  return printableOnly.test(value);
+}
+
+export function looksLikeWord(value: string): boolean {
+  return wordLike.test(value);
+}

--- a/tests/fixtures/sample-js-project-positive/regex-empty-alternative.ts
+++ b/tests/fixtures/sample-js-project-positive/regex-empty-alternative.ts
@@ -1,0 +1,8 @@
+// `\|` is an escaped literal pipe, not an alternation operator. A pattern that
+// merely has an escaped pipe at its start or end therefore has no empty
+// alternative — the rule must inspect structural `|` operators, not the raw
+// pipe bytes that happen to sit at the pattern boundary.
+
+export const escapedPipe = /\|/;
+
+export const trailingEscapedPipe = /value\|/;

--- a/tests/fixtures/sample-js-project-positive/src/unchecked-array-access-result-guarded.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unchecked-array-access-result-guarded.ts
@@ -1,0 +1,14 @@
+// `process.env[name]` is `string | undefined`, and the very next statement
+// guards the *bound result* with `if (!value)` before it is used. The access
+// is fully handled, so the rule must not flag it merely because the index is a
+// variable — the guard names the result, not the index.
+
+export function boolFromEnv(name: string, fallback: boolean): boolean {
+  const value = process.env[name];
+
+  if (!value) {
+    return fallback;
+  }
+
+  return value === "true";
+}

--- a/tests/fixtures/sample-python-project-negative/cli/release_entrypoint_no_shebang.py
+++ b/tests/fixtures/sample-python-project-negative/cli/release_entrypoint_no_shebang.py
@@ -1,0 +1,15 @@
+"""A release helper that lives in cli/ and is meant to be run directly as
+``./release_entrypoint_no_shebang.py``. It is a genuine executable script, but
+the author forgot the shebang line, so the kernel cannot pick an interpreter.
+"""
+import sys
+
+
+def publish(tag):
+    print(f"publishing {tag}")
+    return 0
+
+
+# VIOLATION: reliability/deterministic/shebang-error
+if __name__ == "__main__":
+    sys.exit(publish(sys.argv[1]))

--- a/tests/fixtures/sample-python-project-positive/dual_use_main_guard_no_shebang.py
+++ b/tests/fixtures/sample-python-project-positive/dual_use_main_guard_no_shebang.py
@@ -1,0 +1,11 @@
+"""A small status module that the service layer imports, and that can also be
+run for ad-hoc local debugging through the project's task runtime. It keeps an
+``if __name__ == "__main__":`` guard for that convenience, but it is never
+invoked as a standalone ``./file.py`` executable, so it needs no shebang.
+"""
+
+STATUS_MESSAGE = "ready"
+
+
+if __name__ == "__main__":
+    print(STATUS_MESSAGE)


### PR DESCRIPTION
Batch of 4 false-positive fixes from the `triggerdotdev/trigger.dev` campaign (target ref `2dd9f37b4045d2a414c0a300995d068f28926d50`). Each fix paraphrases the upstream FP into the analyzer's positive fixture (asserts zero violations), adds a true-bug case to the negative fixture, and narrows the visitor.

Closes #402
Closes #403
Closes #404
Closes #405

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/regex-duplicate-char-class` | #402 | `tests/fixtures/sample-js-project-positive/regex-duplicate-char-class.ts` | `tests/fixtures/sample-js-project-negative/regex-duplicate-char-class.ts` |
| `reliability/deterministic/shebang-error` | #403 | `tests/fixtures/sample-python-project-positive/dual_use_main_guard_no_shebang.py` | `tests/fixtures/sample-python-project-negative/cli/release_entrypoint_no_shebang.py` |
| `code-quality/deterministic/regex-empty-alternative` | #404 | `tests/fixtures/sample-js-project-positive/regex-empty-alternative.ts` | `tests/fixtures/sample-js-project-negative/regex-empty-alternative.ts` |
| `reliability/deterministic/unchecked-array-access` | #405 | `tests/fixtures/sample-js-project-positive/src/unchecked-array-access-result-guarded.ts` | `tests/fixtures/sample-js-project-negative/unchecked-array-access-bound-unguarded.ts` |

## code-quality/deterministic/regex-duplicate-char-class

OSS source: [otlpExporter.server.ts#L1164](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/otlpExporter.server.ts#L1164) — `/^[\p{ASCII}]*$/u`

Positive fixture (new):
```ts
const printableOnly = /^[\p{ASCII}]*$/u;
const wordLike = /[\p{Letter}\p{Number}]+/u;
export function isPrintable(value: string): boolean { return printableOnly.test(value); }
export function looksLikeWord(value: string): boolean { return wordLike.test(value); }
```

Negative fixture (new):
```ts
// VIOLATION: code-quality/deterministic/regex-duplicate-char-class
const delimiter = /[,;; ]/g;   // ';' listed twice
```

**Summary:** The character-class tokenizer treated `\p` as a generic single-char escape and then tokenized the following `{ASCII}` letter-by-letter, so the two `I`s in `ASCII` looked like a duplicate member. Added `\p{…}`/`\P{…}` handling so the whole Unicode property escape is consumed as one atomic token (mirroring the existing `\u{…}` handling). Genuine duplicates still fire — the second occurrence in the repo (`packages/build/src/extensions/typescript.ts`, a real duplicate `(` in a class) remains flagged, so this rule goes 2 → 1.

## reliability/deterministic/shebang-error

OSS source: [crawler.py#L1](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/references/d3-chat/src/trigger/python/crawler.py#L1) (also `references/d3-openai-agents/.../agent.py`, `references/python-catalog/src/python/html2text_url.py`)

Positive fixture (new):
```python
"""...dual-use module run via the task runtime, never as ./file.py..."""
STATUS_MESSAGE = "ready"
if __name__ == "__main__":
    print(STATUS_MESSAGE)
```

Negative fixture (new, in `cli/`):
```python
import sys
def publish(tag):
    print(f"publishing {tag}")
    return 0
# VIOLATION: reliability/deterministic/shebang-error
if __name__ == "__main__":
    sys.exit(publish(sys.argv[1]))
```

**Summary:** The rule fired on any Python module with an `if __name__ == "__main__":` guard, regardless of location. That over-fires on dual-use modules under `src/.../python/` that are run via a runtime / `python file.py`, not executed as `./file.py`, so they need no shebang. Added a location gate: fire only for `__main__.py` entrypoints or files in a conventional executable-script directory (`bin/`, `scripts/`, `tools/`, `cli/`, `cmd/`). Genuine `bin`/`scripts` entrypoints missing a shebang still fire. Rule goes 3 → 0 on the target.

## code-quality/deterministic/regex-empty-alternative

OSS source: [query.ts#L96](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/mcp/tools/query.ts#L96) — `.replace(/\|/g, …)`

Positive fixture (new):
```ts
export const escapedPipe = /\|/;
export const trailingEscapedPipe = /value\|/;
```

Negative fixture (new):
```ts
// VIOLATION: code-quality/deterministic/regex-empty-alternative
export const danglingBranch = /red|green|/;   // trailing empty alternative
```

**Summary:** The empty-alternative checks (`||`, `^|`, `|$`, `(|`, `|)`) ran against the raw pattern, so an escaped literal pipe (`\|`) or a pipe inside a character class was mistaken for a structural alternation operator — `/\|/` was flagged because its body ends with `|`. Added `stripRegexLiterals()` to neutralize escaped characters and character-class contents before the checks, so only real alternation pipes are considered. Genuine empty alternatives like `/red|green|/` still fire. Rule goes 1 → 0.

## reliability/deterministic/unchecked-array-access

OSS source: [util.ts#L2](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/coordinator/src/util.ts#L2) — `const value = process.env[env]; if (!value) …`

Positive fixture (new):
```ts
export function boolFromEnv(name: string, fallback: boolean): boolean {
  const value = process.env[name];
  if (!value) { return fallback; }
  return value === "true";
}
```

Negative fixture (new):
```ts
export function fieldAt(parts: string[], offset: number): string {
  // VIOLATION: reliability/deterministic/unchecked-array-access
  const field = parts[offset];
  return field.trim();
}
```

**Summary:** The rule looked for nearby guards that mention the *index* variable, but missed the common shape where the access result is bound to a local and *that* local is guarded — `const value = process.env[name]; if (!value) return …`. Added `declaredResultName()` to capture the bound result variable when the subscript is a declarator initializer, and extended the sibling-statement scan to treat an `if` referencing that result variable as a valid guard. Genuine unguarded accesses (result bound but never checked, or used inline) still fire. This was the highest-impact fix: 196 → 144 (−52) across the repo.

## Skipped this batch

- #406 `bugs/deterministic/fallthrough-case` — **blocked.** The remaining FPs are all exhaustive *nested switches*; a zero-violation positive fixture for them inherently also trips `code-quality/deterministic/nested-switch` and `code-quality/deterministic/case-without-break`, so the FP can't be isolated without a coordinated multi-rule change. ([detail](https://github.com/truecourse-ai/truecourse/issues/406#issuecomment-4755487270))
- #407 `code-quality/deterministic/elseif-without-else` — **blocked.** The FP claim conflicts with the rule's deliberate design: the committed TP fixture `elseif-without-else-distinct-conditions.ts` is the same default-before-chain shape and is asserted to fire. Excusing the reported cases (reachable `else`) would break that fixture / be unsound — a rule-philosophy decision for a human. ([detail](https://github.com/truecourse-ai/truecourse/issues/407#issuecomment-4755501214))

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a freshly-built `pnpm build:dist` (the exact artifact publish.yml ships), before vs after this batch's visitor edits.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/regex-duplicate-char-class` | 2 | 1 | -1 |
| `reliability/deterministic/shebang-error` | 3 | 0 | -3 |
| `code-quality/deterministic/regex-empty-alternative` | 1 | 0 | -1 |
| `reliability/deterministic/unchecked-array-access` | 196 | 144 | -52 |
| **Total (these 4 rules)** | 202 | 145 | -57 |
| **All-rules total on target** | 34987 | 34930 | -57 |

The all-rules delta equals the 4-rule subtotal, confirming no collateral changes to other rules.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEdtEnL3zidUTQy3RcLmAb)_