### PR TITLE
fix(csharp): stop Roslyn host crashing on uninstalled-SDK global.json (#658)

### DIFF
--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/dashboard-server",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/analyzer/src/lsp-client.ts
+++ b/packages/analyzer/src/lsp-client.ts
@@ -97,12 +97,21 @@ export class LspClient {
       // Pyright logs to stderr — ignore unless debugging
     })
 
-    this.process.on('error', (err) => {
-      for (const pending of this.pendingRequests.values()) {
-        pending.reject(err)
-      }
-      this.pendingRequests.clear()
-    })
+    this.process.on('error', (err) => this.rejectAllPending(err))
+
+    // If the server dies, a write to its now-closed stdin emits an 'error' on the
+    // stream; without this listener that is an unhandled event that crashes the
+    // whole process (the same EPIPE defect class as issue #658). And a server that
+    // exits before answering would leave requests hanging forever, since requests
+    // have no per-call timeout — so reject anything still pending on either signal.
+    this.process.stdin!.on('error', (err) =>
+      this.rejectAllPending(new Error(`${this.config.name} LSP stdin error: ${err.message}`)),
+    )
+    this.process.on('exit', (code, signal) =>
+      this.rejectAllPending(
+        new Error(`${this.config.name} LSP server exited (${signal ?? `code ${code}`}) before responding`),
+      ),
+    )
 
     // Initialize
     const initResult = await this.sendRequest('initialize', {
@@ -339,19 +348,40 @@ export class LspClient {
   // Internal: JSON-RPC transport
   // -------------------------------------------------------------------------
 
+  /** Reject and clear every in-flight request — used when the server dies. */
+  private rejectAllPending(err: Error): void {
+    if (this.pendingRequests.size === 0) return
+    for (const pending of this.pendingRequests.values()) pending.reject(err)
+    this.pendingRequests.clear()
+  }
+
   private sendRequest(method: string, params: any): Promise<any> {
     return new Promise((resolve, reject) => {
       const id = ++this.requestId
       this.pendingRequests.set(id, { resolve, reject })
 
       const msg: LspMessage = { jsonrpc: '2.0', id, method, params }
-      this.process!.stdin!.write(encodeMessage(msg))
+      // A synchronous throw here means the stream is already closed (write after
+      // end); reject this request rather than letting it hang. Async failures
+      // (EPIPE) arrive via the stdin 'error' handler wired in start().
+      try {
+        this.process!.stdin!.write(encodeMessage(msg))
+      } catch (err) {
+        this.pendingRequests.delete(id)
+        reject(err instanceof Error ? err : new Error(String(err)))
+      }
     })
   }
 
   private sendNotification(method: string, params: any): void {
     const msg: LspMessage = { jsonrpc: '2.0', method, params }
-    this.process!.stdin!.write(encodeMessage(msg))
+    // Fire-and-forget: a closed stream just means the server is gone, which the
+    // stdin 'error' / process 'exit' handlers already surface to pending requests.
+    try {
+      this.process!.stdin!.write(encodeMessage(msg))
+    } catch {
+      /* server already exited — nothing waiting on this notification */
+    }
   }
 
   private onData(chunk: Buffer): void {

--- a/packages/analyzer/src/roslyn-host-client.ts
+++ b/packages/analyzer/src/roslyn-host-client.ts
@@ -13,6 +13,7 @@
 
 import { spawn } from 'child_process'
 import { existsSync } from 'fs'
+import { tmpdir } from 'os'
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 
@@ -67,44 +68,104 @@ interface HostResponse {
 /** Spawn the host with one request line and resolve its single JSON response. */
 function invokeHost(bin: string, request: object): Promise<RoslynHostViolation[]> {
   return new Promise<RoslynHostViolation[]>((resolvePromise, reject) => {
-    const child = spawn(bin, [], { stdio: ['pipe', 'pipe', 'pipe'] })
+    // Run the host in a neutral working directory with no project build config on
+    // its path. The host is a read-only semantic analyzer — it compiles file texts
+    // (or opens an already-restored project by absolute path) and never builds the
+    // target — so it must not honor the target repo's `global.json` SDK pin.
+    // Inheriting the analyze cwd (the target repo) let the .NET SDK resolver walk
+    // up to that `global.json` and abort at startup when the pinned SDK wasn't
+    // installed; tmpdir() is guaranteed free of one. See issue #658.
+    const child = spawn(bin, [], { stdio: ['pipe', 'pipe', 'pipe'], cwd: tmpdir() })
     let stdout = ''
     let stderr = ''
+    let settled = false
+    const fail = (err: Error) => {
+      if (settled) return
+      settled = true
+      reject(err)
+    }
+    const succeed = (violations: RoslynHostViolation[]) => {
+      if (settled) return
+      settled = true
+      resolvePromise(violations)
+    }
+
     child.stdout.setEncoding('utf8')
     child.stderr.setEncoding('utf8')
     child.stdout.on('data', (d: string) => (stdout += d))
     child.stderr.on('data', (d: string) => (stderr += d))
 
     child.on('error', (e) =>
-      reject(
+      fail(
         new RoslynHostUnavailableError(
           `Failed to start the Roslyn host (${bin}): ${e.message}. Is the .NET runtime installed?`,
         ),
       ),
     )
 
-    child.on('close', () => {
-      const line = stdout.split('\n').find((l) => l.trim())
-      if (!line) {
-        reject(new Error(`Roslyn host produced no output.${stderr ? ` stderr: ${stderr}` : ''}`))
+    // If the host exits while we're still streaming a large request, the write
+    // hits a closed pipe and `child.stdin` emits 'error' (EPIPE). Swallow it here
+    // so it isn't an unhandled stream error that crashes the whole process; the
+    // real diagnosis comes from the 'close' handler below (exit code + stderr).
+    child.stdin.on('error', () => {})
+
+    child.on('close', (code, signalName) => {
+      // A non-zero exit or a terminating signal means the host died before
+      // answering (e.g. the SDK resolver aborted). The reason is on stderr — the
+      // ".NET SDK was not found … global.json …" diagnostic — so surface that
+      // instead of trying to JSON-parse whatever leaked onto stdout (on small
+      // requests the host's own SDK banner lands there and mis-parses).
+      if (code !== 0 || signalName) {
+        const reason = stderr.trim() || stdout.trim() || '(no output)'
+        fail(
+          new RoslynHostUnavailableError(
+            `The Roslyn host exited ${signalName ? `via ${signalName}` : `with code ${code}`} ` +
+              `before responding. Is a compatible .NET runtime installed? Host output: ${reason}`,
+          ),
+        )
         return
       }
-      let resp: HostResponse
-      try {
-        resp = JSON.parse(line) as HostResponse
-      } catch {
-        reject(new Error(`Roslyn host returned invalid JSON: ${line}`))
+      const lines = stdout
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+      if (lines.length === 0) {
+        fail(new Error(`Roslyn host produced no output.${stderr ? ` stderr: ${stderr}` : ''}`))
+        return
+      }
+      // The protocol is one JSON response per line, but the .NET SDK resolver can
+      // leak a stray banner (e.g. `8.0.128 [/usr/.../sdk]`) onto stdout. Locate the
+      // actual response line rather than assuming it's the first one.
+      let resp: HostResponse | undefined
+      for (const l of lines) {
+        try {
+          const parsed = JSON.parse(l) as HostResponse
+          if (parsed && typeof parsed.ok === 'boolean') {
+            resp = parsed
+            break
+          }
+        } catch {
+          /* not the JSON response line — skip leaked SDK/runtime banners */
+        }
+      }
+      if (!resp) {
+        fail(new Error(`Roslyn host returned invalid JSON: ${lines[0]}`))
         return
       }
       if (!resp.ok) {
-        reject(new Error(`Roslyn host error: ${resp.error ?? 'unknown'}`))
+        fail(new Error(`Roslyn host error: ${resp.error ?? 'unknown'}`))
         return
       }
-      resolvePromise(resp.violations ?? [])
+      succeed(resp.violations ?? [])
     })
 
-    child.stdin.write(JSON.stringify(request) + '\n')
-    child.stdin.end()
+    try {
+      child.stdin.write(JSON.stringify(request) + '\n')
+      child.stdin.end()
+    } catch {
+      // The host already closed stdin (raced with an early exit); the 'close'
+      // handler will fire and produce the real error.
+    }
   })
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecourse/core",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/src/services/llm/cli-provider.ts
+++ b/packages/core/src/services/llm/cli-provider.ts
@@ -273,9 +273,19 @@ export abstract class BaseCLIProvider implements LLMProvider {
         reject(new Error(`[CLI] Failed to spawn ${this.binaryName}: ${err.message}`));
       });
 
-      // Pipe prompt via stdin
-      child.stdin!.write(prompt);
-      child.stdin!.end();
+      // Pipe prompt via stdin. Guard against the child having already exited
+      // (early auth/crash failure): a write to a closed pipe emits an 'error' on
+      // the stdin stream, which without a listener is an unhandled event that
+      // crashes the whole process instead of surfacing via the 'close' handler
+      // above. The prompt routinely exceeds the OS pipe buffer (~64 KB), so this
+      // is a real path, not a corner case (same defect class as issue #658).
+      child.stdin!.on('error', () => {});
+      try {
+        child.stdin!.write(prompt);
+        child.stdin!.end();
+      } catch {
+        // Child already gone; the 'close'/'error' handlers above reject with the cause.
+      }
     });
   }
 

--- a/tests/analyzer/lsp-client.test.ts
+++ b/tests/analyzer/lsp-client.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { tmpdir } from 'os'
+import { LspClient } from '../../packages/analyzer/src/lsp-client'
+
+// Regression for the EPIPE defect class (issue #658, generalized): a language
+// server that dies must surface as a rejected promise, never as an unhandled
+// 'error' event on the child's stdin that crashes the whole process — and never
+// as a request that hangs forever (LSP requests have no per-call timeout).
+//
+// We stand in a real, dependency-free "server" with `node`: it accepts the
+// request bytes on stdin but exits without ever replying to `initialize`. Before
+// the fix this either crashed the worker (write to a closed pipe) or hung; after
+// it, the process 'exit' / stdin 'error' handlers reject the in-flight request,
+// so `start()` rejects cleanly and this test simply completes.
+describe('LspClient — resilient when the server dies', () => {
+  it('rejects start() instead of crashing when the server exits without responding', async () => {
+    const client = new LspClient({
+      name: 'FakeServer',
+      command: process.execPath, // node — always present
+      // Stay alive briefly to absorb the initialize write, then exit without
+      // ever sending an LSP response.
+      args: ['-e', 'process.stdin.resume(); setTimeout(() => process.exit(1), 50)'],
+    })
+
+    await expect(client.start(tmpdir())).rejects.toThrow(/FakeServer/)
+  })
+})

--- a/tests/analyzer/roslyn-host.test.ts
+++ b/tests/analyzer/roslyn-host.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import {
   runRoslynHost,
   resolveRoslynHostBinary,
@@ -41,6 +44,37 @@ describe.skipIf(!hostBuilt)('Roslyn host client (semantic C#)', () => {
       ['some/other/rule'],
     )
     expect(violations).toEqual([])
+  })
+
+  // Regression for #658: a C# repo whose root global.json pins an uninstalled SDK
+  // must not break loose-text analysis. The host runs read-only over file texts
+  // with the runtime's reference set — it never builds the target — so the SDK pin
+  // is irrelevant to it. Before the fix, the host inherited the analyze cwd, the
+  // .NET SDK resolver found this global.json, and the host aborted at startup
+  // (manifesting as `write EPIPE` on the Node side). The client now spawns the host
+  // in a neutral cwd, so the pin is never on the resolver's search path.
+  it('analyzes even when the working directory pins an uninstalled .NET SDK (global.json)', async () => {
+    const badRepo = mkdtempSync(join(tmpdir(), 'tc-bad-globaljson-'))
+    writeFileSync(
+      join(badRepo, 'global.json'),
+      JSON.stringify({ sdk: { version: '999.999.999', rollForward: 'disable' } }),
+    )
+    const prevCwd = process.cwd()
+    process.chdir(badRepo)
+    try {
+      const violations = await runRoslynHost([
+        {
+          path: 'Pos.cs',
+          text: 'class C { void M() { int a = 1; int b = 2; var x = object.ReferenceEquals(a, b); } }',
+        },
+      ])
+      expect(violations.map((v) => v.ruleKey)).toContain(
+        'bugs/deterministic/referenceequals-on-value-type',
+      )
+    } finally {
+      process.chdir(prevCwd)
+      rmSync(badRepo, { recursive: true, force: true })
+    }
   })
 })
 

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truecourse",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "type": "module",
   "bin": {
     "truecourse": "./dist/index.js"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -63,7 +63,7 @@ const program = new Command();
 
 program
   .name("truecourse")
-  .version("0.6.9")
+  .version("0.6.10")
   .description("TrueCourse CLI — analyze your repository and open the dashboard");
 
 const dashboardCmd = program

--- a/tools/csharp-roslyn-host/CSharpRoslynHost.csproj
+++ b/tools/csharp-roslyn-host/CSharpRoslynHost.csproj
@@ -15,7 +15,8 @@
     <!-- MSBuildWorkspace project loading (the `analyze-project` op): opens a real
          .csproj/.sln with its actual references for full-fidelity semantics.
          Microsoft.Build.Locator must register an installed SDK before any MSBuild
-         type is touched — see Program.Main. -->
+         type is touched — see Program.AnalyzeProjectGuarded (lazy + guarded so the
+         runtime-only `analyze` op never needs an SDK). -->
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
     <!-- The C# language-specific workspace service; without it MSBuildWorkspace
          reports "language 'C#' is not supported". -->

--- a/tools/csharp-roslyn-host/Program.cs
+++ b/tools/csharp-roslyn-host/Program.cs
@@ -40,9 +40,11 @@ internal static class Program
 
     private static int Main()
     {
-        // Register an installed .NET SDK with MSBuildLocator before any MSBuild
-        // type is touched (the analyze-project path). Must run first.
-        if (!MSBuildLocator.IsRegistered) MSBuildLocator.RegisterDefaults();
+        // Deliberately do NOT resolve an SDK here. `ping` and the loose-text
+        // `analyze` op need only the .NET *runtime*, so they must work even when
+        // no SDK is installed, or the ambient global.json pins an uninstalled one
+        // (the analyze cwd may be a target repo with such a pin — see issue #658).
+        // MSBuildLocator runs lazily, and guarded, only for `analyze-project`.
 
         // Line-buffered request/response loop. Blocks until stdin closes.
         for (string? line; (line = Console.In.ReadLine()) is not null;)
@@ -69,9 +71,34 @@ internal static class Program
     {
         "ping" => new Response(true),
         "analyze" => Analyze(req),
-        "analyze-project" => AnalyzeProject(req).GetAwaiter().GetResult(),
+        "analyze-project" => AnalyzeProjectGuarded(req),
         _ => new Response(false, Error: $"unknown op: {req.Op}"),
     };
+
+    // analyze-project is the only op that needs MSBuild. Register an installed SDK
+    // lazily and BEFORE any MSBuild type resolves — MSBuildLocator lives in its own
+    // assembly, so referencing it here does not pull MSBuild in, and AnalyzeProject
+    // (which does touch MSBuild types) stays NoInlining so its body JITs only after
+    // this returns. If no SDK can be resolved — none installed, or the ambient
+    // global.json pins an uninstalled one — report it as a normal protocol error so
+    // the caller can skip the project-aware tier, rather than letting RegisterDefaults
+    // throw and abort the whole process (which surfaced as an EPIPE crash on the Node
+    // side — see issue #658).
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Response AnalyzeProjectGuarded(Request req)
+    {
+        try
+        {
+            if (!MSBuildLocator.IsRegistered) MSBuildLocator.RegisterDefaults();
+        }
+        catch (Exception ex)
+        {
+            return new Response(false, Error:
+                $"could not locate a .NET SDK to open the project via MSBuild: {ex.Message}. " +
+                "Install a compatible .NET SDK (and restore the project) for project-aware C# rules.");
+        }
+        return AnalyzeProject(req).GetAwaiter().GetResult();
+    }
 
     private static Response Analyze(Request req)
     {
@@ -101,8 +128,9 @@ internal static class Program
 
     // Open a real project/solution via MSBuildWorkspace and run every host rule
     // (single-model and project-aware) against its documents with the project's
-    // own references. NoInlining: keeps MSBuild types out of Main's JIT body so
-    // MSBuildLocator.RegisterDefaults runs before they resolve.
+    // own references. NoInlining: keeps MSBuild types out of the caller's JIT body
+    // so AnalyzeProjectGuarded's MSBuildLocator.RegisterDefaults runs before they
+    // resolve.
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static async Task<Response> AnalyzeProject(Request req)
     {

--- a/tools/csharp-roslyn-host/README.md
+++ b/tools/csharp-roslyn-host/README.md
@@ -36,6 +36,15 @@ One JSON request per line in, one JSON response per line out. Two analysis modes
 `{"ok":false,"error":"..."}`. In `analyze-project`, an unrestored project (no
 reference set — `System.Object` unresolved) is reported as an error, not analyzed.
 
+## Working directory & SDK resolution
+`ping` and `analyze` need only the .NET **runtime** — they compile file texts with
+the runtime's own reference set and never build the target. So MSBuild/SDK resolution
+is deferred and **guarded**: it runs lazily only for `analyze-project`, and an
+SDK-resolution failure comes back as a normal `{"ok":false,...}` error rather than
+aborting the process. The Node client also spawns the host in a neutral working
+directory (`os.tmpdir()`), so a target repo's `global.json` SDK pin is never on the
+resolver's search path and can't block read-only analysis (issue #658).
+
 ## Adding a semantic rule
 Mirror the tree-sitter recipe, but in C#/Roslyn. Add a file under `Rules/<Domain>/`
 implementing one of:


### PR DESCRIPTION
Fixes #658.

## Problem
`truecourse analyze` crashed with an unhandled `write EPIPE` on any C# repo whose root `global.json` pins a **.NET SDK** that isn't installed (e.g. abp → `10.0.100`, Polly → `10.0.301`) — even though loose-text analysis needs only the .NET **runtime**. Because C# is fail-hard (no tree-sitter fallback), the whole analyze aborted with no `LATEST.json`.

Two compounding defects:
1. **The host honored the target's `global.json`.** It eagerly resolved an *SDK* at startup (`MSBuildLocator.RegisterDefaults`) and inherited the analyze cwd (the target repo), so the SDK resolver walked up to the target's `global.json` and aborted the host (SIGABRT) before it read stdin.
2. **That early exit became an unhandled `EPIPE`.** The Node side was still streaming the request to a now-closed pipe; `child.stdin` had no `'error'` handler, so the stream error crashed the process (small requests instead mis-parsed a leaked SDK banner as "invalid JSON").

## Root-cause fixes
- **Host (`Program.cs`):** defer MSBuild/SDK resolution. `ping`/`analyze` need only the runtime, so `MSBuildLocator` now registers **lazily and guarded** inside a new `AnalyzeProjectGuarded` — only for `analyze-project`. SDK-resolution failure returns a structured `{ok:false,error}` (clean skip of the project-aware tier) instead of aborting. `NoInlining` guarantee preserved.
- **Client (`roslyn-host-client.ts`):** spawn the host in a **neutral cwd** (`os.tmpdir()`), so a target's SDK pin is never on the resolver's search path.

## Defense in depth — same EPIPE defect class, fixed generally
A sweep of every `child_process` spawn that writes to stdin found the identical unguarded-`stdin.write` pattern in two more places:
- **`roslyn-host-client.ts`:** stdin `'error'` handler + write guard; abnormal exit → `RoslynHostUnavailableError` carrying stderr; locate the JSON response among any leaked banner lines.
- **`cli-provider.ts`:** the LLM prompt pipe (payloads routinely exceed the ~64 KB pipe buffer — the exact EPIPE trigger, on every analysis) — add stdin `'error'` handler + write guard so a dead CLI surfaces via the existing `close` handler.
- **`lsp-client.ts` (Pyright/Python):** add a `rejectAllPending` helper wired to stdin `'error'` and process `'exit'`, and guard both writes, so a dead language server rejects in-flight requests instead of crashing or hanging.

(`cli-binary.ts` / `transport.ts` use `stdio: ['ignore', …]` — no stdin write, unaffected. Defect #1's cwd/`global.json` is Roslyn-specific and correctly does *not* apply to the LSP client, where `cwd: rootPath` is intentional.)

## Tests
- `roslyn-host`: `analyze` succeeds even when cwd pins an uninstalled SDK (reproduces #658).
- `lsp-client`: `start()` rejects cleanly when the server exits without responding — verified to hang/fail without the fix.
- 16/16 tests pass across the touched areas; touched files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)