### PR TITLE
test(cs-fp): add true-bug negative fixtures for #680's narrowed C# rules

### DIFF
--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -481,6 +481,12 @@
       "layer": "api"
     },
     {
+      "name": "GuardedLocalAssignmentBug",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "HandlerBase",
       "service": "ApiGateway",
       "kind": "class",
@@ -620,6 +626,12 @@
     },
     {
       "name": "IMetricsRecorder",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "ImplicitPrivateMembersBug",
       "service": "ApiGateway",
       "kind": "class",
       "layer": "service"
@@ -896,6 +908,12 @@
     },
     {
       "name": "NetworkSection",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "NonDelegatingGetAccessors",
       "service": "ApiGateway",
       "kind": "class",
       "layer": "service"

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/GuardedLocalAssignmentBug.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/GuardedLocalAssignmentBug.cs
@@ -1,0 +1,22 @@
+namespace ApiGateway.Violations.Bugs;
+
+/// <summary>
+/// Guards an assignment to a plain local with the same value it already holds.
+/// Unlike a guarded write to an observable entity property (whose setter can drive
+/// change-tracking), a local assignment has no side effect, so the `!=` guard is a
+/// genuine no-op and check-against-value-being-assigned must still fire.
+/// </summary>
+internal sealed class GuardedLocalAssignmentBug
+{
+    internal int Clamp(int value, int seed)
+    {
+        int result = seed;
+        // VIOLATION: bugs/deterministic/check-against-value-being-assigned
+        if (result != value)
+        {
+            result = value;
+        }
+
+        return result;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/ImplicitPrivateMembersBug.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/ImplicitPrivateMembersBug.cs
@@ -12,10 +12,11 @@ internal sealed class ImplicitPrivateMembersBug
     // VIOLATION: code-quality/deterministic/unused-private-member
     private readonly string _unusedTag = "n/a";
 
-    // VIOLATION: code-quality/deterministic/missing-access-modifier
-    // VIOLATION: code-quality/deterministic/static-method-candidate
-    decimal Subtotal(decimal net, decimal rate) => net * rate;
+    private readonly decimal _rate = decimal.One;
 
-    /// <summary>Grosses up the net amount at the given rate.</summary>
-    public decimal Total(decimal net, decimal rate) => Subtotal(net, rate);
+    // VIOLATION: code-quality/deterministic/missing-access-modifier
+    decimal Subtotal(decimal net) => net * _rate;
+
+    /// <summary>Grosses up the net amount at the captured rate.</summary>
+    public decimal Total(decimal net) => Subtotal(net);
 }

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/ImplicitPrivateMembersBug.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/ImplicitPrivateMembersBug.cs
@@ -1,0 +1,21 @@
+namespace ApiGatewayApp.Violations.CodeQuality;
+
+/// <summary>
+/// Ordinary members that lack an access modifier — NOT explicit interface
+/// implementations (which are forbidden a modifier). An implicitly-private member
+/// with no modifier is genuinely ambiguous, so missing-access-modifier must still
+/// fire; a private field that is never read is genuinely dead, so
+/// unused-private-member must still fire.
+/// </summary>
+internal sealed class ImplicitPrivateMembersBug
+{
+    // VIOLATION: code-quality/deterministic/unused-private-member
+    private readonly string _unusedTag = "n/a";
+
+    // VIOLATION: code-quality/deterministic/missing-access-modifier
+    // VIOLATION: code-quality/deterministic/static-method-candidate
+    decimal Subtotal(decimal net, decimal rate) => net * rate;
+
+    /// <summary>Grosses up the net amount at the given rate.</summary>
+    public decimal Total(decimal net, decimal rate) => Subtotal(net, rate);
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/NonDelegatingGetAccessors.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/NonDelegatingGetAccessors.cs
@@ -1,0 +1,17 @@
+namespace ApiGatewayApp.Violations.CodeQuality;
+
+/// <summary>
+/// A property and a matching GetX() method that do NOT share one implementation:
+/// the property stores its own value while the method computes a different result.
+/// This is the confusing "two competing ways to obtain the value" shape (not the
+/// idiomatic property-delegates-to-GetX() pattern), so both
+/// property-name-matches-get-method and property-matches-get-method must still fire.
+/// </summary>
+internal sealed class NonDelegatingGetAccessors
+{
+    public string DisplayName { get; set; } = string.Empty;
+
+    // VIOLATION: code-quality/deterministic/property-name-matches-get-method
+    // VIOLATION: code-quality/deterministic/property-matches-get-method
+    public string GetDisplayName() => DisplayName.Trim();
+}


### PR DESCRIPTION
## Problem

[PR #680](https://github.com/truecourse-ai/truecourse/pull/680) narrows five C# rules to drop false positives, but ships only **positive** fixtures (assert zero violations). The [`fp-next-fix` routine](https://github.com/truecourse-ai/truecourse/blob/main/docs/fp-automation/prompts/fp-next-fix.md) requires **both** — step 5 adds the FP to the positive fixture, and **step 6** adds a paraphrased *true-bug* case to the negative fixture, proving the narrowed rule still catches the real bug. #680 relied on pre-existing negative markers instead of adding the discriminating near-miss that sits right next to each exempted FP shape.

This PR adds those missing negative fixtures.

## Fixtures added

All three are marker-driven (`// VIOLATION: <rule-key>`) files under `sample-csharp-project-negative`, each the true-bug counterpart of one of #680's positive fixtures:

| Negative fixture | Rule(s) that must still fire | Discriminates from the FP #680 exempted |
|---|---|---|
| `Bugs/GuardedLocalAssignmentBug.cs` | `bugs/deterministic/check-against-value-being-assigned` | #676 exempts a guarded write to an **enclosing-type property** (observable setter). A guard on a plain **local** is a genuine no-op → still fires. |
| `CodeQuality/NonDelegatingGetAccessors.cs` | `code-quality/deterministic/property-name-matches-get-method`, `code-quality/deterministic/property-matches-get-method` | #675 exempts a property whose getter **delegates** to `GetX()`. A stored property + a `GetX()` that computes a **different** result is the confusing colliding pair → still fires. |
| `CodeQuality/ImplicitPrivateMembersBug.cs` | `code-quality/deterministic/missing-access-modifier`, `code-quality/deterministic/unused-private-member` | #674 exempts **explicit interface** members (which forbid a modifier). An ordinary member with no modifier, and a genuinely unread private field, are real → still fire. |

The two incidental co-fires in `ImplicitPrivateMembersBug.cs` (`static-method-candidate` on the helper, and `docstring-completeness` resolved by giving `Total` a real doc comment) are handled so the strict Level-2 harness stays clean.

## Verification

Loose-text C# negative harness green — every fire in the new files sits on a marker, and every tree-sitter marker fires:

```
tests/analyzer/csharp-negative.test.ts  (6 tests) — 6 passed
```

`property-matches-get-method` is a `roslyn-host` rule, so its marker is verified in CI where the .NET 8 host is built (this environment has no .NET, mirroring #679). The shape is non-delegating, so it is not caught by #680's delegation exemption.

These true-bug shapes fire on the current `main` visitors as well as post-#680 — #680 only *narrowed* the rules, so the near-misses were never in the exempted set.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaE3Ze6azv18GrxtrYy5a9)_