### PR TITLE
ci(deploy-dev): add manual workflow_dispatch to deploy main to dev

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,9 +1,12 @@
 name: Deploy (dev)
 
-# Opt-in: add the `deploy-dev` label to a PR to build its branch and
-# create-or-update the shared Dev Container App. Pushing new commits to a
-# still-labeled PR re-deploys; removing the label stops it. Nothing deploys
-# automatically on open/merge.
+# Two opt-in ways to deploy the shared Dev Container App — nothing auto-deploys:
+#   1. Label a PR `deploy-dev` → builds that PR's branch (pushes while labeled
+#      re-deploy; remove the label to stop).
+#   2. Actions → Deploy (dev) → Run workflow → pick a branch (usually main) →
+#      builds that branch's HEAD. Use this to roll merged main onto Dev.
+# Unlike prod, dev allows any branch and has no reviewer gate — it's the safe
+# place to try things.
 # The foundation resources (ACR, Container Apps env, identity, Key Vault) are
 # discovered from the resource group at runtime, so the only variables you set are
 # the OIDC identity + AZURE_RG + APP_NAME. GitHub touches nothing in the runtime
@@ -12,11 +15,12 @@ on:
   pull_request:
     branches: [main]
     types: [labeled, synchronize]
+  workflow_dispatch:
 
 permissions:
   id-token: write      # OIDC federated login to Azure (no stored secret)
   contents: read
-  pull-requests: write # post the Dev URL as a comment
+  pull-requests: write # post the Dev URL as a comment (PR runs only)
 
 concurrency:
   group: deploy-dev
@@ -24,7 +28,10 @@ concurrency:
 
 jobs:
   deploy:
-    if: contains(github.event.pull_request.labels.*.name, 'deploy-dev')
+    # Manual dispatch always runs; PR runs only when the `deploy-dev` label is on.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'deploy-dev')
     runs-on: ubuntu-latest
     environment: dev
     steps:
@@ -51,7 +58,12 @@ jobs:
       - name: Build & push image (ACR builds it — no local Docker)
         id: build
         run: |
-          TAG="pr-${{ github.event.pull_request.number }}-${GITHUB_SHA::7}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            TAG="pr-${{ github.event.pull_request.number }}-${GITHUB_SHA::7}"
+          else
+            TAG="${{ github.ref_name }}-${GITHUB_SHA::7}"
+          fi
+          TAG="${TAG//\//-}"   # ref names can contain slashes; tags can't
           az acr build --registry "${{ steps.infra.outputs.acr_name }}" \
             --image "truecourse:${TAG}" --file Dockerfile .
           echo "image=${{ steps.infra.outputs.acr_login }}/truecourse:${TAG}" >> "$GITHUB_OUTPUT"
@@ -70,7 +82,14 @@ jobs:
             --query properties.outputs.url.value -o tsv)
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 
+      - name: Job summary
+        run: |
+          echo "🚀 Deployed to **Dev**: ${{ steps.deploy.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Image: \`${{ steps.build.outputs.image }}\`" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Comment the Dev URL
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -81,5 +100,5 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: `🚀 Deployed to **Dev**: ${url}\n\nImage: \`${image}\`\n` +
-                `_The Dev environment is shared — the most recent PR push wins._`,
+                `_The Dev environment is shared — the most recent push wins._`,
             });

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -179,10 +179,14 @@ manual gate before production rolls.
 
 Neither environment deploys on open or merge. You opt in each time:
 
-- **Dev (`deploy-dev.yml`)** — add the **`deploy-dev`** label to a PR. It builds
-  that PR's branch and rolls the shared Dev Container App. Pushing more commits
-  while the label is on re-deploys; remove the label to stop. (Create the label
-  once under the repo's Labels, or just type it when adding it to a PR.)
+- **Dev (`deploy-dev.yml`)** — two opt-in ways:
+  - **Label** a PR **`deploy-dev`** → builds that PR's branch and rolls the
+    shared Dev Container App. Pushing more commits while the label is on
+    re-deploys; remove the label to stop. (Create the label once under the
+    repo's Labels, or just type it when adding it to a PR.)
+  - **Manual:** Actions → Deploy (dev) → **Run workflow** → pick a branch
+    (usually `main`) → builds that branch's HEAD. Use this to roll merged main
+    onto Dev. Dev allows any branch and has no reviewer gate.
 - **Prod (`deploy-prod.yml`)** — **Actions → Deploy (prod) → Run workflow**, on
   the **`main`** branch. It builds main's current HEAD; a `main`-only guard
   refuses any other branch, and the `prod` Environment's required reviewer still


### PR DESCRIPTION
## What

Dev was **PR-label-only**, so once PRs are merged there was no way to roll **main** onto the Dev app. This adds a manual **`workflow_dispatch`** trigger to `deploy-dev`, keeping the `deploy-dev` label path unchanged.

After merge: **Actions → Deploy (dev) → Run workflow → pick `main`** → builds main's HEAD and deploys to Dev. Any branch is allowed; no reviewer gate (dev is the safe place for that).

## Changes

- `on:` adds `workflow_dispatch`.
- Job `if` runs on `workflow_dispatch` OR the `deploy-dev` label (PR behavior unchanged).
- Image tag handles the non-PR case: `<ref>-<sha>` for dispatch vs `pr-<n>-<sha>` for PRs (slashes sanitized).
- PR-comment step skipped on manual runs; URL + image go to the **job summary**.
- README "Deploy triggers" updated.

## Note
The **Run workflow** button only appears once this is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)