### PR TITLE
chore(drift-fp): start discovery for redwoodjs/redwood

### DIFF
--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -154,7 +154,7 @@ campaigns:
       - docs/docs                # 44 top-level + subdirs (skip versioned_docs/* — versioned snapshots, redundant)
     priority: 7
     status: discovering
-    baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
+    baseline: { verified_at: "2026-06-24", target_ref: "a7852fb92d0e4ac2bcce1d9a755717ba6cf53ffd", total_drifts: 10, tp: 0, fp: 7, info: 3, fp_rate: 1.00 }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes: ["Probe 2026-06-06: 121 .md/.mdx under docs/docs/ (current version). Strong behavioral surface in how-to (20), deploy (9), auth (9), graphql (5), tutorial/chapter1 (6). Note: versioned_docs/version-{8.2…8.8} are frozen snapshots of the same docs/docs/ content; doc_scope excludes them to avoid 8x duplication of every claim."]
 

--- a/docs/drift-fp-automation/campaigns.yaml
+++ b/docs/drift-fp-automation/campaigns.yaml
@@ -153,7 +153,7 @@ campaigns:
     doc_scope:
       - docs/docs                # 44 top-level + subdirs (skip versioned_docs/* — versioned snapshots, redundant)
     priority: 7
-    status: pending
+    status: discovering
     baseline: { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     final:    { verified_at: null, target_ref: null, total_drifts: null, tp: null, fp: null, info: null, fp_rate: null }
     notes: ["Probe 2026-06-06: 121 .md/.mdx under docs/docs/ (current version). Strong behavioral surface in how-to (20), deploy (9), auth (9), graphql (5), tutorial/chapter1 (6). Note: versioned_docs/version-{8.2…8.8} are frozen snapshots of the same docs/docs/ content; doc_scope excludes them to avoid 8x duplication of every claim."]


### PR DESCRIPTION
Starting a drift discovery run for **redwoodjs/redwood**.

This PR marks the campaign `status: discovering` in `docs/drift-fp-automation/campaigns.yaml`. The `drift-fp-discover` routine will:

1. Build truecourse from local source (`pnpm build:dist`).
2. Clone `redwoodjs/redwood` at the pinned `target_ref` from the storage branch's `meta.yaml`.
3. Run the deterministic `verify` against the pinned contracts on `claude/drift-fp-store/redwoodjs-redwood`.
4. Triage drifts (TP / FP / info) and file one `drift-fp-fix` issue per drift-kind with ≥1 clear FP.
5. Fill the campaign `baseline.*` and post a summary.

Contracts (from the storage branch `meta.yaml`): 7 artifacts — 6 Enum (LogLevel, SupportedVerifiers, TrailingSlashes, WebAuthnType, RouteParameterType, EmptyAs) + 1 Operation (GET /graphql/readiness). `target_ref: a7852fb92d0e4ac2bcce1d9a755717ba6cf53ffd`, `code_dir: .`

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN77WcHCVTr1NSdi9zH976)_