### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/function-return-type-varies.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/function-return-type-varies.ts
@@ -11,13 +11,18 @@ import { TS_LANGUAGES } from './_helpers.js'
 
 /** Normalize TypeScript literal types to their base types */
 function normalizeType(typeStr: string): string {
+  // `T & {}` is the literal-preserving widening idiom: it keeps editor
+  // autocomplete for known members while still accepting any `T` (e.g.
+  // `"a" | "b" | (string & {})`). It is semantically the base type `T`, so
+  // strip the empty-object intersection before comparing return types.
+  let t = typeStr.replace(/\s*&\s*\{\s*\}/g, '').trim()
   // String literal types: "hello", 'world' → string
-  if (/^["']/.test(typeStr)) return 'string'
+  if (/^["']/.test(t)) return 'string'
   // Number literal types: 42, 3.14 → number
-  if (/^-?\d/.test(typeStr)) return 'number'
+  if (/^-?\d/.test(t)) return 'number'
   // Boolean literal types
-  if (typeStr === 'true' || typeStr === 'false') return 'boolean'
-  return typeStr
+  if (t === 'true' || t === 'false') return 'boolean'
+  return t
 }
 
 /**

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/empty-function.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/empty-function.ts
@@ -27,6 +27,8 @@ export const jsEmptyFunctionVisitor: CodeRuleVisitor = {
     //  - JSX attribute value — `onClick={() => {}}` placeholder
     //  - return value of another function — `return () => {}` no-op
     //  - default in `||` / `??` fallback — `cb || (() => {})`
+    //  - object-property value — `{ cleanup: async () => {} }` provides a
+    //    deliberate no-op callable for an interface/config slot
     if (node.type === 'arrow_function') {
       let parent = node.parent
       // Look through parentheses, e.g. `(() => {})` in `x || (() => {})`
@@ -34,6 +36,7 @@ export const jsEmptyFunctionVisitor: CodeRuleVisitor = {
       if (parent?.type === 'arguments') return null
       if (parent?.type === 'jsx_expression' || parent?.type === 'jsx_attribute') return null
       if (parent?.type === 'return_statement') return null
+      if (parent?.type === 'pair') return null
       if (parent?.type === 'binary_expression') {
         const op = parent.childForFieldName('operator')
         if (op?.text === '||' || op?.text === '??') return null

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/no-empty-function.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/no-empty-function.ts
@@ -50,6 +50,9 @@ export const jsNoEmptyFunctionVisitor: CodeRuleVisitor = {
     if (parent?.type === 'arguments') return null
     if (parent?.type === 'jsx_expression' || parent?.type === 'jsx_attribute') return null
     if (parent?.type === 'return_statement') return null
+    // Object-property value — `{ cleanup: async () => {} }` provides a
+    // deliberate no-op callable for an interface/config slot.
+    if (parent?.type === 'pair') return null
     if (parent?.type === 'binary_expression') {
       const op = parent.childForFieldName('operator')
       if (op?.text === '||' || op?.text === '??') return null

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/restricted-api-usage.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/restricted-api-usage.ts
@@ -38,6 +38,9 @@ export const restrictedApiUsageVisitor: CodeRuleVisitor = {
       if (parent.type === 'formal_parameters' || parent.type === 'required_parameter') return null
       if (parent.type === 'property_identifier') return null
       if (parent.type === 'import_specifier' || parent.type === 'export_specifier') return null
+      // `[event: string]: ...` — the identifier is an index-signature parameter
+      // name, a local binding, not the global.
+      if (parent.type === 'index_signature') return null
 
       // Skip if identifier is declared as a local variable or parameter
       // in any enclosing scope. Closures can reference outer-scope bindings,
@@ -50,7 +53,8 @@ export const restrictedApiUsageVisitor: CodeRuleVisitor = {
           if (declPattern.test(scope.text)) return null
         }
         if (scope.type === 'arrow_function' || scope.type === 'function_declaration' ||
-            scope.type === 'function_expression' || scope.type === 'method_definition') {
+            scope.type === 'function_expression' || scope.type === 'method_definition' ||
+            scope.type === 'generator_function' || scope.type === 'generator_function_declaration') {
           const params = scope.childForFieldName('parameters')
           if (params && paramPattern.test(params.text)) return null
         }

--- a/packages/analyzer/src/rules/security/visitors/javascript/eval-usage.ts
+++ b/packages/analyzer/src/rules/security/visitors/javascript/eval-usage.ts
@@ -3,6 +3,8 @@ import { makeViolation } from '../../../types.js'
 
 const EVAL_FUNCTIONS = new Set(['eval'])
 const TIMER_FUNCTIONS = new Set(['setTimeout', 'setInterval'])
+// Objects whose `.eval` member genuinely is the global eval function.
+const GLOBAL_OBJECTS = new Set(['window', 'globalThis', 'global', 'self'])
 
 export const evalUsageVisitor: CodeRuleVisitor = {
   ruleKey: 'security/deterministic/eval-usage',
@@ -13,15 +15,24 @@ export const evalUsageVisitor: CodeRuleVisitor = {
     if (!fn) return null
 
     let funcName = ''
+    let isMemberCall = false
+    let objectText = ''
     if (fn.type === 'identifier') {
       funcName = fn.text
     } else if (fn.type === 'member_expression') {
+      isMemberCall = true
       const prop = fn.childForFieldName('property')
       if (prop) funcName = prop.text
+      const obj = fn.childForFieldName('object')
+      if (obj) objectText = obj.text
     }
 
-    // eval(), exec()
-    if (EVAL_FUNCTIONS.has(funcName)) {
+    // eval() — only the global eval function. A bare `eval(...)` identifier
+    // call, or an explicit global access like `globalThis.eval(...)`. A
+    // member call such as `client.eval(...)` is that object's own method
+    // (e.g. a key/value store's server-side scripting primitive), not the
+    // global eval the rule targets.
+    if (EVAL_FUNCTIONS.has(funcName) && (!isMemberCall || GLOBAL_OBJECTS.has(objectText))) {
       return makeViolation(
         this.ruleKey, node, filePath, 'high',
         'Dynamic code evaluation',

--- a/packages/analyzer/src/rules/security/visitors/universal.ts
+++ b/packages/analyzer/src/rules/security/visitors/universal.ts
@@ -397,6 +397,19 @@ const DB_PASSWORD_KV_PATTERNS = [
 // connection string is templated, not hardcoded.
 const NON_LITERAL_PASSWORD_SEGMENT = /^\{[^{}]*\}$|^\$\{[^}]*\}$|^%s$|^%\([^)]+\)s$|^<[^>]+>$|^\$\([^)]*\)$|^\$[A-Z_][A-Z0-9_]*$|process\.env/i
 
+// Well-known placeholder passwords used in usage examples and documentation
+// (e.g. `postgresql://user:pass@localhost/db` printed in a `--help` message).
+// These are never real credentials, so a DSN whose password slot is one of
+// them is a documented example, not a hardcoded secret.
+// Kept deliberately narrow to unambiguous documentation tokens: a real
+// (if weak) credential like `mypassword` or `secret123` must still be
+// flagged, so compound `*password` values are intentionally excluded.
+const PLACEHOLDER_PASSWORDS = new Set([
+  'pass', 'passwd', 'pwd',
+  'xxx', 'xxxx', 'xxxxx', 'xxxxxx',
+  'changeme', 'placeholder', 'example', 'redacted',
+])
+
 export const hardcodedDatabasePasswordVisitor: CodeRuleVisitor = {
   ruleKey: 'security/deterministic/hardcoded-database-password',
   nodeTypes: STRING_NODE_TYPES,
@@ -415,6 +428,8 @@ export const hardcodedDatabasePasswordVisitor: CodeRuleVisitor = {
       // the generic exclusion above misses (Python f-strings use `{...}`,
       // not `${...}`).
       if (NON_LITERAL_PASSWORD_SEGMENT.test(urlMatch[1])) return null
+      // Documented example DSN (`user:pass@…`) rather than a real secret.
+      if (PLACEHOLDER_PASSWORDS.has(urlMatch[1].toLowerCase())) return null
       return makeViolation(
         this.ruleKey, node, filePath, 'critical',
         'Hardcoded database password',

--- a/tests/fixtures/sample-js-project-negative/empty-function-unimplemented-stub.ts
+++ b/tests/fixtures/sample-js-project-negative/empty-function-unimplemented-stub.ts
@@ -1,0 +1,5 @@
+// A top-level function with no implementation and no explanatory comment —
+// a real "forgot to implement / dead stub" case, not a deliberate no-op
+// placeholder. This is what the rule is meant to catch.
+// VIOLATION: code-quality/deterministic/empty-function
+export function processPendingJobs() {}

--- a/tests/fixtures/sample-js-project-negative/eval-usage-global-call.ts
+++ b/tests/fixtures/sample-js-project-negative/eval-usage-global-call.ts
@@ -1,0 +1,8 @@
+// Evaluating a caller-supplied string with the global `eval()` runs
+// arbitrary code — a real injection risk. This is the genuine bug the
+// rule should catch: a bare `eval(...)` identifier call, not a method
+// named `eval` on some object.
+export function computeExpression(userInput: string): unknown {
+  // VIOLATION: security/deterministic/eval-usage
+  return eval(userInput);
+}

--- a/tests/fixtures/sample-js-project-negative/function-return-type-varies-mixed-string-number.ts
+++ b/tests/fixtures/sample-js-project-negative/function-return-type-varies-mixed-string-number.ts
@@ -1,0 +1,10 @@
+// Genuinely returns a string from one path and a number from another, with
+// no return annotation — callers can't rely on a single return type. This
+// is the real inconsistency the rule is meant to catch.
+// VIOLATION: bugs/deterministic/function-return-type-varies
+export function parseAmount(raw: string) {
+  if (raw.trim() === "") {
+    return "empty";
+  }
+  return Number(raw);
+}

--- a/tests/fixtures/sample-js-project-negative/hardcoded-database-password-real-dsn.ts
+++ b/tests/fixtures/sample-js-project-negative/hardcoded-database-password-real-dsn.ts
@@ -1,0 +1,5 @@
+// A real database password embedded directly in a connection string —
+// exactly the credential leak the rule must catch. The password is a
+// concrete secret value, not a documentation placeholder.
+// VIOLATION: security/deterministic/hardcoded-database-password
+export const DB_DSN = "postgresql://admin:S3cr3tDbKey9281@db.internal:5432/app";

--- a/tests/fixtures/sample-js-project-negative/restricted-api-usage-global-location.ts
+++ b/tests/fixtures/sample-js-project-negative/restricted-api-usage-global-location.ts
@@ -1,0 +1,7 @@
+// Directly reads and mutates the global `location` object — there is no
+// local binding named `location` in scope, so this is the real restricted
+// global usage the rule targets (router navigation should be used instead).
+export function goHome(): void {
+  // VIOLATION: code-quality/deterministic/restricted-api-usage
+  location.href = "/home";
+}

--- a/tests/fixtures/sample-js-project-positive/empty-function-object-property-noop.ts
+++ b/tests/fixtures/sample-js-project-positive/empty-function-object-property-noop.ts
@@ -1,0 +1,8 @@
+// Empty arrow functions provided as object-property values are intentional
+// no-op placeholders — e.g. default `cleanup` / `onEvent` handlers that
+// satisfy an interface or config slot. The empty body is the whole point,
+// so neither empty-function nor no-empty-function should flag them.
+export const lifecycleHooks = {
+  cleanup: () => {},
+  onEvent: () => {},
+};

--- a/tests/fixtures/sample-js-project-positive/eval-usage-client-script-method.ts
+++ b/tests/fixtures/sample-js-project-positive/eval-usage-client-script-method.ts
@@ -1,0 +1,14 @@
+// A key/value store client exposes an `eval` method for running
+// server-side scripts (the store's own scripting primitive, e.g. a Lua
+// script). A bare member call like `store.eval(script, ...)` is the
+// store's method — not the global `eval()` the rule is meant to flag.
+// The rule must only fire on the global `eval(...)` identifier call, so
+// wrapping `store.eval(...)` should produce no violation.
+
+interface ScriptableStore {
+  eval(script: string, keyCount: number): Promise<number>;
+}
+
+export function runCounterScript(store: ScriptableStore, script: string): Promise<number> {
+  return store.eval(script, 0);
+}

--- a/tests/fixtures/sample-js-project-positive/function-return-type-varies-widening-intersection.ts
+++ b/tests/fixtures/sample-js-project-positive/function-return-type-varies-widening-intersection.ts
@@ -1,0 +1,24 @@
+// `T & {}` (here `string & {}`) is the literal-preserving widening idiom:
+// a union like `"free" | "pro" | (string & {})` keeps autocomplete for the
+// known members while still accepting any string. In the `default` branch
+// the parameter narrows to `string & {}`, which is semantically just
+// `string` — the same base type the other branches return. The
+// return-type-varies rule must not treat `string & {}` as a distinct type,
+// so this function should produce no violation.
+//
+// (Named `loader` so the unrelated missing-return-type rule, which exempts
+// framework route exports, stays out of the way — the point here is the
+// widening idiom, not the missing annotation.)
+
+type Tier = "free" | "pro" | (string & {});
+
+export function loader(tier: Tier) {
+  switch (tier) {
+    case "free":
+      return "Free plan";
+    case "pro":
+      return "Pro plan";
+    default:
+      return tier;
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/hardcoded-database-password-example-placeholder.ts
+++ b/tests/fixtures/sample-js-project-positive/hardcoded-database-password-example-placeholder.ts
@@ -1,0 +1,5 @@
+// Help text that embeds an example connection string. `user:pass` is an
+// obvious documentation placeholder, not a real credential, so the
+// hardcoded-database-password rule should not flag this DSN.
+export const USAGE_EXAMPLE =
+  'Run: migrate "postgresql://user:pass@localhost:5432/appdb"';

--- a/tests/fixtures/sample-js-project-positive/restricted-api-usage-local-bindings.ts
+++ b/tests/fixtures/sample-js-project-positive/restricted-api-usage-local-bindings.ts
@@ -1,0 +1,16 @@
+// Two local bindings that happen to share a name with a restricted global:
+//   - `event` as an index-signature parameter name is just the local name
+//     for the key type, not the implicit global `event`.
+//   - `location` as a generator function's destructured parameter is that
+//     function's own binding, not the global `location`.
+// Neither should be reported as restricted global usage.
+
+export interface EventHandlerMap {
+  [event: string]: (payload: unknown) => void;
+}
+
+export const placeStream = {
+  generate: async function* ({ location }: { location: string }) {
+    yield location.toUpperCase();
+  },
+};


### PR DESCRIPTION
Batch of 5 false-positive fixes discovered against `triggerdotdev/trigger.dev` @ `2dd9f37b4045d2a414c0a300995d068f28926d50`.

Closes #408
Closes #409
Closes #410
Closes #411
Closes #412

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `security/deterministic/eval-usage` | #408 | `eval-usage-client-script-method.ts` | `eval-usage-global-call.ts` |
| `bugs/deterministic/function-return-type-varies` | #409 | `function-return-type-varies-widening-intersection.ts` | `function-return-type-varies-mixed-string-number.ts` |
| `code-quality/deterministic/restricted-api-usage` | #410 | `restricted-api-usage-local-bindings.ts` | `restricted-api-usage-global-location.ts` |
| `security/deterministic/hardcoded-database-password` | #411 | `hardcoded-database-password-example-placeholder.ts` | `hardcoded-database-password-real-dsn.ts` |
| `code-quality/deterministic/empty-function` | #412 | `empty-function-object-property-noop.ts` | `empty-function-unimplemented-stub.ts` |

## security/deterministic/eval-usage

OSS source: [rateLimiter.server.ts#L97](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/services/rateLimiter.server.ts#L97) — `redis.eval(...)` is the Redis Lua-scripting call, misread as JavaScript `eval()`.

Positive fixture (no violation expected):
```diff
+interface ScriptableStore {
+  eval<TResult>(script: string, keyCount: number, ...rest: (string | number)[]): Promise<TResult>;
+}
+
+export function makeCounter(store: ScriptableStore) { ... return store.eval<TResult>(...) }
```
Negative fixture (true bug):
```diff
+export function computeExpression(userInput: string): unknown {
+  // VIOLATION: security/deterministic/eval-usage
+  return eval(userInput);
+}
```
Visitor: the rule now only flags the global `eval` — a bare `eval(...)` identifier call, or an explicit global access (`window`/`globalThis`/`global`/`self`.eval). A member call such as `redis.eval(...)` / `store.eval(...)` is that object's own method (a key/value store's server-side scripting primitive), not the global, and is no longer reported.

## bugs/deterministic/function-return-type-varies

OSS source: [CloudProvider.tsx#L1](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/CloudProvider.tsx#L1) — `"a" | "b" | (string & {})` is the literal-preserving widening trick; the `string & {}`-narrowed default branch was treated as a different base type than the string-literal branches.

Positive fixture (no violation expected):
```diff
+type Tier = "free" | "pro" | (string & {});
+export function loader(tier: Tier) {
+  switch (tier) {
+    case "free": return "Free plan";
+    case "pro": return "Pro plan";
+    default: return tier;            // narrows to `string & {}`
+  }
+}
```
Negative fixture (true bug):
```diff
+// VIOLATION: bugs/deterministic/function-return-type-varies
+export function parseAmount(raw: string) {
+  if (raw.trim() === "") { return "empty"; }   // string
+  return Number(raw);                          // number
+}
```
Visitor: `normalizeType` now strips the empty-object intersection so `T & {}` collapses to its base type `T` before return-type comparison. (The fixture is named `loader` purely so the unrelated `missing-return-type` rule — which exempts framework route exports — stays out of the way; the point under test is the widening idiom.)

## code-quality/deterministic/restricted-api-usage

OSS sources: [workloadServer/index.ts#L38](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/supervisor/src/workloadServer/index.ts#L38) (`[event: string]` index signature), [rsc.tsx#L45](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/references/nextjs-realtime/src/trigger/rsc.tsx#L45) and [#L46](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/references/nextjs-realtime/src/trigger/rsc.tsx#L46) (`location` as a generator-function destructured parameter).

Positive fixture (no violation expected):
```diff
+export interface EventHandlerMap {
+  [event: string]: (payload: unknown) => void;   // index-sig param name
+}
+export const placeStream = {
+  generate: async function* ({ location }: { location: string }) {
+    yield location.toUpperCase();                 // generator param
+  },
+};
```
Negative fixture (true bug):
```diff
+export function goHome(): void {
+  // VIOLATION: code-quality/deterministic/restricted-api-usage
+  location.href = "/home";                        // genuine global `location`
+}
```
Visitor: skip identifiers that are index-signature parameter names (`[event: string]`), and add `generator_function` / `generator_function_declaration` to the enclosing-scope walk so parameters of generator functions (e.g. `async function* ({ location })`) are recognized as locals. Genuine global use such as `location.pathname` (no local `location` in scope) is still flagged — verified by the delta below (4 → 1, keeping the one real positive).

## security/deterministic/hardcoded-database-password

OSS source: [recover-stuck-runs.ts#L81](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/scripts/recover-stuck-runs.ts#L81) — `postgresql://user:pass@localhost:5432/...` inside a `console.error` usage message; `user:pass` is an obvious documentation placeholder.

Positive fixture (no violation expected):
```diff
+export const USAGE_EXAMPLE =
+  'Run: migrate "postgresql://user:pass@localhost:5432/appdb"';
```
Negative fixture (true bug):
```diff
+// VIOLATION: security/deterministic/hardcoded-database-password
+export const DB_DSN = "postgresql://admin:S3cr3tDbKey9281@db.internal:5432/app";
```
Visitor: a DSN whose password slot is an unambiguous documentation token (`pass`, `pwd`, `xxx`, `changeme`, `placeholder`, …) is treated as a documented example. The set is intentionally narrow — compound `*password` values (e.g. `mypassword`) and other concrete credentials are still flagged, preserving the existing `security-rules` unit tests.

## code-quality/deterministic/empty-function

OSS sources: [presence.ts#L37](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/engine.v1.dev.presence.ts#L37) (`cleanup: async () => {}`), [worker.server.ts#L291](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/services/worker.server.ts#L291) (`handler: async (...) => {}`), [eventRepository.server.ts#L163](``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/eventRepository/eventRepository.server.ts#L163).``

Positive fixture (no violation expected):
```diff
+export const lifecycleHooks = {
+  cleanup: () => {},
+  onEvent: () => {},
+};
```
Negative fixture (true bug):
```diff
+// VIOLATION: code-quality/deterministic/empty-function
+export function processPendingJobs() {}
```
Visitor: an empty arrow used as an object-property (`pair`) value is an intentional no-op placeholder for an interface/config slot, consistent with the existing argument/JSX/return/`||`/`??` carve-outs. **The same carve-out is applied to the sibling `code-quality/deterministic/no-empty-function` rule**, which duplicates this logic and fires on the identical shape — without it, no clean positive fixture is possible. (No separate open `fp-fix` issue tracks `no-empty-function`.)

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

Measured with `node dist/cli.mjs analyze --no-llm` from a freshly-built `dist` (the exact artifact `publish.yml` ships).

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `security/deterministic/eval-usage` | 2 | 0 | -2 |
| `bugs/deterministic/function-return-type-varies` | 262 | 261 | -1 |
| `code-quality/deterministic/restricted-api-usage` | 4 | 1 | -3 |
| `security/deterministic/hardcoded-database-password` | 2 | 0 | -2 |
| `code-quality/deterministic/empty-function` | 59 | 44 | -15 |
| **Total (these 5 rules)** | 329 | 306 | -23 |
| **All-rules total on target** | 34930 | 34892 | -38 |

(The all-rules delta exceeds the 5-rule subtotal because the shared `no-empty-function` carve-out also dropped `no-empty-function` 62 → 47.)

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01BALMdvWhv2XmaJAmknLRhm)_