### PR TITLE
docs(csharp): C# rule coverage + semantic-engine plan (closed; moved internal)

### DIFF
--- a/docs/CSHARP_OUTPERFORM_SONAR_PLAN.md
+++ b/docs/CSHARP_OUTPERFORM_SONAR_PLAN.md
@@ -1,0 +1,153 @@
+# C# Plan — Outperform Sonar (Roslyn semantic engine)
+
+> Goal, stated bluntly: **TrueCourse C# must equal-or-exceed SonarC# on coverage
+> AND correctness, then add what Sonar can't do (decisions/contracts/drift +
+> LLM).** Optimize for best-in-class, not for any current constraint. The
+> build-free / tree-sitter-only property is *not* sacred; it becomes a fallback,
+> not the ceiling.
+
+## Clean-room / competitive boundary (read first)
+
+Sonar is a **competitor**. This plan is clean-room and symmetric with how we
+already treat JS/TS and Python:
+
+- We **never run, bundle, or depend on** SonarAnalyzer.CSharp (or any Sonar code)
+  in the product. Same for any non-permissive analyzer.
+- We **copy rules (coverage), never logic.** We reimplement detections as our own
+  analyzers — our own rule keys, our own names, our own wording. Exactly what
+  `ALL-RULES.md` already does: `Our Key` / `Name` / `Description` are ours; the
+  upstream id lives only in the **`Source ID`** column for sync bookkeeping.
+- We do **not** copy upstream rule descriptions or identifiers verbatim. The
+  harvested rule catalogs (Sonar, Roslyn CA, StyleCop, Roslynator) are **coverage
+  checklists only** — they tell us *which defects exist to catch*, nothing more.
+- We do **not** run Microsoft CA / StyleCop / Roslynator either. We reimplement
+  their rule sets as our own analyzers, the same way we reimplemented ESLint /
+  SonarJS / Ruff / SonarPython as our own visitors (we never ran those tools).
+
+Roslyn is used **only as a semantic-information provider** (types, symbols,
+dataflow) — the same role `ts-compiler.ts` plays for JS/TS and Pyright plays for
+Python. It is an information source for *our* analyzers, not a diagnostic engine
+we surface.
+
+## The strategic reframe
+
+Reproducing a semantic compiler with a syntax tree is a race we lose forever — we
+will always lag Sonar on dataflow/nullability and re-introduce false positives
+they already fixed. The fix is not to run their analyzer; it's to **author our own
+analyzers on the same class of semantic model they use**:
+
+> Use Roslyn for the semantic model → author our own analyzers that consult it →
+> drive coverage from the rule *catalogs* of the whole C# linter ecosystem
+> (tracked as checklists in `truecourse-rules-sync`) → layer
+> **contracts/decisions/drift + LLM** on the typed model (the moat Sonar has no
+> answer for). Our own keys, our own logic, throughout.
+
+Coverage identity we're building (all implemented by **us**):
+
+```
+TrueCourse-C#  =  our analyzers covering { Roslyn CA ∪ StyleCop ∪ Roslynator ∪ Sonar } rule sets
+               ∪  our domain analyzers   (architecture/db/reliability/contract-aware)
+               ∪  TrueCourse contract/decision/drift/verify/infer layer
+               ∪  LLM enrichment of the typed model
+   ⊇  SonarC#  +  things Sonar cannot do
+```
+
+## Architecture
+
+A **.NET Roslyn semantic host** — a small .NET worker process spawned by the Node
+analyzer over stdio/IPC, exactly the pattern we already use for Pyright (Python).
+
+- Loads the real `.sln`/`.csproj` via **MSBuildWorkspace** (full fidelity:
+  references, generated code, nullable context).
+- Exposes a **semantic query API** (types, symbols, references, type hierarchy,
+  dataflow) that **our own analyzers** call — the C# equivalent of
+  `ts-compiler.ts`'s `TypeQueryService` and the Pyright LSP. It does **not** run
+  third-party analyzer packs.
+- Registered in `lsp-servers/registry.ts` at the existing `csharp:` slot (already
+  stubbed: `// csharp: createOmniSharpConfig`). We use a **Roslyn-based host**,
+  not classic OmniSharp (archived).
+
+**Tiering (preserves a zero-setup path, doesn't cap the flagship):**
+
+| Tier | Engine | When | Coverage |
+|---|---|---|---|
+| Flagship | Roslyn host (SDK present) | CI / PR-gate / hosted / local-with-SDK | full — superset of Sonar |
+| Fallback | existing tree-sitter visitors | no .NET SDK, quick local pass | syntactic subset only |
+
+The 308 tree-sitter C# visitors are **kept** as the SDK-free fallback and as the
+behavioral basis for the domain analyzers we re-home onto Roslyn.
+
+## Phases
+
+### Phase 0 — Benchmark harness (define "win" before building)
+A corpus of real, diverse C# repos (OSS apps, libraries, ASP.NET services). Run
+**SonarC# (Sonar way)** and current TrueCourse head-to-head; record per-rule
+coverage and TP/FP. This is the baseline we must beat and the regression gate for
+every later phase. (Direct application of our battle-test / zero-FP cycle.) Sonar
+is run here **only as an external benchmark to measure against** — its output
+never enters our product.
+
+### Phase 1 — Roslyn semantic host (the foundation)
+The .NET worker + IPC protocol + MSBuildWorkspace load + semantic query API.
+Node-side `csharp` provider in the registry. Tree-sitter path becomes the
+documented fallback. Deliverable: "given a solution, answer type/symbol/dataflow
+queries for our analyzers."
+
+### Phase 2 — Catalog the gap, drive from `truecourse-rules-sync`
+Add the C# linter catalogs as **checklist sources** in the sync repo (sonar-csharp,
+roslyn-ca, later stylecop/roslynator). Diff against our existing 308 C# rules to
+produce the net-new coverage list, each assigned **our own** key. No upstream code
+or text enters the repo — only the coverage delta + Source-ID bookkeeping.
+
+### Phase 3 — Our analyzers (where we match and exceed)
+Author **our own Roslyn analyzers** for the net-new coverage and re-home our
+domain rules (architecture/database/reliability/contract-aware) onto the semantic
+model — far higher recall than the tree-sitter ports. Fixture-first, zero-FP cycle
+against the Phase 0 corpus. Detection logic, identifiers, and wording are entirely
+ours.
+
+### Phase 4 — The moat (what Sonar cannot do)
+Feed the typed model into the TrueCourse layer:
+- **Contracts/decisions/verify/infer/drift for C#** become type-accurate (today
+  they're tree-sitter approximations) — occurrence-level drift, contract
+  extraction, the PR-gate contract semantics.
+- **LLM enrichment** of findings over the typed model — catch the
+  statically-undecidable defects Sonar structurally can't, and explain/triage
+  findings. Sonar has no equivalent.
+
+### Phase 5 — Prove it
+Re-run Phase 0. Ship gate: **coverage ≥ Sonar AND false-positive rate ≤ Sonar**
+across the corpus, per domain. Publish the head-to-head (doubles as landing-page
+OSS analysis material).
+
+## Decisions needed (my recommendations inline)
+
+1. **Build requirement.** Flagship = Roslyn (needs .NET SDK + restore); keep
+   tree-sitter as the no-SDK fallback. *Recommend: yes — flagship Roslyn, fallback
+   tree-sitter.* This is the only way to reach the type-dependent 323; CI and the
+   PR-gate already have an SDK.
+2. **Confirm clean-room sourcing** (above) is the bar: catalogs as checklists,
+   our own analyzers/keys/wording, no third-party analyzer ever run or bundled.
+   *Recommend: yes — it's already our JS/Python practice.*
+
+## Risks / cross-cutting
+
+- **Distribution**: shipping a .NET host beside a Node CLI — package a
+  self-contained .NET binary per-platform, or require the SDK. Needs a story.
+- **Performance**: solution load is seconds–minutes; cache the Compilation,
+  analyze PR diffs incrementally.
+- **Double-maintenance**: don't maintain 300+ rules in two engines forever —
+  Roslyn analyzers become the long-term home for C# deterministic rules;
+  tree-sitter C# narrows to fallback + shared cross-language structural extraction.
+
+## Why this beats Sonar (not ties)
+
+1. Same class of semantic engine → our analyzers match their dataflow/type rules
+   instead of forever chasing them in a syntax tree.
+2. We reimplement the union of the whole ecosystem's rule *coverage* (CA ∪
+   StyleCop ∪ Roslynator ∪ Sonar) as our own analyzers → more deterministic
+   coverage than any single tool.
+3. Our analyzers tuned on our corpus with a zero-FP gate → fewer false positives.
+4. The contract/decision/drift/verify layer + LLM → an entire dimension Sonar has
+   no product for. **Sonar finds issues; we find issues *and* track the decisions,
+   contracts, and drift behind them, with compiler-grade fidelity.**

