### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/generic-error-message.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/generic-error-message.ts
@@ -43,6 +43,12 @@ export const genericErrorMessageVisitor: CodeRuleVisitor = {
     // property is present.
     if (isLabeledWithDescriptionSibling(node)) return null
 
+    // The same title+detail pairing also appears as JSX attributes
+    // (`<ErrorView title="Oops" message={detail} />`). The vague headline is
+    // paired with a sibling attribute carrying the actionable detail, so
+    // flagging the title alone is noise — mirror the object-literal carve-out.
+    if (isJsxTitleWithDescriptionSibling(node)) return null
+
     return makeViolation(
       this.ruleKey, node, filePath, 'low',
       'Generic error message',
@@ -51,6 +57,33 @@ export const genericErrorMessageVisitor: CodeRuleVisitor = {
       'Replace with a specific error message that includes an error code or actionable detail.',
     )
   },
+}
+
+// JSX analogue of isLabeledWithDescriptionSibling: a string that is the value
+// of a `title`/`heading`/... JSX attribute whose element also carries a
+// `message`/`description`/... attribute. The attribute name is the first named
+// child of the `jsx_attribute`; sibling attributes live on the enclosing
+// opening / self-closing element.
+function isJsxTitleWithDescriptionSibling(node: SyntaxNode): boolean {
+  const attr = node.parent
+  if (!attr || attr.type !== 'jsx_attribute') return false
+
+  const nameNode = attr.namedChild(0)
+  if (!nameNode) return false
+  const attrName = nameNode.text.replace(/['"`]/g, '')
+  if (!TITLE_KEYS.has(attrName)) return false
+
+  const element = attr.parent
+  if (!element) return false
+
+  for (const child of element.namedChildren) {
+    if (child.id === attr.id || child.type !== 'jsx_attribute') continue
+    const k = child.namedChild(0)
+    if (!k) continue
+    const kn = k.text.replace(/['"`]/g, '')
+    if (DESCRIPTION_KEYS.has(kn)) return true
+  }
+  return false
 }
 
 function isLabeledWithDescriptionSibling(node: SyntaxNode): boolean {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/explicit-any-in-return.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/explicit-any-in-return.ts
@@ -6,6 +6,15 @@ export const explicitAnyInReturnVisitor: CodeRuleVisitor = {
   languages: ['typescript', 'tsx'],
   nodeTypes: ['function_declaration', 'function_expression', 'arrow_function', 'method_definition'],
   visit(node, filePath, sourceCode) {
+    // Skip visitor-pattern dispatch methods (`visit`, `visitChildren`,
+    // `visitTerminal`, `visit<Node>`, `visit_<node>`). Their `any` return is
+    // imposed by the visitor interface contract (e.g. antlr's generated
+    // ParseTreeVisitor), not a typing oversight the author can narrow.
+    if (node.type === 'method_definition') {
+      const methodName = node.childForFieldName('name')?.text
+      if (methodName && /^visit(?:[A-Z_].*)?$/.test(methodName)) return null
+    }
+
     // Look for return type annotation `: any`
     // In tree-sitter TS, return type is a type_annotation child
     for (let i = 0; i < node.childCount; i++) {

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/no-explicit-any.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/no-explicit-any.ts
@@ -9,6 +9,17 @@ export const noExplicitAnyVisitor: CodeRuleVisitor = {
     const typeNode = node.namedChildren[0]
     if (!typeNode) return null
     if (typeNode.type === 'predefined_type' && typeNode.text === 'any') {
+      // Skip the `any` return type of a visitor-pattern dispatch method
+      // (`visit`, `visitChildren`, `visit<Node>`, ...). The visitor interface
+      // contract fixes the return type, so it's interface-imposed, not a
+      // typing oversight. A method's return-type annotation sits directly
+      // under the method node (param annotations are nested in parameters),
+      // so this never suppresses `any` parameters.
+      const owner = node.parent
+      if (owner?.type === 'method_definition') {
+        const methodName = owner.childForFieldName('name')?.text
+        if (methodName && /^visit(?:[A-Z_].*)?$/.test(methodName)) return null
+      }
       return makeViolation(
         this.ruleKey, node, filePath, 'medium',
         'Explicit `any` type',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/restricted-types.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/restricted-types.ts
@@ -41,6 +41,22 @@ export const restrictedTypesVisitor: CodeRuleVisitor = {
       parent.type !== 'implements_clause'
     ) return null
 
+    // Don't flag a restricted type that is a member of a union which forms a
+    // type alias, e.g. `type Builtin = Date | Function | Uint8Array | ...`.
+    // Such a union is a type-set used for structural matching in conditional
+    // types (`T extends Builtin ? ...`); its members are matchers, not usable
+    // annotations. Direct annotations (`x: Object | undefined`, `cb: Function`)
+    // are unaffected — their union resolves to a type_annotation, not an alias.
+    // `A | B | C` nests as chained union_type nodes, so walk to the outermost
+    // union before checking what it belongs to.
+    if (parent.type === 'union_type') {
+      let union = parent
+      while (union.parent && union.parent.type === 'union_type') {
+        union = union.parent
+      }
+      if (union.parent?.type === 'type_alias_declaration') return null
+    }
+
     return makeViolation(
       this.ruleKey, node, filePath, 'low',
       'Restricted type usage',

--- a/packages/analyzer/src/rules/security/visitors/javascript/hardcoded-password-function-arg.ts
+++ b/packages/analyzer/src/rules/security/visitors/javascript/hardcoded-password-function-arg.ts
@@ -28,6 +28,10 @@ export const hardcodedPasswordFunctionArgVisitor: CodeRuleVisitor = {
     for (const arg of args.namedChildren) {
       if (arg.type === 'string') {
         const val = arg.text.replace(/['"]/g, '')
+        // Skip kebab-case identifier labels/slugs (e.g. "failed-pod-informer",
+        // "email-link") — lowercase hyphen-joined words used as names, not
+        // credentials. A real password carries mixed case, digits, or symbols.
+        if (/^[a-z][a-z0-9]*(?:-[a-z0-9]+)+$/.test(val)) continue
         if (val.length >= 8 && PLAINTEXT_PASSWORD_PATTERN.test(val) &&
             !/^https?:\/\//.test(val) && !/localhost/.test(val)) {
           return makeViolation(

--- a/packages/analyzer/src/rules/security/visitors/universal.ts
+++ b/packages/analyzer/src/rules/security/visitors/universal.ts
@@ -137,6 +137,13 @@ export const hardcodedIpVisitor: CodeRuleVisitor = {
     // Skip version-like numbers in User-Agent strings, semver, etc.
     if (/Mozilla|Chrome|Safari|Firefox|AppleWebKit|Gecko/i.test(stripped)) return null
 
+    // Skip outline / section / step labels: a single leading word followed
+    // by a dotted run of small integers (e.g. "span 2.1.1.1", "step 3.2.1.1").
+    // This is hierarchical numbering, not a network address — a real
+    // hardcoded IP appears bare, in a URL/host:port, or inside multi-word
+    // prose, never as the sole dotted-number tail of a one-word label.
+    if (/^[A-Za-z][\w-]*\s+\d{1,3}(?:\.\d{1,3}){3}$/.test(stripped.trim())) return null
+
     // Skip when the match is embedded in a longer numeric sequence — SVG
     // `<path d="...">` coordinate strings are the main source of these,
     // e.g. `013.002.027.012` snapped out of `.013.002.027.012.013`. The

--- a/tests/fixtures/sample-js-project-negative/explicit-any-in-return-json-parse.ts
+++ b/tests/fixtures/sample-js-project-negative/explicit-any-in-return-json-parse.ts
@@ -1,0 +1,13 @@
+/**
+ * Negative fixture for code-quality/deterministic/explicit-any-in-return.
+ *
+ * A plain helper that declares an `: any` return type instead of `unknown`
+ * or a concrete type — the loose typing this rule is meant to catch. It is a
+ * free function, not a visitor-interface method, so the carve-out must not
+ * apply.
+ */
+
+// VIOLATION: code-quality/deterministic/explicit-any-in-return
+export function parseConfig(text: string): any {
+  return JSON.parse(text);
+}

--- a/tests/fixtures/sample-js-project-negative/generic-error-message-bare-throw.ts
+++ b/tests/fixtures/sample-js-project-negative/generic-error-message-bare-throw.ts
@@ -1,0 +1,11 @@
+/**
+ * Negative fixture for bugs/deterministic/generic-error-message.
+ *
+ * A bare vague message thrown with no error code or actionable detail — the
+ * unhelpful pattern this rule is meant to catch.
+ */
+
+export function loadProfile(): never {
+  // VIOLATION: bugs/deterministic/generic-error-message
+  throw new Error("Something went wrong");
+}

--- a/tests/fixtures/sample-js-project-negative/hardcoded-ip-service-endpoint.ts
+++ b/tests/fixtures/sample-js-project-negative/hardcoded-ip-service-endpoint.ts
@@ -1,0 +1,12 @@
+/**
+ * Negative fixture for security/deterministic/hardcoded-ip.
+ *
+ * A worker is pinned to a specific machine by a raw IPv4 address baked
+ * into a URL instead of reading the host from configuration — exactly the
+ * bug this rule is meant to catch.
+ */
+
+export function metricsEndpoint(): string {
+  // VIOLATION: security/deterministic/hardcoded-ip
+  return "https://203.0.113.10:9090/metrics";
+}

--- a/tests/fixtures/sample-js-project-negative/hardcoded-password-function-arg-plaintext.ts
+++ b/tests/fixtures/sample-js-project-negative/hardcoded-password-function-arg-plaintext.ts
@@ -1,0 +1,15 @@
+/**
+ * Negative fixture for security/deterministic/hardcoded-password-function-arg.
+ *
+ * A real plaintext credential passed straight into an authenticate call —
+ * exactly the leak this rule is meant to catch.
+ */
+
+function authenticateUser(token: string): boolean {
+  return token.length > 0;
+}
+
+// VIOLATION: security/deterministic/hardcoded-password-function-arg
+export function login(): boolean {
+  return authenticateUser("S3cretP0wer99");
+}

--- a/tests/fixtures/sample-js-project-negative/restricted-types-function-param.ts
+++ b/tests/fixtures/sample-js-project-negative/restricted-types-function-param.ts
@@ -1,0 +1,12 @@
+/**
+ * Negative fixture for code-quality/deterministic/restricted-types.
+ *
+ * A callback parameter typed as the bare `Function` wrapper instead of a
+ * precise call signature — unsafe to invoke and exactly the loose typing
+ * this rule is meant to catch.
+ */
+
+// VIOLATION: code-quality/deterministic/restricted-types
+export function runLater(task: Function): void {
+  setTimeout(() => task(), 0);
+}

--- a/tests/fixtures/sample-js-project-positive/explicit-any-in-return-visitor-methods.ts
+++ b/tests/fixtures/sample-js-project-positive/explicit-any-in-return-visitor-methods.ts
@@ -1,0 +1,26 @@
+/**
+ * Positive fixture for code-quality/deterministic/explicit-any-in-return
+ * (and the sibling code-quality/deterministic/no-explicit-any).
+ *
+ * Visitor-pattern dispatch methods (`visit`, `visitChildren`, `visit<Node>`)
+ * return `any` because the visitor interface they implement fixes the return
+ * type — the author cannot narrow it. Both the explicit-any-in-return rule and
+ * the no-explicit-any rule must treat these interface-imposed `any` returns as
+ * acceptable. (This is the shape emitted by parser-generator visitor base
+ * classes.)
+ */
+
+interface TreeNode {
+  kind: string;
+  children: TreeNode[];
+}
+
+export class TreeWalker {
+  visit(node: TreeNode): any {
+    return node.children.length === 0 ? node.kind : this.visitChildren(node);
+  }
+
+  visitChildren(node: TreeNode): any {
+    return node.children.map((child) => this.visit(child));
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/generic-error-message-jsx-title-detail.tsx
+++ b/tests/fixtures/sample-js-project-positive/generic-error-message-jsx-title-detail.tsx
@@ -1,0 +1,21 @@
+/**
+ * Positive fixture for bugs/deterministic/generic-error-message.
+ *
+ * A vague headline in a `title` JSX attribute is acceptable when a sibling
+ * attribute (`message`/`description`/...) carries the actionable detail — the
+ * user still sees something useful. The rule must not flag the title in
+ * isolation, mirroring its existing object-literal title+description carve-out.
+ */
+
+function InfoCard(props: { readonly title: string; readonly message: string }): JSX.Element {
+  return (
+    <div>
+      {props.title}
+      {props.message}
+    </div>
+  );
+}
+
+export function FailureBanner(props: { readonly detail: string }): JSX.Element {
+  return <InfoCard title="Oops" message={props.detail} />;
+}

--- a/tests/fixtures/sample-js-project-positive/hardcoded-ip-version-label.ts
+++ b/tests/fixtures/sample-js-project-positive/hardcoded-ip-version-label.ts
@@ -1,0 +1,14 @@
+/**
+ * Positive fixture for security/deterministic/hardcoded-ip.
+ *
+ * Outline / step labels such as "step 2.1.1.1" share the four-octet shape
+ * of an IPv4 literal: a single descriptive word followed by a dotted run
+ * of small integers. These are hierarchical section identifiers, not
+ * network addresses, so the rule must not fire on them.
+ */
+
+export function recordSteps(track: (label: string) => void): void {
+  track("step 2.1.1.1");
+  track("step 3.1.1.1");
+  track("step 3.2.4.5");
+}

--- a/tests/fixtures/sample-js-project-positive/hardcoded-password-function-arg-kebab-label.ts
+++ b/tests/fixtures/sample-js-project-positive/hardcoded-password-function-arg-kebab-label.ts
@@ -1,0 +1,15 @@
+/**
+ * Positive fixture for security/deterministic/hardcoded-password-function-arg.
+ *
+ * A kebab-case slug/label passed to a function whose name happens to contain
+ * "connect"/"authenticate" is an identifier, not a credential. The rule must
+ * not treat lowercase hyphenated labels as hardcoded passwords.
+ */
+
+function makeConnectHandler(label: string): () => string {
+  return () => label;
+}
+
+export function registerWatchers(): () => string {
+  return makeConnectHandler("failed-task-watcher");
+}

--- a/tests/fixtures/sample-js-project-positive/restricted-types-builtin-union-alias.ts
+++ b/tests/fixtures/sample-js-project-positive/restricted-types-builtin-union-alias.ts
@@ -1,0 +1,17 @@
+/**
+ * Positive fixture for code-quality/deterministic/restricted-types.
+ *
+ * A union type alias that enumerates built-in / primitive types is a
+ * type-set used purely for structural matching in a conditional type
+ * (`T extends Primitiveish ? ...`). The `Function` member is a matcher,
+ * not a usable annotation, so the rule must not flag it. (This is the
+ * `Builtin`/`DeepPartial` idiom emitted by protobuf-to-TS code generators.)
+ */
+
+type Primitiveish = Date | Function | Uint8Array | string;
+
+export type DeepReadonly<T> = T extends Primitiveish
+  ? T
+  : T extends Array<infer U>
+    ? Array<DeepReadonly<U>>
+    : { readonly [K in keyof T]: DeepReadonly<T[K]> };


### PR DESCRIPTION
Batch of 5 false-positive fixes paraphrased from `triggerdotdev/trigger.dev` (`2dd9f37b4045d2a414c0a300995d068f28926d50`). Each adds a paraphrased FP to the positive fixtures, a true-bug case to the negative fixtures, and a scoped visitor fix.

Closes #413
Closes #414
Closes #415
Closes #416
Closes #417

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `security/deterministic/hardcoded-ip` | #413 | `sample-js-project-positive/hardcoded-ip-version-label.ts` | `sample-js-project-negative/hardcoded-ip-service-endpoint.ts` |
| `code-quality/deterministic/restricted-types` | #414 | `sample-js-project-positive/restricted-types-builtin-union-alias.ts` | `sample-js-project-negative/restricted-types-function-param.ts` |
| `code-quality/deterministic/explicit-any-in-return` | #415 | `sample-js-project-positive/explicit-any-in-return-visitor-methods.ts` | `sample-js-project-negative/explicit-any-in-return-json-parse.ts` |
| `security/deterministic/hardcoded-password-function-arg` | #416 | `sample-js-project-positive/hardcoded-password-function-arg-kebab-label.ts` | `sample-js-project-negative/hardcoded-password-function-arg-plaintext.ts` |
| `bugs/deterministic/generic-error-message` | #417 | `sample-js-project-positive/generic-error-message-jsx-title-detail.tsx` | `sample-js-project-negative/generic-error-message-bare-throw.ts` |

## security/deterministic/hardcoded-ip

OSS source: [circularPayload.ts#L26](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/references/hello-world/src/trigger/circularPayload.ts#L26) (issue sample); the dominant shape is span labels like `logger.trace("span 2.1.1.1", …)` in [telemetry.ts](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/references/hello-world/src/trigger/telemetry.ts#L90) (57 of 58 violations).

Positive fixture (`hardcoded-ip-version-label.ts`):
```ts
export function recordSteps(track: (label: string) => void): void {
  track("step 2.1.1.1");
  track("step 3.1.1.1");
  track("step 3.2.4.5");
}
```
Negative fixture (`hardcoded-ip-service-endpoint.ts`):
```ts
export function metricsEndpoint(): string {
  // VIOLATION: security/deterministic/hardcoded-ip
  return "https://203.0.113.10:9090/metrics";
}
```
**Visitor summary:** Outline/section/step labels (`"span 2.1.1.1"`) share the four-octet shape of an IPv4 literal. Added a skip in `hardcodedIpVisitor` for strings of the form `<word> <dotted-quad>` (a single leading word + a dotted run of small integers) — hierarchical numbering, not a network address. Real hardcoded IPs appear bare, in a URL/host:port, or in multi-word prose, none of which match that one-word-label shape, so the negative fixtures (private IPs in URLs/prose) still fire. (The single remaining hardcoded-ip hit is the `192.168.1.1` demo value, which is indistinguishable from the genuine internal-host bugs the existing negative fixtures require.)

## code-quality/deterministic/restricted-types

OSS source: generated ts-proto `Builtin` unions — [logs_service.ts#L294](``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/otlp-importer/src/generated/opentelemetry/proto/collector/logs/v1/logs_service.ts#L294),`` ``[metrics_service.ts#L294](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/otlp-importer/src/generated/opentelemetry/proto/collector/metrics/v1/metrics_service.ts#L294),`` [trace_service.ts#L294](``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/otlp-importer/src/generated/opentelemetry/proto/collector/trace/v1/trace_service.ts#L294),`` [common.ts#L565](``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/otlp-importer/src/generated/opentelemetry/proto/common/v1/common.ts#L565).``

Positive fixture (`restricted-types-builtin-union-alias.ts`):
```ts
type Primitiveish = Date | Function | Uint8Array | string;

export type DeepReadonly<T> = T extends Primitiveish
  ? T
  : T extends Array<infer U>
    ? Array<DeepReadonly<U>>
    : { readonly [K in keyof T]: DeepReadonly<T[K]> };
```
Negative fixture (`restricted-types-function-param.ts`):
```ts
export function runLater(task: Function): void {
  // VIOLATION: code-quality/deterministic/restricted-types
  setTimeout(() => task(), 0);
}
```
**Visitor summary:** A restricted type used as a member of a union that forms a type alias (`type Builtin = Date | Function | …`) is a type-set used for structural matching in conditional types (`T extends Builtin ? …`), not a usable annotation. Added a skip that walks to the outermost `union_type` and, if its parent is a `type_alias_declaration`, treats the member as a matcher. Direct annotations (`x: Object | undefined`, `cb: Function`) resolve to a `type_annotation`, not an alias, so they still fire.

## code-quality/deterministic/explicit-any-in-return

OSS source: antlr visitor methods — [parser.ts#L360](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/query/parser.ts#L360), [#L366](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/query/parser.ts#L366), [#L380](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/query/parser.ts#L380), [#L386](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/query/parser.ts#L386), [property_types.ts#L234](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/tsql/src/query/property_types.ts#L234).

Positive fixture (`explicit-any-in-return-visitor-methods.ts`):
```ts
export class TreeWalker {
  visit(node: TreeNode): any {
    return node.children.length === 0 ? node.kind : this.visitChildren(node);
  }

  visitChildren(node: TreeNode): any {
    return node.children.map((child) => this.visit(child));
  }
}
```
Negative fixture (`explicit-any-in-return-json-parse.ts`):
```ts
export function parseConfig(text: string): any {
  // VIOLATION: code-quality/deterministic/explicit-any-in-return
  return JSON.parse(text);
}
```
**Visitor summary:** Visitor-pattern dispatch methods (`visit`, `visitChildren`, `visit<Node>`, `visit_<node>`) return `any` because the visitor interface (e.g. antlr's generated `ParseTreeVisitor`) fixes the return type. Added a name-based carve-out (`/^visit(?:[A-Z_].*)?$/` on `method_definition`) to `explicit-any-in-return`. The identical `: any` return is also flagged by the sibling `no-explicit-any` rule, so the same carve-out is applied there — scoped to the method's return-type annotation only (parameter `any`s are nested in the parameter list and remain flagged).

## security/deterministic/hardcoded-password-function-arg

OSS source: [failedPodHandler.ts#L67](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/supervisor/src/services/failedPodHandler.ts#L67) — `makeOnConnect("failed-pod-informer")`; also `authenticator.authenticate("email-link", …)`.

Positive fixture (`hardcoded-password-function-arg-kebab-label.ts`):
```ts
function makeConnectHandler(label: string): () => string {
  return () => label;
}

export function registerWatchers(): () => string {
  return makeConnectHandler("failed-task-watcher");
}
```
Negative fixture (`hardcoded-password-function-arg-plaintext.ts`):
```ts
export function login(): boolean {
  // VIOLATION: security/deterministic/hardcoded-password-function-arg
  return authenticateUser("S3cretP0wer99");
}
```
**Visitor summary:** A kebab-case slug (`"failed-pod-informer"`, `"email-link"`) passed to a `connect`/`authenticate`-named function is an identifier, not a credential. Added a skip for args matching `/^[a-z][a-z0-9]*(?:-[a-z0-9]+)+$/` — the same kebab-case carve-out already used by the `hardcoded-secret` scanner. Real plaintext passwords carry mixed case, digits, or symbols and still fire.

## bugs/deterministic/generic-error-message

OSS source: [ErrorDisplay.tsx#L33](https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/ErrorDisplay.tsx#L33) — `<ErrorDisplay title="Oops" message={JSON.stringify(error)} />`.

Positive fixture (`generic-error-message-jsx-title-detail.tsx`):
```tsx
export function FailureBanner(props: { readonly detail: string }): JSX.Element {
  return <InfoCard title="Oops" message={props.detail} />;
}
```
Negative fixture (`generic-error-message-bare-throw.ts`):
```ts
export function loadProfile(): never {
  // VIOLATION: bugs/deterministic/generic-error-message
  throw new Error("Something went wrong");
}
```
**Visitor summary:** The rule already skips a vague `title` paired with a sibling `description` in an **object literal**. The same pairing also occurs as **JSX attributes** (`title="Oops"` next to `message={detail}`). Added `isJsxTitleWithDescriptionSibling`, mirroring the object-literal carve-out: a `title`/`heading`/… attribute whose enclosing element also has a `message`/`description`/… attribute is not flagged. (The conventional-HTTP-500 `json({ error: "Internal Server Error" }, { status: 500 })` cases are a distinct borderline pattern and are left untouched.)

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a freshly-built `pnpm build:dist` — the exact artifact `publish.yml` ships.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `security/deterministic/hardcoded-ip` | 58 | 1 | -57 |
| `code-quality/deterministic/restricted-types` | 22 | 14 | -8 |
| `code-quality/deterministic/explicit-any-in-return` | 16 | 10 | -6 |
| `security/deterministic/hardcoded-password-function-arg` | 4 | 0 | -4 |
| `bugs/deterministic/generic-error-message` | 86 | 85 | -1 |
| **Total (these 5 rules)** | 186 | 110 | -76 |
| **All-rules total on target** | 34892 | 34810 | -82 |

The all-rules delta (-82) exceeds the 5-rule subtotal (-76) by the 6 `no-explicit-any` hits also resolved by the #415 visitor carve-out (515 → 509). No rule's count increased.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZEwPqPhXswm8cZ6NXnjZH)_