### PR TITLE
fix(drift-fp): resolve 1 drift FP from dagster-io/dagster

### DIFF
--- a/packages/contract-verifier/src/comparator/enum.ts
+++ b/packages/contract-verifier/src/comparator/enum.ts
@@ -122,9 +122,10 @@ export function compareEnum(input: EnumCompareInput): ContractDrift[] {
     }
     // `extra-value` (code has a value the spec omits) is only meaningful for an
     // EXACT declared value set. Synthesized code enums (sibling-id-literal,
-    // py-instance-registry, py-discriminated-union) are heuristic supersets that
-    // sweep in internal/alias/composed members a docs enum legitimately omits,
-    // so skip extra-value for them. Real declared enums still report extras.
+    // py-instance-registry, py-discriminated-union, py-selector-union) are
+    // heuristic supersets that sweep in internal/alias/composed members a docs
+    // enum legitimately omits, so skip extra-value for them. Real declared enums
+    // still report extras.
     for (const m of nameMatches) {
       if (isSynthesizedEnumShape(m.shape)) continue;
       const extra = m.values.filter((v) => !specNorm.has(normalizeValue(v)));
@@ -293,7 +294,8 @@ function isSynthesizedEnumShape(shape: ExtractedEnum['shape']): boolean {
     shape === 'sibling-id-literal' ||
     shape === 'py-instance-registry' ||
     shape === 'py-discriminated-union' ||
-    shape === 'py-constant-cluster'
+    shape === 'py-constant-cluster' ||
+    shape === 'py-selector-union'
   );
 }
 

--- a/packages/contract-verifier/src/extractor/enum/py-enums.ts
+++ b/packages/contract-verifier/src/extractor/enum/py-enums.ts
@@ -44,6 +44,7 @@ export function extractPyEnumsFromFile(
   out.push(...synthesizeInstanceRegistryEnum(tree.rootNode, filePath, source));
   out.push(...synthesizeDiscriminatedUnionEnum(tree.rootNode, filePath, source));
   out.push(...synthesizeConstantClusterEnums(tree.rootNode, filePath, source, stringTable));
+  out.push(...synthesizeSelectorUnionEnum(tree.rootNode, filePath, source));
   return out;
 }
 
