### PR TITLE
feat(csharp): wire the Roslyn host into the analyze pipeline

### DIFF
--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -196,3 +196,11 @@ export async function analyzeRepository(rootPath: string): Promise<{
 
 // Config file checkers
 export { checkPyprojectToml } from './rules/bugs/pyproject-checker.js'
+
+export {
+  runRoslynHost,
+  resolveRoslynHostBinary,
+  RoslynHostUnavailableError,
+  type RoslynFile,
+  type RoslynHostViolation,
+} from './roslyn-host-client.js'

--- a/packages/analyzer/src/roslyn-host-client.ts
+++ b/packages/analyzer/src/roslyn-host-client.ts
@@ -1,0 +1,124 @@
+/**
+ * Client for the C# Roslyn semantic host (tools/csharp-roslyn-host).
+ *
+ * The host is NOT an LSP — it speaks our own newline-delimited JSON protocol and
+ * runs our C# rules against Roslyn's semantic model, returning violations. This
+ * client spawns it as a batch child process: one `analyze` request with all the
+ * C# files, one response, then the process exits.
+ *
+ * C# semantic analysis is build-required: if the host binary isn't available (or
+ * the .NET runtime can't run it), this FAILS — there is no tree-sitter fallback,
+ * by design (a silent half-analysis is worse than a clear error).
+ */
+
+import { spawn } from 'child_process'
+import { existsSync } from 'fs'
+import { dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const HOST_BINARY_ENV = 'TRUECOURSE_ROSLYN_HOST'
+
+export interface RoslynFile {
+  path: string
+  text: string
+}
+
+/** Raw violation as emitted by the host (enriched into a CodeViolation by the caller). */
+export interface RoslynHostViolation {
+  ruleKey: string
+  path: string
+  line: number
+  column: number
+  message: string
+}
+
+/** Thrown when the host can't be located or started — C# analysis cannot proceed. */
+export class RoslynHostUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RoslynHostUnavailableError'
+  }
+}
+
+/**
+ * Resolve the built host binary. Honours $TRUECOURSE_ROSLYN_HOST, otherwise looks
+ * in the in-repo build output relative to this module. Returns null if not found.
+ */
+export function resolveRoslynHostBinary(): string | null {
+  const override = process.env[HOST_BINARY_ENV]
+  if (override) return existsSync(override) ? override : null
+
+  const here = dirname(fileURLToPath(import.meta.url))
+  const rel = 'tools/csharp-roslyn-host/bin/Release/net8.0/csharp-roslyn-host'
+  // works from packages/analyzer/src and from a bundled dist a level or two deeper
+  for (const up of ['../../..', '../../../..', '../../../../..']) {
+    const candidate = resolve(here, up, rel)
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+interface HostResponse {
+  ok: boolean
+  violations?: RoslynHostViolation[]
+  error?: string
+}
+
+/**
+ * Run the C# semantic rules over `files` via the Roslyn host.
+ * @param rules optional allow-list of rule keys; omit to run all host rules.
+ * @throws RoslynHostUnavailableError if the host is missing or can't start.
+ */
+export function runRoslynHost(files: RoslynFile[], rules?: string[]): Promise<RoslynHostViolation[]> {
+  const bin = resolveRoslynHostBinary()
+  if (!bin) {
+    return Promise.reject(
+      new RoslynHostUnavailableError(
+        'C# semantic analysis requires the Roslyn host. Build it with ' +
+          '`dotnet build -c Release tools/csharp-roslyn-host`, or set ' +
+          `$${HOST_BINARY_ENV} to the built binary.`,
+      ),
+    )
+  }
+
+  return new Promise<RoslynHostViolation[]>((resolvePromise, reject) => {
+    const child = spawn(bin, [], { stdio: ['pipe', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (d: string) => (stdout += d))
+    child.stderr.on('data', (d: string) => (stderr += d))
+
+    child.on('error', (e) =>
+      reject(
+        new RoslynHostUnavailableError(
+          `Failed to start the Roslyn host (${bin}): ${e.message}. Is the .NET runtime installed?`,
+        ),
+      ),
+    )
+
+    child.on('close', () => {
+      const line = stdout.split('\n').find((l) => l.trim())
+      if (!line) {
+        reject(new Error(`Roslyn host produced no output.${stderr ? ` stderr: ${stderr}` : ''}`))
+        return
+      }
+      let resp: HostResponse
+      try {
+        resp = JSON.parse(line) as HostResponse
+      } catch {
+        reject(new Error(`Roslyn host returned invalid JSON: ${line}`))
+        return
+      }
+      if (!resp.ok) {
+        reject(new Error(`Roslyn host error: ${resp.error ?? 'unknown'}`))
+        return
+      }
+      resolvePromise(resp.violations ?? [])
+    })
+
+    child.stdin.write(JSON.stringify({ op: 'analyze', files, rules }) + '\n')
+    child.stdin.end()
+  })
+}

--- a/packages/analyzer/src/rules/bugs/deterministic.ts
+++ b/packages/analyzer/src/rules/bugs/deterministic.ts
@@ -241,6 +241,17 @@ export const BUGS_DETERMINISTIC_RULES: AnalysisRule[] = [
     type: 'deterministic',
   },
   {
+    key: 'bugs/deterministic/referenceequals-on-value-type',
+    category: 'code',
+    domain: 'bugs',
+    name: 'ReferenceEquals on a value type',
+    description: 'object.ReferenceEquals on a value type is always false — the arguments are boxed into distinct objects.',
+    enabled: true,
+    severity: 'high',
+    type: 'deterministic',
+    engine: 'roslyn-host',
+  },
+  {
     key: 'bugs/deterministic/fallthrough-case',
     category: 'code',
     domain: 'bugs',

--- a/packages/analyzer/src/rules/language-support.ts
+++ b/packages/analyzer/src/rules/language-support.ts
@@ -2346,6 +2346,16 @@ export function withLanguageSupport(rules: AnalysisRule[], visitors: CodeRuleVis
         continue
       }
 
+      if (rule.engine === 'roslyn-host') {
+        // Implemented in the C# Roslyn semantic host (no tree-sitter visitor).
+        // These are C#-specific semantic defects, inexpressible elsewhere.
+        support[language] =
+          language === 'csharp'
+            ? { status: 'supported' }
+            : { status: 'not-applicable', reason: 'C# semantic rule (Roslyn host); no equivalent in this language' }
+        continue
+      }
+
       const hasExplicit = explicitFamilies.get(rule.key)?.has(language) ?? false
       const hasUniversal = universalRuleKeys.has(rule.key) && UNIVERSAL_VISITOR_FAMILIES.includes(language)
 

--- a/packages/core/src/services/rules.service.ts
+++ b/packages/core/src/services/rules.service.ts
@@ -26,6 +26,7 @@ function toAnalysisRule(
     severity: rule.severity,
     type: rule.type,
     contextRequirement: rule.contextRequirement,
+    engine: rule.engine,
     languageSupport: rule.languageSupport,
   };
 }

--- a/packages/core/src/services/violation-pipeline.service.ts
+++ b/packages/core/src/services/violation-pipeline.service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import { checkCodeRules, withParsedTree, detectLanguage, buildScopedCompilerOptions, createTypeQueryService, hasTypeAwareVisitors, hasSchemaAwareVisitors, buildSchemaIndex, initParsers, type TypeQueryService, type SchemaIndex } from '@truecourse/analyzer';
+import { checkCodeRules, withParsedTree, detectLanguage, buildScopedCompilerOptions, createTypeQueryService, hasTypeAwareVisitors, hasSchemaAwareVisitors, buildSchemaIndex, initParsers, runRoslynHost, type TypeQueryService, type SchemaIndex } from '@truecourse/analyzer';
 import type { CodeViolation } from '@truecourse/shared';
 import type { ModuleViolation, ServiceViolation } from '@truecourse/analyzer';
 import { runDeterministicModuleChecks, runDeterministicMethodChecks, runDeterministicServiceChecks, type AnalysisResult } from './analyzer.service.js';
@@ -429,6 +429,43 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
         // Re-check after yielding — the SIGINT handler runs during the
         // event-loop tick we just gave it, so the flag may have flipped.
         if (signal?.aborted) throw new DOMException('Analysis cancelled', 'AbortError');
+      }
+    }
+  }
+
+  // C# semantic rules run in the out-of-process Roslyn host (build-required).
+  // Batch: one host invocation over all C# files. Fail-hard — if there are C#
+  // files and host rules but the host is unavailable, runRoslynHost throws and
+  // the analysis errors out (no tree-sitter fallback, by design).
+  const enabledHostRules = enabledCodeRules.filter((r) => r.engine === 'roslyn-host');
+  if (enabledHostRules.length > 0) {
+    const csharpFiles: { path: string; text: string }[] = [];
+    for (const { filePath, resolve } of filesToScan) {
+      if (detectLanguage(filePath) !== 'csharp') continue;
+      const absPath = resolve ? path.resolve(repoPath, filePath) : (path.isAbsolute(filePath) ? filePath : path.join(repoPath, filePath));
+      const key = changedFileSet ? absPath : filePath;
+      const fc = fileContents.get(key);
+      if (fc) csharpFiles.push({ path: key, text: fc.content });
+    }
+    if (csharpFiles.length > 0) {
+      const ruleByKey = new Map(enabledHostRules.map((r) => [r.key, r]));
+      const hostViolations = await runRoslynHost(csharpFiles, enabledHostRules.map((r) => r.key));
+      for (const v of hostViolations) {
+        const rule = ruleByKey.get(v.ruleKey);
+        if (!rule) continue;
+        const snippet = (fileContents.get(v.path)?.content.split('\n')[v.line - 1] ?? '').trim();
+        allCodeViolations.push({
+          ruleKey: v.ruleKey,
+          filePath: v.path,
+          lineStart: v.line,
+          lineEnd: v.line,
+          columnStart: v.column,
+          columnEnd: v.column,
+          severity: rule.severity,
+          title: rule.name,
+          content: v.message,
+          snippet,
+        });
       }
     }
   }

--- a/packages/shared/src/types/rules.ts
+++ b/packages/shared/src/types/rules.ts
@@ -102,6 +102,12 @@ export const AnalysisRuleSchema = z.object({
   type: RuleTypeSchema,
   contextRequirement: ContextRequirementSchema.optional(),
   /**
+   * Which engine implements this rule's detection. Omitted = the default
+   * tree-sitter visitor. `roslyn-host` rules need the C# semantic model and run
+   * in the out-of-process Roslyn host (tools/csharp-roslyn-host) instead.
+   */
+  engine: z.enum(['tree-sitter', 'roslyn-host']).optional(),
+  /**
    * Per-language support status. Populated by the analyzer's rule registry
    * (derived from visitor coverage plus curated dispositions) — every rule
    * carries an entry for every AnalysisLanguage.

--- a/tests/analyzer/roslyn-host.test.ts
+++ b/tests/analyzer/roslyn-host.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import {
+  runRoslynHost,
+  resolveRoslynHostBinary,
+  RoslynHostUnavailableError,
+} from '../../packages/analyzer/src/roslyn-host-client'
+
+// These exercise the real .NET host. They run only when it's been built
+// (`dotnet build -c Release tools/csharp-roslyn-host`); otherwise they skip.
+const hostBuilt = resolveRoslynHostBinary() !== null
+
+describe.skipIf(!hostBuilt)('Roslyn host client (semantic C#)', () => {
+  it('flags ReferenceEquals on a value type — impossible without the type model', async () => {
+    const violations = await runRoslynHost([
+      {
+        path: 'Pos.cs',
+        text: 'class C { void M() { int a = 1; int b = 2; var x = object.ReferenceEquals(a, b); } }',
+      },
+    ])
+    expect(violations.map((v) => v.ruleKey)).toContain('bugs/deterministic/referenceequals-on-value-type')
+    expect(violations[0].path).toBe('Pos.cs')
+    expect(violations[0].line).toBeGreaterThan(0)
+  })
+
+  it('does not flag ReferenceEquals on reference types', async () => {
+    const violations = await runRoslynHost([
+      {
+        path: 'Neg.cs',
+        text: 'class C { void M() { var a = new object(); var b = new object(); var x = object.ReferenceEquals(a, b); } }',
+      },
+    ])
+    expect(violations).toEqual([])
+  })
+
+  it('respects the rule allow-list', async () => {
+    const violations = await runRoslynHost(
+      [{ path: 'Pos.cs', text: 'class C { void M() { int a = 1; var x = object.ReferenceEquals(a, a); } }' }],
+      ['some/other/rule'],
+    )
+    expect(violations).toEqual([])
+  })
+})
+
+describe('Roslyn host client — fail-hard when unavailable', () => {
+  it('rejects with a clear error when the host binary is missing (no fallback)', async () => {
+    const prev = process.env.TRUECOURSE_ROSLYN_HOST
+    process.env.TRUECOURSE_ROSLYN_HOST = '/nonexistent/roslyn-host'
+    try {
+      await expect(runRoslynHost([{ path: 'A.cs', text: 'class C {}' }])).rejects.toBeInstanceOf(
+        RoslynHostUnavailableError,
+      )
+    } finally {
+      if (prev === undefined) delete process.env.TRUECOURSE_ROSLYN_HOST
+      else process.env.TRUECOURSE_ROSLYN_HOST = prev
+    }
+  })
+})

--- a/tests/analyzer/rule-language-support.test.ts
+++ b/tests/analyzer/rule-language-support.test.ts
@@ -49,6 +49,8 @@ describe('rule language-support matrix', () => {
     const phantom: string[] = [];
     for (const rule of rules) {
       if (rule.category !== 'code' || rule.type !== 'deterministic') continue;
+      // roslyn-host rules are implemented by the C# semantic host, not a tree-sitter visitor
+      if (rule.engine === 'roslyn-host') continue;
       for (const language of ANALYSIS_LANGUAGES) {
         const entry = rule.languageSupport?.[language];
         if (!entry || (entry.status !== 'supported' && entry.status !== 'partial')) continue;

--- a/tests/cli/analyze-csharp-roslyn-host.test.ts
+++ b/tests/cli/analyze-csharp-roslyn-host.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execSync } from 'node:child_process'
+
+// Same socket stub as analyze-csharp.test.ts — emits require a live socket server.
+vi.mock('../../apps/dashboard/server/src/socket/handlers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../apps/dashboard/server/src/socket/handlers')>()
+  class NoopTracker {
+    start() {}
+    done() {}
+    error() {}
+    detail() {}
+  }
+  return {
+    ...actual,
+    emitAnalysisProgress: vi.fn(),
+    emitAnalysisComplete: vi.fn(),
+    emitViolationsReady: vi.fn(),
+    emitFilesChanged: vi.fn(),
+    emitAnalysisCanceled: vi.fn(),
+    createSocketTracker: () => new NoopTracker(),
+    createSocketLlmEstimateHandler: () => () => Promise.resolve(true),
+  }
+})
+
+import { analyzeInProcess } from '../../packages/core/src/commands/analyze-in-process'
+import { readLatest, clearLatestCache } from '../../packages/core/src/lib/analysis-store'
+import { registerProject, unregisterProject, type RegistryEntry } from '../../packages/core/src/config/registry'
+import { updateProjectConfig } from '../../packages/core/src/config/project-config'
+import { resolveRoslynHostBinary } from '../../packages/analyzer/src/roslyn-host-client'
+
+const HOST_KEY = 'bugs/deterministic/referenceequals-on-value-type'
+const hostBuilt = resolveRoslynHostBinary() !== null
+
+const PROJECT = `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+</Project>
+`
+// Value-type ReferenceEquals — only the semantic (Roslyn) engine can catch this.
+const SOURCE = `namespace Demo;
+
+public class IdentityChecks
+{
+    public bool SameValue(int a, int b) => object.ReferenceEquals(a, b);
+
+    public bool SameRef(object a, object b) => object.ReferenceEquals(a, b);
+}
+`
+
+describe.skipIf(!hostBuilt)('CLI analyze e2e — Roslyn host violations reach the store', () => {
+  let workDir: string
+  let project: RegistryEntry
+
+  beforeAll(async () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'truecourse-e2e-roslyn-'))
+    fs.writeFileSync(path.join(workDir, 'Demo.csproj'), PROJECT)
+    fs.writeFileSync(path.join(workDir, 'IdentityChecks.cs'), SOURCE)
+    const env = { ...process.env, GIT_AUTHOR_NAME: 'test', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 'test', GIT_COMMITTER_EMAIL: 't@t' }
+    execSync('git init -q -b main', { cwd: workDir, env })
+    execSync('git add -A', { cwd: workDir, env })
+    execSync('git -c commit.gpgsign=false commit -q -m init', { cwd: workDir, env })
+    project = await registerProject(workDir)
+    await updateProjectConfig(workDir, { enableLlmRules: false })
+    clearLatestCache()
+  }, 30_000)
+
+  afterAll(async () => {
+    if (project) await unregisterProject(project.slug)
+    if (workDir) fs.rmSync(workDir, { recursive: true, force: true })
+    clearLatestCache()
+  })
+
+  it('flags ReferenceEquals on a value type via the semantic host (once)', async () => {
+    const result = await analyzeInProcess(project, { enableLlmRulesOverride: false })
+    expect(result.analysisId).toBeTruthy()
+
+    const latest = await readLatest(workDir)
+    expect(latest).not.toBeNull()
+
+    const hostHits = latest!.violations.filter((v) => v.ruleKey === HOST_KEY)
+    expect(hostHits.length).toBe(1)
+    expect(hostHits[0].filePath).toMatch(/IdentityChecks\.cs$/)
+    expect(hostHits[0].severity).toBe('high')
+    expect(hostHits[0].title).toBe('ReferenceEquals on a value type')
+    expect(hostHits[0].lineStart).toBeGreaterThan(0)
+  }, 180_000)
+})


### PR DESCRIPTION
Stacked on #622 (base = `csharp-roslyn-host`). Makes the C# semantic host **live in the product** — its rules flow through `truecourse analyze` end-to-end.

## What's wired
- **Node client** (`roslyn-host-client.ts`) — spawns the host as a batch child process, sends C# files + enabled host-rule keys, returns violations. **Fail-hard**: missing host/.NET runtime → `RoslynHostUnavailableError`, no tree-sitter fallback.
- **`engine` field** on `AnalysisRule` (`tree-sitter` default | `roslyn-host`). language-support derives host rules as `csharp: supported` (no visitor), `not-applicable` elsewhere.
- **Pipeline hook** — after the tree-sitter pass, one batch host call over all C# files; violations enriched into `CodeViolation` (severity/title from the rule, snippet from source).
- **Bug fix** — `toAnalysisRule` was dropping the new `engine` field, so host rules never reached the pipeline.

## Validation
- Client round-trip: 4 tests (value-type flagged, ref-type clean, allow-list, fail-hard).
- **End-to-end**: a value-type `ReferenceEquals` surfaces in the store from a real analyze (correct severity/title/path, once).
- Full analyzer + C# analyze suites green — **3889 tests**, no regressions (the existing C# analyze now invokes the host too).

## Next
Port the ~210 deferred rules as `ISemanticRule` walkers in the host (waves), then MSBuildWorkspace project loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)