### PR TITLE
fix(fp): resolve 4 FPs from abpframework/abp

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/csharp/empty-catch.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/csharp/empty-catch.ts
@@ -45,12 +45,17 @@ export const csharpEmptyCatchVisitor: CodeRuleVisitor = {
           const stmt = tryStatements[0]!
           // tryParse pattern: a single parse/deserialize attempt
           if (/\b(Parse|TryParse|Deserialize)\s*[<(]/.test(stmt.text)) return null
-          // Best-effort cleanup: a single Dispose/Close/Delete-style call
-          const expr = stmt.namedChildren[0]
-          if (expr?.type === 'invocation_expression' && BEST_EFFORT_METHODS.has(getCSharpMethodName(expr))) {
+          // Best-effort cleanup: a single Dispose/Close/Delete-style call. The
+          // call may be awaited (`await stream.DisposeAsync()`), so unwrap the
+          // `await_expression` and treat the `…Async` variant of a best-effort
+          // method as best-effort too.
+          let expr = stmt.namedChildren[0]
+          if (expr?.type === 'await_expression') expr = expr.namedChildren[0]
+          const isBestEffort = (name: string): boolean => BEST_EFFORT_METHODS.has(name.replace(/Async$/, ''))
+          if (expr?.type === 'invocation_expression' && isBestEffort(getCSharpMethodName(expr))) {
             return null
           }
-          if (expr?.type === 'conditional_access_expression' && BEST_EFFORT_METHODS.has((expr.text.match(/\.(\w+)\s*\([^()]*\)\s*$/) ?? [])[1] ?? '')) {
+          if (expr?.type === 'conditional_access_expression' && isBestEffort((expr.text.match(/\.(\w+)\s*\([^()]*\)\s*$/) ?? [])[1] ?? '')) {
             return null
           }
         }

--- a/packages/analyzer/src/rules/bugs/visitors/csharp/redundant-base-call.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/csharp/redundant-base-call.ts
@@ -62,7 +62,14 @@ export const csharpRedundantBaseCallVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     const receiver = node.childForFieldName('expression')
     if (receiver?.type !== 'base' && receiver?.text !== 'base') return null
-    const memberName = node.childForFieldName('name')?.text
+    // A generic member access (`base.Execute<TResult>()`) exposes a `generic_name`
+    // node whose text includes the type arguments (`Execute<TResult>`), whereas a
+    // declaring method's `name` field is the bare identifier (`Execute`). Compare
+    // on the bare name so a generic override is recognized as declared.
+    const nameNode = node.childForFieldName('name')
+    const memberName = nameNode?.type === 'generic_name'
+      ? nameNode.namedChildren.find((c) => c?.type === 'identifier')?.text
+      : nameNode?.text
     if (!memberName) return null
 
     const typeDecl = enclosingType(node)

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/generic-parameter-not-inferable.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/generic-parameter-not-inferable.ts
@@ -31,6 +31,10 @@ function parameterTypeIdentifiers(method: SyntaxNode): Set<string> {
     if (param?.type !== 'parameter') continue
     for (const id of identifiersIn(param.childForFieldName('type'))) used.add(id)
   }
+  // A trailing `params T[]` parameter is not wrapped in a `parameter` node by
+  // tree-sitter-c-sharp; its type is attached directly as the `type` field of
+  // the parameter list. Fold those identifiers in so `T` still counts as used.
+  for (const id of identifiersIn(params.childForFieldName('type'))) used.add(id)
   return used
 }
 

--- a/packages/analyzer/src/rules/reliability/visitors/csharp/unsafe-json-parse.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/csharp/unsafe-json-parse.ts
@@ -1,3 +1,4 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { getCSharpArguments, getCSharpMethodName, getCSharpReceiver } from '../../../_shared/csharp-helpers.js'
@@ -11,14 +12,62 @@ const JSON_PARSERS: Record<string, Set<string>> = {
   JsonNode: new Set(['Parse']),
 }
 
+const TYPE_DECLS = new Set([
+  'class_declaration', 'struct_declaration', 'record_declaration', 'record_struct_declaration',
+])
+
+/** True when `body` directly declares a field or property named `name`. */
+function bodyDeclaresMember(body: SyntaxNode, name: string): boolean {
+  for (const member of body.namedChildren) {
+    if (!member) continue
+    if (member.type === 'property_declaration') {
+      if (member.childForFieldName('name')?.text === name) return true
+    } else if (member.type === 'field_declaration') {
+      const decl = member.namedChildren.find((c) => c?.type === 'variable_declaration')
+      for (const d of decl?.namedChildren ?? []) {
+        if (d?.type === 'variable_declarator' && d.childForFieldName('name')?.text === name) return true
+      }
+    }
+  }
+  return false
+}
+
+/**
+ * True when an enclosing type declares a field/property named `name`. Such a
+ * member shadows a same-named BCL type in a `name.Member(...)` access — the
+ * receiver is the instance member, not the type.
+ */
+function enclosingTypeDeclaresMember(node: SyntaxNode, name: string): boolean {
+  let current: SyntaxNode | null = node.parent
+  while (current) {
+    if (TYPE_DECLS.has(current.type)) {
+      const body = current.childForFieldName('body')
+      if (body && bodyDeclaresMember(body, name)) return true
+    }
+    current = current.parent
+  }
+  return false
+}
+
 export const csharpUnsafeJsonParseVisitor: CodeRuleVisitor = {
   ruleKey: 'reliability/deterministic/unsafe-json-parse',
   languages: ['csharp'],
   nodeTypes: ['invocation_expression'],
   visit(node, filePath, sourceCode) {
-    const receiver = simpleTypeName(getCSharpReceiver(node))
+    const rawReceiver = getCSharpReceiver(node)
+    const receiver = simpleTypeName(rawReceiver)
     const method = getCSharpMethodName(node)
     if (!JSON_PARSERS[receiver]?.has(method)) return null
+
+    // Receiver name-collision guard. Code that injects a member named after the
+    // BCL entry point — e.g. abp's `protected IJsonSerializer JsonSerializer { get; }`
+    // called as `JsonSerializer.Deserialize<T>(...)` — is invoking that instance
+    // member, not the same-named static BCL type, so it is not a BCL JSON parse.
+    // A bare `Name` (or `this.Name`) that an enclosing type declares as a
+    // field/property resolves to the member; a namespace-qualified receiver
+    // (`System.Text.Json.JsonSerializer`, other dots) still fires.
+    const bareReceiver = rawReceiver.startsWith('this.') ? rawReceiver.slice(5) : rawReceiver
+    if (!bareReceiver.includes('.') && enclosingTypeDeclaresMember(node, bareReceiver)) return null
 
     // `JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(x))` is the
     // deep-clone idiom — the input was just produced by the serializer and is

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -1957,7 +1957,19 @@
       "layer": "service"
     },
     {
+      "name": "GenericReturnOnlyFactory",
+      "service": "UserService",
+      "kind": "standalone",
+      "layer": "service"
+    },
+    {
       "name": "GlobalAuditMarker",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "GreeterBase",
       "service": "UserService",
       "kind": "class",
       "layer": "service"
@@ -2329,6 +2341,18 @@
       "layer": "service"
     },
     {
+      "name": "RawConfig",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "RawConfigLoader",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "ReconciliationTracer",
       "service": "UserService",
       "kind": "class",
@@ -2336,6 +2360,12 @@
     },
     {
       "name": "Record",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "RedundantBaseGreeter",
       "service": "UserService",
       "kind": "class",
       "layer": "service"
@@ -2486,6 +2516,12 @@
     },
     {
       "name": "StringFormattingHelpers",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "SwallowedFlushErrors",
       "service": "UserService",
       "kind": "class",
       "layer": "service"

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Bugs/RedundantBaseGreeter.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Bugs/RedundantBaseGreeter.cs
@@ -1,0 +1,21 @@
+namespace UserServiceApp.Violations.Bugs;
+
+internal class GreeterBase
+{
+    internal virtual string Greet()
+    {
+        return "hi";
+    }
+}
+
+internal sealed class RedundantBaseGreeter : GreeterBase
+{
+    internal string Announce()
+    {
+        // RedundantBaseGreeter declares no `Greet` member of its own, so the
+        // `base.` qualifier is unnecessary and misleads readers about which
+        // member runs.
+        // VIOLATION: bugs/deterministic/redundant-base-call
+        return base.Greet();
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Bugs/SwallowedFlushErrors.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Bugs/SwallowedFlushErrors.cs
@@ -1,0 +1,27 @@
+using System.IO;
+
+namespace UserServiceApp.Violations.Bugs;
+
+internal sealed class SwallowedFlushErrors
+{
+    private int _writes;
+    private int _cursor;
+
+    internal void Flush()
+    {
+        try
+        {
+            Write();
+            Advance();
+        }
+        // Not a single best-effort cleanup call — this genuinely swallows the error.
+        // VIOLATION: bugs/deterministic/empty-catch
+        catch (IOException)
+        {
+        }
+    }
+
+    private void Write() => _writes++;
+
+    private void Advance() => _cursor++;
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/GenericReturnOnlyFactory.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/GenericReturnOnlyFactory.cs
@@ -1,0 +1,12 @@
+namespace UserServiceApp.Violations.CodeQuality;
+
+internal static class GenericReturnOnlyFactory
+{
+    // The type parameter appears only in the return type — it is used by no
+    // parameter at all, so callers must always spell it out (`Build<Ledger>()`).
+    // VIOLATION: code-quality/deterministic/generic-parameter-not-inferable
+    internal static T Build<T>() where T : new()
+    {
+        return new T();
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Reliability/RawConfigLoader.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Reliability/RawConfigLoader.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+
+namespace UserServiceApp.Violations.Reliability;
+
+internal sealed class RawConfigLoader
+{
+    internal RawConfig Load(string raw)
+    {
+        // Genuine System.Text.Json.JsonSerializer static call with no try/catch —
+        // malformed input throws JsonException and crashes the caller.
+        // VIOLATION: reliability/deterministic/unsafe-json-parse
+        return JsonSerializer.Deserialize<RawConfig>(raw);
+    }
+}
+
+internal sealed class RawConfig
+{
+    internal string? Name { get; init; }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/BugsSamples1/EmptyCatchAsyncDisposeSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/BugsSamples1/EmptyCatchAsyncDisposeSafe.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Positive.Boundary.Bugs;
+
+/// <summary>
+/// A single best-effort <c>await x.DisposeAsync()</c> cleanup wrapped in a
+/// try/catch. Swallowing the failure of a best-effort async dispose is the same
+/// idiom the rule already exempts for the synchronous <c>Dispose()</c> form, so
+/// the awaited variant must not be flagged either.
+/// </summary>
+public sealed class EmptyCatchAsyncDisposeSafe
+{
+    /// <summary>Disposes the stream, ignoring a failure during the dispose itself.</summary>
+    public async Task ReleaseAsync(Stream stream)
+    {
+        try
+        {
+            await stream.DisposeAsync();
+        }
+        // SAFE: bugs/deterministic/empty-catch
+        catch (IOException)
+        {
+        }
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/RedundantBaseCallGenericOverrideSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/RedundantBaseCallGenericOverrideSafe.cs
@@ -1,0 +1,29 @@
+namespace Positive.Boundary.Bugs;
+
+/// <summary>Base converter exposing an overridable generic normalization hook.</summary>
+public class ConverterBase
+{
+    /// <summary>Normalizes a seed value; subclasses may override.</summary>
+    public virtual TValue Normalize<TValue>(TValue seed)
+    {
+        return seed;
+    }
+}
+
+/// <summary>
+/// A converter that overrides the generic method and legitimately calls
+/// <c>base.Normalize&lt;TValue&gt;(...)</c>. Because the type overrides
+/// <c>Normalize</c>, the <c>base.</c> qualifier is required (dropping it would
+/// recurse into this override), so the rule must not flag it — even though the
+/// call carries an explicit type argument.
+/// </summary>
+public sealed class RedundantBaseCallGenericOverrideSafe : ConverterBase
+{
+    /// <summary>Applies the base normalization twice.</summary>
+    public override TValue Normalize<TValue>(TValue seed)
+    {
+        // SAFE: bugs/deterministic/redundant-base-call
+        var first = base.Normalize<TValue>(seed);
+        return base.Normalize<TValue>(first);
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/GenericParameterNotInferableParamsArraySafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/GenericParameterNotInferableParamsArraySafe.cs
@@ -1,0 +1,18 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// A generic method whose type parameter appears only in a trailing
+/// <c>params</c>-array parameter. The compiler still infers the type argument
+/// from the supplied elements (<c>Choose(1, 2, 3)</c> infers <c>int</c>), so the
+/// rule must not flag it — the parameter usage is present even though it lives in
+/// the params array rather than an ordinary parameter.
+/// </summary>
+public sealed class GenericParameterNotInferableParamsArraySafe
+{
+    /// <summary>Returns the first supplied option; T is inferred from the arguments.</summary>
+    // SAFE: code-quality/deterministic/generic-parameter-not-inferable
+    internal T Choose<T>(params T[] options)
+    {
+        return options[0];
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/ReliabilitySamples/UnsafeJsonParseMemberShadowSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/ReliabilitySamples/UnsafeJsonParseMemberShadowSafe.cs
@@ -1,0 +1,28 @@
+namespace Positive.Boundary.Reliability;
+
+internal interface IValueSerializer
+{
+    object Deserialize(string content);
+}
+
+/// <summary>
+/// Reads values through an injected serializer exposed as a member named
+/// <c>JsonSerializer</c>. The receiver of <c>JsonSerializer.Deserialize(...)</c>
+/// is that instance member, not <c>System.Text.Json.JsonSerializer</c>, so the
+/// unsafe-json-parse rule must not flag it (no BCL parse happens here).
+/// </summary>
+internal sealed class UnsafeJsonParseMemberShadowSafe
+{
+    private IValueSerializer JsonSerializer { get; }
+
+    internal UnsafeJsonParseMemberShadowSafe(IValueSerializer jsonSerializer)
+    {
+        JsonSerializer = jsonSerializer;
+    }
+
+    // SAFE: reliability/deterministic/unsafe-json-parse
+    internal object Read(string content)
+    {
+        return JsonSerializer.Deserialize(content);
+    }
+}


### PR DESCRIPTION
Resolves four C# false positives found on `abpframework/abp`, each a genuine tree-sitter detector bug (not a policy change). Every fix is a narrowing that keeps the rule's existing unit tests and negative fixtures firing; each adds a paraphrased positive fixture (asserts zero violations) and a negative fixture (asserts the true bug still fires).

Closes #683
Closes #684
Closes #685
Closes #686

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/generic-parameter-not-inferable` | #683 | `…/CodeQualitySamples1/GenericParameterNotInferableParamsArraySafe.cs` | `…/UserService/Violations/CodeQuality/GenericReturnOnlyFactory.cs` |
| `bugs/deterministic/empty-catch` | #684 | `…/BugsSamples1/EmptyCatchAsyncDisposeSafe.cs` | `…/UserService/Violations/Bugs/SwallowedFlushErrors.cs` |
| `bugs/deterministic/redundant-base-call` | #685 | `…/BugsSamples2/RedundantBaseCallGenericOverrideSafe.cs` | `…/UserService/Violations/Bugs/RedundantBaseGreeter.cs` |
| `reliability/deterministic/unsafe-json-parse` | #686 | `…/ReliabilitySamples/UnsafeJsonParseMemberShadowSafe.cs` | `…/UserService/Violations/Reliability/RawConfigLoader.cs` |

## code-quality/deterministic/generic-parameter-not-inferable

OSS source:

- https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Core/Volo/Abp/RandomHelper.cs#L68

**visitor summary:** A trailing `params T[]` parameter is not wrapped in a `parameter` node by tree-sitter-c-sharp — its type is attached directly to the `parameter_list` as the list's `type` field — so the visitor never counted `T` as used by a parameter and wrongly reported `GetRandomOf<T>(params T[] objs)` as non-inferable. The fix also folds the parameter list's own `type`-field identifiers into the "used in a parameter" set. A type parameter that appears only in the return type (e.g. `T Build<T>()`) is still correctly flagged.

Positive fixture:
```diff
+public sealed class GenericParameterNotInferableParamsArraySafe
+{
+    // SAFE: code-quality/deterministic/generic-parameter-not-inferable
+    internal T Choose<T>(params T[] options)
+    {
+        return options[0];
+    }
+}
```

Negative fixture:
```diff
+internal static class GenericReturnOnlyFactory
+{
+    // VIOLATION: code-quality/deterministic/generic-parameter-not-inferable
+    internal static T Build<T>() where T : new()
+    {
+        return new T();
+    }
+}
```

## bugs/deterministic/empty-catch

OSS sources:

- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.MultiTenancy/Volo/Abp/AspNetCore/MultiTenancy/AbpAspNetCoreMultiTenancyOptions.cs#L128``
- https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.RabbitMQ/Volo/Abp/RabbitMQ/ConnectionPool.cs#L75
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Projects/Pdf/ProjectPdfGenerator.cs#L97``

**visitor summary:** The single best-effort-cleanup exemption (`try { x.Dispose(); } catch {}`) only matched a bare `invocation_expression`, so an awaited cleanup `await x.DisposeAsync()` — parsed as an `await_expression` wrapping the call — slipped through, and the `…Async` names weren't in the best-effort set. The fix unwraps a leading `await_expression` and strips a trailing `Async` before checking the best-effort method names. Multi-statement try bodies and non-cleanup calls are still flagged.

Positive fixture:
```diff
+public sealed class EmptyCatchAsyncDisposeSafe
+{
+    public async Task ReleaseAsync(Stream stream)
+    {
+        try
+        {
+            await stream.DisposeAsync();
+        }
+        // SAFE: bugs/deterministic/empty-catch
+        catch (IOException)
+        {
+        }
+    }
+}
```

Negative fixture:
```diff
+internal sealed class SwallowedFlushErrors
+{
+    internal void Flush()
+    {
+        try
+        {
+            Write();
+            Advance();
+        }
+        // Not a single best-effort cleanup call — this genuinely swallows the error.
+        // VIOLATION: bugs/deterministic/empty-catch
+        catch (IOException)
+        {
+        }
+    }
+}
```

## bugs/deterministic/redundant-base-call

OSS sources:

- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpEntityQueryProvider.cs#L37``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpEntityQueryProvider.cs#L45``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs#L782``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs#L856``

**visitor summary:** For a generic base call `base.Execute<TResult>(…)`, the member-access `name` is a `generic_name` whose text carries the type arguments (`Execute<TResult>`); the declaring method's `name` field is the bare identifier (`Execute`). The mismatch meant the enclosing type was judged to declare no such member, so the rule fired on a required override call (dropping `base.` there would recurse infinitely). The fix extracts the bare identifier from a `generic_name` before the "does the type declare this member?" lookup. Non-generic redundant base calls to members the type does not declare are still flagged.

Positive fixture:
```diff
+public sealed class RedundantBaseCallGenericOverrideSafe : ConverterBase
+{
+    public override TValue Normalize<TValue>(TValue seed)
+    {
+        // SAFE: bugs/deterministic/redundant-base-call
+        var first = base.Normalize<TValue>(seed);
+        return base.Normalize<TValue>(first);
+    }
+}
```

Negative fixture:
```diff
+internal sealed class RedundantBaseGreeter : GreeterBase
+{
+    internal string Announce()
+    {
+        // RedundantBaseGreeter declares no `Greet` member of its own.
+        // VIOLATION: bugs/deterministic/redundant-base-call
+        return base.Greet();
+    }
+}
```

## reliability/deterministic/unsafe-json-parse

OSS sources:

- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.BackgroundJobs.Quartz/Volo/Abp/BackgroundJobs/Quartz/QuartzJobExecutionAdapter.cs#L41``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Caching/Volo/Abp/Caching/Utf8JsonDistributedCacheSerializer.cs#L23``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.BackgroundJobs.Abstractions/Volo/Abp/BackgroundJobs/DefaultDynamicBackgroundJobManager.cs#L89``

**visitor summary:** The rule matched purely on the receiver's simple name, so an instance member named after a BCL type — abp's injected `protected IJsonSerializer JsonSerializer { get; }`, called as `JsonSerializer.Deserialize(...)` — was mistaken for `System.Text.Json.JsonSerializer`. The fix skips a bare (or `this.`-qualified) receiver when an enclosing type declares a field/property of that name, since that member shadows the type; namespace-qualified BCL calls (`System.Text.Json.JsonSerializer.Deserialize`) and receivers with no shadowing member still fire.

Positive fixture:
```diff
+internal sealed class UnsafeJsonParseMemberShadowSafe
+{
+    private IValueSerializer JsonSerializer { get; }
+    // SAFE: reliability/deterministic/unsafe-json-parse
+    internal object Read(string content)
+    {
+        return JsonSerializer.Deserialize(content);
+    }
+}
```

Negative fixture:
```diff
+using System.Text.Json;
+
+internal sealed class RawConfigLoader
+{
+    internal RawConfig Load(string raw)
+    {
+        // Genuine System.Text.Json.JsonSerializer static call with no try/catch.
+        // VIOLATION: reliability/deterministic/unsafe-json-parse
+        return JsonSerializer.Deserialize<RawConfig>(raw);
+    }
+}
```

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

Measured with `node dist/cli.mjs analyze --no-llm` from a fresh `pnpm build:dist` (the exact artifact publish.yml ships), before vs. after this batch's visitor fixes, on the same target ref.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/generic-parameter-not-inferable` | 327 | 326 | -1 |
| `bugs/deterministic/empty-catch` | 82 | 79 | -3 |
| `bugs/deterministic/redundant-base-call` | 21 | 17 | -4 |
| `reliability/deterministic/unsafe-json-parse` | 92 | 76 | -16 |
| **Total (these 4 rules)** | **522** | **498** | **-24** |
| **All-rules total on target** | **83173** | **83149** | **-24** |

The all-rules delta equals the four-rule subtotal, confirming the fixes removed only the intended false positives with no collateral change elsewhere.

cc @mushgev