@@ -327,6 +328,163 @@ function commonPrefix(a: string, b: string): string {
   let i = 0;
   while (i < len && a.charCodeAt(i) === b.charCodeAt(i)) i++;
   return a.slice(0, i);
+}
+
+// ---------------------------------------------------------------------------
+// Config-schema Selector union → enum
+//
+// A closed, mutually-exclusive set of options is commonly modeled in a config
+// DSL as a `Selector({...})` whose dict KEYS are the allowed alternatives —
+// "exactly one of these" — which is precisely an enumeration:
+//
+//   def _base_source_schema():
+//       return {"local_file": ..., "s3_bucket": ..., "http_feed": ...}
+//
+//   IMPORT_SCHEMA = {
+//       "source": Field([Selector(merge_dicts(_base_source_schema(),
+//                                             {"database_table": {...}}))]),
+//   }
+//
+// The "enum" is the set of Selector keys (`local_file`, `s3_bucket`,
+// `http_feed`, `database_table`). The schema dict is often assembled with a
+// `merge_dicts(...)`-style helper over a dict-returning function plus inline
+// literals, so we resolve those statically (same-file functions whose body
+// returns a dict literal, and merge/union calls) to recover the full key set.
+// Named after the nearest enclosing schema key or assignment so the comparator
+// binds it (by value-set, like the other synthesized shapes) to a spec enum
+// such as `WorkspaceLoadMethod`. `extra-value` is suppressed against this
+// heuristic shape (a Selector may carry internal keys a docs enum omits).
+// ---------------------------------------------------------------------------
+
+function synthesizeSelectorUnionEnum(
+  root: SyntaxNode,
+  filePath: string,
+  source: string,
+): ExtractedEnum[] {
+  // Same-file functions whose body is `return {<string-key>: ...}` → their keys.
+  // These are the building blocks a schema assembles via merge helpers.
+  const fnReturnKeys = collectDictReturningFunctions(root, source);
+  const out: ExtractedEnum[] = [];
+  walk(root, (node) => {
+    if (node.type !== 'call') return true;
+    const fn = node.childForFieldName('function');
+    if (!fn) return true;
+    const fnName = source.slice(fn.startIndex, fn.endIndex);
+    if (!/(^|\.)Selector$/.test(fnName)) return true;
+    const arg = firstCallArgument(node);
+    if (!arg) return true;
+    const keys = collectSchemaDictKeys(arg, source, fnReturnKeys, 0);
+    if (keys.length < 2) return true;
+    const name = enclosingSchemaName(node, source) ?? fnName;
+    out.push(mkEnum(name, keys, 'py-selector-union', node, filePath));
+    return true;
+  });
+  return out;
+}
+
+/** Map of same-file `def f(): return {<string>: ...}` functions → their dict
+ *  keys. Only a direct dict-literal return is resolved (no control flow). */
+function collectDictReturningFunctions(
+  root: SyntaxNode,
+  source: string,
+): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  walk(root, (node) => {
+    if (node.type !== 'function_definition') return true;
+    const name = textOfField(node, 'name', source);
+    const body = node.childForFieldName('body');
+    if (!name || !body) return true;
+    for (let i = 0; i < body.namedChildCount; i++) {
+      const stmt = body.namedChild(i);
+      if (stmt?.type !== 'return_statement') continue;
+      let val = stmt.namedChild(0);
+      if (val?.type === 'expression_list') val = val.namedChild(0);
+      if (val?.type === 'dictionary') {
+        const keys = dictStringKeys(val, source);
+        if (keys.length > 0) out.set(name, keys);
+      }
+    }
+    return true;
+  });
+  return out;
+}
+
+/** The first positional argument of a call (unwrapping a `keyword_argument`
+ *  value if the schema is passed by keyword). */
+function firstCallArgument(callNode: SyntaxNode): SyntaxNode | null {
+  const args = callNode.childForFieldName('arguments');
+  const first = args?.namedChild(0);
+  if (!first) return null;
+  if (first.type === 'keyword_argument') return first.childForFieldName('value');
+  return first;
+}
+
+/** Recover the closed key set of a Selector schema argument: a dict literal's
+ *  keys, a same-file dict-returning function call, or a `merge_dicts(...)`-style
+ *  union over several such sources. Bounded recursion guards malformed input. */
+function collectSchemaDictKeys(
+  node: SyntaxNode,
+  source: string,
+  fnReturnKeys: Map<string, string[]>,
+  depth: number,
+): string[] {
+  if (depth > 6) return [];
+  if (node.type === 'dictionary') return dictStringKeys(node, source);
+  if (node.type === 'call') {
+    const fn = node.childForFieldName('function');
+    if (!fn) return [];
+    const fnName = source.slice(fn.startIndex, fn.endIndex);
+    // merge_dicts(a, b, …) / merge(a, b) — union the keys of every argument.
+    if (/(^|\.)(?:merge_dicts|merge)$/.test(fnName)) {
+      const args = node.childForFieldName('arguments');
+      const acc: string[] = [];
+      for (let i = 0; args && i < args.namedChildCount; i++) {
+        const a = args.namedChild(i);
+        if (a) acc.push(...collectSchemaDictKeys(a, source, fnReturnKeys, depth + 1));
+      }
+      return acc;
+    }
+    // A bare same-file helper call returning a dict literal.
+    const bare = fnName.replace(/^.*\./, '');
+    return fnReturnKeys.get(fnName) ?? fnReturnKeys.get(bare) ?? [];
+  }
+  return [];
+}
+
+/** The string keys of a dict literal (`{"a": …, "b": …}`). Non-string keys are
+ *  skipped — only a stable, name-like key set is an enumeration. */
+function dictStringKeys(dictNode: SyntaxNode, source: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < dictNode.namedChildCount; i++) {
+    const pair = dictNode.namedChild(i);
+    if (pair?.type !== 'pair') continue;
+    const key = pair.childForFieldName('key');
+    if (key?.type !== 'string') continue;
+    const v = stringValue(key, source);
+    if (v !== null) out.push(v);
+  }
+  return [...new Set(out)];
+}
+
+/** Name a Selector union after the nearest enclosing schema key (`"source":
+ *  Selector(...)`) or assignment (`X = Selector(...)`), walking up the tree. */
+function enclosingSchemaName(callNode: SyntaxNode, source: string): string | null {
+  let n: SyntaxNode | null = callNode.parent;
+  for (let hops = 0; n && hops < 8; hops++) {
+    if (n.type === 'pair') {
+      const key = n.childForFieldName('key');
+      if (key?.type === 'string') {
+        const v = stringValue(key, source);
+        if (v !== null) return v;
+      }
+    }
+    if (n.type === 'assignment') {
+      const left = n.childForFieldName('left');
+      if (left?.type === 'identifier') return source.slice(left.startIndex, left.endIndex);
+    }
+    n = n.parent;
+  }
+  return null;
 }
 
 function synthesizeInstanceRegistryEnum(

--- a/packages/contract-verifier/src/extractor/enum/types.ts
+++ b/packages/contract-verifier/src/extractor/enum/types.ts
@@ -23,6 +23,7 @@ export type EnumShape =
   | 'py-instance-registry'    // NAME = Subclass()  ×N of a common base → enum of NAMEs
   | 'py-discriminated-union'  // Union[A, B, …] of models each with type: Literal["x"]
   | 'py-constant-cluster'     // ≥3 module-level string constants sharing a value prefix
+  | 'py-selector-union'       // Selector({...}) config-schema union → enum of dict keys
   | 'py-set-difference'       // NAME = set(X) - Y — transient; resolved in enum/index.ts
   | 'cs-enum'                 // enum X { A, B }  (member names lowercased)
   | 'cs-set';                 // static readonly HashSet<string> XSet = new() { 'a', 'b' }

--- a/tests/fixtures/sample-python-project-il/code/app/config_dsl.py
+++ b/tests/fixtures/sample-python-project-il/code/app/config_dsl.py
@@ -1,0 +1,24 @@
+"""Minimal config-schema DSL for validating environment-driven settings.
+
+A `Selector` models a closed, mutually-exclusive set of option keys — exactly
+one of the keys may be supplied — which is how the app expresses "pick one of
+these alternatives" config blocks. `merge_dicts` assembles a schema from
+reusable fragments so common option groups can be shared across schemas.
+"""
+
+from collections.abc import Mapping
+
+
+def merge_dicts(*fragments: Mapping) -> dict:
+    """Shallow-merge schema fragments left-to-right into a single dict."""
+    merged: dict = {}
+    for fragment in fragments:
+        merged.update(fragment)
+    return merged
+
+
+class Selector:
+    """A config schema accepting exactly one of the provided option keys."""
+
+    def __init__(self, fields: Mapping) -> None:
+        self.fields = dict(fields)

--- a/tests/fixtures/sample-python-project-il/code/app/notifications.py
+++ b/tests/fixtures/sample-python-project-il/code/app/notifications.py
@@ -2,12 +2,34 @@
 
 from typing import Literal
 
+from app.config_dsl import Selector
+
 # Channels the platform can notify customers on. The product supports exactly
 # these three today — an undocumented decision: no PRD or spec enumerates the
 # allowed notification channels.
 NotificationChannel = Literal["email", "sms", "push"]
 
 
+# Notification transport selection. Exactly one transport is configured per
+# delivery, so the closed set is a config-schema Selector union (its keys are
+# transports). This is a DIFFERENT closed set from any receipt-status family.
+NOTIFICATION_TRANSPORT_SCHEMA = {
+    "transport": Selector(
+        {
+            "smtp_relay": {"host": str},
+            "sms_gateway": {"account_sid": str},
+            "push_service": {"app_id": str},
+        }
+    ),
+}
+
+
+# IL-DRIFT: Enum:DeliveryReceiptStatus / enum.DeliveryReceiptStatus.no-code-counterpart
+# DeliveryReceiptStatus is documented with [queued, sent, bounced], but receipt
+# tracking is delegated entirely to the downstream transport provider — there is
+# no code-side enum or config-schema for it here, so the documented status set
+# genuinely has no code counterpart. The transport Selector above is an unrelated
+# closed set (transports, not statuses) and must NOT be mistaken for it.
 def notify(channel: NotificationChannel, customer_id: str, message: str) -> None:
     """Enqueue a transactional notification.
 

--- a/tests/fixtures/sample-python-project-il/code/app/services/imports_service.py
+++ b/tests/fixtures/sample-python-project-il/code/app/services/imports_service.py
@@ -7,8 +7,41 @@ upload into the import pipeline, and returns a JSON acknowledgement.
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from app.config_dsl import Selector, merge_dicts
+
 
 async def catalog_feed_import_endpoint(request: Request) -> JSONResponse:
     feed_key = request.path_params["feed_key"]
     body = await request.body()
     return JSONResponse({"feed_key": feed_key, "accepted_bytes": len(body)})
+
+
+# --- Catalog import source configuration -------------------------------------
+#
+# A catalog import is loaded from exactly one source. The allowed sources are a
+# closed set, so the schema models them as a Selector (mutually-exclusive keys).
+# The reusable base sources are assembled by a helper and merged with the
+# inline database-table source — the same fragment-merge shape used elsewhere.
+def _base_import_sources() -> dict:
+    return {
+        "local_file": {"path": str},
+        "s3_object": {"bucket": str, "key": str},
+        "http_feed": {"url": str},
+        "inline_payload": {"rows": list},
+    }
+
+
+# FP-GUARD: enum/no-code-counterpart — must NOT drift
+# ImportSourceType is documented with [local_file, s3_object, http_feed]. In code
+# the closed source set is this config-schema Selector union — a superset that
+# also carries `inline_payload` and `database_table`. The verifier must lift the
+# Selector keys as a code-side enumeration and bind it by value, rather than
+# report "no code-side enum matches by name".
+CATALOG_IMPORT_SCHEMA = {
+    "provider": Selector(
+        merge_dicts(
+            _base_import_sources(),
+            {"database_table": {"table": str, "schema_name": str}},
+        )
+    ),
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/notificationchannel/notificationchannel.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/_inferred/notificationchannel/notificationchannel.tc
@@ -1,6 +1,6 @@
 enum NotificationChannel {
   // inferred — enum defined in code but documented in no spec
-  inferred-from "app/notifications.py" 8..8
+  inferred-from "app/notifications.py" 10..10
   confidence high
   representation string-literal
   closed

--- a/tests/fixtures/sample-python-project-il/reference/contracts/imports/import-source-type.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/imports/import-source-type.tc
@@ -1,0 +1,4 @@
+enum ImportSourceType {
+  origin "reference/specs/modules/imports/sources.md" "Import source types" 1..1
+  values [local_file, s3_object, http_feed]
+}

--- a/tests/fixtures/sample-python-project-il/reference/contracts/notifications/delivery-receipt-status.tc
+++ b/tests/fixtures/sample-python-project-il/reference/contracts/notifications/delivery-receipt-status.tc
@@ -1,0 +1,4 @@
+enum DeliveryReceiptStatus {
+  origin "reference/specs/modules/notifications/receipts.md" "Delivery receipt status" 1..1
+  values [queued, sent, bounced]
+}


### PR DESCRIPTION
Closes #610

Deterministic `verify` against the frozen contracts on `claude/drift-fp-store/dagster-io-dagster` reported one false-positive drift on `dagster-io/dagster` @ `4fb00173b453ac4151c88454e30b567af14c1808`. The fix lands entirely in `packages/contract-verifier/src/` (Python enum extractor + comparator shape list) plus IL fixtures.

## Fixes

| drift_kind | issue | fp-guard fixture | regression fixture |
|---|---|---|---|
| `enum/no-code-counterpart` | #610 | `imports_service.py` + `config_dsl.py` + `imports/import-source-type.tc` | `notifications.py` + `notifications/delivery-receipt-status.tc` |

## enum/no-code-counterpart

**OSS source** (pinned ref): the documented `WorkspaceLoadMethod` enumeration (`python_file`, `python_module`, `grpc_server`) exists in code as the keys of a closed config-schema `Selector` union, not a named `Enum`:
- [`_core/workspace/config_schema.py`](https://github.com/dagster-io/dagster/blob/4fb00173b453ac4151c88454e30b567af14c1808/python_modules/dagster/dagster/_core/workspace/config_schema.py) — `Selector(merge_dicts(_get_target_config(), {"grpc_server": …}))`, keys `python_file`/`python_module`/`python_package`/`autoload_defs_module`/`grpc_server`.
- [`_core/workspace/load.py`](https://github.com/dagster-io/dagster/blob/4fb00173b453ac4151c88454e30b567af14c1808/python_modules/dagster/dagster/_core/workspace/load.py) — dispatches on those same keys.

**Cited contract:** `contracts/workspaceloadmethod/workspaceloadmethod.tc` — `values [python_file, python_module, grpc_server]`.

**Root cause:** the Python enum extractor only lifted *named* `Enum` classes, `Literal` aliases, set/list constants, discriminated unions and constant clusters. A closed `Selector({...})` key-union — a mutually-exclusive "pick exactly one" config schema, which is structurally an enumeration — was not lifted, so the comparator found no code-side counterpart and emitted `enum.WorkspaceLoadMethod.no-code-counterpart` (info). The Selector key-set is a *superset* of the documented values (3 of the spec's 3 values are present among the 5 keys → value-set overlap 0.6, size-diff 2), so once lifted it binds by value-set exactly like the other synthesized shapes.

**fix_summary:** Added a `py-selector-union` synthesizer to `extractor/enum/py-enums.ts` that recognizes `Selector(...)` calls and recovers the closed key set from a dict literal, a `merge_dicts(...)`-style union, or a same-file dict-returning helper, naming the union after the nearest enclosing schema key / assignment. Registered `py-selector-union` in `types.ts` and added it to the comparator's synthesized-shape list in `comparator/enum.ts` so `extra-value` is suppressed against it (a Selector may carry internal keys a docs enum legitimately omits). The fix is scoped to the extractor + comparator; no contract, analyzer-rule, or resolver changes.

**FP-guard fixture** (must NOT drift — paraphrased import-source schema; upstream identifiers anonymized):

```python
# services/imports_service.py
from app.config_dsl import Selector, merge_dicts

def _base_import_sources() -> dict:
    return {
        "local_file": {"path": str},
        "s3_object": {"bucket": str, "key": str},
        "http_feed": {"url": str},
        "inline_payload": {"rows": list},
    }

# FP-GUARD: enum/no-code-counterpart — must NOT drift
CATALOG_IMPORT_SCHEMA = {
    "provider": Selector(
        merge_dicts(
            _base_import_sources(),
            {"database_table": {"table": str, "schema_name": str}},
        )
    ),
}
```
```
# reference/contracts/imports/import-source-type.tc
enum ImportSourceType {
  origin "reference/specs/modules/imports/sources.md" "Import source types" 1..1
  values [local_file, s3_object, http_feed]
}
```
(`config_dsl.py` adds minimal `Selector` / `merge_dicts` primitives so the fixture reads as real application code.)

**Regression fixture** (must STILL drift after the fix):

```python
# notifications.py — an unrelated transport Selector is present, proving the
# synthesizer does not over-bind to a disjoint spec enum.
NOTIFICATION_TRANSPORT_SCHEMA = {
    "transport": Selector({
        "smtp_relay": {"host": str},
        "sms_gateway": {"account_sid": str},
        "push_service": {"app_id": str},
    }),
}

# IL-DRIFT: Enum:DeliveryReceiptStatus / enum.DeliveryReceiptStatus.no-code-counterpart
# DeliveryReceiptStatus [queued, sent, bounced] has no code-side enum/schema —
# the transport Selector above is a different closed set and must not satisfy it.
```
```
# reference/contracts/notifications/delivery-receipt-status.tc
enum DeliveryReceiptStatus {
  origin "reference/specs/modules/notifications/receipts.md" "Delivery receipt status" 1..1
  values [queued, sent, bounced]
}
```

(The committed `_inferred/notificationchannel.tc` line number shifts `8..8 → 10..10` because of the added import.)

The full `contract-verifier` suite is green (54 files / 586 tests), including both IL marker tests and the `infer` corpus snapshot. Pre-existing `ee-*`/`github-app`/`dashboard-server` failures in this checkout are unrelated `@truecourse/ee-db` / `@truecourse/ee-data-store` unbuilt-package resolution errors.

## Drift-count delta (vs `4fb00173b453ac4151c88454e30b567af14c1808` on `dagster-io/dagster`, pinned contracts)

Measured with `node dist/cli.mjs verify --no-stash` (fresh `pnpm build:dist`) before and after the fix.

| Drift-kind | Before | After | Delta |
|---|---:|---:|---:|
| `Enum / enum.WorkspaceLoadMethod.no-code-counterpart` | 1 | 0 | -1 |
| **Total (these 1 kinds)** | 1 | 0 | -1 |
| **All-kinds total on target** | 1 | 0 | -1 |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbXftp9ZJDq4ChKCZkvwoJ)_