### PR TITLE
chore(drift-fp): start discovery for dagster-io/dagster

### DIFF
--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -137,7 +137,7 @@ campaigns:
       - docs/docs/integrations/libraries  # 36 — integration adapters (aws/gcp/snowflake/dbt/…)
     priority: 6
     status: discovering
-    baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    baseline: { verified_at: 2026-06-20, target_ref: 4fb00173b453ac4151c88454e30b567af14c1808, total_drifts: 1, tp: 0, fp: 1, info: 0, fp_rate: 1.0 }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes:
       - "Probe 2026-06-06: rich in-repo docs at docs/docs/guides/build/assets (12), build/external-resources (11), deployment/dagster-plus/management (12), integrations/libraries/aws (12). Python monorepo (python_modules/dagster/, python_modules/libraries/*); narrow code_dir if generate runs hot, but start with `.` like the other monorepos."

--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -136,7 +136,7 @@ campaigns:
       - docs/docs/deployment         # 19 — deployment behavior (kubernetes, dagster-plus)
       - docs/docs/integrations/libraries  # 36 — integration adapters (aws/gcp/snowflake/dbt/…)
     priority: 6
-    status: pending
+    status: discovering
     baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes:


### PR DESCRIPTION
Starting a **drift-fp-discover** run for `dagster-io/dagster`.

- Storage branch: `claude/drift-fp-store/dagster-io-dagster` (fired by storage PR #608)
- Contracts pinned at `target_ref` `4fb00173b453ac4151c88454e30b567af14c1808` (from meta.yaml)
- `code_dir`: `.`
- Marked the campaign `status: discovering` in `campaigns.yaml`.

Next: build truecourse from source, run deterministic `verify` against the pinned contracts, triage drifts, file one issue per drift-kind with FPs, and fill `baseline.*`. This PR will be updated with results.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfD3iXXNFr6RZ2sowWnRz4)_