--- a/docs/CSHARP_RULE_COVERAGE_GAP.md
+++ b/docs/CSHARP_RULE_COVERAGE_GAP.md
@@ -1,0 +1,158 @@
+# C# Rule Coverage Gap — SonarC# / Roslyn / StyleCop / Roslynator vs TrueCourse
+
+> Status: analysis only. No code yet. This is the C# analog of the JS/Python
+> coverage work tracked in the private `truecourse-rules-sync` repo, which never
+> included a single C#/.NET source. It answers: *what C#-native rules do the
+> standard C# linters catch that we don't, and which of those can our build-free
+> analyzer actually implement?*
+
+## TL;DR
+
+- Our C# rule set (308 visitors) was **ported from the JS/Python catalog**, never
+  sourced from C#'s own linters. `truecourse-rules-sync` tracks ESLint, SonarJS,
+  Ruff, SonarPython — **zero C# sources**.
+- The single most important constraint: **our analyze is build-free** (tree-sitter
+  only, no Roslyn semantic model). So the *addressable* universe is the
+  **syntactic** (type-independent) external rules. Type-dependent rules are
+  out of scope by design (deferred to the .NET SDK's analyzers at compile time —
+  this is exactly what `language-support.ts` already documents).
+- Against **SonarC#** (the benchmark — 470 rules, **147 syntactic**): we already
+  cover **~60**, leaving **~87 net-new syntactic**. Of those, **~45 are worth
+  porting** (real bugs/smells) and **~40 are low-value** (formatting, assembly
+  attributes, framework-niche).
+- **Roslyn CA** adds only ~5 genuinely-new syntactic rules (it's 310/326
+  type-dependent; its syntactic rules overlap Sonar's).
+- **StyleCop (190 syntactic)** and **Roslynator (216 syntactic)** are
+  overwhelmingly formatting / mechanical-refactor rules — deprioritize wholesale;
+  they're a `dotnet format` + `.editorconfig` concern, not a decisions/contracts
+  concern.
+- **The real gap is the 323 type-dependent SonarC# rules** (IDisposable/dispose,
+  nullability/dataflow, LINQ-method resolution, ConfigureAwait, ASP.NET/Blazor,
+  crypto). We can't touch those without a semantic model (Roslyn or an LSP) — a
+  separate, larger architectural decision.
+
+## The numbers
+
+| Source | Total | Syntactic (addressable) | Type-dependent (out of scope, build-free) |
+|---|---|---|---|
+| SonarC# | 470 | 147 | 323 |
+| Roslyn CA (quality) | 326 | 16 | 310 |
+| Roslyn IDE (style) | 125 | 42 | 83 |
+| StyleCop SA | 195 | 190 | 5 |
+| Roslynator RCS | 340 | 216 | 124 |
+
+Our current C#: **308 visitors**. `language-support.ts` already records the
+deliberate exclusions: **671 not-applicable**, **58 unsupported** (51 of which
+read "requires a type checker"), **26 partial**.
+
+## SonarC# syntactic diff (the benchmark)
+
+147 syntactic rules. **~60 already covered**, **~87 net-new**. Net-new triaged:
+
+### Tier 1 — port first (real bugs / hotspots, clearly syntactic)
+
+| Sonar | What it flags | Notes |
+|---|---|---|
+| S2183 | integer shift by zero or ≥ bit-width | no shift rule today |
+| S1313 | hardcoded IP address literals | we only catch `0.0.0.0`/`IPAddress.Any` |
+| S6640 | `unsafe` code block used | security hotspot |
+| S5753 | ASP.NET request validation disabled | |
+| S1116 | empty statements / stray `;` | |
+| S3458 | empty `case` falling through to `default` | |
+| S3532 | empty `default` clause | |
+| S1048 | `throw` inside a finalizer | we have throw-in-`finally` only |
+| S3880 | empty finalizer (≡ CA1821) | |
+| S2327 | adjacent `try` with identical catch/finally | |
+| S1940 | inverted boolean check — `!(a==b)` → `a!=b` | |
+| S2437 | useless bit ops (`& -1`, `\| 0`, `^ 0`) | |
+| S3052 | member initialized to its default (≡ CA1805) | |
+| S6418 | secret-named var assigned high-entropy literal | broadens our AWS-only secret check |
+| S2345/S2346/S2344/S4016/S4022 | Flags-enum & enum hygiene (powers-of-two, zero-`None`, no `Enum`/`Flags` suffix, no `Reserved`, Int32 storage) | group as one "enum hygiene" visitor family |
+
+### Tier 2 — valuable smells / cleanups
+
+S126 (if/else-if missing final else), S1110 + S1121 (broaden our redundant-parens
+& assignment-in-subexpression beyond return/throw/condition), S1123 (`[Obsolete]`
+without explanation), S2292 (trivial property → auto-property), S2302 (`nameof`
+instead of string param name in throw), S2357 (fields should be private), S2339 +
+S2360 (public `const` / optional params — contested), S2342 (enum naming),
+S3261 (empty namespace), S3400 (broaden method-returns-constant), S3441 (redundant
+property name in anonymous object), S3442 (≡ CA1012 abstract class public ctor),
+S3447/S3450/S3451 (`[Optional]`/`[DefaultParameterValue]`/`[DefaultValue]`
+correctness), S3872 (param name duplicates method name), S3874 (≡ CA1021/CA1045
+`out`/`ref` in public method), S3967 (multidim array), S4136 (overloads grouped),
+S4201 (redundant null-check combined with `is`), S4663 (empty comment), S3235
+(redundant empty parens), S3237 (`value` unused in setter).
+
+### Tier 3 — low value / defer
+
+- **Formatting/layout** (a formatter's job): S103 line length, S104 file LOC,
+  S105 tabs, S113 newline-at-EOF, S122 statements-per-line, S1109 brace
+  placement, S1659 multi-var declarations, S2148 number underscores, S3937 digit
+  groups, S818 literal-suffix case, S3972/S3973 conditional layout, S1151 case
+  length, S1451 license header, S1199/S121 brace style (partly covered).
+- **Comment tracking**: S1134 (FIXME), S1135 (TODO), S1309 (suppressions — partly
+  covered by our `ban-ts-comment`).
+- **Assembly-level**: S3904 (AssemblyVersion), S3990 (CLSCompliant), S3992
+  (ComVisible).
+- **Framework / language niche**: S3598/S3603 (WCF/`[Pure]`), S6421/S6802
+  (Azure Functions/Blazor markup), S6798/S6930 (Blazor/route backslash), S2290
+  (virtual event), S2306 (async as identifier), S4061 (`__arglist`), S2436
+  (generic-param count), S2368 (multidim param), S2156 (sealed protected member),
+  S8368/S8380/S8381 (C# 14 contextual-keyword escaping), S2857 (SQL keyword
+  whitespace), S3343 (caller-info param order), S7039 (CSP header — we mark the
+  CSP family not-applicable for C#), S5856 already covered.
+
+## Roslyn CA syntactic (16) — small net-new
+
+Most overlap Sonar (CA1502≡S1541, CA1707≡naming, CA1012≡S3442, CA1021≡S3874,
+CA1805≡S3052). **Genuinely net-new and worth it:** CA1716 (identifiers matching
+keywords), CA1008 (enum zero value), CA1505 (maintainability-index metric).
+**Niche:** CA1200 (cref prefix), CA1509 (metrics config), CA2243 (attribute
+literal parse). Note: CA1708 (identifiers differ only by case) and CA1069 (enum
+duplicate values) are things we *deliberately* marked not-applicable — worth a
+second look since Sonar/Roslyn both flag them.
+
+## StyleCop (190) + Roslynator (216) — deprioritize as a class
+
+- **StyleCop**: 190/195 syntactic, but 100% formatting/spacing/ordering/
+  documentation-presence/naming-text. This is what `dotnet format` + an
+  `.editorconfig` enforce. Not a TrueCourse differentiator.
+- **Roslynator**: RCS0xxx (62) is pure formatting; RCS1xxx syntactic (~150) is
+  mechanical "remove redundant / merge / simplify" refactors, heavily overlapping
+  the Sonar Tier-2 cleanups above. Cherry-pick from Tier 2; skip the rest.
+
+## The bigger gap: 323 type-dependent SonarC# rules
+
+These are where C# "feels" under-covered, and **none are reachable build-free**:
+dispose/`IDisposable` correctness (S2930/S2931/S2952/S3881/CA1063…), nullability &
+dataflow (S2259/S1854/S2583/S2589/S3655), LINQ-method resolution (the S660x band),
+`ConfigureAwait(false)` (S3216), logging-framework rules (S66xx), ASP.NET/Blazor
+(S69xx), and the crypto/TLS/deserialization security families (S44xx/S5xxx — many
+of which we approximate syntactically today but Sonar does semantically).
+
+Closing this requires a **semantic model** — Roslyn as a backend, or a C# LSP/
+OmniSharp seam — which is a deliberate architecture decision, not a rule port.
+That is the fork in the road below.
+
+## Recommendation
+
+1. **Now (build-free, no architecture change):** port SonarC# Tier 1 (~18 rules,
+   several grouped) + the high-value Tier-2/CA rules (~30). Net ~45 new visitors,
+   same engine, same fixture-first cycle. This is the direct analog of the
+   JS/Python rules-sync work.
+2. **Add C# sources to `truecourse-rules-sync`** (SonarC# RSPEC JSON + Roslyn CA
+   index) so the catalog tracks C# linter releases the same way it tracks ESLint/
+   Ruff — otherwise this gap silently reopens every release.
+3. **Separately decide** whether to invest in a Roslyn/LSP semantic backend to
+   unlock the 323 type-dependent rules. Big lift; the only path to true Sonar/
+   Roslyn parity for C#.
+
+### Sources
+
+- SonarC#: `SonarSource/sonar-dotnet` → `analyzers/rspec/cs/*.json` (470/470).
+- Roslyn CA/IDE: `dotnet/docs` quality-rules + style-rules indexes.
+- StyleCop: `DotNetAnalyzers/StyleCopAnalyzers` documentation.
+- Roslynator: `dotnet/roslynator` → `src/Analyzers.xml`.
+- Our inventory: `packages/analyzer/src/rules/<domain>/visitors/csharp/` +
+  `language-support.ts`.


### PR DESCRIPTION
Two planning docs for the C# rule effort.

- **`CSHARP_RULE_COVERAGE_GAP.md`** — our 308 C# rules were ported from the JS/Python catalog and never sourced from C#'s own linters. Gap analysis vs SonarC# (470), Roslyn CA/IDE (451), StyleCop (195), Roslynator (340).
- **`CSHARP_OUTPERFORM_SONAR_PLAN.md`** — clean-room plan to equal/exceed Sonar on C#: a Roslyn semantic host (the role `tsc` plays for JS, Pyright for Python), our own analyzers (never run or bundle a competitor's), with contracts/decisions/drift + LLM as the moat Sonar has no product for.

Catalog side (the rule tracking) is in `truecourse-ai/truecourse-rules-sync#1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)