### PR TITLE
test(cs-fp): add positive fixtures for the 6 Roslyn FPs fixed in #678

### DIFF
--- a/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/MissingFormatProviderOverloadInvariantSpecifierSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/MissingFormatProviderOverloadInvariantSpecifierSafe.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Positive.Boundary.Bugs;
+
+/// <summary>
+/// Formats timestamps with the standard specifiers that .NET defines to always produce
+/// culture-invariant output: "r"/"R" (RFC1123), "o"/"O" (round-trip), "s" (sortable),
+/// "u" (universal sortable). Passing an <c>IFormatProvider</c> to these overloads changes
+/// nothing, so upgrading to <c>ToString(format, provider)</c> is pointless and
+/// missing-format-provider-overload must not fire.
+/// </summary>
+public sealed class MissingFormatProviderOverloadInvariantSpecifierSafe
+{
+    /// <summary>Renders an RFC1123 timestamp for an HTTP date header.</summary>
+    public string ToHttpDate(DateTimeOffset when)
+    {
+        // SAFE: bugs/deterministic/missing-format-provider-overload
+        return when.ToString("r");
+    }
+
+    /// <summary>Renders a round-trippable timestamp for serialization.</summary>
+    public string ToRoundTrip(DateTime when)
+    {
+        // SAFE: bugs/deterministic/missing-format-provider-overload
+        return when.ToString("O");
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/NormalizeToLowerNotUpperInterpolationSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/NormalizeToLowerNotUpperInterpolationSafe.cs
@@ -1,0 +1,18 @@
+namespace Positive.Boundary.Bugs;
+
+/// <summary>
+/// Lowercases a value ONLY to embed it in display/markup output (a CSS class name) via a
+/// string-interpolation hole. This is a presentation context, not storage/comparison
+/// normalization, and switching to <c>ToUpperInvariant</c> would produce the wrong markup,
+/// so normalize-to-lower-not-upper must not fire on a <c>ToLower</c> that sits directly
+/// inside an interpolation hole.
+/// </summary>
+public sealed class NormalizeToLowerNotUpperInterpolationSafe
+{
+    /// <summary>Builds a CSS class name for the given status label.</summary>
+    public string StatusCssClass(string status)
+    {
+        // SAFE: bugs/deterministic/normalize-to-lower-not-upper
+        return $"badge-{status.ToLower()}";
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/NormalizeToLowerNotUpperInterpolationSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/NormalizeToLowerNotUpperInterpolationSafe.cs
@@ -1,11 +1,11 @@
 namespace Positive.Boundary.Bugs;
 
 /// <summary>
-/// Lowercases a value ONLY to embed it in display/markup output (a CSS class name) via a
+/// Case-folds a value ONLY to embed it in display/markup output (a CSS class name) via a
 /// string-interpolation hole. This is a presentation context, not storage/comparison
-/// normalization, and switching to <c>ToUpperInvariant</c> would produce the wrong markup,
-/// so normalize-to-lower-not-upper must not fire on a <c>ToLower</c> that sits directly
-/// inside an interpolation hole.
+/// normalization, so normalize-to-lower-not-upper must not fire on a case-fold that sits
+/// directly inside an interpolation hole. <c>ToLowerInvariant</c> is used so the fold is
+/// culture-independent (no culture-unaware-string-operation concern).
 /// </summary>
 public sealed class NormalizeToLowerNotUpperInterpolationSafe
 {
@@ -13,6 +13,6 @@ public sealed class NormalizeToLowerNotUpperInterpolationSafe
     public string StatusCssClass(string status)
     {
         // SAFE: bugs/deterministic/normalize-to-lower-not-upper
-        return $"badge-{status.ToLower()}";
+        return $"badge-{status.ToLowerInvariant()}";
     }
 }

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/InterfaceCollidingBaseMembersDiamondSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/InterfaceCollidingBaseMembersDiamondSafe.cs
@@ -1,0 +1,64 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>Base contract exposing a single operation.</summary>
+public interface IReportBase
+{
+    /// <summary>Runs the report.</summary>
+    void Run();
+}
+
+/// <summary>Left branch of a diamond — inherits the base contract unchanged.</summary>
+public interface IReportLeftBranch : IReportBase { }
+
+/// <summary>Right branch of a diamond — inherits the base contract unchanged.</summary>
+public interface IReportRightBranch : IReportBase { }
+
+/// <summary>
+/// Diamond inheritance: <c>Run</c> reaches this interface through two branches, but both
+/// expose the SAME original declaration on <see cref="IReportBase"/> (one declaring type).
+/// That is not a genuine collision, so interface-colliding-base-members must not fire.
+/// </summary>
+// SAFE: code-quality/deterministic/interface-colliding-base-members
+public interface IDiamondReport : IReportLeftBranch, IReportRightBranch { }
+
+/// <summary>Query contract with two overloads that share a name but not a signature.</summary>
+public interface IQuerySource
+{
+    /// <summary>Fetches by id.</summary>
+    void Fetch(int id);
+
+    /// <summary>Fetches by id with a filter.</summary>
+    void Fetch(int id, string filter);
+}
+
+/// <summary>Metadata contract with an unrelated member.</summary>
+public interface IMetadataSource
+{
+    /// <summary>Describes the source.</summary>
+    void Describe();
+}
+
+/// <summary>
+/// Overloads with distinct parameter-type signatures are independent members, each with a
+/// single origin — not an ambiguous name collision — so the rule must not fire here either.
+/// </summary>
+// SAFE: code-quality/deterministic/interface-colliding-base-members
+public interface ICompositeSource : IQuerySource, IMetadataSource { }
+
+/// <summary>Consumes the diamond and composite contracts through their derived interfaces.</summary>
+public sealed class InterfaceCollidingBaseMembersDiamondSafe
+{
+    private readonly IDiamondReport _report;
+
+    /// <summary>Wraps a report reached through a diamond interface.</summary>
+    public InterfaceCollidingBaseMembersDiamondSafe(IDiamondReport report)
+    {
+        _report = report;
+    }
+
+    /// <summary>Runs the wrapped report; <c>Run</c> resolves unambiguously despite the diamond.</summary>
+    public void Execute()
+    {
+        _report.Run();
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/TypeNameMatchesNamespaceNestedTypeSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/TypeNameMatchesNamespaceNestedTypeSafe.cs
@@ -9,12 +9,8 @@ namespace Positive.Boundary.CodeQuality;
 public sealed class TypeNameMatchesNamespaceNestedTypeSafe
 {
     // SAFE: code-quality/deterministic/type-name-matches-namespace
-    private sealed class CodeQuality
-    {
-        /// <summary>The enclosing marker value.</summary>
-        public int Marker { get; init; }
-    }
+    private sealed class CodeQuality { }
 
-    /// <summary>Uses the nested type so it is not an unused private member.</summary>
-    public int NestedMarker() => new CodeQuality { Marker = 1 }.Marker;
+    /// <summary>Instantiates the nested type so it is not an unused private member.</summary>
+    public object NestedMarker() => new CodeQuality();
 }

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/TypeNameMatchesNamespaceNestedTypeSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/TypeNameMatchesNamespaceNestedTypeSafe.cs
@@ -1,0 +1,20 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// Hosts a NESTED type whose simple name (<c>CodeQuality</c>) matches a namespace declared
+/// in this compilation (the enclosing <c>Positive.Boundary.CodeQuality</c>). A nested type
+/// is reached through its enclosing type, so it can never create namespace ambiguity at a
+/// use site, and type-name-matches-namespace must not fire on it.
+/// </summary>
+public sealed class TypeNameMatchesNamespaceNestedTypeSafe
+{
+    // SAFE: code-quality/deterministic/type-name-matches-namespace
+    private sealed class CodeQuality
+    {
+        /// <summary>The enclosing marker value.</summary>
+        public int Marker { get; init; }
+    }
+
+    /// <summary>Uses the nested type so it is not an unused private member.</summary>
+    public int NestedMarker() => new CodeQuality { Marker = 1 }.Marker;
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/UnusedFunctionParameterImplicitInterfaceSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/UnusedFunctionParameterImplicitInterfaceSafe.cs
@@ -1,0 +1,22 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>Provider contract that mandates a lookup signature.</summary>
+public interface ILookupProvider
+{
+    /// <summary>Resolves a value for the given category.</summary>
+    string Get(string category);
+}
+
+/// <summary>
+/// A null-object implementation whose <c>Get</c> ignores its <c>category</c> argument. The
+/// parameter is contract-mandated by <see cref="ILookupProvider"/> — this is an implicit
+/// interface implementation, so the parameter cannot be removed — and unused-function-parameter
+/// must not fire on it (the tree-sitter variant used to, because it could not see the
+/// implicit implementation; the Roslyn rule resolves it).
+/// </summary>
+public sealed class UnusedFunctionParameterImplicitInterfaceSafe : ILookupProvider
+{
+    // SAFE: code-quality/deterministic/unused-function-parameter
+    /// <summary>Always returns the default value regardless of category.</summary>
+    public string Get(string category) => "default";
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples4/WritableCollectionPropertyBlazorParameterSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples4/WritableCollectionPropertyBlazorParameterSafe.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>Minimal stand-in for the Blazor component-parameter attribute.</summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ParameterAttribute : Attribute { }
+
+/// <summary>Minimal stand-in for the Blazor cascading-parameter attribute.</summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class CascadingParameterAttribute : Attribute { }
+
+/// <summary>
+/// A component whose collection properties carry the framework binding attributes
+/// (<c>[Parameter]</c> / <c>[CascadingParameter]</c>). The framework mandates a public
+/// setter so it can assign the bound value through it — the setter is contract-required,
+/// not a replaceable-backing-collection hazard — so writable-collection-property must not
+/// fire even though the setter is public.
+/// </summary>
+public sealed class WritableCollectionPropertyBlazorParameterSafe
+{
+    // SAFE: code-quality/deterministic/writable-collection-property
+    /// <summary>Breadcrumb items supplied by the parent component via binding.</summary>
+    [Parameter] public List<string> BreadcrumbItems { get; set; } = new();
+
+    // SAFE: code-quality/deterministic/writable-collection-property
+    /// <summary>Ambient tags supplied through a cascading value.</summary>
+    [CascadingParameter] public List<string> AmbientTags { get; set; } = new();
+}


### PR DESCRIPTION
## Problem

PR #678 fundamentally fixed six C# Roslyn false positives — but it only added **inline rule-unit tests** (`roslyn-rules-*.test.ts`) and updated the **negative** fixture markers. It added nothing to the **positive fixture project**.

`docs/fp-automation/prompts/fp-next-fix.md` **step 5** requires every fixed FP to be paraphrased into the positive fixture — the whole-project *zero-violation* corpus asserted by `tests/analyzer/csharp-positive.test.ts`. That's the integration-level guard: it runs the real (fixed) Roslyn host over the entire project, so the specific FP shape can't silently regress later. Without it, only the isolated per-rule unit test protects each fix.

## Fix

One `Safe` boundary case per fixed rule, each mirroring #678's own verified "does not flag" case:

| Rule | New fixture | FP shape guarded |
|---|---|---|
| `writable-collection-property` | `CodeQualitySamples4/WritableCollectionPropertyBlazorParameterSafe.cs` | Blazor `[Parameter]`/`[CascadingParameter]` collection property with a public setter |
| `missing-format-provider-overload` | `BugsSamples2/MissingFormatProviderOverloadInvariantSpecifierSafe.cs` | culture-invariant specifiers `ToString("r")` / `ToString("O")` |
| `interface-colliding-base-members` | `CodeQualitySamples1/InterfaceCollidingBaseMembersDiamondSafe.cs` | diamond inheritance (single declaration via two paths) + same-name overloads with distinct signatures |
| `normalize-to-lower-not-upper` | `BugsSamples2/NormalizeToLowerNotUpperInterpolationSafe.cs` | `ToLower()` inside a string-interpolation hole (display/markup) |
| `type-name-matches-namespace` | `CodeQualitySamples3/TypeNameMatchesNamespaceNestedTypeSafe.cs` | nested type whose name matches an enclosing namespace segment |
| `unused-function-parameter` | `CodeQualitySamples3/UnusedFunctionParameterImplicitInterfaceSafe.cs` | implicit interface implementation whose parameter is contract-mandated |

Each carries a `// SAFE: <ruleKey>` marker and uses neutral, domain-agnostic identifiers (the Blazor attributes are local `sealed` stand-ins with `[AttributeUsage]` so they resolve and don't trip the attribute rules).

## Verification

- `csharp-positive.test.ts` **tree-sitter pass** and `csharp-positive-coverage.test.ts` are **green** — the new files trip **no other** C# rule (I fixed two collateral hits found this way: an interface missing its `I` prefix, and a publicly-visible nested type).
- The **Roslyn-host 0-FP block** is skipped locally — this environment has **no .NET 8 SDK**, so the host can't be built here. Those six shapes are copied from #678's own passing inline tests, so a host-built machine / CI will assert them green.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_