### PR TITLE
ci(publish): build the C# Roslyn host before tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,13 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
+      # The C# semantic rules run in an out-of-process .NET Roslyn host. Without
+      # the SDK + a built host, analyze-csharp fails (the pipeline is host-required
+      # for C#). Build it so `pnpm test` passes here just like in test.yml.
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       # OIDC trusted publishing needs a recent npm; Node 20 ships npm 10.x.
       - name: Upgrade npm (OIDC trusted publishing)
         run: npm install -g npm@latest
@@ -31,6 +38,9 @@ jobs:
 
       - name: Build packages
         run: pnpm build
+
+      - name: Build C# Roslyn host
+        run: dotnet build -c Release tools/csharp-roslyn-host
 
       - name: Run tests
         run: pnpm test


### PR DESCRIPTION
## Why

The npm publish run [failed](https://github.com/truecourse-ai/truecourse/actions/runs/28065851979/job/83089851295) with `RoslynHostUnavailableError` (1 failed / 6201 passed), aborting before `npm publish`.

**Root cause:** commit `0c714932` added a C# end-to-end test (`tests/cli/analyze-csharp.test.ts`) that requires the out-of-process .NET Roslyn host, and updated `test.yml` to install the .NET 8 SDK + build the host. But `publish.yml` *also* runs `pnpm test` and was never updated — so it had no SDK and no built host, and the C# e2e test failed hard.

## Change

Mirror the two missing steps from `test.yml` into `publish.yml`:
- `actions/setup-dotnet@v4` (8.0.x)
- `Build C# Roslyn host` (`dotnet build -c Release tools/csharp-roslyn-host`) before `Run tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)