### PR TITLE
fix(fp): resolve 5 FPs from abpframework/abp

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/csharp/action-missing-producesresponsetype.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/csharp/action-missing-producesresponsetype.ts
@@ -31,6 +31,11 @@ export const csharpActionMissingProducesResponseTypeVisitor: CodeRuleVisitor = {
     const classAttrs = attributeNames(cls)
     if (classAttrs.some((a) => a.startsWith('ProducesResponseType') || a === 'ProducesDefaultResponseType')) return null
 
+    // An action (or whole controller) marked [ApiExplorerSettings(IgnoreApi = true)]
+    // is excluded from the OpenAPI/API description, so [ProducesResponseType] would
+    // never surface anywhere — requiring it is a false positive.
+    if (excludedFromApiExplorer(node) || excludedFromApiExplorer(cls)) return null
+
     const name = node.childForFieldName('name')
     return makeViolation(
       this.ruleKey, name ?? node, filePath, 'low',
@@ -40,6 +45,25 @@ export const csharpActionMissingProducesResponseTypeVisitor: CodeRuleVisitor = {
       'Annotate the action with [ProducesResponseType] for each status code it can return.',
     )
   },
+}
+
+/**
+ * True when a declaration carries <c>[ApiExplorerSettings(IgnoreApi = true)]</c>,
+ * which hides the controller/action from the API description. Other
+ * <c>[ApiExplorerSettings(...)]</c> uses (e.g. <c>GroupName</c>) keep the action
+ * in the description and do not exempt it.
+ */
+function excludedFromApiExplorer(node: SyntaxNode): boolean {
+  for (const child of node.children) {
+    if (child?.type !== 'attribute_list') continue
+    for (const attr of child.namedChildren) {
+      if (attr?.type !== 'attribute') continue
+      const name = (attr.childForFieldName('name')?.text ?? '').split('.').pop()
+      if (name !== 'ApiExplorerSettings') continue
+      if (/\bIgnoreApi\s*=\s*true\b/i.test(attr.text)) return true
+    }
+  }
+  return false
 }
 
 /** Attribute names (last segment) applied directly to a declaration node. */

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/csharp-filename-type-mismatch.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/csharp-filename-type-mismatch.ts
@@ -19,12 +19,22 @@ export const csharpFilenameTypeMismatchVisitor: CodeRuleVisitor = {
   nodeTypes: ['compilation_unit'],
   visit(node, filePath, sourceCode) {
     const base = filePath.split('/').pop() ?? ''
-    const fileName = base.replace(/\.[^.]*$/, '')
+    // Razor Pages / Blazor code-behind: `X.cshtml.cs` / `X.razor.cs` pairs with a
+    // type named `X` or, by ASP.NET convention, `XModel`. Strip the full compound
+    // extension so the page base name (not `X.cshtml`) is what we match against.
+    const lower = base.toLowerCase()
+    const compoundExt = ['.cshtml.cs', '.razor.cs'].find((ext) => lower.endsWith(ext))
+    const fileName = compoundExt
+      ? base.slice(0, base.length - compoundExt.length)
+      : base.replace(/\.[^.]*$/, '')
     if (!fileName) return null
 
     const identifiers = topLevelTypeIdentifiers(node)
     if (identifiers.length === 0) return null
-    if (identifiers.some((id) => nameMatches(fileName, id.text))) return null
+    // For code-behind files the conventional `Model` suffix is an accepted match.
+    const matches = (id: SyntaxNode): boolean =>
+      nameMatches(fileName, id.text) || (compoundExt !== undefined && id.text === `${fileName}Model`)
+    if (identifiers.some(matches)) return null
 
     const first = identifiers[0]
     return makeViolation(

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/no-extraneous-class.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/no-extraneous-class.ts
@@ -18,6 +18,11 @@ export const csharpNoExtraneousClassVisitor: CodeRuleVisitor = {
     if (hasCSharpModifier(node, 'partial')) return null
     // Inheritance / interface implementation requires an instance type.
     if (node.namedChildren.some((c) => c?.type === 'base_list')) return null
+    // A class decorated with an attribute is metadata-bearing — a marker/token type
+    // (often consumed as a generic type argument, where a `static class` is illegal,
+    // or carrying framework metadata). Converting it to `static` would change its
+    // meaning or break compilation, so it is not an extraneous static holder.
+    if (node.namedChildren.some((c) => c?.type === 'attribute_list')) return null
 
     const body = node.childForFieldName('body')
     if (!body) return null

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -1927,6 +1927,12 @@
       "layer": "service"
     },
     {
+      "name": "GroupedReportController",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "api"
+    },
+    {
       "name": "GuardExpressions",
       "service": "UserService",
       "kind": "class",
@@ -2395,6 +2401,12 @@
       "layer": "service"
     },
     {
+      "name": "StatelessScoreCombiner",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "StatementResidue",
       "service": "UserService",
       "kind": "class",
@@ -2402,6 +2414,12 @@
     },
     {
       "name": "StockContext",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "StringFormattingHelpers",
       "service": "UserService",
       "kind": "class",
       "layer": "service"
@@ -2443,6 +2461,12 @@
       "layer": "service"
     },
     {
+      "name": "TimestampFormatter",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "Token",
       "service": "UserService",
       "kind": "class",
@@ -2468,6 +2492,12 @@
     },
     {
       "name": "TrialExpiryService",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "UnrelatedReportState",
       "service": "UserService",
       "kind": "class",
       "layer": "service"
@@ -2978,6 +3008,11 @@
       "method": "GET",
       "path": "/users/{userId}",
       "file": "services/UserService/Program.cs"
+    },
+    {
+      "method": "GET",
+      "path": "/",
+      "file": "services/UserService/Violations/Architecture/GroupedReportController.cs"
     },
     {
       "method": "GET",

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/GroupedReportController.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/GroupedReportController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace UserService.Violations.Architecture;
+
+/// <summary>A controller that is documented in the API but omits response metadata.</summary>
+[ApiController]
+[ApiExplorerSettings(GroupName = "v1")]
+public sealed class GroupedReportController : ControllerBase
+{
+    // [ApiExplorerSettings] is present but IgnoreApi is not set, so the action is
+    // still part of the API description; declaring no [ProducesResponseType] leaves
+    // its response shape and status codes missing from the OpenAPI document.
+    // VIOLATION: architecture/deterministic/action-missing-producesresponsetype
+    [HttpGet]
+    public IActionResult List() => Ok();
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/Orphan.cshtml.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/Orphan.cshtml.cs
@@ -1,0 +1,19 @@
+namespace UserService.Violations.CodeQuality;
+
+/// <summary>
+/// Razor Pages code-behind whose type follows neither the page name nor the
+/// <c>X.cshtml.cs</c> -&gt; <c>XModel</c> convention, so the file is genuinely
+/// misnamed and hard to locate.
+/// </summary>
+// VIOLATION: code-quality/deterministic/csharp-filename-type-mismatch
+public class UnrelatedReportState
+{
+    /// <summary>Number of rows processed.</summary>
+    public int Count { get; private set; }
+
+    /// <summary>Records that another row was processed.</summary>
+    public void Bump()
+    {
+        Count++;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/StatelessScoreCombiner.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/StatelessScoreCombiner.cs
@@ -1,0 +1,39 @@
+namespace UserService.Violations.CodeQuality;
+
+/// <summary>Computes weighted scores; one private helper ignores the receiver.</summary>
+internal sealed class StatelessScoreCombiner
+{
+    private readonly int _weight;
+
+    /// <summary>Captures the instance weight applied to scores.</summary>
+    internal StatelessScoreCombiner(int weight)
+    {
+        _weight = weight;
+    }
+
+    /// <summary>Scales the value by the instance weight.</summary>
+    internal int Weighted(int value)
+    {
+        return value * _weight;
+    }
+
+    /// <summary>Drives the stateless helper for a pair of inputs.</summary>
+    internal int Total(int a, int b)
+    {
+        return Combine(a, b);
+    }
+
+    // Takes inputs, delegates only to a static helper, and never touches the
+    // receiver, so it should be declared static.
+    // VIOLATION: code-quality/deterministic/unused-this-parameter
+    // VIOLATION: code-quality/deterministic/static-method-candidate
+    private int Combine(int a, int b)
+    {
+        return Twice(a) + Twice(b);
+    }
+
+    private static int Twice(int n)
+    {
+        return n * 2;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/StringFormattingHelpers.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/StringFormattingHelpers.cs
@@ -1,0 +1,15 @@
+namespace UserService.Violations.CodeQuality;
+
+/// <summary>
+/// A plain helper bag: instantiable and subclassable, holding nothing but static
+/// members and carrying no marker attribute. It should be declared <c>static</c>.
+/// </summary>
+// VIOLATION: code-quality/deterministic/no-extraneous-class
+// VIOLATION: code-quality/deterministic/static-holder-type-not-sealed
+internal class StringFormattingHelpers
+{
+    internal static int DoubleIt(int value)
+    {
+        return value * 2;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/TimestampFormatter.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/TimestampFormatter.cs
@@ -1,0 +1,16 @@
+namespace UserService.Violations.CodeQuality;
+
+/// <summary>
+/// Holds nothing but a static member, carries no marker attribute, and is neither
+/// <c>static</c> nor <c>sealed</c> — so it is pointlessly instantiable and
+/// subclassable and should be declared <c>static</c>.
+/// </summary>
+// VIOLATION: code-quality/deterministic/no-extraneous-class
+// VIOLATION: code-quality/deterministic/static-holder-type-not-sealed
+internal class TimestampFormatter
+{
+    internal static int PadWidth()
+    {
+        return 2;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/IgnoredApiController.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/IgnoredApiController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Positive.Boundary.Architecture;
+
+/// <summary>
+/// A controller excluded from API exploration via
+/// <c>[ApiExplorerSettings(IgnoreApi = true)]</c>. It never appears in the
+/// generated OpenAPI description, so <c>[ProducesResponseType]</c> would have no
+/// effect and must not be required of its actions.
+/// </summary>
+[ApiController]
+[ApiExplorerSettings(IgnoreApi = true)]
+public sealed class IgnoredApiController : ControllerBase
+{
+    /// <summary>Infrastructure endpoint that is hidden from the API description.</summary>
+    // SAFE: architecture/deterministic/action-missing-producesresponsetype
+    [HttpGet]
+    public IActionResult Ping() => Ok();
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/WidgetPanel.cshtml.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/WidgetPanel.cshtml.cs
@@ -1,0 +1,20 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// Razor Pages code-behind. The framework mandates the <c>X.cshtml.cs</c> file to
+/// declare an <c>XModel</c> type, so the file name and the type differ only by the
+/// conventional <c>Model</c> suffix and the compound <c>.cshtml.cs</c> extension —
+/// the file is correctly named.
+/// </summary>
+// SAFE: code-quality/deterministic/csharp-filename-type-mismatch
+public class WidgetPanelModel
+{
+    /// <summary>The label rendered by the page.</summary>
+    public string Label { get; private set; } = "widget";
+
+    /// <summary>Updates the rendered label.</summary>
+    public void Rename(string label)
+    {
+        Label = label;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/NoExtraneousClassMarker.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/NoExtraneousClassMarker.cs
@@ -1,0 +1,15 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// A marker type carrying a domain attribute whose only member is the const name
+/// the attribute references. The rule sees "nothing but static members", but a
+/// metadata-bearing marker (often consumed where a <c>static class</c> is illegal,
+/// e.g. as a generic type argument) must not be told to become <c>static</c>.
+/// </summary>
+// SAFE: code-quality/deterministic/no-extraneous-class
+[StorageBucket(Name)]
+public sealed class NoExtraneousClassMarker
+{
+    /// <summary>The container name carried by the marker attribute.</summary>
+    internal const string Name = "default";
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/StaticHolderMarker.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/StaticHolderMarker.cs
@@ -1,0 +1,16 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// A marker/token type that carries a domain attribute and is consumed elsewhere
+/// as a generic type argument. Its only member is the const the attribute
+/// references, so it looks like a "static holder" — but a <c>static</c> class
+/// cannot be used as a type argument, so making it static (or sealed) would change
+/// its meaning or break callers.
+/// </summary>
+// SAFE: code-quality/deterministic/static-holder-type-not-sealed
+[StorageBucket(Name)]
+public class StaticHolderMarker
+{
+    /// <summary>The container name carried by the marker attribute.</summary>
+    internal const string Name = "default";
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/UnusedThisParameterVirtualDispatch.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/UnusedThisParameterVirtualDispatch.cs
@@ -1,0 +1,32 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// Walks the entries of a bundle and delegates each one to a protected virtual
+/// hook through the implicit receiver. The method depends on instance dispatch —
+/// a subclass can override the hook — so it cannot be made static. The only
+/// receiver use is an unqualified call whose argument type lives in an assembly
+/// this loose-text pass does not resolve, which must still count as instance use.
+/// </summary>
+public class UnusedThisParameterVirtualDispatch
+{
+    /// <summary>Normalizes the supplied bundle by delegating to the per-entry pass.</summary>
+    public void Normalize(MetadataBundle bundle)
+    {
+        NormalizeEntries(bundle);
+    }
+
+    /// <summary>Applies the default state to every rule carried by the bundle.</summary>
+    private void NormalizeEntries(MetadataBundle bundle)
+    {
+        foreach (var rule in bundle.Rules)
+        {
+            ApplyDefault(rule);
+        }
+    }
+
+    /// <summary>Overridable hook that fills in a rule's default state.</summary>
+    protected virtual void ApplyDefault(ValidationRule rule)
+    {
+        rule.Reset();
+    }
+}

--- a/tools/csharp-roslyn-host/Rules/CodeQuality/StaticHolderTypeNotSealed.cs
+++ b/tools/csharp-roslyn-host/Rules/CodeQuality/StaticHolderTypeNotSealed.cs
@@ -19,6 +19,12 @@ internal sealed class StaticHolderTypeNotSealed : ISemanticRule
         {
             if (model.GetDeclaredSymbol(classDecl) is not INamedTypeSymbol type) continue;
             if (type.IsStatic || type.IsSealed || type.IsAbstract) continue;
+            // A class decorated with an attribute is a metadata-bearing marker/token
+            // type — frequently consumed as a generic type argument, where a `static`
+            // class is illegal. Making it static (or sealed) would change its meaning
+            // or break callers, so it is not a pointless static holder. Checked on the
+            // syntax so it holds even when the attribute type is unresolved.
+            if (classDecl.AttributeLists.Count > 0) continue;
             // A base class other than object means it participates in a hierarchy; out of scope.
             if (type.BaseType is { SpecialType: not SpecialType.System_Object }) continue;
             if (type.Interfaces.Length > 0) continue;

--- a/tools/csharp-roslyn-host/Rules/CodeQuality/UnusedThisParameter.cs
+++ b/tools/csharp-roslyn-host/Rules/CodeQuality/UnusedThisParameter.cs
@@ -76,16 +76,27 @@ internal sealed class UnusedThisParameter : ISemanticRule
                     // Skip the right-hand name of a member access (`x.Foo`) — that's
                     // qualified and resolved via the receiver, not the implicit `this`.
                     if (id.Parent is MemberAccessExpressionSyntax ma && ma.Name == id) break;
-                    var symbol = model.GetSymbolInfo(id).Symbol;
-                    if (symbol is null) break;
-                    if (symbol.IsStatic) break;
-                    // An unqualified instance field/property/method/event of THIS type
-                    // (or a base) means the method depends on the receiver.
-                    if (symbol is IFieldSymbol or IPropertySymbol or IEventSymbol
-                        || (symbol is IMethodSymbol { MethodKind: MethodKind.Ordinary }))
+                    var info = model.GetSymbolInfo(id);
+                    // Normally one resolved symbol. But when an argument's type is
+                    // unresolved (loose-text analysis without the full reference set),
+                    // overload resolution can fail to commit to a single symbol even
+                    // though every candidate is an instance member of THIS type — e.g.
+                    // an unqualified call `Configure(option)` where `option`'s type lives
+                    // in an unreferenced assembly. Fall back to the candidate set so such
+                    // a call still counts as receiver use rather than a phantom "static".
+                    foreach (var symbol in info.Symbol is { } resolved
+                                 ? new[] { resolved }
+                                 : info.CandidateSymbols.AsEnumerable())
                     {
-                        if (symbol.ContainingType is { } owner && InheritsFrom(type, owner))
-                            return true;
+                        if (symbol.IsStatic) continue;
+                        // An unqualified instance field/property/method/event of THIS type
+                        // (or a base) means the method depends on the receiver.
+                        if (symbol is IFieldSymbol or IPropertySymbol or IEventSymbol
+                            || (symbol is IMethodSymbol { MethodKind: MethodKind.Ordinary }))
+                        {
+                            if (symbol.ContainingType is { } owner && InheritsFrom(type, owner))
+                                return true;
+                        }
                     }
                     break;
             }


### PR DESCRIPTION
Resolves five C# false positives surfaced by the FP-discovery campaign on
[`abpframework/abp`](https://github.com/abpframework/abp) at ref
`8665ce0a23622f658b531b0627c7c025935fdb3b`.

Closes #650
Closes #651
Closes #652
Closes #653
Closes #654

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/unused-this-parameter` | #650 | `sample-csharp-project-positive/services/CodeQualitySamples3/UnusedThisParameterVirtualDispatch.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/StatelessScoreCombiner.cs` |
| `architecture/deterministic/action-missing-producesresponsetype` | #651 | `sample-csharp-project-positive/services/ArchitectureSamples/IgnoredApiController.cs` | `sample-csharp-project-negative/services/UserService/Violations/Architecture/GroupedReportController.cs` |
| `code-quality/deterministic/no-extraneous-class` | #652 | `sample-csharp-project-positive/services/CodeQualitySamples2/NoExtraneousClassMarker.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/StringFormattingHelpers.cs` |
| `code-quality/deterministic/csharp-filename-type-mismatch` | #653 | `sample-csharp-project-positive/services/CodeQualitySamples1/WidgetPanel.cshtml.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/Orphan.cshtml.cs` |
| `code-quality/deterministic/static-holder-type-not-sealed` | #654 | `sample-csharp-project-positive/services/CodeQualitySamples3/StaticHolderMarker.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/TimestampFormatter.cs` |

> Note: `#650` and `#654` are C# **semantic** rules whose implementation lives in the
> out-of-process Roslyn host (`tools/csharp-roslyn-host/Rules/`), the C# equivalent of a
> tree-sitter visitor. Those two edits are in that directory; `#651`/`#652`/`#653` are
> tree-sitter visitors under `packages/analyzer/src/rules/`.

## code-quality/deterministic/unused-this-parameter (#650)

OSS source: ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ModelBinding/Metadata/AbpModelMetadataProvider.cs#L39``

Positive fixture (asserts zero violations — the paraphrased FP):

```csharp
namespace Positive.Boundary.CodeQuality;

/// <summary>
/// Walks the entries of a bundle and delegates each one to a protected virtual
/// hook through the implicit receiver. The method depends on instance dispatch —
/// a subclass can override the hook — so it cannot be made static. The only
/// receiver use is an unqualified call whose argument type lives in an assembly
/// this loose-text pass does not resolve, which must still count as instance use.
/// </summary>
public class UnusedThisParameterVirtualDispatch
{
    /// <summary>Normalizes the supplied bundle by delegating to the per-entry pass.</summary>
    public void Normalize(MetadataBundle bundle)
    {
        NormalizeEntries(bundle);
    }

    /// <summary>Applies the default state to every rule carried by the bundle.</summary>
    private void NormalizeEntries(MetadataBundle bundle)
    {
        foreach (var rule in bundle.Rules)
        {
            ApplyDefault(rule);
        }
    }

    /// <summary>Overridable hook that fills in a rule's default state.</summary>
    protected virtual void ApplyDefault(ValidationRule rule)
    {
        rule.Reset();
    }
}
```

Negative fixture (true-bug case the rule must still catch):

```csharp
namespace UserService.Violations.CodeQuality;

/// <summary>Computes weighted scores; one private helper ignores the receiver.</summary>
internal sealed class StatelessScoreCombiner
{
    private readonly int _weight;

    /// <summary>Captures the instance weight applied to scores.</summary>
    internal StatelessScoreCombiner(int weight)
    {
        _weight = weight;
    }

    /// <summary>Scales the value by the instance weight.</summary>
    internal int Weighted(int value)
    {
        return value * _weight;
    }

    /// <summary>Drives the stateless helper for a pair of inputs.</summary>
    internal int Total(int a, int b)
    {
        return Combine(a, b);
    }

    // Takes inputs, delegates only to a static helper, and never touches the
    // receiver, so it should be declared static.
    // VIOLATION: code-quality/deterministic/unused-this-parameter
    // VIOLATION: code-quality/deterministic/static-method-candidate
    private int Combine(int a, int b)
    {
        return Twice(a) + Twice(b);
    }

    private static int Twice(int n)
    {
        return n * 2;
    }
}
```

**Visitor summary:** `UnusedThisParameter` (Roslyn host) missed unqualified instance-member calls when overload resolution was defeated by an error-typed argument (loose-text analysis without the full reference set) — `GetSymbolInfo().Symbol` was null, so the call read as no-receiver-use and the method was wrongly flagged 'mark static'. It now falls back to `CandidateSymbols`, so an unqualified call to an instance member of the type still counts as receiver use. The genuine 'should be static' case (calls only static helpers) still fires.

## architecture/deterministic/action-missing-producesresponsetype (#651)

OSS source: ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Localization/AbpLanguagesController.cs#L27``

Positive fixture (asserts zero violations — the paraphrased FP):

```csharp
using Microsoft.AspNetCore.Mvc;

namespace Positive.Boundary.Architecture;

/// <summary>
/// A controller excluded from API exploration via
/// <c>[ApiExplorerSettings(IgnoreApi = true)]</c>. It never appears in the
/// generated OpenAPI description, so <c>[ProducesResponseType]</c> would have no
/// effect and must not be required of its actions.
/// </summary>
[ApiController]
[ApiExplorerSettings(IgnoreApi = true)]
public sealed class IgnoredApiController : ControllerBase
{
    /// <summary>Infrastructure endpoint that is hidden from the API description.</summary>
    // SAFE: architecture/deterministic/action-missing-producesresponsetype
    [HttpGet]
    public IActionResult Ping() => Ok();
}
```

Negative fixture (true-bug case the rule must still catch):

```csharp
using Microsoft.AspNetCore.Mvc;

namespace UserService.Violations.Architecture;

/// <summary>A controller that is documented in the API but omits response metadata.</summary>
[ApiController]
[ApiExplorerSettings(GroupName = "v1")]
public sealed class GroupedReportController : ControllerBase
{
    // [ApiExplorerSettings] is present but IgnoreApi is not set, so the action is
    // still part of the API description; declaring no [ProducesResponseType] leaves
    // its response shape and status codes missing from the OpenAPI document.
    // VIOLATION: architecture/deterministic/action-missing-producesresponsetype
    [HttpGet]
    public IActionResult List() => Ok();
}
```

**Visitor summary:** the rule flagged actions on controllers hidden from API exploration. Added `excludedFromApiExplorer`, which skips an action (or whole controller) carrying `[ApiExplorerSettings(IgnoreApi = true)]` — such endpoints never appear in the OpenAPI description, so `[ProducesResponseType]` would have no effect. Other `[ApiExplorerSettings(...)]` uses (e.g. `GroupName`) keep the action in the description and still require it.

## code-quality/deterministic/no-extraneous-class (#652)

OSS source: ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/DefaultContainer.cs#L3``

Positive fixture (asserts zero violations — the paraphrased FP):

```csharp
namespace Positive.Boundary.CodeQuality;

/// <summary>
/// A marker type carrying a domain attribute whose only member is the const name
/// the attribute references. The rule sees "nothing but static members", but a
/// metadata-bearing marker (often consumed where a <c>static class</c> is illegal,
/// e.g. as a generic type argument) must not be told to become <c>static</c>.
/// </summary>
// SAFE: code-quality/deterministic/no-extraneous-class
[StorageBucket(Name)]
public sealed class NoExtraneousClassMarker
{
    /// <summary>The container name carried by the marker attribute.</summary>
    internal const string Name = "default";
}
```

Negative fixture (true-bug case the rule must still catch):

```csharp
namespace UserService.Violations.CodeQuality;

/// <summary>
/// A plain helper bag: instantiable and subclassable, holding nothing but static
/// members and carrying no marker attribute. It should be declared <c>static</c>.
/// </summary>
// VIOLATION: code-quality/deterministic/no-extraneous-class
// VIOLATION: code-quality/deterministic/static-holder-type-not-sealed
internal class StringFormattingHelpers
{
    internal static int DoubleIt(int value)
    {
        return value * 2;
    }
}
```

**Visitor summary:** the rule flagged marker/token classes that hold only static members but carry a class-level attribute (e.g. `DefaultContainer` with `[BlobContainerName]`). Such markers are commonly consumed as generic type arguments — where a `static class` is illegal — so the suggested fix would break compilation. Added a guard skipping any class decorated with an attribute.

## code-quality/deterministic/csharp-filename-type-mismatch (#653)

OSS source: ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.MultiTenancy/Pages/Abp/MultiTenancy/TenantSwitchModal.cshtml.cs#L14``

Positive fixture (asserts zero violations — the paraphrased FP):

```csharp
namespace Positive.Boundary.CodeQuality;

/// <summary>
/// Razor Pages code-behind. The framework mandates the <c>X.cshtml.cs</c> file to
/// declare an <c>XModel</c> type, so the file name and the type differ only by the
/// conventional <c>Model</c> suffix and the compound <c>.cshtml.cs</c> extension —
/// the file is correctly named.
/// </summary>
// SAFE: code-quality/deterministic/csharp-filename-type-mismatch
public class WidgetPanelModel
{
    /// <summary>The label rendered by the page.</summary>
    public string Label { get; private set; } = "widget";

    /// <summary>Updates the rendered label.</summary>
    public void Rename(string label)
    {
        Label = label;
    }
}
```

Negative fixture (true-bug case the rule must still catch):

```csharp
namespace UserService.Violations.CodeQuality;

/// <summary>
/// Razor Pages code-behind whose type follows neither the page name nor the
/// <c>X.cshtml.cs</c> -&gt; <c>XModel</c> convention, so the file is genuinely
/// misnamed and hard to locate.
/// </summary>
// VIOLATION: code-quality/deterministic/csharp-filename-type-mismatch
public class UnrelatedReportState
{
    /// <summary>Number of rows processed.</summary>
    public int Count { get; private set; }

    /// <summary>Records that another row was processed.</summary>
    public void Bump()
    {
        Count++;
    }
}
```

**Visitor summary:** the rule stripped only the final `.cs`, leaving `X.cshtml` which never matches the Razor Pages code-behind type `XModel`. It now strips the full compound `.cshtml.cs`/`.razor.cs` extension and, for code-behind files, accepts the conventional `Model` suffix (so `X.cshtml.cs` declaring `XModel` is well-named). A `.cshtml.cs` whose type follows neither the page name nor the `Model` convention still fires.

## code-quality/deterministic/static-holder-type-not-sealed (#654)

OSS source: ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/DefaultContainer.cs#L4``

Positive fixture (asserts zero violations — the paraphrased FP):

```csharp
namespace Positive.Boundary.CodeQuality;

/// <summary>
/// A marker/token type that carries a domain attribute and is consumed elsewhere
/// as a generic type argument. Its only member is the const the attribute
/// references, so it looks like a "static holder" — but a <c>static</c> class
/// cannot be used as a type argument, so making it static (or sealed) would change
/// its meaning or break callers.
/// </summary>
// SAFE: code-quality/deterministic/static-holder-type-not-sealed
[StorageBucket(Name)]
public class StaticHolderMarker
{
    /// <summary>The container name carried by the marker attribute.</summary>
    internal const string Name = "default";
}
```

Negative fixture (true-bug case the rule must still catch):

```csharp
namespace UserService.Violations.CodeQuality;

/// <summary>
/// Holds nothing but a static member, carries no marker attribute, and is neither
/// <c>static</c> nor <c>sealed</c> — so it is pointlessly instantiable and
/// subclassable and should be declared <c>static</c>.
/// </summary>
// VIOLATION: code-quality/deterministic/no-extraneous-class
// VIOLATION: code-quality/deterministic/static-holder-type-not-sealed
internal class TimestampFormatter
{
    internal static int PadWidth()
    {
        return 2;
    }
}
```

**Visitor summary:** the rule (Roslyn host) flagged marker/token classes (only static members, e.g. `DefaultContainer` with `[BlobContainerName]`) used as generic type arguments — where a `static` class is illegal — so sealing/making-static would break compilation. Added a syntactic guard skipping any class decorated with an attribute (works even when the attribute type is unresolved in loose-text analysis).

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

Measured with `node dist/cli.mjs analyze --no-llm` from a fresh `pnpm build:dist`
(plus the rebuilt Roslyn host) — the exact artifact `publish.yml` ships to npm.
Project-aware (`roslyn-workspace`) rules are uniformly skipped before and after
(the target's projects are not restored), so they contribute nothing to the delta;
all five fixed rules are tree-sitter/loose-text rules unaffected by that.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/unused-this-parameter` | 323 | 298 | -25 |
| `architecture/deterministic/action-missing-producesresponsetype` | 260 | 249 | -11 |
| `code-quality/deterministic/no-extraneous-class` | 200 | 199 | -1 |
| `code-quality/deterministic/csharp-filename-type-mismatch` | 253 | 120 | -133 |
| `code-quality/deterministic/static-holder-type-not-sealed` | 152 | 151 | -1 |
| **Total (these 5 rules)** | 1188 | 1017 | -171 |
| **All-rules total on target** | 84214 | 84043 | -171 |

The all-rules total drop equals the five-rule subtotal, confirming the changes
touched only the targeted rules.

## Testing

- `tests/analyzer/` — all 62 files / 5016 tests green (the full blast radius of
  these C#-only changes), including the C# positive (zero-FP) and negative
  (marker recall + no-unmarked-fires) harnesses and the regenerated C# graph
  snapshot.
- Other suites (`ee-*`, `dashboard-server`, `github-app`, parts of `core`) fail
  to load in this environment because the `@truecourse/ee-db` /
  `@truecourse/ee-data-store` packages are unbuilt and no database is available —
  pre-existing/environmental, untouched by this change.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLUPAi5cVsh5pkc4g94xwV)_