### PR TITLE
fix(fp): resolve 1 FP from abpframework/abp

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/csharp/infinite-recursion.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/csharp/infinite-recursion.ts
@@ -29,9 +29,14 @@ export const csharpInfiniteRecursionVisitor: CodeRuleVisitor = {
     if (!name) return null
 
     if (node.type === 'property_declaration') {
-      // Expression-bodied property: `public int Age => Age;`
+      // Expression-bodied property: `public int Age => Age;`. Only an
+      // `arrow_expression_clause` is an expression body; an auto-property
+      // initializer (`public Color Color { get; set; } = Color.Default;`) also
+      // surfaces on the `value` field — as a `member_access_expression` whose
+      // leading type identifier can coincide with the property name — and that
+      // is a backing-field read, not self-recursion.
       const arrow = node.childForFieldName('value')
-      const arrowExpr = arrow?.namedChildren[0]
+      const arrowExpr = arrow?.type === 'arrow_expression_clause' ? arrow.namedChildren[0] : null
       if (arrowExpr?.type === 'identifier' && arrowExpr.text === name) {
         return makeViolation(
           this.ruleKey, node, filePath, 'critical',

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -625,6 +625,12 @@
       "layer": "service"
     },
     {
+      "name": "InfiniteRecursionExpressionBodyProperty",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "INotificationContract",
       "service": "ApiGateway",
       "kind": "class",
@@ -1094,6 +1100,12 @@
     },
     {
       "name": "RateCache",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "RecursionGuardMode",
       "service": "ApiGateway",
       "kind": "class",
       "layer": "service"

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/InfiniteRecursionExpressionBodyProperty.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/InfiniteRecursionExpressionBodyProperty.cs
@@ -1,0 +1,19 @@
+namespace ApiGateway.Violations.Bugs;
+
+internal enum RecursionGuardMode
+{
+    None,
+    Linear,
+}
+
+internal sealed class InfiniteRecursionExpressionBodyProperty
+{
+    // An expression-bodied getter that returns the property itself (rather than
+    // a backing field) recurses until StackOverflowException — even though the
+    // property name coincides with the enum type `RecursionGuardMode`. This is
+    // the genuine bug the rule must keep catching once auto-property
+    // initializers (whose leading type identifier merely matches the name) are
+    // exempted.
+    // VIOLATION: bugs/deterministic/infinite-recursion
+    internal RecursionGuardMode RecursionGuardMode => RecursionGuardMode;
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/BugsSamples1/InfiniteRecursionAutoPropertyInitializerSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/BugsSamples1/InfiniteRecursionAutoPropertyInitializerSafe.cs
@@ -1,0 +1,33 @@
+namespace Positive.Boundary.Bugs;
+
+/// <summary>Visual emphasis level for a rendered banner.</summary>
+public enum BannerKind
+{
+    Plain,
+    Highlighted,
+}
+
+/// <summary>Severity attached to a surfaced notice.</summary>
+public enum AlertLevel
+{
+    Info,
+    Critical,
+}
+
+/// <summary>
+/// Options whose auto-properties are each named after their own type and
+/// initialized to a static member of that type. Every property is a plain
+/// auto-property backed by a compiler-generated field, so reading it returns
+/// that field and never recurses. The initializer (for instance
+/// <c>BannerKind.Plain</c>) is a member access whose leading type identifier
+/// coincides with the property name — that must not be read as an
+/// expression-body self-reference.
+/// </summary>
+public sealed class InfiniteRecursionAutoPropertyInitializerSafe
+{
+    // SAFE: bugs/deterministic/infinite-recursion
+    public BannerKind BannerKind { get; set; } = BannerKind.Plain;
+
+    // SAFE: bugs/deterministic/infinite-recursion
+    public AlertLevel AlertLevel { get; set; } = AlertLevel.Info;
+}


### PR DESCRIPTION
Resolves a C# tree-sitter false positive on [`abpframework/abp`](https://github.com/abpframework/abp) at `8665ce0a23622f658b531b0627c7c025935fdb3b`, surfaced by the **fp-next-fix queue-empty re-measurement** of this campaign. Adds a paraphrased zero-FP positive fixture and a true-bug negative fixture; the C# negative-project graph snapshot is regenerated for the new negative module.

Closes #672

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `bugs/deterministic/infinite-recursion` | #672 | `sample-csharp-project-positive/services/BugsSamples1/InfiniteRecursionAutoPropertyInitializerSafe.cs` | `sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/InfiniteRecursionExpressionBodyProperty.cs` |

## bugs/deterministic/infinite-recursion

OSS sources (FP): [AbpAlertTagHelper.cs#L7](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Alert/AbpAlertTagHelper.cs#L7)`` (`public AlertType AlertType { get; set; } = AlertType.Default;`), [AbpCompilationRazorPageBase.cs#L43](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/RazorViews/AbpCompilationRazorPageBase.cs#L43)`` (`protected HtmlEncoder HtmlEncoder { get; set; } = HtmlEncoder.Default;`), [AbpEventBusBoxesOptions.cs#L42](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Distributed/AbpEventBusBoxesOptions.cs#L42),`` [UiPageProgress.razor.cs#L14](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.MudBlazorUI/Components/UiPageProgress.razor.cs#L14``) — auto-properties named after their own type, initialized to a static member of that type.

Positive fixture (asserts zero violations):
```diff
+namespace Positive.Boundary.Bugs;
+
+/// <summary>Visual emphasis level for a rendered banner.</summary>
+public enum BannerKind
+{
+    Plain,
+    Highlighted,
+}
+
+/// <summary>Severity attached to a surfaced notice.</summary>
+public enum AlertLevel
+{
+    Info,
+    Critical,
+}
+
+/// <summary>
+/// Options whose auto-properties are each named after their own type and
+/// initialized to a static member of that type. Every property is a plain
+/// auto-property backed by a compiler-generated field, so reading it returns
+/// that field and never recurses. The initializer (for instance
+/// <c>BannerKind.Plain</c>) is a member access whose leading type identifier
+/// coincides with the property name — that must not be read as an
+/// expression-body self-reference.
+/// </summary>
+public sealed class InfiniteRecursionAutoPropertyInitializerSafe
+{
+    // SAFE: bugs/deterministic/infinite-recursion
+    public BannerKind BannerKind { get; set; } = BannerKind.Plain;
+
+    // SAFE: bugs/deterministic/infinite-recursion
+    public AlertLevel AlertLevel { get; set; } = AlertLevel.Info;
+}
```
Negative fixture (true bug, still fires):
```diff
+namespace ApiGateway.Violations.Bugs;
+
+internal enum RecursionGuardMode
+{
+    None,
+    Linear,
+}
+
+internal sealed class InfiniteRecursionExpressionBodyProperty
+{
+    // An expression-bodied getter that returns the property itself (rather than
+    // a backing field) recurses until StackOverflowException — even though the
+    // property name coincides with the enum type `RecursionGuardMode`. This is
+    // the genuine bug the rule must keep catching once auto-property
+    // initializers (whose leading type identifier merely matches the name) are
+    // exempted.
+    // VIOLATION: bugs/deterministic/infinite-recursion
+    internal RecursionGuardMode RecursionGuardMode => RecursionGuardMode;
+}
```
**Visitor summary:** the rule's expression-bodied-property branch read the property's `value` field and took its first named child. For a genuine expression body (`public int Age => Age;`) that field is an `arrow_expression_clause` whose inner expression is the self-identifier — a real `StackOverflowException`. But for an **auto-property initializer** (`public Color Color { get; set; } = Color.Default;`) the same `value` field is a `member_access_expression` whose first child is the leading type identifier (`Color`), which coincides with the property name and produced a false positive. The branch now fires only when `value` is an `arrow_expression_clause`, so auto-property initializers are never treated as self-returning getters. The block-getter and method self-call branches are unchanged.

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `bugs/deterministic/infinite-recursion` | 19 | 3 | -16 |
| **Total (these 1 rules)** | 19 | 3 | -16 |
| **All-rules total on target** | 83537 | 83521 | -16 |

`Before` (83537 total / 19 for this rule) is the full `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` run from a fresh `pnpm build:dist` (the exact artifact `publish.yml` ships), against the Roslyn host built at `-c Release`, with the clone's `global.json`/`.csproj`/`.sln` removed so the project-aware `roslyn-workspace` pass is uniformly skipped (consistent with this campaign's earlier deltas). The post-fix full re-analyze ran but did not complete within this session's budget (an environmental slowdown on the 7.8k-file repo), so `After` was derived by re-running the **only** rule this PR changes over the **same target ref** via the identical `discoverFiles()` file set — which reproduces the full analyze's before-count for this rule **exactly** (19), confirming the file sets match. The fixed visitor yields 3 (a clean −16). Because the change touches a single rule, the all-rules total moves by exactly that −16 → 83521. The residual 3 are a distinct *method self-call* shape (e.g. `IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();` delegating to a different overload) that this auto-property fix intentionally does not touch — a candidate for a follow-up.

## Testing

- Full `tests/analyzer/` suite green, including the C# positive (zero-FP, Roslyn host built) and negative (marker recall) harnesses and the regenerated C# graph snapshot. (The repo's `ee-*`/`dashboard-server`/`github-app` suites fail to collect in this environment because `@truecourse/ee-db` is unbuilt — pre-existing and unrelated to this analyzer change.)

cc @mushgev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6xroU1HZ2ZuwSWscUQPTQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6xroU1HZ2ZuwSWscUQPTQ)_