### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/_helpers.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/_helpers.ts
@@ -39,6 +39,14 @@ export const PURE_ARRAY_METHODS = new Set([
   'indexOf', 'lastIndexOf', 'includes', 'every', 'some', 'reduce', 'reduceRight',
 ])
 
+// Receiver names that denote a socket.io-style realtime connection. Its
+// `.join(room)` is a side-effecting room-subscription command that returns
+// void — NOT `Array.prototype.join`, whose joined-string result must be
+// consumed. The two collide on the bare method name, and type information is
+// usually unavailable (the socket.io types live in uninstalled node_modules),
+// so the receiver name is the reliable signal.
+export const SOCKET_IO_RECEIVERS = new Set(['socket', 'sockets'])
+
 export const KNOWN_ARG_ORDERS: Array<{ fn: string; params: string[][] }> = [
   { fn: 'startsWith', params: [['prefix', 'str', 'string', 'start', 'needle', 'search']] },
   { fn: 'endsWith', params: [['suffix', 'str', 'string', 'end', 'needle', 'search']] },

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/ignored-return-value.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/ignored-return-value.ts
@@ -1,6 +1,20 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
-import { JS_LANGUAGES, PURE_ARRAY_METHODS } from './_helpers.js'
+import type { Node as SyntaxNode } from 'web-tree-sitter'
+import { JS_LANGUAGES, PURE_ARRAY_METHODS, SOCKET_IO_RECEIVERS } from './_helpers.js'
+
+// Leftmost identifier name of a receiver expression: `socket` → "socket",
+// `this.socket` / `client.socket` → "socket". Used to recognize a socket.io
+// connection without type information.
+function receiverBaseName(obj: SyntaxNode | null): string | null {
+  if (!obj) return null
+  if (obj.type === 'identifier') return obj.text.toLowerCase()
+  if (obj.type === 'member_expression') {
+    const prop = obj.childForFieldName('property')
+    return prop ? prop.text.toLowerCase() : null
+  }
+  return null
+}
 
 export const ignoredReturnValueVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/ignored-return-value',
@@ -15,6 +29,14 @@ export const ignoredReturnValueVisitor: CodeRuleVisitor = {
 
     const prop = fn.childForFieldName('property')
     if (!prop || !PURE_ARRAY_METHODS.has(prop.text)) return null
+
+    // `socket.join(room)` is socket.io's side-effecting room subscription, not
+    // `Array.prototype.join` — its void result is correctly ignored. Skip when
+    // the receiver names a realtime connection.
+    if (prop.text === 'join') {
+      const base = receiverBaseName(fn.childForFieldName('object'))
+      if (base && SOCKET_IO_RECEIVERS.has(base)) return null
+    }
 
     // Skip if used as an await expression target or similar
     return makeViolation(

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/loss-of-precision.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/loss-of-precision.ts
@@ -17,6 +17,19 @@ export const lossOfPrecisionVisitor: CodeRuleVisitor = {
     const num = Number(text)
     if (!Number.isFinite(num)) return null
 
+    // `BigInt(<literal>)` is an explicit, intentional conversion — the
+    // developer has opted into big-integer handling, so the generic
+    // large-literal precision warning is noise here. Skip when the literal is
+    // a direct argument of a BigInt(...) call.
+    const parent = node.parent
+    if (parent?.type === 'arguments') {
+      const call = parent.parent
+      if (call?.type === 'call_expression') {
+        const fn = call.childForFieldName('function')
+        if (fn?.type === 'identifier' && fn.text === 'BigInt') return null
+      }
+    }
+
     if (!Number.isSafeInteger(num)) {
       return makeViolation(
         this.ruleKey, node, filePath, 'high',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/expression-complexity.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/expression-complexity.ts
@@ -17,11 +17,25 @@ export const expressionComplexityVisitor: CodeRuleVisitor = {
     }
     if (!expr) return null
 
-    // Unwrap parentheses for the function / JSX shape checks below.
+    // Unwrap parentheses and type-cast wrappers for the shape checks below.
     let target = expr
-    while (target.type === 'parenthesized_expression' && target.namedChildren[0]) {
+    while (
+      (target.type === 'parenthesized_expression'
+        || target.type === 'as_expression'
+        || target.type === 'satisfies_expression'
+        || target.type === 'non_null_expression')
+      && target.namedChildren[0]
+    ) {
       target = target.namedChildren[0]
     }
+
+    // Skip object / array literals. These are collections of independent
+    // members, not a single tangled expression — their keys/positions already
+    // name the parts, so "break it into named variables" does not apply.
+    // Summing operators across every property value or array element (e.g. a
+    // table of `{ value: 5 * 60 * 1000 }` rows, or `{ a: x - y, b: z - w }`
+    // perf maps) inflates the score for reasons unrelated to any one member.
+    if (target.type === 'object' || target.type === 'array') return null
 
     // Skip declarators / returns whose value is itself a function. The
     // function body is visited as its own statements, so counting
@@ -42,6 +56,15 @@ export const expressionComplexityVisitor: CodeRuleVisitor = {
       || target.type === 'jsx_self_closing_element') return null
 
     let operatorCount = 0
+    // Track which kinds of operator appear, to tell a flat boolean predicate
+    // list (`x === "a" || x === "b" || …`, `x.startsWith(p) || …`) apart from
+    // genuinely tangled arithmetic/mixed logic. The former reads like a set
+    // membership test — extracting intermediates does not improve it — so it
+    // is exempt; the latter (which mixes in `+`, `*`, etc.) is still flagged.
+    let hasLogical = false
+    let hasArithmetic = false
+    const LOGICAL_OPS = new Set(['&&', '||', '??'])
+    const ARITHMETIC_OPS = new Set(['+', '-', '*', '/', '%', '**', '&', '|', '^', '<<', '>>', '>>>'])
     const BINARY_TYPES = new Set(['binary_expression', 'logical_expression'])
     // Don't recurse into nested function bodies. Each nested function's
     // expressions are visited as their own `expression_statement` /
@@ -61,6 +84,11 @@ export const expressionComplexityVisitor: CodeRuleVisitor = {
     function countOps(n: SyntaxNode) {
       if (BINARY_TYPES.has(n.type)) {
         operatorCount++
+        const op = n.childForFieldName('operator')?.text
+        if (op) {
+          if (LOGICAL_OPS.has(op)) hasLogical = true
+          else if (ARITHMETIC_OPS.has(op)) hasArithmetic = true
+        }
       }
       for (let i = 0; i < n.childCount; i++) {
         const child = n.child(i)
@@ -73,6 +101,9 @@ export const expressionComplexityVisitor: CodeRuleVisitor = {
     countOps(expr)
 
     if (operatorCount > 5) {
+      // Flat boolean predicate list (logical operators + comparisons only, no
+      // arithmetic): a readable membership/guard test, not tangled logic.
+      if (hasLogical && !hasArithmetic) return null
       return makeViolation(
         this.ruleKey, node, filePath, 'medium',
         'Complex expression',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/selector-parameter.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/selector-parameter.ts
@@ -24,6 +24,19 @@ export const selectorParameterVisitor: CodeRuleVisitor = {
   languages: ['typescript', 'tsx', 'javascript'],
   nodeTypes: JS_FUNCTION_TYPES,
   visit(node, filePath, sourceCode) {
+    // Skip callbacks: a function passed as a call argument (`promise.then(cb)`,
+    // `useCallback(cb)`) or a JSX prop (`onCollapseChange={cb}`) receives its
+    // parameters from the consumer's API contract, not from a public API the
+    // author is designing. The "split into two functions" remedy does not
+    // apply — the callback's signature is fixed by its caller.
+    const fnParent = node.parent
+    if (
+      (node.type === 'arrow_function' || node.type === 'function_expression')
+      && (fnParent?.type === 'arguments' || fnParent?.type === 'jsx_expression')
+    ) {
+      return null
+    }
+
     const params = node.childForFieldName('parameters')
     if (!params) return null
 

--- a/packages/analyzer/src/rules/security/exclusions.ts
+++ b/packages/analyzer/src/rules/security/exclusions.ts
@@ -38,6 +38,13 @@ export const GLOBAL_ALLOWLIST: RegExp[] = [
   // Docker / container image references
   /^(?:docker|ghcr|quay|gcr|ecr)\.io\//,
 
+  // PostHog public project API key (phc_…) — intentionally client-exposed,
+  // embedded in frontend code to send analytics events. Its 40+ char base62
+  // body collides with the generic Cohere-token shape, but it is not a
+  // private credential. Private PostHog keys use the phx_/phs_ prefixes and
+  // are deliberately NOT allowlisted here.
+  /^phc_[A-Za-z0-9]{30,}$/,
+
   // Common config patterns that aren't secrets
   /^\*+$/, // All asterisks (masked values)
   /^x+$/i, // All x's (placeholder)

--- a/tests/fixtures/sample-js-project-negative/expression-complexity-arithmetic-boolean-mix.ts
+++ b/tests/fixtures/sample-js-project-negative/expression-complexity-arithmetic-boolean-mix.ts
@@ -1,0 +1,13 @@
+/**
+ * Negative fixture for code-quality/deterministic/expression-complexity.
+ *
+ * A single return that tangles arithmetic with boolean logic across many
+ * operators. Unlike a flat membership test or an object/array literal, this
+ * genuinely benefits from being broken into named intermediate variables, so
+ * it must still be flagged.
+ */
+
+export function isOverloaded(load: number, errors: number, latency: number, quota: number): boolean {
+  // VIOLATION: code-quality/deterministic/expression-complexity
+  return load * 2 + errors > quota && latency - errors * 3 > quota && load + errors + latency > quota;
+}

--- a/tests/fixtures/sample-js-project-negative/hardcoded-secret-private-api-token.ts
+++ b/tests/fixtures/sample-js-project-negative/hardcoded-secret-private-api-token.ts
@@ -1,0 +1,10 @@
+/**
+ * Negative fixture for security/deterministic/hardcoded-secret.
+ *
+ * A genuine private API token hardcoded in source — the real bug this rule
+ * catches. Unlike a PostHog public `phc_` key, this is a private credential
+ * with no public-prefix carve-out, so it must still be flagged.
+ */
+
+// VIOLATION: security/deterministic/hardcoded-secret
+export const inferenceApiToken = "kP3xQ9mViBn7sL0wRt2YfHdZ4aJ8cElNgUoPbT6kMqAvD";

--- a/tests/fixtures/sample-js-project-negative/ignored-return-value-array-join.ts
+++ b/tests/fixtures/sample-js-project-negative/ignored-return-value-array-join.ts
@@ -1,0 +1,13 @@
+/**
+ * Negative fixture for bugs/deterministic/ignored-return-value.
+ *
+ * `Array.prototype.join` returns the joined string and does not mutate the
+ * array; discarding its result is the real bug this rule catches. The
+ * socket.io carve-out is keyed to realtime-connection receivers, so a plain
+ * array receiver must still be flagged.
+ */
+
+export function renderPath(parts: string[]): void {
+  // VIOLATION: bugs/deterministic/ignored-return-value
+  parts.join("/");
+}

--- a/tests/fixtures/sample-js-project-negative/loss-of-precision-bare-literal.ts
+++ b/tests/fixtures/sample-js-project-negative/loss-of-precision-bare-literal.ts
@@ -1,0 +1,10 @@
+/**
+ * Negative fixture for bugs/deterministic/loss-of-precision.
+ *
+ * A bare integer literal beyond Number.MAX_SAFE_INTEGER silently loses
+ * precision at runtime — the real bug this rule catches. There is no explicit
+ * `BigInt(...)` conversion, so it must still be flagged.
+ */
+
+// VIOLATION: bugs/deterministic/loss-of-precision
+export const externalAccountId = 9007199254740993;

--- a/tests/fixtures/sample-js-project-negative/selector-parameter-owned-function.ts
+++ b/tests/fixtures/sample-js-project-negative/selector-parameter-owned-function.ts
@@ -1,0 +1,15 @@
+/**
+ * Negative fixture for code-quality/deterministic/selector-parameter.
+ *
+ * A function the author owns that takes a boolean to switch behavior — the
+ * real selector-parameter anti-pattern. It is a top-level declaration, not a
+ * callback, so it must still be flagged.
+ */
+
+// VIOLATION: code-quality/deterministic/selector-parameter
+export function renderReport(data: string, isVerbose: boolean): string {
+  if (isVerbose) {
+    return `verbose:${data}`;
+  }
+  return data;
+}

--- a/tests/fixtures/sample-js-project-positive/expression-complexity-collections-and-predicates.ts
+++ b/tests/fixtures/sample-js-project-positive/expression-complexity-collections-and-predicates.ts
@@ -1,0 +1,47 @@
+/**
+ * Positive fixture for code-quality/deterministic/expression-complexity.
+ *
+ * Three shapes that the operator counter over-reports but that do not benefit
+ * from being split into named variables:
+ *   1. A flat boolean predicate list (membership / guard test) joined by a
+ *      single logical operator, with no arithmetic.
+ *   2. An object literal whose independent property values happen to contain
+ *      operators (a perf-timing map).
+ *   3. An array literal of independent elements.
+ * The keys / positions already name the parts, and a flat predicate reads as
+ * one membership test, so none of these is tangled logic.
+ */
+
+export function isNumericKind(kind: string): boolean {
+  return (
+    kind.startsWith("Int") ||
+    kind.startsWith("UInt") ||
+    kind.startsWith("Float") ||
+    kind === "Decimal" ||
+    kind === "Numeric" ||
+    kind === "Currency" ||
+    kind === "Percent"
+  );
+}
+
+export function timingReport(marks: readonly number[]): Record<string, number> {
+  return {
+    parse: marks[1] - marks[0],
+    plan: marks[2] - marks[1],
+    exec: marks[3] - marks[2],
+    fetch: marks[4] - marks[3],
+    encode: marks[5] - marks[4],
+    flush: marks[6] - marks[5],
+  };
+}
+
+export function collectFlags(input: Record<string, boolean | undefined>): boolean[] {
+  return [
+    input.a ?? false,
+    input.b ?? false,
+    input.c ?? false,
+    input.d ?? false,
+    input.e ?? false,
+    input.f ?? false,
+  ];
+}

--- a/tests/fixtures/sample-js-project-positive/hardcoded-secret-posthog-public-key.ts
+++ b/tests/fixtures/sample-js-project-positive/hardcoded-secret-posthog-public-key.ts
@@ -1,0 +1,11 @@
+/**
+ * Positive fixture for security/deterministic/hardcoded-secret.
+ *
+ * A PostHog public project API key (the `phc_…` prefix) is meant to ship in
+ * client code so the browser can send analytics events — it is intentionally
+ * public, not a private credential. Its 40+ char base62 body otherwise
+ * collides with the generic Cohere-token shape, so the scanner must allowlist
+ * the `phc_` prefix and not flag it.
+ */
+
+export const analyticsProjectKey = "phc_9fK2pQ7mWxZr4tLbN1cV8aH3eD6sJ0uYgQwRtZxMpK";

--- a/tests/fixtures/sample-js-project-positive/ignored-return-value-socket-room-join.ts
+++ b/tests/fixtures/sample-js-project-positive/ignored-return-value-socket-room-join.ts
@@ -1,0 +1,16 @@
+/**
+ * Positive fixture for bugs/deterministic/ignored-return-value.
+ *
+ * A realtime connection's `.join(room)` is a side-effecting subscribe command
+ * that returns void — it is not `Array.prototype.join`, whose joined-string
+ * result must be consumed. The rule must not flag a bare `socket.join(...)`
+ * statement just because the method name collides with the array method.
+ */
+
+interface RoomConnection {
+  join(room: string): void;
+}
+
+export function subscribeToRoom(socket: RoomConnection, room: string): void {
+  socket.join(room);
+}

--- a/tests/fixtures/sample-js-project-positive/loss-of-precision-bigint-conversion.ts
+++ b/tests/fixtures/sample-js-project-positive/loss-of-precision-bigint-conversion.ts
@@ -1,0 +1,14 @@
+/**
+ * Positive fixture for bugs/deterministic/loss-of-precision.
+ *
+ * Wrapping a large integer literal in an explicit `BigInt(...)` conversion
+ * signals the developer has opted into big-integer handling. The generic
+ * "literal exceeds MAX_SAFE_INTEGER" warning is noise in that case, so the
+ * rule must not fire on the argument of a `BigInt(...)` call.
+ */
+
+const LEDGER_BASE = BigInt(1000000000000000000);
+
+export function defaultLedgerBalance(): bigint {
+  return LEDGER_BASE;
+}

--- a/tests/fixtures/sample-js-project-positive/selector-parameter-callback-arg.ts
+++ b/tests/fixtures/sample-js-project-positive/selector-parameter-callback-arg.ts
@@ -1,0 +1,22 @@
+/**
+ * Positive fixture for code-quality/deterministic/selector-parameter.
+ *
+ * A boolean parameter is only a "selector" when the author designed the
+ * function's public signature. A callback passed as a call argument
+ * (`promise.then(cb)`, `useCallback(cb)`) receives its parameter from the
+ * consumer's contract, so its boolean parameter is not a flag the author can
+ * refactor away by splitting the function in two.
+ *
+ * (The visitor applies the same carve-out to JSX prop callbacks such as
+ * `onCollapseChange={(isCollapsed) => …}`; that shape is not exercised here
+ * because an inline JSX callback independently trips inline-function-in-jsx-prop.)
+ */
+
+export function describeAvailability(check: Promise<boolean>): Promise<string> {
+  return check.then((isUnique) => {
+    if (isUnique) {
+      return 'available';
+    }
+    return 'taken';
+  });
+}


### PR DESCRIPTION
Paraphrased five false positives from `triggerdotdev/trigger.dev` into the analyzer fixtures and fixed each visitor. Each fix ships a positive fixture (asserts zero violations) and a negative fixture (asserts the genuine bug still fires).

Closes #418
Closes #419
Closes #421
Closes #422
Closes #423

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `bugs/deterministic/ignored-return-value` | #418 | `…positive/ignored-return-value-socket-room-join.ts` | `…negative/ignored-return-value-array-join.ts` |
| `security/deterministic/hardcoded-secret` | #419 | `…positive/hardcoded-secret-posthog-public-key.ts` | `…negative/hardcoded-secret-private-api-token.ts` |
| `bugs/deterministic/loss-of-precision` | #421 | `…positive/loss-of-precision-bigint-conversion.ts` | `…negative/loss-of-precision-bare-literal.ts` |
| `code-quality/deterministic/expression-complexity` | #422 | `…positive/expression-complexity-collections-and-predicates.ts` | `…negative/expression-complexity-arithmetic-boolean-mix.ts` |
| `code-quality/deterministic/selector-parameter` | #423 | `…positive/selector-parameter-callback-arg.ts` | `…negative/selector-parameter-owned-function.ts` |

## bugs/deterministic/ignored-return-value (#418)

OSS source: https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/handleSocketIo.server.ts#L590 — `socket.join(room)` is socket.io's room-join, not `Array.join`.

Positive fixture:
```ts
interface RoomConnection {
  join(room: string): void;
}

export function subscribeToRoom(socket: RoomConnection, room: string): void {
  socket.join(room);
}
```
Negative fixture:
```ts
export function renderPath(parts: string[]): void {
  // VIOLATION: bugs/deterministic/ignored-return-value
  parts.join("/");
}
```
**Visitor:** when the pure-array method name is `join` and the receiver's base identifier is a socket.io connection name (`socket`/`sockets`), skip — `socket.join(room)` is a side-effecting room subscription returning void. The carve-out is receiver-name based because socket.io's types live in uninstalled `node_modules`, so type information is unavailable at analyze time.

## security/deterministic/hardcoded-secret (#419)

OSS source: https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/env.server.ts#L138 — `POSTHOG_PROJECT_KEY` (`phc_…`) is a public PostHog project key, intentionally client-exposed; matched as a Cohere token.

Positive fixture:
```ts
export const analyticsProjectKey = "phc_9fK2pQ7mWxZr4tLbN1cV8aH3eD6sJ0uYgQwRtZxMpK";
```
Negative fixture:
```ts
// VIOLATION: security/deterministic/hardcoded-secret
export const inferenceApiToken = "kP3xQ9mViBn7sL0wRt2YfHdZ4aJ8cElNgUoPbT6kMqAvD";
```
**Visitor:** added a `GLOBAL_ALLOWLIST` entry `/^phc_[A-Za-z0-9]{30,}$/` for PostHog public project keys. These are embedded in frontend code to send analytics events; their 40+ char base62 body collided with the generic Cohere-token shape. Private PostHog keys (`phx_`/`phs_`) are deliberately not allowlisted.

## bugs/deterministic/loss-of-precision (#421)

OSS source: https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/references/hello-world/src/trigger/example.ts#L369 — `BigInt(1000000000000000000)` is an explicit conversion.

Positive fixture:
```ts
const LEDGER_BASE = BigInt(1000000000000000000);

export function defaultLedgerBalance(): bigint {
  return LEDGER_BASE;
}
```
Negative fixture:
```ts
// VIOLATION: bugs/deterministic/loss-of-precision
export const externalAccountId = 9007199254740993;
```
**Visitor:** skip a numeric literal when it is the direct argument of a `BigInt(...)` call — an explicit, intentional big-integer conversion. A bare large literal (no `BigInt(...)`) still fires.

## code-quality/deterministic/expression-complexity (#422)

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/coordinator/src/checkpointer.ts#L557 — object literal of perf timings.
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/ChartConfigPanel.tsx#L40 (also L53, L65) — flat OR-chains of type checks.
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/QueryResultsChart.tsx#L280 — constant array of interval definitions.

Positive fixture:
```ts
export function isNumericKind(kind: string): boolean {
  return (
    kind.startsWith("Int") ||
    kind.startsWith("UInt") ||
    kind.startsWith("Float") ||
    kind === "Decimal" ||
    kind === "Numeric" ||
    kind === "Currency" ||
    kind === "Percent"
  );
}

export function timingReport(marks: readonly number[]): Record<string, number> {
  return {
    parse: marks[1] - marks[0],
    plan: marks[2] - marks[1],
    exec: marks[3] - marks[2],
    fetch: marks[4] - marks[3],
    encode: marks[5] - marks[4],
    flush: marks[6] - marks[5],
  };
}

export function collectFlags(input: Record<string, boolean | undefined>): boolean[] {
  return [
    input.a ?? false,
    input.b ?? false,
    input.c ?? false,
    input.d ?? false,
    input.e ?? false,
    input.f ?? false,
  ];
}
```
Negative fixture:
```ts
export function isOverloaded(load: number, errors: number, latency: number, quota: number): boolean {
  // VIOLATION: code-quality/deterministic/expression-complexity
  return load * 2 + errors > quota && latency - errors * 3 > quota && load + errors + latency > quota;
}
```
**Visitor:** two changes. (1) Skip object/array literal targets — collections of independent members whose keys/positions already name the parts, so summing operators across all property values or array elements is meaningless. (2) Exempt flat boolean predicate lists — expressions whose operators are exclusively logical + comparison with **no arithmetic** read as a single membership/guard test. Genuinely tangled expressions that mix in arithmetic (`+`, `*`, …) are still flagged (the negative fixture, and existing fixtures, survive).

## code-quality/deterministic/selector-parameter (#423)

OSS sources:
- ``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.models._index/route.tsx#L1258`` — `isCollapsed` is a JSX prop callback param.
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/account._index/route.tsx#L62 — `isUnique` is a `.then()` callback result.

Positive fixture:
```ts
export function describeAvailability(check: Promise<boolean>): Promise<string> {
  return check.then((isUnique) => {
    if (isUnique) {
      return 'available';
    }
    return 'taken';
  });
}
```
Negative fixture:
```ts
// VIOLATION: code-quality/deterministic/selector-parameter
export function renderReport(data: string, isVerbose: boolean): string {
  if (isVerbose) {
    return `verbose:${data}`;
  }
  return data;
}
```
**Visitor:** skip callback functions — an arrow/function expression passed as a call argument (`promise.then(cb)`, `useCallback(cb)`) or as a JSX prop callback (`onCollapseChange={cb}`) receives its parameters from the consumer's contract, so a boolean parameter there is not a selector the author can refactor away by splitting the function. Author-owned declarations and methods still fire. (The JSX-prop shape is covered by the visitor but not by the positive fixture, since an inline JSX callback independently trips `inline-function-in-jsx-prop`.)

## Skipped this batch

- #420 `security/deterministic/hidden-file-exposure` — **refactor-required / out of scope.** The correct fix (Express's `dotfiles` defaults to `"ignore"`, so flag only an explicit `dotfiles: "allow"`) is logically incompatible with a hand-authored unit test, `tests/analyzer/security-rules.test.ts:944` (`detects express.static without dotfiles option`), which lives outside the routine's allowed change surface. Reverted and flagged `fp-blocked` for human review.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a fresh `pnpm build:dist` (the exact artifact publish.yml ships).

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `bugs/deterministic/ignored-return-value` | 4 | 3 | -1 |
| `security/deterministic/hardcoded-secret` | 24 | 23 | -1 |
| `bugs/deterministic/loss-of-precision` | 1 | 0 | -1 |
| `code-quality/deterministic/expression-complexity` | 207 | 29 | -178 |
| `code-quality/deterministic/selector-parameter` | 24 | 18 | -6 |
| **Total (these 5 rules)** | 260 | 73 | -187 |
| **All-rules total on target** | 34810 | 34623 | -187 |

The all-rules delta equals the sum of the five rule deltas, confirming no collateral changes to other rules.

> Note: `pnpm build:dist` and the full `pnpm test` run require building the `@truecourse/llm` and `ee/*` workspace packages first; on a clean checkout `tests/ee-*`, `tests/github-app/`, and a few `tests/dashboard-server/` files fail to collect due to unbuilt `@truecourse/ee-db` / `@truecourse/ee-data-store` (a pre-existing environment issue independent of this change). All 3883 `tests/analyzer` tests pass.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4xh2KUMWCDBkqhsQetPF3)_