### PR TITLE
fix(fp): resolve 4 FPs from abpframework/abp

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/csharp/_uri-helpers.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/csharp/_uri-helpers.ts
@@ -8,7 +8,15 @@ import type { Node as SyntaxNode } from 'web-tree-sitter'
  */
 const URI_NAME_PATTERN = /(^|[^a-z])(url|uri|uris|urls|endpoint|endpoints|webhook|webhookurl|callbackurl|redirecturi|redirecturl|hreflink|baseurl|baseaddress)$/i
 
+// A URI token preceded by a preposition (`…InUrl`, `…AsUri`, `…OfEndpoint`)
+// describes the *context* a value appears in, not a URI value — e.g.
+// `ActionNameInUrl` holds an action-name segment that merely travels in the URL.
+// The genuine URI names this rule targets read as "the X URL" (`CallbackUrl`,
+// `BaseUrl`), where the preceding token names which URL, not a preposition.
+const PREPOSITION_BEFORE_URI = /(In|As|Of|At|By|Within)(Url|Uri|Uris|Urls|Endpoint|Endpoints|Webhook)$/
+
 export function nameLooksLikeUri(name: string): boolean {
+  if (PREPOSITION_BEFORE_URI.test(name)) return false
   if (URI_NAME_PATTERN.test(name)) return true
   // PascalCase composite ending in Url/Uri/Endpoint (CallbackUrl, ImageUri…).
   return /(Url|Uri|Endpoint|Webhook)$/.test(name)

--- a/packages/analyzer/src/rules/architecture/visitors/csharp/value-type-action-param-under-posting.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/csharp/value-type-action-param-under-posting.ts
@@ -24,6 +24,29 @@ function isModelType(classDecl: SyntaxNode): boolean {
   return MODEL_NAME_SUFFIX.test(name)
 }
 
+/**
+ * A type that is constructed in code rather than model-bound from a request:
+ * it declares a parameterized constructor or a static factory method
+ * (`Create`/`From…`). Under-posting can only happen to request/binding models,
+ * which are parameterlessly constructed and populated through their setters;
+ * an output/response DTO built server-side (e.g. via a `Create(...)` factory or
+ * an all-args constructor) is never bound from the wire, so its non-nullable
+ * value types do not silently mask a missing field.
+ */
+function isServerConstructed(classDecl: SyntaxNode, body: SyntaxNode): boolean {
+  for (const member of body.namedChildren) {
+    if (member?.type === 'constructor_declaration') {
+      const params = member.childForFieldName('parameters')
+      if (params && params.namedChildCount > 0) return true
+    }
+    if (member?.type === 'method_declaration' && hasCSharpModifier(member, 'static')) {
+      const mName = member.childForFieldName('name')?.text ?? ''
+      if (mName === 'Create' || mName.startsWith('From')) return true
+    }
+  }
+  return false
+}
+
 function flaggablePropertyType(typeNode: SyntaxNode | null): string | null {
   if (typeNode?.type !== 'predefined_type') return null
   const t = typeNode.text
@@ -38,6 +61,8 @@ export const csharpValueTypeActionParamUnderPostingVisitor: CodeRuleVisitor = {
     if (!isModelType(node)) return null
     const body = node.childForFieldName('body')
     if (!body) return null
+    // Response/output DTOs are constructed server-side, never request-bound.
+    if (isServerConstructed(node, body)) return null
 
     for (const member of body.namedChildren) {
       if (member?.type !== 'property_declaration') continue

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/empty-function.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/empty-function.ts
@@ -15,6 +15,22 @@ export function csharpEmptyBodyIsIntentional(node: SyntaxNode, body: SyntaxNode)
   }
   // No-op lambdas in callback positions are deliberate placeholders.
   if (isCSharpNoOpCallbackPosition(node)) return true
+  // Null-object / no-op pattern: a type named `Null…`/`Noop…`/`Empty…` exists
+  // precisely to satisfy an interface or base contract with do-nothing members
+  // (e.g. `NullLogger.Log`, `EmptyDisposable.Dispose`). Empty bodies there are
+  // the intended implementation, not a missing one. The guard requires an
+  // uppercase letter or digit after the prefix so `Nullable`/`Emptiness` don't
+  // match.
+  let enclosingType: SyntaxNode | null = node.parent
+  while (enclosingType
+    && enclosingType.type !== 'class_declaration'
+    && enclosingType.type !== 'struct_declaration'
+    && enclosingType.type !== 'record_declaration'
+    && enclosingType.type !== 'record_struct_declaration') {
+    enclosingType = enclosingType.parent
+  }
+  const typeName = enclosingType?.childForFieldName('name')?.text
+  if (typeName && /^(Null|Noop|NoOp|Empty)[A-Z0-9]/.test(typeName)) return true
   // `virtual`/`override` empty methods are template-method hooks or
   // intentional suppression of inherited behavior; `partial` methods may be
   // filled in by a generator.

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/nested-generic-parameter.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/nested-generic-parameter.ts
@@ -9,7 +9,20 @@ import { makeViolation } from '../../../types.js'
  * on a `parameter` whose type is a `generic_name` containing another
  * `generic_name` in its `type_argument_list`. `Dictionary<K, V>`,
  * `List<Order>`, `Task<int>` and other single-level generics are fine.
+ *
+ * Delegate and expression-tree shapes are exempt: `Func<…>`, `Action<…>`,
+ * `Predicate<…>` and `Expression<…>` routinely nest a generic type argument
+ * (`Func<X, Task<Y>>`, `Expression<Func<T, bool>>`) as their canonical idiom,
+ * and many are externally mandated (ASP.NET Core `IHubFilter` `next`, LINQ
+ * expression trees). A named type cannot replace them, so flagging is noise.
  */
+const DELEGATE_OR_EXPRESSION_GENERICS = new Set(['Func', 'Action', 'Predicate', 'Expression'])
+
+/** The simple identifier of a generic_name (`Func` for `Func<…>`). */
+function genericBaseName(generic: SyntaxNode): string {
+  return generic.namedChildren.find((c) => c?.type === 'identifier')?.text ?? ''
+}
+
 /** The generic_name a type position resolves to, unwrapping a qualified name's
  *  final segment (`System.Collections.Generic.IEnumerable<…>`). */
 function asGenericName(typeNode: SyntaxNode | null): SyntaxNode | null {
@@ -25,6 +38,8 @@ function asGenericName(typeNode: SyntaxNode | null): SyntaxNode | null {
 function hasNestedGeneric(typeNode: SyntaxNode): boolean {
   const generic = asGenericName(typeNode)
   if (!generic) return false
+  // Delegate/expression-tree generics nest by design and can't be named away.
+  if (DELEGATE_OR_EXPRESSION_GENERICS.has(genericBaseName(generic))) return false
   const args = generic.namedChildren.find((c) => c?.type === 'type_argument_list')
   if (!args) return false
   return args.namedChildren.some((arg) => asGenericName(arg) !== null)

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -1717,6 +1717,12 @@
       "layer": "data"
     },
     {
+      "name": "AvatarLink",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "BaseFormatter",
       "service": "UserService",
       "kind": "class",
@@ -2185,6 +2191,12 @@
       "layer": "service"
     },
     {
+      "name": "PaymentReconciler",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "PaymentRelay",
       "service": "UserService",
       "kind": "class",
@@ -2407,6 +2419,12 @@
       "layer": "service"
     },
     {
+      "name": "TagReducer",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "TenantResolver",
       "service": "UserService",
       "kind": "class",
@@ -2450,6 +2468,12 @@
     },
     {
       "name": "TrialExpiryService",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "UpdateQuotaCommand",
       "service": "UserService",
       "kind": "class",
       "layer": "service"

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/AvatarLink.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/AvatarLink.cs
@@ -1,0 +1,10 @@
+namespace UserServiceApp.Violations.Architecture;
+
+/// <summary>A user's avatar reference.</summary>
+public sealed class AvatarLink
+{
+    // A public URL-named property typed as a bare string, losing the parsing and
+    // validation System.Uri would give — the rule should flag it.
+    // VIOLATION: architecture/deterministic/uri-property-as-string
+    public string AvatarUrl { get; set; } = string.Empty;
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/UpdateQuotaCommand.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/UpdateQuotaCommand.cs
@@ -1,0 +1,13 @@
+namespace UserServiceApp.Violations.Architecture;
+
+/// <summary>Request payload to update a tenant's quota via the public API.</summary>
+public sealed class UpdateQuotaCommand
+{
+    /// <summary>The tenant whose quota changes.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    // A bound, non-nullable value type with no `required`/nullable and no default:
+    // a missing field binds silently to 0 instead of failing validation.
+    // VIOLATION: architecture/deterministic/value-type-action-param-under-posting
+    public int MaxSeats { get; set; }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/PaymentReconciler.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/PaymentReconciler.cs
@@ -1,0 +1,12 @@
+namespace UserServiceApp.Violations.CodeQuality;
+
+/// <summary>Settles pending payment batches.</summary>
+internal sealed class PaymentReconciler
+{
+    /// <summary>Should settle the pending batch, but the body was left empty by mistake.</summary>
+    // VIOLATION: code-quality/deterministic/empty-function
+    // VIOLATION: code-quality/deterministic/no-empty-function
+    internal void SettleBatch()
+    {
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/TagReducer.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/TagReducer.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace UserServiceApp.Violations.CodeQuality;
+
+/// <summary>Folds batches of tags into a running count.</summary>
+internal sealed class TagReducer
+{
+    private int _calls;
+
+    // A genuinely awkward nested collection generic (IEnumerable&lt;List&lt;string&gt;&gt;)
+    // that a named type would communicate far better — the rule should flag it.
+    // VIOLATION: code-quality/deterministic/nested-generic-parameter
+    internal int Merge(IEnumerable<List<string>> tagBatches)
+    {
+        _calls++;
+        return _calls + (tagBatches != null ? 1 : 0);
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/SessionStateDto.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/SessionStateDto.cs
@@ -1,0 +1,24 @@
+namespace Positive.Boundary.Architecture;
+
+/// <summary>
+/// A response/output DTO describing a session's lifetime. It is built server-side
+/// through its constructor and serialized to clients — never model-bound from a
+/// request — so its non-nullable value-type members cannot under-post. The
+/// under-posting rule must not flag a type that is constructed in code.
+/// </summary>
+public sealed class SessionStateDto
+{
+    /// <summary>The opaque session identifier.</summary>
+    public string SessionId { get; set; } = string.Empty;
+
+    // SAFE: architecture/deterministic/value-type-action-param-under-posting
+    /// <summary>Seconds until the session expires; set server-side, not bound.</summary>
+    public int ExpiresInSeconds { get; set; }
+
+    /// <summary>Builds the response from server-computed values.</summary>
+    public SessionStateDto(string sessionId, int expiresInSeconds)
+    {
+        SessionId = sessionId;
+        ExpiresInSeconds = expiresInSeconds;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/UriPropertyPrepositionSample.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/UriPropertyPrepositionSample.cs
@@ -1,0 +1,14 @@
+namespace Positive.Boundary.Architecture;
+
+/// <summary>
+/// Holds a route segment that travels inside a URL but is itself an identifier,
+/// not a URI. The name ends in <c>…InUrl</c> — a preposition before the URI token
+/// signals the *context* a value appears in, not a URI value — so the
+/// uri-property rule must not flag it.
+/// </summary>
+public sealed class UriPropertyPrepositionSample
+{
+    // SAFE: architecture/deterministic/uri-property-as-string
+    /// <summary>The action-name segment carried within the route URL.</summary>
+    public string SegmentInUrl { get; set; } = string.Empty;
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/INotificationSink.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/INotificationSink.cs
@@ -1,0 +1,8 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>The contract a notification sink fulfils.</summary>
+public interface INotificationSink
+{
+    /// <summary>Delivers a notification on the given topic.</summary>
+    void Publish(string topic, string payload);
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/NullNotificationSink.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/NullNotificationSink.cs
@@ -1,0 +1,16 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// A null-object implementation of <see cref="INotificationSink"/>: every member
+/// is an intentional no-op, which is the whole purpose of the type. The
+/// empty-function rules must treat these do-nothing bodies as deliberate, not as
+/// missing implementations.
+/// </summary>
+// SAFE: code-quality/deterministic/empty-function
+public sealed class NullNotificationSink : INotificationSink
+{
+    /// <summary>Drops the notification; the null sink never delivers anything.</summary>
+    public void Publish(string topic, string payload)
+    {
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/NestedGenericExpressionSample.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/NestedGenericExpressionSample.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Linq.Expressions;
+
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// Accepts a LINQ predicate expression. The nested generic
+/// <c>Expression&lt;Func&lt;string, bool&gt;&gt;</c> is the canonical expression-tree
+/// idiom, not an author-controllable shape that a named type could replace, so
+/// the nested-generic rule must not fire on it.
+/// </summary>
+public sealed class NestedGenericExpressionSample
+{
+    /// <summary>Returns whether a predicate expression was supplied.</summary>
+    // SAFE: code-quality/deterministic/nested-generic-parameter
+    public bool Matches(Expression<Func<string, bool>> predicate)
+    {
+        return predicate != null;
+    }
+}


### PR DESCRIPTION
Resolves 4 tree-sitter C# false positives surfaced by the `abpframework/abp` campaign (target ref `8665ce0a23622f658b531b0627c7c025935fdb3b`).

Closes #643
Closes #644
Closes #646
Closes #649

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/empty-function` | #643 | `…/CodeQualitySamples1/NullNotificationSink.cs` (+ `INotificationSink.cs`) | `…/UserService/Violations/CodeQuality/PaymentReconciler.cs` |
| `architecture/deterministic/value-type-action-param-under-posting` | #644 | `…/ArchitectureSamples/SessionStateDto.cs` | `…/UserService/Violations/Architecture/UpdateQuotaCommand.cs` |
| `code-quality/deterministic/nested-generic-parameter` | #646 | `…/CodeQualitySamples2/NestedGenericExpressionSample.cs` | `…/UserService/Violations/CodeQuality/TagReducer.cs` |
| `architecture/deterministic/uri-property-as-string` | #649 | `…/ArchitectureSamples/UriPropertyPrepositionSample.cs` | `…/UserService/Violations/Architecture/AvatarLink.cs` |

## code-quality/deterministic/empty-function

OSS sources (#643): null-object `Dispose`/no-op service members, e.g.
- https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Core/Volo/Abp/NullDisposable.cs#L14
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Distributed/NullDistributedEventBus.cs#L69``

**Positive fixture** (must NOT fire — a null-object's empty members are by design):
```cs
// NullNotificationSink.cs
public sealed class NullNotificationSink : INotificationSink
{
    public void Publish(string topic, string payload)
    {
    }
}
```
**Negative fixture** (must still fire — a genuinely empty body that should have an implementation):
```cs
// PaymentReconciler.cs
internal sealed class PaymentReconciler
{
    // VIOLATION: code-quality/deterministic/empty-function
    // VIOLATION: code-quality/deterministic/no-empty-function
    internal void SettleBatch()
    {
    }
}
```
**Visitor change:** the shared `csharpEmptyBodyIsIntentional` helper (used by both `empty-function` and `no-empty-function`) now treats an empty member as intentional when its enclosing type is a null-object/no-op type — name matching `^(Null|Noop|NoOp|Empty)[A-Z0-9]` (guarded so `Nullable`/`Emptiness` don't match). Such types exist precisely to satisfy a contract with do-nothing members.

## architecture/deterministic/value-type-action-param-under-posting

OSS sources (#644): server-built response/output DTOs in the app-configuration payload, e.g.
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Mvc.Contracts/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/CurrentUserDto.cs#L8``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Mvc.Contracts/Volo/Abp/AspNetCore/Mvc/MultiTenancy/CurrentTenantDto.cs#L11``

**Positive fixture** (must NOT fire — a server-constructed response DTO is never request-bound):
```cs
// SessionStateDto.cs
public sealed class SessionStateDto
{
    public string SessionId { get; set; } = string.Empty;
    public int ExpiresInSeconds { get; set; }
    public SessionStateDto(string sessionId, int expiresInSeconds)
    {
        SessionId = sessionId;
        ExpiresInSeconds = expiresInSeconds;
    }
}
```
**Negative fixture** (must still fire — a bound request model with a bare value type):
```cs
// UpdateQuotaCommand.cs
public sealed class UpdateQuotaCommand
{
    public string TenantId { get; set; } = string.Empty;
    // VIOLATION: architecture/deterministic/value-type-action-param-under-posting
    public int MaxSeats { get; set; }
}
```
**Visitor change:** model-shaped types that are *constructed in code* — they declare a parameterized constructor or a static factory (`Create`/`From…`) — are skipped. Under-posting can only affect request/binding models, which are parameterlessly constructed and populated via setters; an output DTO built server-side is never bound from the wire.

## code-quality/deterministic/nested-generic-parameter

OSS sources (#646): framework-mandated delegate / expression-tree signatures, e.g.
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.SignalR/Volo/Abp/AspNetCore/SignalR/Auditing/AbpAuditHubFilter.cs#L17``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AutoMapper/Volo/Abp/AutoMapper/AutoMapperExpressionExtensions.cs#L10``

**Positive fixture** (must NOT fire — `Expression<Func<…>>` is the canonical idiom):
```cs
// NestedGenericExpressionSample.cs
public sealed class NestedGenericExpressionSample
{
    public bool Matches(Expression<Func<string, bool>> predicate)
    {
        return predicate != null;
    }
}
```
**Negative fixture** (must still fire — an awkward nested collection generic):
```cs
// TagReducer.cs
internal sealed class TagReducer
{
    private int _calls;
    // VIOLATION: code-quality/deterministic/nested-generic-parameter
    internal int Merge(IEnumerable<List<string>> tagBatches)
    {
        _calls++;
        return _calls + (tagBatches != null ? 1 : 0);
    }
}
```
**Visitor change:** when the *outer* generic of a nested-generic parameter is a delegate or expression-tree shape (`Func`, `Action`, `Predicate`, `Expression`), the nesting is idiomatic and often externally mandated (ASP.NET Core `IHubFilter` `next`, LINQ expression trees), so a named type cannot replace it — these are exempted.

## architecture/deterministic/uri-property-as-string

OSS sources (#649): a `…Url`-named property that holds an identifier, not a URI, e.g.
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Conventions/UrlActionNameNormalizerContext.cs#L13``

**Positive fixture** (must NOT fire — `…InUrl` names a value's context, not a URI):
```cs
// UriPropertyPrepositionSample.cs
public sealed class UriPropertyPrepositionSample
{
    public string SegmentInUrl { get; set; } = string.Empty;
}
```
**Negative fixture** (must still fire — a real URL-named string property):
```cs
// AvatarLink.cs
public sealed class AvatarLink
{
    // VIOLATION: architecture/deterministic/uri-property-as-string
    public string AvatarUrl { get; set; } = string.Empty;
}
```
**Visitor change:** `nameLooksLikeUri` no longer matches a URI token preceded by a preposition (`…InUrl`, `…AsUri`, `…OfEndpoint`). Genuine URI names read as "the X URL" (`CallbackUrl`, `BaseUrl`) where the preceding token names *which* URL; a preposition instead signals the value merely *travels in* a URL (e.g. an action-name segment).

## Skipped this batch

Six issues were attempted but skipped (counted toward the 10-attempt cap, not the 5-success cap). All are **Roslyn-host semantic rules** (`engine: roslyn-host`, in `tools/csharp-roslyn-host/Rules/`) — outside this tree-sitter routine's change set, which only edits `packages/analyzer/src/rules/` and rebuilds the JS dist (never the .NET host):

- #640 `type-name-matches-namespace` — refactor-required (roslyn-host)
- #641 `normalize-to-lower-not-upper` — refactor-required (roslyn-host)
- #642 `interface-colliding-base-members` — refactor-required (roslyn-host)
- #645 `unused-function-parameter` — needs semantic interface-member resolution; the only tree-sitter proxy is too broad and conflicts with a curated true-positive (`SessionSnapshot.GetObjectData`)
- #647 `missing-format-provider-overload` — refactor-required (roslyn-host)
- #648 `writable-collection-property` — refactor-required (roslyn-host)

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/empty-function` | 125 | 98 | -27 |
| `code-quality/deterministic/no-empty-function` (collateral — same shared helper) | 135 | 108 | -27 |
| `architecture/deterministic/value-type-action-param-under-posting` | 138 | 112 | -26 |
| `code-quality/deterministic/nested-generic-parameter` | 393 | 69 | -324 |
| `architecture/deterministic/uri-property-as-string` | 130 | 129 | -1 |
| **Total (these 5 rules)** | 921 | 516 | -405 |
| **All-rules total on target** | 84619 | 84214 | -405 |

The all-rules-total delta (-405) is exactly the sum of the five affected rule keys above — the changes touched no other rule. `uri-property-as-string` drops by only 1 because just the preposition sub-FP (`…InUrl`) is fixed here; the interface-contract sub-FP from #649 (`BaseAddress` fixed to `string` by a framework interface) needs semantic resolution and is left for the host process.

> Measured with `node dist/cli.mjs` from a fresh `pnpm build:dist` (the exact artifact `publish.yml` ships), before vs after on the same clone. The clone's `global.json` (which pins a .NET SDK absent here) and its `.csproj`/`.sln` files were removed so the project-aware `roslyn-workspace` pass is skipped — those rules need a restored project (unavailable in this sandbox) and contribute zero violations either way. The identical setup was used for both measurements, so the delta reflects only this PR's visitor changes.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_016baUwR6gxdefacS2tEv8hV)_