### PR TITLE
chore: remove competitor (Sonar) references from the public repo

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -798,7 +798,7 @@ type DiffCheckResult = {
 
 ## Phase 7: Code-Level Analysis & Code Viewer `STATUS: DONE`
 
-Extend the analyzer to detect code-level issues (like SonarQube) and add a code viewer to the frontend for browsing source files with inline violation annotations.
+Extend the analyzer to detect code-level issues and add a code viewer to the frontend for browsing source files with inline violation annotations.
 
 ### Code-Level Analysis
 
@@ -2892,7 +2892,7 @@ Architecture-level violations (service-level, no line number) appear in a dedica
 
 ## Phase 30: Comprehensive Code Rules `STATUS: DONE`
 
-Build all valuable ESLint, @typescript-eslint, eslint-plugin-security, eslint-plugin-sonarjs, Ruff, and SonarQube rules into TrueCourse's tree-sitter analysis engine. The goal is not to match these tools — it's to **beat them**: better detection, fewer false positives, one tool instead of four.
+Build a comprehensive set of bug, code-quality, and security rules into TrueCourse's tree-sitter analysis engine. The goal is best-in-class: high detection, low false positives, one tool instead of several.
 
 Master rule catalog: `docs/research/ALL-RULES.md` (1,156 rules). Private sync repo for tracking linter releases: `truecourse-rules-sync`.
 
@@ -2977,9 +2977,9 @@ The fix prompt is part of the rule definition, not an LLM call.
 ### Verification (Phase 30)
 
 1. Run TrueCourse on benchmark repos → catches everything ESLint catches (minus formatting)
-2. Run TrueCourse on benchmark repos → catches everything SonarQube catches for JS/TS/Python
+2. Run TrueCourse on benchmark repos → catches the full range of bug, smell, and security issues for JS/TS/Python
 3. Head-to-head: FP rate lower than ESLint on same code
-4. Head-to-head: FP rate lower than SonarQube on same code
+4. Head-to-head: low false-positive rate on the same code
 5. `BEARER_TOKEN` in a type map → not flagged (the tester's original complaint)
 6. Duplicate code: 15-line copy-paste across files → flagged
 8. Cognitive complexity > 15 → flagged with specific refactoring suggestion
@@ -3016,7 +3016,7 @@ Add a Settings page to the web UI for per-repo configuration. Web UI counterpart
 
 ## Phase 32: Head-to-Head Competition Framework `STATUS: TODO`
 
-Prove TrueCourse is better than the tools it replaces. Systematic benchmarking against ESLint, SonarQube, madge, and gitleaks.
+Prove TrueCourse is better than the tools it replaces. Systematic benchmarking against comparable open-source tools.
 
 ### Benchmark Repository Suite
 
@@ -3024,14 +3024,14 @@ Curate real-world open-source repos for head-to-head comparison:
 
 - **Repos with known circular deps** — compare madge vs TrueCourse
 - **Repos with planted/known secrets** — compare gitleaks vs TrueCourse
-- **Repos previously scanned by SonarQube** — compare findings
+- **Repos previously scanned by other analyzers** — compare findings
 - **Test fixtures** — intentional bugs, security holes, code smells, and patterns that cause false positives in other tools
 
 ### Automated Comparison Test Suite
 
 For each rule, automated test that:
 
-1. Runs ESLint / SonarQube / madge / gitleaks on the same code
+1. Runs the comparable tools on the same code
 2. Runs TrueCourse on the same code
 3. Compares: true positives, unique finds, false positives, false negatives
 
@@ -3053,7 +3053,7 @@ Runs in CI on every change to the rules engine. Any regression = build fails.
 ### Coverage Scorecard
 
 ```
-                        ESLint  SonarQube  madge  gitleaks  TrueCourse
+                        ESLint  Analyzer   madge  gitleaks  TrueCourse
 Bug detection             ✅       ✅       —       —         ✅
 Code smells               ✅       ✅       —       —         ✅
 Security (single-file)    ⚠️       ✅       —       —         ✅
@@ -3124,7 +3124,7 @@ You can safely remove ESLint.
 
 Build a taint tracking engine that follows untrusted data from where it enters the system (HTTP requests, user input) through function calls across files to where it's used dangerously (SQL queries, eval, file system, redirects). Upgrades existing security rules with deeper detection — same rule keys, no new rules.
 
-This is TrueCourse's competitive differentiator against SonarQube. Requires symbolic execution engine, inter-procedural analysis, object sensitivity, path sensitivity, and framework-specific models.
+This is TrueCourse's competitive differentiator. Requires symbolic execution engine, inter-procedural analysis, object sensitivity, path sensitivity, and framework-specific models.
 
 **Architecture:**
 

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/argument-type-mismatch.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/argument-type-mismatch.ts
@@ -15,7 +15,6 @@ const ARGUMENT_MISMATCH_CODES = new Set<number>([2345, 2769, 2554, 2555])
 
 /**
  * Detect: Arguments to built-in functions that don't match documented types.
- * Corresponds to sonarjs S3782 (argument-type).
  * Checks first argument type against function parameter type for common built-ins.
  */
 export const argumentTypeMismatchVisitor: CodeRuleVisitor = {

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/function-return-type-varies.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/function-return-type-varies.ts
@@ -5,7 +5,6 @@ import { TS_LANGUAGES } from './_helpers.js'
 
 /**
  * Detect: Function returns different types from different paths.
- * Corresponds to sonarjs S3800 (function-return-type).
  * Uses type query to check the return type of the function.
  */
 

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/non-number-arithmetic.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/non-number-arithmetic.ts
@@ -39,7 +39,6 @@ function isConfidentlyNonNumeric(t: string): boolean {
 
 /**
  * Detect: Arithmetic operator used with non-numeric operands.
- * Corresponds to sonarjs S3760 (non-number-in-arithmetic-expression).
  */
 export const nonNumberArithmeticVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/non-number-arithmetic',

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/values-not-convertible-to-number.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/values-not-convertible-to-number.ts
@@ -6,7 +6,6 @@ const RELATIONAL_OPS = new Set(['<', '>', '<=', '>='])
 
 /**
  * Detect: Values not convertible to numbers used in numeric comparisons.
- * Corresponds to sonarjs S3758 (values-not-convertible-to-numbers).
  */
 export const valuesNotConvertibleToNumberVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/values-not-convertible-to-number',

--- a/packages/analyzer/src/rules/bugs/visitors/python/confusing-implicit-concat.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/python/confusing-implicit-concat.ts
@@ -5,7 +5,7 @@ import { makeViolation } from '../../../types.js'
  * Detects adjacent string/byte literals that are implicitly concatenated in contexts
  * where this looks like a mistake (e.g., inside a list or set, or as function arguments
  * where two separate strings were likely intended).
- * S5799: Confusing implicit string/byte concatenation.
+ * Confusing implicit string/byte concatenation.
  */
 export const pythonConfusingImplicitConcatVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/confusing-implicit-concat',

--- a/packages/analyzer/src/rules/bugs/visitors/python/datetime-constructor-range.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/python/datetime-constructor-range.ts
@@ -3,7 +3,7 @@ import { makeViolation } from '../../../types.js'
 
 /**
  * Detects datetime/date/time constructor calls with out-of-range literal values.
- * S6882: datetime constructor with invalid values raises ValueError at runtime.
+ * datetime constructor with invalid values raises ValueError at runtime.
  */
 
 // datetime(year, month, day, hour=0, minute=0, second=0, microsecond=0)

--- a/packages/analyzer/src/rules/bugs/visitors/python/fastapi-cors-middleware-order.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/python/fastapi-cors-middleware-order.ts
@@ -3,7 +3,7 @@ import { makeViolation } from '../../../types.js'
 
 /**
  * Detects CORSMiddleware added before other middlewares in FastAPI.
- * S8414: CORSMiddleware should be added last in the middleware chain.
+ * CORSMiddleware should be added last in the middleware chain.
  *
  * Pattern: app.add_middleware(CORSMiddleware, ...) appears before other
  * app.add_middleware() calls.

--- a/packages/analyzer/src/rules/bugs/visitors/python/ml-reduction-axis-missing.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/python/ml-reduction-axis-missing.ts
@@ -4,7 +4,6 @@ import { makeViolation } from '../../../types.js'
 /**
  * Detects ML reduction operations (sum, mean, max, min, etc.) called without
  * specifying axis/dim — may reduce entire tensor unexpectedly.
- * S6929.
  */
 
 // Methods on numpy/torch/tensorflow arrays that perform reductions

--- a/packages/analyzer/src/rules/bugs/visitors/python/numpy-weekmask-invalid.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/python/numpy-weekmask-invalid.ts
@@ -3,7 +3,7 @@ import { makeViolation } from '../../../types.js'
 
 /**
  * Detects invalid NumPy busdaycalendar weekmask values.
- * S6900: The weekmask argument must be a 7-character string of '0's and '1's,
+ * The weekmask argument must be a 7-character string of '0's and '1's,
  * or one of the named day abbreviations.
  */
 

--- a/packages/analyzer/src/rules/bugs/visitors/python/tf-function-side-effects.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/python/tf-function-side-effects.ts
@@ -3,7 +3,7 @@ import { makeViolation } from '../../../types.js'
 
 /**
  * Detects Python side effects inside @tf.function decorated functions.
- * S6928: Side effects (print, list.append, etc.) only execute during tracing, not at runtime.
+ * Side effects (print, list.append, etc.) only execute during tracing, not at runtime.
  */
 
 const SIDE_EFFECT_CALLS = new Set([

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/eq-without-hash.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/eq-without-hash.ts
@@ -25,7 +25,6 @@ function isGetHashCodeOverride(member: SyntaxNode): boolean {
  * `override Equals(object)` without `override GetHashCode()` — instances
  * misbehave in Dictionary/HashSet (equal objects landing in different
  * buckets). The compiler warns (CS0659) but warnings don't gate review;
- * Sonar ships the same check as S1206.
  */
 export const csharpEqWithoutHashVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/eq-without-hash',

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/static-method-candidate.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/static-method-candidate.ts
@@ -53,7 +53,7 @@ function usesInstanceState(body: SyntaxNode, instanceMembers: Set<string>): bool
 }
 
 /**
- * Mirrors Sonar S2325: only private/protected methods are flagged — public
+ * Only private/protected methods are flagged — public
  * methods on concrete classes are often kept non-static deliberately for DI
  * registration and mocking, which would be false positives.
  */

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/unused-collection.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/unused-collection.ts
@@ -40,7 +40,7 @@ function isCollectionInit(value: SyntaxNode, declaredType: SyntaxNode | null): b
 }
 
 /**
- * Sonar S4030 semantics: a local collection whose every subsequent reference
+ * A local collection whose every subsequent reference
  * only MUTATES it (Add/Push/Enqueue/indexer writes) — its contents are never
  * read, so all that work is dead. Locals with zero references are left to
  * unused-variable; this rule requires at least one write.

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/html-table-accessibility.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/html-table-accessibility.ts
@@ -4,14 +4,14 @@ import { makeViolation } from '../../../types.js'
 type SyntaxNode = import('web-tree-sitter').Node
 
 /**
- * sonarjs accessibility rules for HTML tables in JSX:
- * - S5257: HTML tables should not be used for layout purposes
- * - S5256: Tables should have header elements
- * - S5264: <object> tags should provide alternative content
+ * Accessibility rules for HTML tables in JSX:
+ * - HTML tables should not be used for layout purposes
+ * - Tables should have header elements
+ * - <object> tags should provide alternative content
  *
  * Detects:
- * 1. <table> without any <th> or <thead> elements (S5256)
- * 2. <object> without fallback content (S5264)
+ * 1. <table> without any <th> or <thead> elements
+ * 2. <object> without fallback content
  */
 
 function getJsxElementName(node: SyntaxNode): string | null {
@@ -81,7 +81,7 @@ export const htmlTableAccessibilityVisitor: CodeRuleVisitor = {
     // Only apply to JSX files
     if (!filePath.endsWith('.tsx') && !filePath.endsWith('.jsx')) return null
 
-    // S5256: <table> should have <th> or <thead>
+    // <table> should have <th> or <thead>
     if (tagName === 'table') {
       // Skip generic reusable table wrapper components that forward content
       // via `{...props}` — accessibility is the consumer's responsibility.
@@ -111,7 +111,7 @@ export const htmlTableAccessibilityVisitor: CodeRuleVisitor = {
       }
     }
 
-    // S5264: <object> should have fallback content
+    // <object> should have fallback content
     if (tagName === 'object') {
       if (node.type === 'jsx_self_closing_element') {
         return makeViolation(

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/test-code-after-done.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/test-code-after-done.ts
@@ -4,7 +4,7 @@ import { makeViolation } from '../../../types.js'
 type SyntaxNode = import('web-tree-sitter').Node
 
 /**
- * sonarjs/S6079 (no-code-after-done)
+ * no-code-after-done
  * Detects code executed after done() callback is called in a test.
  */
 function findDoneCallIndex(stmts: SyntaxNode[]): number {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/test-deterministic-assertion.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/test-deterministic-assertion.ts
@@ -2,7 +2,7 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
 /**
- * sonarjs/S6092 (chai-determinate-assertion)
+ * chai-determinate-assertion
  * Detects Chai assertions that are non-determinate — have more than one way to succeed.
  *
  * Specifically:

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/test-incomplete-assertion.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/test-incomplete-assertion.ts
@@ -2,7 +2,7 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
 /**
- * sonarjs/S2970 (no-incomplete-assertions)
+ * no-incomplete-assertions
  * Detects incomplete Chai/Jest/Jasmine assertions that don't actually assert anything:
  * - expect(x).to.be (missing final assertion call)
  * - expect(x).toBe (missing invocation)

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/test-missing-exception-check.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/test-missing-exception-check.ts
@@ -2,7 +2,7 @@ import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
 /**
- * sonarjs/S5958 (test-check-exception)
+ * test-check-exception
  * Detects test cases that use expect().toThrow() or expect().rejects without
  * verifying the specific exception type.
  *


### PR DESCRIPTION
Removes all Sonar fingerprints — the **word** (`Sonar`/`sonarjs`) and the **rule-ID citations** (`Sxxxx`) — from the public repo. Competitor analysis lives only in the private catalog repo.

- **19 analyzer visitor files** — provenance comments scrubbed/reworded (the rule logic is unchanged; only comments).
- **`docs/PLAN.md`** — the competitive-benchmark passages genericized to drop Sonar naming.
- **Kept on purpose:** `secret-rules.ts` / `stopwords.ts` / `secret-scanning.test.ts` detect SonarQube API *tokens* as secrets — that's legitimate functionality.

Comment/doc-only; analyzer builds clean, no behavior change.