### PR TITLE
fix(fp): resolve 3 blocked C# FPs (#674, #675, #676) + 2 coupled rules

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/csharp/check-against-value-being-assigned.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/csharp/check-against-value-being-assigned.ts
@@ -2,6 +2,43 @@ import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
+/** The enclosing class/struct/record declaration of a node, if any. */
+function enclosingTypeDecl(node: SyntaxNode): SyntaxNode | null {
+  let p = node.parent
+  while (p) {
+    if (p.type === 'class_declaration' || p.type === 'struct_declaration' || p.type === 'record_declaration') {
+      return p
+    }
+    p = p.parent
+  }
+  return null
+}
+
+/**
+ * The simple name of an assignment target when it is a bare identifier (`Name`)
+ * or a `this.Name` member access — the two shapes that can refer to a property
+ * declared on the enclosing type. Anything else (`obj.Name`, indexers, etc.)
+ * returns null.
+ */
+function selfMemberName(target: SyntaxNode): string | null {
+  if (target.type === 'identifier') return target.text
+  if (target.type === 'member_access_expression') {
+    const obj = target.childForFieldName('expression')
+    if (obj?.type === 'this') return target.childForFieldName('name')?.text ?? null
+  }
+  return null
+}
+
+/** True when the enclosing type declares a property with the given name. */
+function enclosingTypeHasProperty(typeDecl: SyntaxNode, name: string): boolean {
+  const body =
+    typeDecl.childForFieldName('body') ?? typeDecl.namedChildren.find((c) => c?.type === 'declaration_list')
+  if (!body) return false
+  return body.namedChildren.some(
+    (m) => m?.type === 'property_declaration' && m.childForFieldName('name')?.text === name,
+  )
+}
+
 /** The single statement of an if-consequence, unwrapping a one-statement block. */
 function singleStatement(consequence: SyntaxNode): SyntaxNode | null {
   if (consequence.type === 'block') {
@@ -51,6 +88,17 @@ export const csharpCheckAgainstValueBeingAssignedVisitor: CodeRuleVisitor = {
     const sameAB = condLeft.text === target.text && condRight.text === value.text
     const sameBA = condLeft.text === value.text && condRight.text === target.text
     if (!sameAB && !sameBA) return null
+
+    // Skip when the target is a property declared on the enclosing type (a bare
+    // `Name` or `this.Name`). A property setter is observable — it can drive
+    // change-tracking / auditing (e.g. EF Core) — so guarding the assignment with
+    // `!=` is a deliberate optimization to avoid marking the entity dirty, not a
+    // redundant no-op. A guard on a plain local or field still fires.
+    const selfName = selfMemberName(target)
+    if (selfName) {
+      const typeDecl = enclosingTypeDecl(node)
+      if (typeDecl && enclosingTypeHasProperty(typeDecl, selfName)) return null
+    }
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/missing-access-modifier.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/missing-access-modifier.ts
@@ -44,11 +44,17 @@ export const csharpMissingAccessModifierVisitor: CodeRuleVisitor = {
     // Members of an interface are implicitly public.
     if (node.parent?.parent?.type === 'interface_declaration') return null
 
+    // Explicit interface implementations take no access modifier for ANY member
+    // kind — property, indexer, event, method. C# forbids a modifier on an
+    // explicit interface member (adding one is a compile error), so flagging it is
+    // non-actionable. They carry an `explicit_interface_specifier` child, e.g.
+    // `DbContext IFoo.DbContext => ...` or `T IFoo.this[int i] => ...`.
+    if (node.namedChildren.some((c) => c?.type === 'explicit_interface_specifier')) return null
     if (node.type === 'method_declaration') {
-      // Explicit interface implementations (`void IFoo.Bar()`) take no modifier.
+      // Fallback for grammars that surface the qualified name instead of an
+      // explicit_interface_specifier (`void IFoo.Bar()`).
       const nm = node.childForFieldName('name')
       if (nm?.type === 'qualified_name' || (nm?.text ?? '').includes('.')) return null
-      if (node.namedChildren.some((c) => c?.type === 'explicit_interface_specifier')) return null
     }
     if (node.type === 'constructor_declaration' && mods.includes('static')) return null
 

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/property-name-matches-get-method.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/property-name-matches-get-method.ts
@@ -14,6 +14,51 @@ function enclosingTypeBody(node: SyntaxNode): SyntaxNode | null {
   return body?.type === 'declaration_list' ? body : null
 }
 
+/** True when `expr` is a zero-argument call to `GetX` (bare or `this.GetX`). */
+function isZeroArgCallTo(expr: SyntaxNode | null | undefined, getName: string): boolean {
+  if (expr?.type !== 'invocation_expression') return false
+  const fn = expr.childForFieldName('function') ?? expr.namedChildren[0]
+  const fnText = fn?.text
+  if (fnText !== getName && fnText !== `this.${getName}`) return false
+  const args = expr.childForFieldName('arguments') ?? expr.namedChildren.find((c) => c?.type === 'argument_list')
+  const argCount = args?.namedChildren.filter((c) => c?.type === 'argument').length ?? 0
+  return argCount === 0
+}
+
+/**
+ * True when the property's getter body is exactly `GetX()` — an expression-bodied
+ * property (`=> GetX()`), a `get => GetX()` accessor, or a `get { return GetX(); }`
+ * accessor. Such a property *delegates* to the method (one implementation, the
+ * idiomatic public surface over a protected/overridable `GetX()`), so it is not a
+ * confusing duplicate.
+ */
+function getterDelegatesTo(prop: SyntaxNode, getName: string): boolean {
+  // Expression-bodied property: `T X => GetX();`
+  const propArrow = prop.namedChildren.find((c) => c?.type === 'arrow_expression_clause')
+  if (propArrow) return isZeroArgCallTo(propArrow.namedChildren.find(Boolean), getName)
+
+  const accessorList = prop.namedChildren.find((c) => c?.type === 'accessor_list')
+  if (!accessorList) return false
+  const getter = accessorList.namedChildren.find(
+    (a) => a?.type === 'accessor_declaration' && a.children.some((c) => c?.text === 'get'),
+  )
+  if (!getter) return false
+
+  // `get => GetX();`
+  const getArrow = getter.namedChildren.find((c) => c?.type === 'arrow_expression_clause')
+  if (getArrow) return isZeroArgCallTo(getArrow.namedChildren.find(Boolean), getName)
+
+  // `get { return GetX(); }`
+  const block = getter.namedChildren.find((c) => c?.type === 'block')
+  if (block) {
+    const stmts = block.namedChildren.filter((c) => c?.type !== 'comment')
+    if (stmts.length === 1 && stmts[0]?.type === 'return_statement') {
+      return isZeroArgCallTo(stmts[0].namedChildren.find(Boolean), getName)
+    }
+  }
+  return false
+}
+
 export const csharpPropertyNameMatchesGetMethodVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/property-name-matches-get-method',
   languages: ['csharp'],
@@ -33,6 +78,12 @@ export const csharpPropertyNameMatchesGetMethodVisitor: CodeRuleVisitor = {
       return (params?.namedChildren.filter((c) => c?.type === 'parameter').length ?? 0) === 0
     })
     if (!hasGetMethod) return null
+
+    // A property whose getter body is exactly `GetX()` delegates to the method —
+    // a single implementation exposed through the property, not a duplicate. This
+    // is the idiomatic "public property surface over a protected/overridable
+    // `GetX()`" pattern, so it must not fire.
+    if (getterDelegatesTo(node, target)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/unused-private-member.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/unused-private-member.ts
@@ -24,6 +24,11 @@ export const csharpUnusedPrivateMemberVisitor: CodeRuleVisitor = {
     const privateMembers = new Map<string, SyntaxNode>()
     for (const member of body.namedChildren) {
       if (!member) continue
+      // Explicit interface implementations (`T IFoo.Bar => ...`) are contract
+      // members accessed through the interface, not private members — never
+      // "unused". They carry no access modifier, so without this guard they read
+      // as default-private.
+      if (member.namedChildren.some((c) => c?.type === 'explicit_interface_specifier')) continue
       if (!isCSharpPrivateMember(member)) continue
       // Attribute-decorated members are reached via reflection
       // (serializers, DI, Unity [SerializeField], …).

--- a/tests/analyzer/csharp-bugs-rules.test.ts
+++ b/tests/analyzer/csharp-bugs-rules.test.ts
@@ -3527,6 +3527,58 @@ public sealed class Toggle
 `, key)
     expect(found.length).toBe(0)
   })
+
+  it('does not flag a guarded assignment to an enclosing-type property (observable setter)', () => {
+    const found = matches(`namespace Domain;
+public class FeatureRecord
+{
+    public string Name { get; set; }
+
+    public void Patch(FeatureRecord other)
+    {
+        if (Name != other.Name)
+        {
+            Name = other.Name;
+        }
+    }
+}
+`, key)
+    expect(found).toHaveLength(0)
+  })
+
+  it('does not flag a guarded this.Property assignment', () => {
+    const found = matches(`namespace Domain;
+public class SettingRecord
+{
+    public int Value { get; set; }
+
+    public void Copy(SettingRecord other)
+    {
+        if (this.Value != other.Value)
+            this.Value = other.Value;
+    }
+}
+`, key)
+    expect(found).toHaveLength(0)
+  })
+
+  it('still flags a guarded assignment to a local variable', () => {
+    const found = matches(`namespace Domain;
+public class Calc
+{
+    public int Clamp(int value)
+    {
+        int result = 0;
+        if (result != value)
+        {
+            result = value;
+        }
+        return result;
+    }
+}
+`, key)
+    expect(found.length).toBe(1)
+  })
 })
 
 describe('bugs/deterministic/collection-passed-to-own-method (C#)', () => {

--- a/tests/analyzer/csharp-code-quality-rules.test.ts
+++ b/tests/analyzer/csharp-code-quality-rules.test.ts
@@ -2587,6 +2587,16 @@ public class InvoiceService
 `, 'unused-private-member')
     expect(found).toHaveLength(0)
   })
+
+  it('does not flag an explicit interface property implementation', () => {
+    const found = matches(`namespace App;
+public sealed class Repo : IContextHolder
+{
+    DbContext IContextHolder.Context => _factory.Create();
+}
+`, 'unused-private-member')
+    expect(found).toHaveLength(0)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -8388,6 +8398,28 @@ public class Order
 `, 'property-name-matches-get-method')
     expect(found).toHaveLength(0)
   })
+
+  it('does not flag an expression-bodied property that delegates to GetX()', () => {
+    const found = matches(`namespace App;
+public class ClientInfo
+{
+    public string BrowserInfo => GetBrowserInfo();
+    protected string GetBrowserInfo() => "n/a";
+}
+`, 'property-name-matches-get-method')
+    expect(found).toHaveLength(0)
+  })
+
+  it('does not flag a get accessor that returns GetX()', () => {
+    const found = matches(`namespace App;
+public class ThemeManager
+{
+    public string CurrentTheme { get { return GetCurrentTheme(); } }
+    protected string GetCurrentTheme() => "default";
+}
+`, 'property-name-matches-get-method')
+    expect(found).toHaveLength(0)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -8890,6 +8922,14 @@ describe('code-quality/deterministic/missing-access-modifier (C#)', () => {
 
   it('does not flag a partial type (covered by the partial rule)', () => {
     expect(matches(`namespace N; partial class C { }`, 'missing-access-modifier').length).toBe(0)
+  })
+
+  it('does not flag an explicit interface property implementation', () => {
+    expect(matches(`namespace N; public class C : IRepo { DbContext IRepo.DbContext => _ctx; }`, 'missing-access-modifier').length).toBe(0)
+  })
+
+  it('does not flag an explicit interface indexer implementation', () => {
+    expect(matches(`namespace N; public class C : ILoc { string ILoc.this[int i] => _values[i]; }`, 'missing-access-modifier').length).toBe(0)
   })
 })
 

--- a/tests/analyzer/roslyn-rules-code-quality.test.ts
+++ b/tests/analyzer/roslyn-rules-code-quality.test.ts
@@ -1449,6 +1449,22 @@ class C {
 }`
       expect(await keys(src, K)).not.toContain(K)
     })
+    it('does not flag a property that delegates to GetFoo() (expression-bodied)', async () => {
+      const src = `
+class C {
+  public string BrowserInfo => GetBrowserInfo();
+  protected string GetBrowserInfo() => "";
+}`
+      expect(await keys(src, K)).not.toContain(K)
+    })
+    it('does not flag a property whose get accessor returns GetFoo()', async () => {
+      const src = `
+class C {
+  public string Theme { get { return GetTheme(); } }
+  protected string GetTheme() => "";
+}`
+      expect(await keys(src, K)).not.toContain(K)
+    })
   })
 
   // ---- verbose-declaration-initialization ---------------------------------

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -481,6 +481,12 @@
       "layer": "api"
     },
     {
+      "name": "GuardedLocalAssignmentBug",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "HandlerBase",
       "service": "ApiGateway",
       "kind": "class",
@@ -620,6 +626,12 @@
     },
     {
       "name": "IMetricsRecorder",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "ImplicitPrivateMembersBug",
       "service": "ApiGateway",
       "kind": "class",
       "layer": "service"
@@ -896,6 +908,12 @@
     },
     {
       "name": "NetworkSection",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "NonDelegatingGetAccessors",
       "service": "ApiGateway",
       "kind": "class",
       "layer": "service"

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/GuardedLocalAssignmentBug.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/GuardedLocalAssignmentBug.cs
@@ -1,0 +1,22 @@
+namespace ApiGateway.Violations.Bugs;
+
+/// <summary>
+/// Guards an assignment to a plain local with the same value it already holds.
+/// Unlike a guarded write to an observable entity property (whose setter can drive
+/// change-tracking), a local assignment has no side effect, so the `!=` guard is a
+/// genuine no-op and check-against-value-being-assigned must still fire.
+/// </summary>
+internal sealed class GuardedLocalAssignmentBug
+{
+    internal int Clamp(int value, int seed)
+    {
+        int result = seed;
+        // VIOLATION: bugs/deterministic/check-against-value-being-assigned
+        if (result != value)
+        {
+            result = value;
+        }
+
+        return result;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/ImplicitPrivateMembersBug.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/ImplicitPrivateMembersBug.cs
@@ -1,0 +1,22 @@
+namespace ApiGatewayApp.Violations.CodeQuality;
+
+/// <summary>
+/// Ordinary members that lack an access modifier — NOT explicit interface
+/// implementations (which are forbidden a modifier). An implicitly-private member
+/// with no modifier is genuinely ambiguous, so missing-access-modifier must still
+/// fire; a private field that is never read is genuinely dead, so
+/// unused-private-member must still fire.
+/// </summary>
+internal sealed class ImplicitPrivateMembersBug
+{
+    // VIOLATION: code-quality/deterministic/unused-private-member
+    private readonly string _unusedTag = "n/a";
+
+    private readonly decimal _rate = decimal.One;
+
+    // VIOLATION: code-quality/deterministic/missing-access-modifier
+    decimal Subtotal(decimal net) => net * _rate;
+
+    /// <summary>Grosses up the net amount at the captured rate.</summary>
+    public decimal Total(decimal net) => Subtotal(net);
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/NonDelegatingGetAccessors.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/NonDelegatingGetAccessors.cs
@@ -1,0 +1,17 @@
+namespace ApiGatewayApp.Violations.CodeQuality;
+
+/// <summary>
+/// A property and a matching GetX() method that do NOT share one implementation:
+/// the property stores its own value while the method computes a different result.
+/// This is the confusing "two competing ways to obtain the value" shape (not the
+/// idiomatic property-delegates-to-GetX() pattern), so both
+/// property-name-matches-get-method and property-matches-get-method must still fire.
+/// </summary>
+internal sealed class NonDelegatingGetAccessors
+{
+    public string DisplayName { get; set; } = string.Empty;
+
+    // VIOLATION: code-quality/deterministic/property-name-matches-get-method
+    // VIOLATION: code-quality/deterministic/property-matches-get-method
+    public string GetDisplayName() => DisplayName.Trim();
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/BugsSamples1/GuardedEntityPropertyAssignmentSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/BugsSamples1/GuardedEntityPropertyAssignmentSafe.cs
@@ -1,0 +1,24 @@
+namespace Positive.Boundary.Bugs;
+
+/// <summary>
+/// Guards a property assignment with an inequality check so a change-tracked entity
+/// property is written only when the value actually changes. The property setter is
+/// observable (it can drive change-tracking / auditing), so the guard is a deliberate
+/// optimization — not a redundant no-op — and check-against-value-being-assigned must
+/// not fire.
+/// </summary>
+public sealed class GuardedEntityPropertyAssignmentSafe
+{
+    /// <summary>Assigning this property marks the entity modified.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Copies the name from another record only when it differs.</summary>
+    // SAFE: bugs/deterministic/check-against-value-being-assigned
+    public void Patch(GuardedEntityPropertyAssignmentSafe other)
+    {
+        if (Name != other.Name)
+        {
+            Name = other.Name;
+        }
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/DelegatingPropertyAccessorsSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/DelegatingPropertyAccessorsSafe.cs
@@ -1,0 +1,23 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// Each property delegates to its matching GetX() method — a single implementation
+/// exposed through the property surface (the idiomatic public property over an
+/// overridable GetX()), not two competing ways to obtain the value. Neither
+/// property-name-matches-get-method nor property-matches-get-method must fire.
+/// </summary>
+// SAFE: code-quality/deterministic/property-name-matches-get-method
+// SAFE: code-quality/deterministic/property-matches-get-method
+public class DelegatingPropertyAccessorsSafe
+{
+    public string BrowserInfo => GetBrowserInfo();
+
+    public string ClientAddress
+    {
+        get { return GetClientAddress(); }
+    }
+
+    protected virtual string GetBrowserInfo() => "unknown";
+
+    protected virtual string GetClientAddress() => "0.0.0.0";
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/ExplicitInterfaceMembersSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/ExplicitInterfaceMembersSafe.cs
@@ -1,0 +1,21 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>Read-only metadata contract implemented explicitly below.</summary>
+public interface IMetadataView
+{
+    string PrimaryKey { get; }
+    string this[int index] { get; }
+}
+
+/// <summary>
+/// Implements <see cref="IMetadataView"/> explicitly. C# forbids an access modifier
+/// on an explicit interface member (adding one is a compile error), so
+/// missing-access-modifier must not fire on the property or the indexer.
+/// </summary>
+// SAFE: code-quality/deterministic/missing-access-modifier
+public sealed class ExplicitInterfaceMembersSafe : IMetadataView
+{
+    string IMetadataView.PrimaryKey => "id";
+
+    string IMetadataView.this[int index] => index == 0 ? "id" : "name";
+}

--- a/tools/csharp-roslyn-host/Rules/CodeQuality/PropertyMatchesGetMethod.cs
+++ b/tools/csharp-roslyn-host/Rules/CodeQuality/PropertyMatchesGetMethod.cs
@@ -10,6 +10,12 @@ namespace TrueCourse.RoslynHost;
 /// name collision, not a "method should be a property" heuristic: both members must
 /// actually exist. We require the method to be parameterless so it is a genuine
 /// accessor counterpart. CA1721.
+///
+/// One narrow exemption: a property whose getter body is exactly `GetFoo()` (an
+/// expression-bodied property `Foo => GetFoo()`, a `get => GetFoo()`, or a
+/// `get { return GetFoo(); }`) delegates to the method — a single implementation
+/// exposed through the property surface, the idiomatic "public property over an
+/// overridable `GetFoo()`" pattern — not two competing ways to obtain the value.
 /// </summary>
 internal sealed class PropertyMatchesGetMethod : ISemanticRule
 {
@@ -41,6 +47,12 @@ internal sealed class PropertyMatchesGetMethod : ISemanticRule
                 var collides = properties.Contains(bare);
                 if (!collides) continue;
 
+                // Skip when the property `Foo` merely delegates to `GetFoo()` — one
+                // implementation surfaced through the property, not a redundant pair.
+                var prop = type.GetMembers(bare).OfType<IPropertySymbol>()
+                    .FirstOrDefault(p => !p.IsIndexer);
+                if (prop != null && PropertyDelegatesTo(prop, method.Name)) continue;
+
                 var node = method.DeclaringSyntaxReferences
                     .Select(r => r.GetSyntax())
                     .OfType<MethodDeclarationSyntax>()
@@ -53,5 +65,50 @@ internal sealed class PropertyMatchesGetMethod : ISemanticRule
                     $"Method '{method.Name}' collides with property '{bare}' on '{type.Name}'; the pair confuses which exposes the value — keep one.");
             }
         }
+    }
+
+    /// <summary>
+    /// True when the property's getter body is exactly `methodName()` (bare or
+    /// `this.methodName()`), i.e. the property delegates to the method.
+    /// </summary>
+    private static bool PropertyDelegatesTo(IPropertySymbol prop, string methodName)
+    {
+        foreach (var reference in prop.DeclaringSyntaxReferences)
+        {
+            if (reference.GetSyntax() is not PropertyDeclarationSyntax decl) continue;
+
+            ExpressionSyntax? getterExpr = null;
+            if (decl.ExpressionBody != null)
+            {
+                getterExpr = decl.ExpressionBody.Expression;
+            }
+            else if (decl.AccessorList != null)
+            {
+                var getter = decl.AccessorList.Accessors
+                    .FirstOrDefault(a => a.Keyword.ValueText == "get");
+                if (getter?.ExpressionBody != null)
+                    getterExpr = getter.ExpressionBody.Expression;
+                else if (getter?.Body is { Statements.Count: 1 } body
+                         && body.Statements[0] is ReturnStatementSyntax ret)
+                    getterExpr = ret.Expression;
+            }
+
+            if (IsZeroArgCallTo(getterExpr, methodName)) return true;
+        }
+        return false;
+    }
+
+    private static bool IsZeroArgCallTo(ExpressionSyntax? expr, string methodName)
+    {
+        if (expr is not InvocationExpressionSyntax inv) return false;
+        if (inv.ArgumentList.Arguments.Count != 0) return false;
+        var name = inv.Expression switch
+        {
+            IdentifierNameSyntax id => id.Identifier.Text,
+            MemberAccessExpressionSyntax ma when ma.Expression is ThisExpressionSyntax
+                => ma.Name.Identifier.Text,
+            _ => null,
+        };
+        return name == methodName;
     }
 }


### PR DESCRIPTION
Fixes the three remaining blocked `cs-fp-fix` false positives on `abpframework/abp`, plus two sibling rules that share the exact same root FP shapes — so the FP is actually gone on a full re-analyze, not just on one of two rules that fire on the same code.

Closes #674
Closes #675
Closes #676

## Fixes

| rule | issue | engine | fix |
|---|---|---|---|
| `code-quality/deterministic/missing-access-modifier` | #674 | tree-sitter | hoist the explicit-interface exemption to all member kinds |
| `code-quality/deterministic/property-name-matches-get-method` | #675 | tree-sitter | skip a property that delegates to `GetX()` |
| `bugs/deterministic/check-against-value-being-assigned` | #676 | tree-sitter | skip a guarded assignment to an enclosing-type property |
| `code-quality/deterministic/property-matches-get-method` | (coupled with #675) | Roslyn host | same delegation exemption |
| `code-quality/deterministic/unused-private-member` | (coupled with #674) | tree-sitter | exempt explicit interface implementations |

### #674 — missing-access-modifier
The visitor only exempted explicit interface implementations inside the `method_declaration` branch. Explicit interface implementations of **properties, indexers, and events** carry an `explicit_interface_specifier` child (`DbContext IFoo.DbContext => …`, `T IFoo.this[int i] => …`) and were flagged. C# forbids an access modifier on any explicit interface member (adding one is a compile error), so the fix hoists the `explicit_interface_specifier` check to every member kind.

### #675 — property-name-matches-get-method
A property whose getter body is exactly `GetX()` — `X => GetX()`, `get => GetX()`, or `get { return GetX(); }` — **delegates** to the method (one implementation, the idiomatic public property surface over an overridable `GetX()`), not a confusing duplicate. The rule now skips that shape; a property that stores its own value while a separate `GetX()` exists still fires.

### #676 — check-against-value-being-assigned
`if (Name != other.Name) Name = other.Name;` where `Name` is a property on the enclosing type is a deliberate optimization: a property setter is observable (EF Core change-tracking / auditing), so guarding avoids marking the entity dirty when unchanged. The rule now skips when the target is a property declared on the enclosing type (bare `Name` or `this.Name`). A guard on a plain **local or field** still fires (unchanged).

### Coupled fixes (same FP shapes)
- **`property-matches-get-method`** (Roslyn host, CA1721) fires on the *same* delegating-property pattern as #675. Left unfixed, the abp delegating properties would still be flagged by this rule on re-analyze. Applied the identical delegation exemption.
- **`unused-private-member`** treats explicit interface members as default-private and flags them as "unused" — the same blind spot as #674. Exempted explicit interface implementations (they're contract members reached through the interface).

## Tests
- Tree-sitter unit tests (both FP-no-longer-fires and true-bug-still-fires) for all four tree-sitter rules.
- Roslyn-host unit tests for the `property-matches-get-method` delegation exemption.
- New positive-project fixtures (assert **zero** violations) for each pattern; existing negative markers still fire.
- Full C# analyzer suite + CLI e2e + contract verifier green: **5043 tests passing**, verified against a freshly-built Roslyn host (.NET 8).

## Notes
Verified in a session with .NET 8 installed and the Roslyn host built — the same capability the `cs-` routine environment currently lacks (see #679). This PR is the code half; the routine environment still needs .NET 8 for the automation to self-verify C# on future runs.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_013pwu9eEAH5U6bSDim6gu5r)_