### PR TITLE
fix(llm): keep contract prompts off the command line (#660)

### DIFF
--- a/packages/shared/src/llm/transport.ts
+++ b/packages/shared/src/llm/transport.ts
@@ -22,6 +22,7 @@
 import { spawn } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { resolveClaudeBinary } from '../claude-binary.js';
 import { zodToJsonSchema } from 'zod-to-json-schema';
@@ -151,34 +152,64 @@ export function cliTransport(opts: CliTransportOptions = {}): LlmTransport {
       const modelArgs: string[] = [];
       if (req.model) modelArgs.push('--model', req.model);
       if (req.fallbackModel) modelArgs.push('--fallback-model', req.fallbackModel);
+
+      // Keep both prompts OFF the command line. The system prompt (the
+      // contract-extractor's is ~52 KB) and the user prompt (an unbounded spec
+      // slice) are large enough to blow Windows' 32,767-char command-line limit
+      // (CreateProcessW → `spawn ENAMETOOLONG`; issue #660). So the system
+      // prompt goes to a temp file passed via `--append-system-prompt-file`, and
+      // the user prompt is streamed over stdin (`-p` reads the prompt from stdin
+      // when no positional is given — the same path cli-provider.ts uses).
+      const sysFile = path.join(tmpdir(), `tc-claude-sys-${randomUUID()}.txt`);
+      try {
+        fs.writeFileSync(sysFile, req.system, 'utf-8');
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+        return;
+      }
+      const cleanup = () => {
+        try {
+          fs.rmSync(sysFile, { force: true });
+        } catch {
+          /* best-effort temp cleanup */
+        }
+      };
+
       const args = [
         '-p',
-        req.user,
         ...modelArgs,
         '--output-format',
         'json',
-        '--append-system-prompt',
-        req.system,
+        '--append-system-prompt-file',
+        sysFile,
         '--setting-sources',
         'project',
       ];
-      const proc = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      const proc = spawn(bin, args, { stdio: ['pipe', 'pipe', 'pipe'] });
       const out: Buffer[] = [];
       const err: Buffer[] = [];
       const timer = req.timeoutMs
         ? setTimeout(() => {
             proc.kill('SIGKILL');
+            cleanup();
             reject(new Error(`claude timed out after ${req.timeoutMs}ms`));
           }, req.timeoutMs)
         : null;
+      // The prompt routinely exceeds the OS pipe buffer (~64 KB); write + end
+      // streams it in. Swallow stdin errors (EPIPE if the child already exited).
+      proc.stdin.on('error', () => {});
+      proc.stdin.write(req.user);
+      proc.stdin.end();
       proc.stdout.on('data', (b: Buffer) => out.push(b));
       proc.stderr.on('data', (b: Buffer) => err.push(b));
       proc.on('error', (e) => {
         if (timer) clearTimeout(timer);
+        cleanup();
         reject(e);
       });
       proc.on('close', (code) => {
         if (timer) clearTimeout(timer);
+        cleanup();
         if (code !== 0) {
           reject(new Error(`claude exited ${code}: ${Buffer.concat(err).toString('utf-8')}`));
           return;

--- a/tests/shared/llm-transport.test.ts
+++ b/tests/shared/llm-transport.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   agentTransport,
+  cliTransport,
   stripCodeFences,
   type LlmTransport,
 } from '../../packages/shared/src/llm/transport.js';
@@ -71,6 +72,68 @@ describe('agentTransport (filesystem mailbox)', () => {
     await expect(
       agentTransport(io, { pollMs: 5 })({ id: 'slow-1', system: 's', user: 'u', timeoutMs: 40 }),
     ).rejects.toThrow(/timed out/);
+  });
+});
+
+// The fake `claude` is a /bin/sh script, so this runs on Unix CI (ubuntu) and
+// is skipped on Windows. The regression it guards (#660) is itself Windows-only,
+// but the structural assertions — neither prompt on the command line — hold
+// everywhere and are what actually prevent the `spawn ENAMETOOLONG` reappearing.
+describe.skipIf(process.platform === 'win32')('cliTransport (#660: prompts off the command line)', () => {
+  // A fake claude that records its argv + stdin + the system-prompt-file's
+  // content into `rec/`, then emits a valid JSON envelope so cliTransport
+  // resolves. argv carries only flags now, so it is safe to tokenize by line.
+  function fakeClaude(): { bin: string; rec: string } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-fakeclaude-'));
+    const rec = path.join(dir, 'rec');
+    fs.mkdirSync(rec);
+    const bin = path.join(dir, 'claude');
+    fs.writeFileSync(
+      bin,
+      [
+        '#!/bin/sh',
+        `printf '%s\\n' "$@" > "${rec}/argv.txt"`,
+        `cat > "${rec}/stdin.txt"`,
+        'prev=""',
+        'for a in "$@"; do',
+        `  [ "$prev" = "--append-system-prompt-file" ] && cp "$a" "${rec}/sysfile.txt"`,
+        '  prev="$a"',
+        'done',
+        `printf '{"result":"ok"}'`,
+        '',
+      ].join('\n'),
+    );
+    fs.chmodSync(bin, 0o755);
+    return { bin, rec };
+  }
+
+  it('streams the user prompt over stdin and the system prompt via a temp file', async () => {
+    const { bin, rec } = fakeClaude();
+    // Both prompts are deliberately larger than Windows' 32,767-char cmdline cap.
+    const system = 'S'.repeat(50_000);
+    const user = 'U'.repeat(50_000);
+
+    const out = await cliTransport({ bin })({ system, user, model: 'haiku', stage: 'contract.extract' });
+    expect(out).toBe('ok');
+
+    const argvLines = fs.readFileSync(path.join(rec, 'argv.txt'), 'utf-8').split('\n');
+    // The system prompt goes through a file, not the old inline `--append-system-prompt`.
+    expect(argvLines).toContain('--append-system-prompt-file');
+    expect(argvLines).not.toContain('--append-system-prompt');
+    // Neither prompt is present as an argv token.
+    expect(argvLines).not.toContain(system);
+    expect(argvLines).not.toContain(user);
+    // Small flags still ride on argv.
+    expect(argvLines).toContain('--model');
+    expect(argvLines).toContain('haiku');
+
+    // The user prompt arrives via stdin; the system prompt via the temp file.
+    expect(fs.readFileSync(path.join(rec, 'stdin.txt'), 'utf-8')).toBe(user);
+    expect(fs.readFileSync(path.join(rec, 'sysfile.txt'), 'utf-8')).toBe(system);
+
+    // The temp system-prompt file is cleaned up once the call resolves.
+    const sysFilePath = argvLines[argvLines.indexOf('--append-system-prompt-file') + 1];
+    expect(fs.existsSync(sysFilePath)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #660. On Windows, `truecourse contracts generate` failed on every claim-extraction block with `spawn ENAMETOOLONG`, while `spec scan` succeeded.

**Root cause:** `cliTransport` (`packages/shared/src/llm/transport.ts`) passed the system prompt and the user prompt as inline command-line arguments. The contract-extractor's system prompt is ~52 KB, which exceeds Windows' 32,767-character `CreateProcessW` command-line limit on its own. macOS/Linux allow ~1 MB, so the bug never surfaced in development. Spec scan survived because its system prompt is only ~12 KB.

**Fix:** keep both prompts off the command line, reusing the pattern `cli-provider.ts` already uses for its prompt:
- system prompt → temp file, passed via `--append-system-prompt-file` (removed on close/error/timeout)
- user prompt → streamed over stdin instead of `-p <prompt>`

`cliTransport` is the single seam every `claude -p` runner uses (spec-consolidator + contract-extractor), so this fixes the whole CLI pipeline, not just contract generation.

## Audit (is it anywhere else?)

Reviewed every process-spawn site in the repo. `transport.ts` was the only one putting unbounded, input-derived data on the command line:
- `cli-provider.ts` already streams the prompt via stdin; its only inline arg is a static JSON schema (largest ~2.2 KB, input-independent). There is no `--json-schema-file` flag and none is needed.
- EE LLM transport uses the HTTP API (no spawn).
- All other spawns pass fixed/bounded args (service names, single file paths, git commands).

## Testing

- New regression test in `tests/shared/llm-transport.test.ts`: drives `cliTransport` against a recording fake `claude` with 50 KB prompts and asserts neither prompt appears on argv, the user prompt arrives via stdin, the system prompt via the temp file, and the temp file is cleaned up. (Skipped on Windows since the fake binary is a shell script; CI is Ubuntu.)
- `tests/shared/llm-transport.test.ts` → 8 passed.
- Related suites (shared, spec-consolidator, contract-extractor, core LLM) → 320 passed.
- Before/after repro on macOS: a 1.5 MB prompt fails with the old inline pattern (`E2BIG`; `ENAMETOOLONG` on Windows) and succeeds with the fix.

## Note

`--append-system-prompt-file` exists in Claude Code since v1.0.55, so no minimum-version gate was added (the repo pins none today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)