### PR TITLE
fix(fp): resolve 4 FPs from abpframework/abp

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/csharp/recursive-type-inheritance.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/csharp/recursive-type-inheritance.ts
@@ -14,6 +14,25 @@ function baseEntryName(entry: SyntaxNode): string | null {
   return null
 }
 
+/** Generic arity of a base-list entry (0 for a non-generic name). */
+function baseEntryArity(entry: SyntaxNode): number {
+  const generic = entry.type === 'generic_name'
+    ? entry
+    : entry.type === 'qualified_name'
+      ? entry.childForFieldName('name')
+      : null
+  if (generic?.type !== 'generic_name') return 0
+  const args = generic.namedChildren.find((c) => c?.type === 'type_argument_list')
+  return args ? args.namedChildren.filter((c) => c != null).length : 0
+}
+
+/** Generic arity declared by the type itself (count of its type parameters). */
+function declaredArity(node: SyntaxNode): number {
+  const params = node.childForFieldName('type_parameters')
+  if (!params) return 0
+  return params.namedChildren.filter((c) => c?.type === 'type_parameter').length
+}
+
 /**
  * A type that lists itself in its own base list — `class Node : Node` or
  * `class C : Comparable<C>` written as a base class rather than an interface.
@@ -43,6 +62,13 @@ export const csharpRecursiveTypeInheritanceVisitor: CodeRuleVisitor = {
     // For interfaces every entry is a base interface; checking only the first
     // is still sound because a self-referential first interface is the bug.
     if (baseEntryName(firstBase) !== typeName) return null
+
+    // A same-named base of a *different* generic arity is a distinct type, not a
+    // self-reference: `IClient<T> : IClient` and
+    // `IBasicRepository<TEntity, TKey> : IBasicRepository<TEntity>` are idiomatic
+    // generic-extends-lower-arity pairings, not recursive inheritance. Only flag
+    // when the base has the same arity as the declared type (true self-reference).
+    if (baseEntryArity(firstBase) !== declaredArity(node)) return null
 
     return makeViolation(
       this.ruleKey, firstBase, filePath, 'high',

--- a/packages/analyzer/src/rules/bugs/visitors/csharp/self-assignment.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/csharp/self-assignment.ts
@@ -11,6 +11,12 @@ export const csharpSelfAssignmentVisitor: CodeRuleVisitor = {
   languages: ['csharp'],
   nodeTypes: ['assignment_expression'],
   visit(node, filePath, sourceCode) {
+    // Inside an object/collection initializer (`new Dto { Name = Name }`), the
+    // left-hand side names a member of the *new* object while the right-hand
+    // side resolves in the enclosing scope (an implicit `this.Name` / local).
+    // `Name = Name` there copies a value across objects — not a self-assignment.
+    if (node.parent?.type === 'initializer_expression') return null
+
     const left = node.childForFieldName('left')
     const right = node.childForFieldName('right')
     const operator = node.childForFieldName('operator')

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/redundant-jump.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/redundant-jump.ts
@@ -17,7 +17,14 @@ export const csharpRedundantJumpVisitor: CodeRuleVisitor = {
     if (!grandparent) return null
 
     if (node.type === 'return_statement') {
-      if (node.namedChildren.length > 0) return null
+      // A `return <expr>;` carries a value and is never redundant. The returned
+      // expression is not always a *named* child — `this`, `null`, `true`, etc.
+      // parse as anonymous nodes — so detect any child that isn't the `return`
+      // keyword or the trailing `;`.
+      const hasExpression = node.children.some(
+        (c) => c != null && c.type !== 'return' && c.type !== ';',
+      )
+      if (hasExpression) return null
       if (!isCSharpFunctionBoundary(grandparent.type)) return null
       return makeViolation(
         this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/static-holder-type-has-constructor.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/static-holder-type-has-constructor.ts
@@ -29,6 +29,14 @@ export const csharpStaticHolderTypeHasConstructorVisitor: CodeRuleVisitor = {
     if (hasCSharpModifier(node, 'static')) return null
     if (hasCSharpModifier(node, 'abstract')) return null
 
+    // A type that derives from a base class inherits instance state and is
+    // genuinely instantiated through the hierarchy, so its constructor is not a
+    // static-holder artifact. (A type listing a base also cannot be made
+    // `static`, so the rule's fix would not apply.) Skip any type with a base
+    // list — the "all members static" shape only implies a static holder for a
+    // standalone type.
+    if (node.namedChildren.some((c) => c?.type === 'base_list')) return null
+
     const body = node.namedChildren.find((c) => c?.type === 'declaration_list')
     if (!body) return null
 

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -2311,6 +2311,12 @@
       "layer": "service"
     },
     {
+      "name": "RedundantReturnAtEnd",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "ReferenceInterner",
       "service": "UserService",
       "kind": "class",
@@ -2383,6 +2389,18 @@
       "layer": "service"
     },
     {
+      "name": "SelfAssignedField",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "SelfInheritingType",
+      "service": "UserService",
+      "kind": "interface",
+      "layer": "service"
+    },
+    {
       "name": "SessionAuditLog",
       "service": "UserService",
       "kind": "class",
@@ -2410,6 +2428,12 @@
       "name": "StaleSnapshotError",
       "service": "UserService",
       "kind": "interface",
+      "layer": "service"
+    },
+    {
+      "name": "StandaloneStaticHolder",
+      "service": "UserService",
+      "kind": "class",
       "layer": "service"
     },
     {

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Bugs/SelfAssignedField.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Bugs/SelfAssignedField.cs
@@ -1,0 +1,16 @@
+namespace UserService.Violations.Bugs;
+
+/// <summary>Stores a configured weight.</summary>
+internal sealed class SelfAssignedField
+{
+    /// <summary>The configured weight.</summary>
+    internal int Weight { get; set; }
+
+    /// <summary>Re-applies the weight, but assigns the property to itself — a
+    /// no-op that has no effect (a missed assignment from another source).</summary>
+    internal void Reapply()
+    {
+        // VIOLATION: bugs/deterministic/self-assignment
+        Weight = Weight;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Bugs/SelfInheritingType.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Bugs/SelfInheritingType.cs
@@ -1,0 +1,11 @@
+namespace UserService.Violations.Bugs;
+
+/// <summary>
+/// Lists itself as its own base type at the same generic arity — a nonsensical,
+/// self-referential inheritance chain (a copy-paste mistake). The same-name,
+/// same-arity base is the genuine recursion the rule targets.
+/// </summary>
+// VIOLATION: bugs/deterministic/recursive-type-inheritance
+internal class SelfInheritingType : SelfInheritingType
+{
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/RedundantReturnAtEnd.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/RedundantReturnAtEnd.cs
@@ -1,0 +1,17 @@
+namespace UserService.Violations.CodeQuality;
+
+/// <summary>Accumulates a running total.</summary>
+internal sealed class RedundantReturnAtEnd
+{
+    private int _total;
+
+    /// <summary>Adds the amount to the running total.</summary>
+    /// <param name="amount">The amount to add.</param>
+    internal void Add(int amount)
+    {
+        _total += amount;
+        // A bare `return;` as the last statement of a void method does nothing.
+        // VIOLATION: code-quality/deterministic/redundant-jump
+        return;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/StandaloneStaticHolder.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/StandaloneStaticHolder.cs
@@ -1,0 +1,25 @@
+namespace UserService.Violations.CodeQuality;
+
+/// <summary>
+/// Holds only static/const members and has no base type, yet declares a public
+/// parameterless instance constructor. The constructor serves no purpose — there
+/// is no instance state — so the type should be made <c>static</c>.
+/// </summary>
+internal sealed class StandaloneStaticHolder
+{
+    internal const string Key = "k";
+
+    internal static int Width()
+    {
+        return 2;
+    }
+
+    // The empty public constructor on an all-static type is both a static-holder
+    // artifact and a useless constructor (it does nothing the compiler default
+    // wouldn't).
+    // VIOLATION: code-quality/deterministic/static-holder-type-has-constructor
+    // VIOLATION: code-quality/deterministic/useless-constructor
+    public StandaloneStaticHolder()
+    {
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/BugsSamples1/SelfAssignmentInitializerSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/BugsSamples1/SelfAssignmentInitializerSafe.cs
@@ -1,0 +1,27 @@
+namespace Positive.Boundary.Bugs;
+
+/// <summary>
+/// Builds a projection of the current instance. Inside the object initializer,
+/// <c>Name = Name</c> sets the <em>new</em> object's member from the enclosing
+/// instance's property (an implicit <c>this.Name</c>); it copies a value across
+/// two distinct objects and is not a self-assignment.
+/// </summary>
+public sealed class SelfAssignmentInitializerSafe
+{
+    /// <summary>The display name carried by this instance.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Creates a projection copying the name from this instance.</summary>
+    public NameProjectionSafe ToProjection()
+    {
+        // SAFE: bugs/deterministic/self-assignment
+        return new NameProjectionSafe { Name = Name };
+    }
+}
+
+/// <summary>A projection target that mirrors the source's name.</summary>
+public sealed class NameProjectionSafe
+{
+    /// <summary>The projected name.</summary>
+    public string Name { get; set; } = string.Empty;
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/IRecursiveGenericContractSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/IRecursiveGenericContractSafe.cs
@@ -1,0 +1,25 @@
+namespace Positive.Boundary.Bugs;
+
+/// <summary>
+/// The non-generic contract base.
+/// </summary>
+public interface IRecursiveGenericContractSafe
+{
+    /// <summary>Sends a request with no payload.</summary>
+    void Send();
+}
+
+/// <summary>
+/// The strongly-typed contract. It extends the non-generic, same-named base
+/// interface — a distinct type of <em>lower generic arity</em>. This
+/// generic-extends-non-generic pairing is idiomatic, not the self-referential
+/// recursive inheritance the rule targets.
+/// </summary>
+/// <typeparam name="TPayload">The payload type carried by the typed contract.</typeparam>
+// SAFE: bugs/deterministic/recursive-type-inheritance
+public interface IRecursiveGenericContractSafe<TPayload> : IRecursiveGenericContractSafe
+{
+    /// <summary>Sends a typed payload.</summary>
+    /// <param name="payload">The payload to send.</param>
+    void Send(TPayload payload);
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/RedundantJumpFluentReturnSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/RedundantJumpFluentReturnSafe.cs
@@ -1,0 +1,28 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// A fluent options builder whose configuration methods return the builder
+/// instance so calls can be chained. The trailing <c>return this;</c> is the
+/// method's meaningful return value, not a redundant jump statement — removing
+/// it would break the fluent API and fail to compile (the method has a return
+/// type).
+/// </summary>
+public sealed class RedundantJumpFluentReturnSafe
+{
+    private int _retryCount;
+
+    /// <summary>Sets the retry count and returns the builder for chaining.</summary>
+    /// <param name="count">The number of retries to apply.</param>
+    public RedundantJumpFluentReturnSafe WithRetries(int count)
+    {
+        _retryCount = count;
+        // SAFE: code-quality/deterministic/redundant-jump
+        return this;
+    }
+
+    /// <summary>Returns the configured retry count.</summary>
+    public int RetryCount()
+    {
+        return _retryCount;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/StaticHolderDerivedTypeSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/StaticHolderDerivedTypeSafe.cs
@@ -1,0 +1,36 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// Base descriptor carrying genuine instance state. Concrete descriptors derive
+/// from it and are created via <c>new</c>.
+/// </summary>
+public class DescriptorBaseSafe
+{
+    /// <summary>The descriptor's display name (instance state from the base).</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Creates a descriptor with the supplied display name.</summary>
+    /// <param name="displayName">The display name to carry.</param>
+    protected DescriptorBaseSafe(string displayName)
+    {
+        DisplayName = displayName;
+    }
+}
+
+/// <summary>
+/// A concrete descriptor. It declares only a <c>const</c> name of its own, so it
+/// looks like a "static holder", but it derives from a base with instance state
+/// and is instantiated through that hierarchy — its instance constructor is
+/// required, not a removable static-holder artifact. (A type with a base list
+/// also cannot be marked <c>static</c>.)
+/// </summary>
+public sealed class StaticHolderDerivedTypeSafe : DescriptorBaseSafe
+{
+    private const string Identifier = "console";
+
+    /// <summary>Creates the descriptor, forwarding its identifier to the base.</summary>
+    // SAFE: code-quality/deterministic/static-holder-type-has-constructor
+    public StaticHolderDerivedTypeSafe() : base(Identifier)
+    {
+    }
+}


### PR DESCRIPTION
Resolves four C# tree-sitter false positives on [`abpframework/abp`](https://github.com/abpframework/abp) at `8665ce0a23622f658b531b0627c7c025935fdb3b`, surfaced by the **fp-next-fix queue-empty re-measurement** of this campaign (details at the end). Each fix adds a paraphrased zero-FP positive fixture and a true-bug negative fixture; the C# negative-project graph snapshot is regenerated for the four new negative files.

Closes #666
Closes #667
Closes #668
Closes #669

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/redundant-jump` | #666 | `sample-csharp-project-positive/services/CodeQualitySamples1/RedundantJumpFluentReturnSafe.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/RedundantReturnAtEnd.cs` |
| `bugs/deterministic/self-assignment` | #667 | `sample-csharp-project-positive/services/BugsSamples1/SelfAssignmentInitializerSafe.cs` | `sample-csharp-project-negative/services/UserService/Violations/Bugs/SelfAssignedField.cs` |
| `code-quality/deterministic/static-holder-type-has-constructor` | #668 | `sample-csharp-project-positive/services/CodeQualitySamples3/StaticHolderDerivedTypeSafe.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/StandaloneStaticHolder.cs` |
| `bugs/deterministic/recursive-type-inheritance` | #669 | `sample-csharp-project-positive/services/BugsSamples2/IRecursiveGenericContractSafe.cs` | `sample-csharp-project-negative/services/UserService/Violations/Bugs/SelfInheritingType.cs` |

## code-quality/deterministic/redundant-jump

OSS sources (FP): [WorkspaceConfiguration.cs#L19](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AI/Volo/Abp/AI/WorkspaceConfiguration.cs#L19),`` [BusinessException.cs#L36](https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Core/Volo/Abp/BusinessException.cs#L36) — `return this;` fluent returns.

Positive fixture (asserts zero violations):
```diff
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// A fluent options builder whose configuration methods return the builder
+/// instance so calls can be chained. The trailing <c>return this;</c> is the
+/// method's meaningful return value, not a redundant jump statement — removing
+/// it would break the fluent API and fail to compile (the method has a return
+/// type).
+/// </summary>
+public sealed class RedundantJumpFluentReturnSafe
+{
+    private int _retryCount;
+
+    /// <summary>Sets the retry count and returns the builder for chaining.</summary>
+    /// <param name="count">The number of retries to apply.</param>
+    public RedundantJumpFluentReturnSafe WithRetries(int count)
+    {
+        _retryCount = count;
+        // SAFE: code-quality/deterministic/redundant-jump
+        return this;
+    }
+
+    /// <summary>Returns the configured retry count.</summary>
+    public int RetryCount()
+    {
+        return _retryCount;
+    }
+}
```
Negative fixture (true bug, still fires):
```diff
+namespace UserService.Violations.CodeQuality;
+
+/// <summary>Accumulates a running total.</summary>
+internal sealed class RedundantReturnAtEnd
+{
+    private int _total;
+
+    /// <summary>Adds the amount to the running total.</summary>
+    /// <param name="amount">The amount to add.</param>
+    internal void Add(int amount)
+    {
+        _total += amount;
+        // A bare `return;` as the last statement of a void method does nothing.
+        // VIOLATION: code-quality/deterministic/redundant-jump
+        return;
+    }
+}
```
**Visitor summary:** the rule treated `return this;` (and `return null;`, `return true;`, literals) as a bare `return;` because it only skipped returns with a *named* expression child — but `this`/`null`/literals parse as **anonymous** tree-sitter nodes. It now skips any return that has a child other than the `return` keyword or trailing `;`, so only a truly value-less `return;` at the end of a void method fires.

## bugs/deterministic/self-assignment

OSS sources (FP): [ControllerApiDescriptionModel.cs#L74](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Http/Volo/Abp/Http/Modeling/ControllerApiDescriptionModel.cs#L74),`` [AbpUnitOfWorkOptions.cs#L36](https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Uow/Volo/Abp/Uow/AbpUnitOfWorkOptions.cs#L36) — `X = X` inside object initializers.

Positive fixture (asserts zero violations):
```diff
+namespace Positive.Boundary.Bugs;
+
+/// <summary>
+/// Builds a projection of the current instance. Inside the object initializer,
+/// <c>Name = Name</c> sets the <em>new</em> object's member from the enclosing
+/// instance's property (an implicit <c>this.Name</c>); it copies a value across
+/// two distinct objects and is not a self-assignment.
+/// </summary>
+public sealed class SelfAssignmentInitializerSafe
+{
+    /// <summary>The display name carried by this instance.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Creates a projection copying the name from this instance.</summary>
+    public NameProjectionSafe ToProjection()
+    {
+        // SAFE: bugs/deterministic/self-assignment
+        return new NameProjectionSafe { Name = Name };
+    }
+}
+
+/// <summary>A projection target that mirrors the source's name.</summary>
+public sealed class NameProjectionSafe
+{
+    /// <summary>The projected name.</summary>
+    public string Name { get; set; } = string.Empty;
+}
```
Negative fixture (true bug, still fires):
```diff
+namespace UserService.Violations.Bugs;
+
+/// <summary>Stores a configured weight.</summary>
+internal sealed class SelfAssignedField
+{
+    /// <summary>The configured weight.</summary>
+    internal int Weight { get; set; }
+
+    /// <summary>Re-applies the weight, but assigns the property to itself — a
+    /// no-op that has no effect (a missed assignment from another source).</summary>
+    internal void Reapply()
+    {
+        // VIOLATION: bugs/deterministic/self-assignment
+        Weight = Weight;
+    }
+}
```
**Visitor summary:** inside an object/collection initializer (`new Dto { Name = Name }`) the left-hand side names a member of the *new* object while the right-hand side resolves in the enclosing scope (implicit `this.Name`/local), so `Name = Name` copies a value across two objects — not a self-assignment. The visitor now skips assignments whose parent is an `initializer_expression`. A genuine `x = x;` statement still fires.

## code-quality/deterministic/static-holder-type-has-constructor

OSS sources (FP): [AppTemplate.cs#L14](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/App/AppTemplate.cs#L14),`` [ConsoleTemplate.cs#L10](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/Console/ConsoleTemplate.cs#L10)`` — instantiable `TemplateInfo` subclasses.

Positive fixture (asserts zero violations):
```diff
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// Base descriptor carrying genuine instance state. Concrete descriptors derive
+/// from it and are created via <c>new</c>.
+/// </summary>
+public class DescriptorBaseSafe
+{
+    /// <summary>The descriptor's display name (instance state from the base).</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Creates a descriptor with the supplied display name.</summary>
+    /// <param name="displayName">The display name to carry.</param>
+    protected DescriptorBaseSafe(string displayName)
+    {
+        DisplayName = displayName;
+    }
+}
+
+/// <summary>
+/// A concrete descriptor. It declares only a <c>const</c> name of its own, so it
+/// looks like a "static holder", but it derives from a base with instance state
+/// and is instantiated through that hierarchy — its instance constructor is
+/// required, not a removable static-holder artifact. (A type with a base list
+/// also cannot be marked <c>static</c>.)
+/// </summary>
+public sealed class StaticHolderDerivedTypeSafe : DescriptorBaseSafe
+{
+    private const string Identifier = "console";
+
+    /// <summary>Creates the descriptor, forwarding its identifier to the base.</summary>
+    // SAFE: code-quality/deterministic/static-holder-type-has-constructor
+    public StaticHolderDerivedTypeSafe() : base(Identifier)
+    {
+    }
+}
```
Negative fixture (true bug, still fires):
```diff
+namespace UserService.Violations.CodeQuality;
+
+/// <summary>
+/// Holds only static/const members and has no base type, yet declares a public
+/// parameterless instance constructor. The constructor serves no purpose — there
+/// is no instance state — so the type should be made <c>static</c>.
+/// </summary>
+internal sealed class StandaloneStaticHolder
+{
+    internal const string Key = "k";
+
+    internal static int Width()
+    {
+        return 2;
+    }
+
+    // The empty public constructor on an all-static type is both a static-holder
+    // artifact and a useless constructor (it does nothing the compiler default
+    // wouldn't).
+    // VIOLATION: code-quality/deterministic/static-holder-type-has-constructor
+    // VIOLATION: code-quality/deterministic/useless-constructor
+    public StandaloneStaticHolder()
+    {
+    }
+}
```
**Visitor summary:** the rule flagged types that declare only `const`/`static` members of their own but **derive from a base class** (e.g. `AppTemplate : TemplateInfo`). Such types inherit instance state and are created through the hierarchy (`new AppTemplate()`), so the instance constructor is required — and a type with a base list cannot be made `static` anyway. It now skips any class with a `base_list`. A standalone all-static type with an instance constructor still fires.

## bugs/deterministic/recursive-type-inheritance

OSS sources (FP): [IChatClient.cs#L5](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AI.Abstractions/Volo/Abp/AI/IChatClient.cs#L5),`` [IBasicRepository.cs#L83](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/IBasicRepository.cs#L83)`` — generic interface extends a non-generic / lower-arity same-named base.

Positive fixture (asserts zero violations):
```diff
+namespace Positive.Boundary.Bugs;
+
+/// <summary>
+/// The non-generic contract base.
+/// </summary>
+public interface IRecursiveGenericContractSafe
+{
+    /// <summary>Sends a request with no payload.</summary>
+    void Send();
+}
+
+/// <summary>
+/// The strongly-typed contract. It extends the non-generic, same-named base
+/// interface — a distinct type of <em>lower generic arity</em>. This
+/// generic-extends-non-generic pairing is idiomatic, not the self-referential
+/// recursive inheritance the rule targets.
+/// </summary>
+/// <typeparam name="TPayload">The payload type carried by the typed contract.</typeparam>
+// SAFE: bugs/deterministic/recursive-type-inheritance
+public interface IRecursiveGenericContractSafe<TPayload> : IRecursiveGenericContractSafe
+{
+    /// <summary>Sends a typed payload.</summary>
+    /// <param name="payload">The payload to send.</param>
+    void Send(TPayload payload);
+}
```
Negative fixture (true bug, still fires):
```diff
+namespace UserService.Violations.Bugs;
+
+/// <summary>
+/// Lists itself as its own base type at the same generic arity — a nonsensical,
+/// self-referential inheritance chain (a copy-paste mistake). The same-name,
+/// same-arity base is the genuine recursion the rule targets.
+/// </summary>
+// VIOLATION: bugs/deterministic/recursive-type-inheritance
+internal class SelfInheritingType : SelfInheritingType
+{
+}
```
**Visitor summary:** the rule flagged any first base entry with the same *simple name* as the declared type, ignoring generic arity. `IClient<T> : IClient` and `IBasicRepository<TEntity, TKey> : IBasicRepository<TEntity>` are distinct types of different arity (idiomatic generic-extends-lower-arity pairings), not the self-referential `class Node : Node` the rule targets. It now compares the base entry's generic arity to the declared type's arity and only flags a true same-arity self-reference.

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/redundant-jump` | 72 | 3 | -69 |
| `bugs/deterministic/self-assignment` | 62 | 3 | -59 |
| `code-quality/deterministic/static-holder-type-has-constructor` | 14 | 0 | -14 |
| `bugs/deterministic/recursive-type-inheritance` | 78 | 12 | -66 |
| **Total (these 4 rules)** | 226 | 18 | -208 |
| **All-rules total on target** | 83745 | 83537 | -208 |

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a fresh `pnpm build:dist` (the exact artifact `publish.yml` ships), before vs after on the same clone, against the Roslyn host built at `-c Release`. The clone's `global.json`/`.csproj`/`.sln` were removed so the project-aware `roslyn-workspace` pass is uniformly skipped on both runs (consistent with how this campaign's earlier deltas were measured). The all-rules drop (-208) equals the four-rule subtotal, confirming the changes touched only the targeted rules; the residual counts (3/3/0/12) are genuine true positives the rules still catch.

## Testing

- Full `tests/analyzer/` suite green: **62 files / 5016 tests**, including the C# positive (zero-FP, Roslyn host built) and negative (marker recall + no-unmarked-fires) harnesses and the regenerated C# graph snapshot.

## Campaign context — queue-empty re-measurement

This session was triggered by #665 merging. The pickable `cs-fp-fix` queue was empty (the 6 open issues are all `cs-fp-blocked` Roslyn-host rules), so per the routine it re-analyzed abp and re-classified a per-rule sample (fp-discover rubric). Result: **C#-only tp_rate ≈ 0.89, overall tp_rate ≈ 0.86 — both below the 0.90 close threshold**, so the campaign continues. The sweep surfaced ~40 untracked C# tree-sitter FP rules; the four highest-confidence ones are fixed here and filed as #666–#669. The remaining ones (e.g. `infinite-recursion` on auto-property initializers, `circular-module-dependency` on CRTP self-generics, `check-against-value-being-assigned`, `missing-modelstate-validation`) remain for follow-up sessions.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_0157zBTaME9UFo9UdrKqHJVu)_