### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/missing-await.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/missing-await.ts
@@ -33,6 +33,14 @@ export const missingAwaitVisitor: CodeRuleVisitor = {
 
     if (!isInsideAsyncFunction(node)) return null
 
+    // Variables explicitly named `...Promise` follow the convention that they
+    // intentionally hold an un-awaited promise — e.g. the Remix / React Router
+    // `defer` pattern, where a still-pending promise is handed to a deferred
+    // response and resolved later during render. Adding `await` would defeat
+    // that streaming pattern, so this naming signals deliberate deferral.
+    const declaredName = node.childForFieldName('name')
+    if (declaredName?.type === 'identifier' && /Promise$/.test(declaredName.text)) return null
+
     // Check if the call expression returns a Promise using the type system
     const isPromise = typeQuery.isPromiseLike(
       filePath,

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/star-import.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/star-import.ts
@@ -39,6 +39,16 @@ export const jsStarImportVisitor: CodeRuleVisitor = {
         || sourceText.startsWith('fumadocs-core/')) {
         return null
       }
+      // Libraries conventionally consumed under a namespace alias:
+      //   - `semver` exposes many top-level version helpers and is idiomatically
+      //     imported as `import * as semver from 'semver'` → `semver.satisfies(...)`.
+      //   - the Sentry SDK (`@sentry/*`) documents `import * as Sentry` →
+      //     `Sentry.captureException(...)` as its standard usage.
+      // These read more cleanly as a namespace even when referenced only once
+      // or twice, so they don't benefit from the ≥5-reference heuristic below.
+      if (sourceText === 'semver' || sourceText.startsWith('@sentry/')) {
+        return null
+      }
       // Relative imports (./foo, ../bar) — namespace imports for local modules are a valid pattern
       if (sourceText.startsWith('./') || sourceText.startsWith('../')) return null
 

--- a/packages/analyzer/src/rules/security/visitors/javascript/insecure-random.ts
+++ b/packages/analyzer/src/rules/security/visitors/javascript/insecure-random.ts
@@ -1,8 +1,118 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
 /** Security-related variable name keywords that indicate cryptographic use */
 const SECURITY_KEYWORDS = ['token', 'secret', 'key', 'nonce', 'salt', 'csrf', 'password', 'session', 'hash', 'iv']
+
+function isSecuritySensitiveName(name: string): boolean {
+  const lower = name.toLowerCase()
+  return SECURITY_KEYWORDS.some((kw) => lower.includes(kw))
+}
+
+/**
+ * Walk up from the Math.random() call to the name the random value flows
+ * into — the variable it is declared as, the target of an assignment, or
+ * the object-property key it is set under. Returns that leaf name, or null
+ * if the value is not bound to a name before a structural boundary
+ * (function body, loop, conditional) is reached.
+ *
+ * This deliberately inspects only *binding targets*, never the full text of
+ * ancestor nodes. Scanning ancestor text produced false positives whenever
+ * an unrelated binding in scope happened to contain a keyword substring —
+ * e.g. a `for (const { key } of entries)` loop over map-entry keys, where
+ * `key` is a data field, not a cryptographic key.
+ */
+function securityContextName(callNode: SyntaxNode): string | null {
+  let parent = callNode.parent
+  while (parent) {
+    switch (parent.type) {
+      case 'variable_declarator':
+        return leafName(parent.childForFieldName('name'))
+      case 'assignment_expression':
+      case 'augmented_assignment_expression':
+        return leafName(parent.childForFieldName('left'))
+      case 'pair':
+        return leafName(parent.childForFieldName('key'))
+      case 'public_field_definition':
+      case 'field_definition':
+        return leafName(parent.childForFieldName('property') ?? parent.childForFieldName('name'))
+      // The value is returned from the enclosing function (e.g.
+      // `function generateToken() { return Math.random()... }`) — the
+      // function name is the security context.
+      case 'return_statement':
+        return enclosingFunctionName(parent)
+      // Expression-bodied arrow returns the value directly, e.g.
+      // `const genToken = () => Math.random()...`.
+      case 'arrow_function':
+        return functionName(parent)
+      // Structural boundaries: the random value is discarded or otherwise
+      // not bound to a name.
+      case 'expression_statement':
+      case 'statement_block':
+      case 'if_statement':
+      case 'for_statement':
+      case 'for_in_statement':
+      case 'while_statement':
+      case 'do_statement':
+      case 'switch_statement':
+      case 'function_declaration':
+      case 'function_expression':
+      case 'method_definition':
+        return null
+    }
+    parent = parent.parent
+  }
+  return null
+}
+
+/** The name of the function enclosing `node`, resolving anonymous functions to their binding. */
+function enclosingFunctionName(node: SyntaxNode): string | null {
+  let p = node.parent
+  while (p) {
+    if (
+      p.type === 'function_declaration' ||
+      p.type === 'generator_function_declaration' ||
+      p.type === 'method_definition' ||
+      p.type === 'arrow_function' ||
+      p.type === 'function_expression'
+    ) {
+      return functionName(p)
+    }
+    p = p.parent
+  }
+  return null
+}
+
+/** The declared name of a function, or the binding an anonymous function is assigned to. */
+function functionName(fn: SyntaxNode): string | null {
+  const nameField = fn.childForFieldName('name')
+  if (nameField) return leafName(nameField)
+  const p = fn.parent
+  if (!p) return null
+  if (p.type === 'variable_declarator') return leafName(p.childForFieldName('name'))
+  if (p.type === 'pair') return leafName(p.childForFieldName('key'))
+  if (p.type === 'assignment_expression') return leafName(p.childForFieldName('left'))
+  if (p.type === 'public_field_definition' || p.type === 'field_definition') {
+    return leafName(p.childForFieldName('property') ?? p.childForFieldName('name'))
+  }
+  return null
+}
+
+/** Reduce a target node to the identifier that names it (final property for member access). */
+function leafName(node: SyntaxNode | null): string | null {
+  if (!node) return null
+  if (node.type === 'identifier' || node.type === 'property_identifier' || node.type === 'shorthand_property_identifier') {
+    return node.text
+  }
+  if (node.type === 'member_expression') {
+    return node.childForFieldName('property')?.text ?? null
+  }
+  if (node.type === 'string') {
+    return node.text.slice(1, -1)
+  }
+  return node.text
+}
 
 /**
  * Seed scripts and test files generate fixture/dev data — the "tokens"
@@ -41,30 +151,22 @@ export const insecureRandomVisitor: CodeRuleVisitor = {
           if (/\.length\b/.test(parentText)) return null
         }
 
-        // Check if it's in a security-sensitive context by looking at ancestors
-        let parent = node.parent
-        while (parent) {
-          const parentText = parent.text.toLowerCase()
-          // Only flag when the context involves security-sensitive variable names
-          if (SECURITY_KEYWORDS.some((kw) => parentText.includes(kw))) {
-            // Double-check: skip if this is just array index selection even within
-            // a broader security context (e.g., picking from an array of allowed chars)
-            const immediateParent = node.parent
-            if (immediateParent?.type === 'binary_expression' && /\.length\b/.test(immediateParent.text)) {
-              return null
-            }
-
-            return makeViolation(
-              this.ruleKey, node, filePath, 'high',
-              'Insecure random number generator',
-              'Math.random() is not cryptographically secure. Do not use it for tokens, keys, or secrets.',
-              sourceCode,
-              'Use crypto.randomBytes() or crypto.randomUUID() instead.',
-            )
-          }
-          if (parent.type === 'expression_statement' || parent.type === 'variable_declaration' ||
-              parent.type === 'assignment_expression' || parent.type === 'lexical_declaration') break
-          parent = parent.parent
+        // Only flag when the random value is bound to a security-sensitive
+        // name — the variable it is declared as, the target of an assignment,
+        // or the object-property key it is stored under. Checking the binding
+        // *target* (rather than scanning the full text of every ancestor)
+        // avoids false positives from unrelated bindings in scope that merely
+        // contain a keyword substring, such as a `for (const { key } of ...)`
+        // loop over map-entry keys where `key` is a data field, not a secret.
+        const contextName = securityContextName(node)
+        if (contextName && isSecuritySensitiveName(contextName)) {
+          return makeViolation(
+            this.ruleKey, node, filePath, 'high',
+            'Insecure random number generator',
+            'Math.random() is not cryptographically secure. Do not use it for tokens, keys, or secrets.',
+            sourceCode,
+            'Use crypto.randomBytes() or crypto.randomUUID() instead.',
+          )
         }
       }
     }

--- a/packages/analyzer/src/rules/security/visitors/javascript/process-signaling.ts
+++ b/packages/analyzer/src/rules/security/visitors/javascript/process-signaling.ts
@@ -1,5 +1,21 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+
+/**
+ * True when the PID expression reads `.process.pid` off some object — the
+ * idiomatic Node way to reference a forked worker or spawned child process
+ * (`worker.process.pid`, `cluster.workers[id].process.pid`). The parent
+ * process owns these PIDs, so signalling them is not arbitrary-process
+ * manipulation. A user-controlled PID (`req.query.pid`, `params.pid`) has a
+ * different parent (`query`, `params`) and is not skipped.
+ */
+function isOwnedProcessPid(node: SyntaxNode): boolean {
+  if (node.type !== 'member_expression') return false
+  if (node.childForFieldName('property')?.text !== 'pid') return false
+  const obj = node.childForFieldName('object')
+  return obj?.type === 'member_expression' && obj.childForFieldName('property')?.text === 'process'
+}
 
 export const processSignalingVisitor: CodeRuleVisitor = {
   ruleKey: 'security/deterministic/process-signaling',
@@ -21,6 +37,14 @@ export const processSignalingVisitor: CodeRuleVisitor = {
 
     const pidArg = args.namedChildren[0]
     if (!pidArg) return null
+
+    // Skip PIDs read from a process/worker/child the program itself spawned:
+    // `worker.process.pid`, `cluster.workers[id].process.pid`, etc. A
+    // `.process.pid` access is the id of an owned child process — never
+    // attacker-controlled — so forwarding a signal to it is safe. This is
+    // distinct from a user-supplied PID like `req.query.pid`, whose parent
+    // is not `process`.
+    if (isOwnedProcessPid(pidArg)) return null
 
     // Flag when the PID argument is not a literal — it may be user-controlled
     if (pidArg.type !== 'number') {

--- a/packages/analyzer/src/rules/security/visitors/javascript/timing-attack-comparison.ts
+++ b/packages/analyzer/src/rules/security/visitors/javascript/timing-attack-comparison.ts
@@ -105,7 +105,18 @@ export const timingAttackComparisonVisitor: CodeRuleVisitor = {
     const leftLeaf = leafIdentifier(left)
     const rightLeaf = leafIdentifier(right)
 
-    if (SENSITIVE_COMPARISON_PATTERNS.test(leftLeaf) || SENSITIVE_COMPARISON_PATTERNS.test(rightLeaf)) {
+    // A string/template literal is a public, known value — e.g. a
+    // discriminated-union tag like `config.type === 'tokenBucket'`, where
+    // 'tokenBucket' merely contains the substring "token". A timing attack
+    // requires the compared value to be secret to the attacker, which a
+    // literal never is, so the sensitive-name check must ignore literal
+    // sides and only consider identifier-derived leaves.
+    const leftIsLiteral = left.type === 'string' || left.type === 'template_string'
+    const rightIsLiteral = right.type === 'string' || right.type === 'template_string'
+    const leftMatches = !leftIsLiteral && SENSITIVE_COMPARISON_PATTERNS.test(leftLeaf)
+    const rightMatches = !rightIsLiteral && SENSITIVE_COMPARISON_PATTERNS.test(rightLeaf)
+
+    if (leftMatches || rightMatches) {
       // Skip if the file already uses timingSafeEqual — the === is likely a format check, not a secret comparison
       if (sourceCode.includes('timingSafeEqual')) return null
       return makeViolation(

--- a/tests/fixtures/sample-js-project-negative/insecure-random-session-token.ts
+++ b/tests/fixtures/sample-js-project-negative/insecure-random-session-token.ts
@@ -1,0 +1,14 @@
+/**
+ * Negative fixture for security/deterministic/insecure-random.
+ *
+ * Math.random() is used to mint a session token — a security-sensitive value
+ * that must be unpredictable. Math.random() is not cryptographically secure,
+ * so an attacker who can observe or predict its output can forge session
+ * tokens. This is the real bug the rule must catch.
+ */
+
+export function createSessionToken(): string {
+  // VIOLATION: security/deterministic/insecure-random
+  const sessionToken = Math.random().toString(36).slice(2)
+  return sessionToken
+}

--- a/tests/fixtures/sample-js-project-negative/missing-await-forgotten-fetch.ts
+++ b/tests/fixtures/sample-js-project-negative/missing-await-forgotten-fetch.ts
@@ -1,0 +1,23 @@
+/**
+ * Negative fixture for bugs/deterministic/missing-await.
+ *
+ * The async call result is stored and then used as if it were the resolved
+ * value (`user.name`), but the `await` was forgotten — `user` holds a pending
+ * Promise, so `user.name` is `undefined`. This is the real bug the rule
+ * catches. The variable is NOT named with a `...Promise` suffix, so nothing
+ * signals that holding a promise here is intentional.
+ */
+
+interface UserRecord {
+  name: string
+}
+
+function fetchUser(userId: string): Promise<UserRecord> {
+  return Promise.resolve({ name: userId })
+}
+
+export async function loadUserName(userId: string): Promise<string> {
+  // VIOLATION: bugs/deterministic/missing-await
+  const user = fetchUser(userId)
+  return user.name
+}

--- a/tests/fixtures/sample-js-project-negative/process-signaling-user-pid.ts
+++ b/tests/fixtures/sample-js-project-negative/process-signaling-user-pid.ts
@@ -1,0 +1,13 @@
+/**
+ * Negative fixture for security/deterministic/process-signaling.
+ *
+ * The PID comes straight from an inbound request, so an attacker can name any
+ * process on the host and have it signalled. Sending SIGKILL to an
+ * attacker-chosen PID is the real process-manipulation bug this rule catches.
+ */
+
+export function terminateReportedProcess(request: { pid: string }): void {
+  const targetPid = Number.parseInt(request.pid, 10)
+  // VIOLATION: security/deterministic/process-signaling
+  process.kill(targetPid, 'SIGKILL')
+}

--- a/tests/fixtures/sample-js-project-negative/star-import-namespace-util.ts
+++ b/tests/fixtures/sample-js-project-negative/star-import-namespace-util.ts
@@ -1,0 +1,15 @@
+/**
+ * Negative fixture for code-quality/deterministic/star-import.
+ *
+ * A whole utility module is pulled in as a namespace when only a single
+ * helper is used. This is not a namespace-oriented library — named imports
+ * would be clearer and let the bundler tree-shake the rest away. This is the
+ * real smell the rule flags.
+ */
+
+// VIOLATION: code-quality/deterministic/star-import
+import * as stringKit from 'string-kit-toolkit';
+
+export function shout(text: string): string {
+  return stringKit.toUpperCase(text);
+}

--- a/tests/fixtures/sample-js-project-negative/timing-attack-comparison-secret-eq.ts
+++ b/tests/fixtures/sample-js-project-negative/timing-attack-comparison-secret-eq.ts
@@ -1,0 +1,13 @@
+/**
+ * Negative fixture for security/deterministic/timing-attack-comparison.
+ *
+ * Comparing a supplied token against the stored one with `===` short-circuits
+ * on the first differing byte, so response time leaks how long a prefix
+ * matched — an attacker can recover the secret byte by byte. This is the real
+ * bug the rule catches; secrets must be compared in constant time.
+ */
+
+export function tokenMatches(providedToken: string, storedToken: string): boolean {
+  // VIOLATION: security/deterministic/timing-attack-comparison
+  return providedToken === storedToken;
+}

--- a/tests/fixtures/sample-js-project-positive/externals.d.ts
+++ b/tests/fixtures/sample-js-project-positive/externals.d.ts
@@ -119,6 +119,17 @@ declare module 'sample-crypto-shim' {
   export function hashLegacy(input: string, rounds: number): string;
 }
 
+declare module 'semver' {
+  export function satisfies(version: string, range: string): boolean;
+  export function gt(a: string, b: string): boolean;
+  export function valid(version: string): string | null;
+}
+
+declare module '@sentry/node' {
+  export function captureException(error: unknown): string;
+  export function init(options: Record<string, unknown>): void;
+}
+
 declare module 'zod' {
   type ZodTypeAny = unknown;
   interface ZodString { uuid(): ZodString; min(n: number): ZodString }

--- a/tests/fixtures/sample-js-project-positive/insecure-random-sampling-loop.ts
+++ b/tests/fixtures/sample-js-project-positive/insecure-random-sampling-loop.ts
@@ -1,0 +1,36 @@
+/**
+ * Positive fixture for security/deterministic/insecure-random.
+ *
+ * Math.random() drives probabilistic sampling here: for each metadata entry
+ * it decides, via a coin flip weighted by the entry's sample rate, whether to
+ * include that entry in the output. The random value never becomes a token,
+ * key, or secret — it only gates whether an optional entry is emitted.
+ *
+ * The enclosing `for (const { key, value, sampleRate } of ... )` loop binds a
+ * data field literally named `key`, but that is a map-entry name, not a
+ * cryptographic key. Flagging the Math.random() call because an ancestor's
+ * text happens to contain the word "key" is a false positive.
+ */
+
+interface MetadataEntry {
+  key: string
+  value: string
+  sampleRate: number
+}
+
+export function collectSampledEntries(entries: readonly MetadataEntry[]): Record<string, string> {
+  const selected: Record<string, string> = {}
+
+  for (const { key, value, sampleRate } of entries) {
+    if (sampleRate === 1) {
+      selected[key] = value
+      continue
+    }
+
+    if (Math.random() <= sampleRate) {
+      selected[key] = value
+    }
+  }
+
+  return selected
+}

--- a/tests/fixtures/sample-js-project-positive/missing-await-deferred-promise.ts
+++ b/tests/fixtures/sample-js-project-positive/missing-await-deferred-promise.ts
@@ -1,0 +1,36 @@
+/**
+ * Positive fixture for bugs/deterministic/missing-await.
+ *
+ * A loader that streams data to the client: the promise is deliberately NOT
+ * awaited in the loader, it is handed off (still pending) inside a deferred
+ * response and resolved later during render. The `...Promise` variable-name
+ * suffix is the explicit convention signalling "this intentionally holds a
+ * promise". Requiring an `await` here would defeat the streaming pattern, so
+ * flagging it is a false positive.
+ */
+
+interface DeferredDashboard {
+  environmentId: string
+  summaryPromise: Promise<string>
+}
+
+interface Environment {
+  id: string
+}
+
+function resolveEnvironment(orgId: string): Promise<Environment> {
+  return Promise.resolve({ id: orgId })
+}
+
+function fetchSummary(environmentId: string): Promise<string> {
+  return Promise.resolve(environmentId)
+}
+
+export async function loadDashboard(orgId: string): Promise<DeferredDashboard> {
+  const environment = await resolveEnvironment(orgId)
+  const summaryPromise = fetchSummary(environment.id)
+  return {
+    environmentId: environment.id,
+    summaryPromise,
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/process-signaling-worker-pid.ts
+++ b/tests/fixtures/sample-js-project-positive/process-signaling-worker-pid.ts
@@ -1,0 +1,21 @@
+/**
+ * Positive fixture for security/deterministic/process-signaling.
+ *
+ * The PID passed to process.kill() is `worker.process.pid` — the process id
+ * of a worker this program itself forked. A spawned child/worker's
+ * `.process.pid` is owned by the parent, never attacker-controlled, so
+ * forwarding a signal to it is safe. Flagging it as "sending signals to
+ * arbitrary processes" is a false positive.
+ */
+
+interface WorkerHandle {
+  process: { pid: number | undefined }
+}
+
+export function forwardSignalToWorkers(workers: readonly WorkerHandle[], signal: string): void {
+  for (const worker of workers) {
+    if (worker.process.pid) {
+      process.kill(worker.process.pid, signal)
+    }
+  }
+}

--- a/tests/fixtures/sample-js-project-positive/src/star-import-semver-sentry.ts
+++ b/tests/fixtures/sample-js-project-positive/src/star-import-semver-sentry.ts
@@ -1,0 +1,21 @@
+/**
+ * Positive fixture for code-quality/deterministic/star-import.
+ *
+ * `semver` and the error-reporting SDK are designed to be consumed under a
+ * namespace alias (`semver.satisfies(...)`, `Sentry.captureException(...)`).
+ * A namespace import is the idiomatic, documented usage for these packages —
+ * the same carve-out the rule already makes for `zod` and `react` — so even
+ * when the alias is referenced only once or twice, flagging `import * as`
+ * here is a false positive.
+ */
+
+import * as semver from 'semver';
+import * as Sentry from '@sentry/node';
+
+export function isCompatibleVersion(version: string): boolean {
+  return semver.satisfies(version, '>=1.0.0');
+}
+
+export function reportError(error: unknown): void {
+  Sentry.captureException(error);
+}

--- a/tests/fixtures/sample-js-project-positive/timing-attack-comparison-discriminated-union.ts
+++ b/tests/fixtures/sample-js-project-positive/timing-attack-comparison-discriminated-union.ts
@@ -1,0 +1,26 @@
+/**
+ * Positive fixture for security/deterministic/timing-attack-comparison.
+ *
+ * `config.type === 'tokenBucket'` is a discriminated-union tag check: it
+ * narrows a config object by its public `type` discriminator. The string
+ * literal `'tokenBucket'` merely *contains* the substring "token"; it is not
+ * a secret. A timing attack requires the compared value to be secret to the
+ * attacker, and a public union tag never is — so flagging this `===` is a
+ * false positive.
+ */
+
+interface TokenBucketConfig {
+  type: 'tokenBucket';
+  refillRate: number;
+}
+
+interface FixedWindowConfig {
+  type: 'fixedWindow';
+  limit: number;
+}
+
+type RateLimitConfig = TokenBucketConfig | FixedWindowConfig;
+
+export function selectRefillRate(config: RateLimitConfig): number {
+  return config.type === 'tokenBucket' ? config.refillRate : 0;
+}


### PR DESCRIPTION
Paraphrased five false positives found on `triggerdotdev/trigger.dev` into the analyzer's positive/negative fixtures and fixed each visitor. Every fix keeps the rule's true-positive detection intact (verified by a paraphrased negative fixture that still fires) and removes the false positive (verified by a positive fixture that now reports zero violations).

Closes #424
Closes #425
Closes #426
Closes #427
Closes #428

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `security/deterministic/insecure-random` | #424 | `tests/fixtures/sample-js-project-positive/insecure-random-sampling-loop.ts` | `tests/fixtures/sample-js-project-negative/insecure-random-session-token.ts` |
| `security/deterministic/process-signaling` | #425 | `tests/fixtures/sample-js-project-positive/process-signaling-worker-pid.ts` | `tests/fixtures/sample-js-project-negative/process-signaling-user-pid.ts` |
| `bugs/deterministic/missing-await` | #426 | `tests/fixtures/sample-js-project-positive/missing-await-deferred-promise.ts` | `tests/fixtures/sample-js-project-negative/missing-await-forgotten-fetch.ts` |
| `code-quality/deterministic/star-import` | #427 | `tests/fixtures/sample-js-project-positive/src/star-import-semver-sentry.ts` | `tests/fixtures/sample-js-project-negative/star-import-namespace-util.ts` |
| `security/deterministic/timing-attack-comparison` | #428 | `tests/fixtures/sample-js-project-positive/timing-attack-comparison-discriminated-union.ts` | `tests/fixtures/sample-js-project-negative/timing-attack-comparison-secret-eq.ts` |

## security/deterministic/insecure-random

OSS source (FP): https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/kubernetes-provider/src/labelHelper.ts#L145 — `Math.random()` used purely for probabilistic label sampling, not for security tokens/keys.

**Positive fixture**
```diff
+interface MetadataEntry {
+  key: string
+  value: string
+  sampleRate: number
+}
+
+export function collectSampledEntries(entries: readonly MetadataEntry[]): Record<string, string> {
+  const selected: Record<string, string> = {}
+
+  for (const { key, value, sampleRate } of entries) {
+    if (sampleRate === 1) {
+      selected[key] = value
+      continue
+    }
+
+    if (Math.random() <= sampleRate) {
+      selected[key] = value
+    }
+  }
+
+  return selected
+}
```

**Negative fixture**
```diff
+export function createSessionToken(): string {
+  // VIOLATION: security/deterministic/insecure-random
+  const sessionToken = Math.random().toString(36).slice(2)
+  return sessionToken
+}
```

**Visitor fix:** Replaced the visitor's broad ancestor-text keyword scan with precise binding-target detection. It now resolves the name the `Math.random()` value actually flows into — the variable/assignment/property it is bound to, or the enclosing function's name when the value is returned — and only flags when that specific name contains a security keyword (`token`, `secret`, `key`, …). This removes false positives from unrelated in-scope bindings that merely contain a keyword substring, e.g. a `for (const { key } of entries)` loop over map-entry keys, while still catching token/secret generation.

## security/deterministic/process-signaling

OSS source (FP): https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/server.ts#L43 — PID comes from `cluster.workers` — the parent process's own forked workers, fully trusted, not user-controlled.

**Positive fixture**
```diff
+interface WorkerHandle {
+  process: { pid: number | undefined }
+}
+
+export function forwardSignalToWorkers(workers: readonly WorkerHandle[], signal: string): void {
+  for (const worker of workers) {
+    if (worker.process.pid) {
+      process.kill(worker.process.pid, signal)
+    }
+  }
+}
```

**Negative fixture**
```diff
+export function terminateReportedProcess(request: { pid: string }): void {
+  const targetPid = Number.parseInt(request.pid, 10)
+  // VIOLATION: security/deterministic/process-signaling
+  process.kill(targetPid, 'SIGKILL')
+}
```

**Visitor fix:** Added a skip for PIDs read as `X.process.pid` — the process id of a worker/child the program itself spawned (cluster workers, forked children). These PIDs are owned by the parent process and are never attacker-controlled, so signalling them is safe. A user-supplied PID (`req.query.pid`, `params.pid`) has a different parent (`query`/`params`, not `process`) and continues to be flagged.

## bugs/deterministic/missing-await

OSS sources (FP) — Remix `defer` streaming pattern:
- ``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/_app.orgs.%24organizationSlug.projects.%24projectParam.env.%24envParam.errors.%24fingerprint/route.tsx#L252``
- ``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/_app.orgs.%24organizationSlug.projects.%24projectParam.env.%24envParam.errors.%24fingerprint/route.tsx#L273``
- ``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/_app.orgs.%24organizationSlug.projects.%24projectParam.env.%24envParam.errors._index/route.tsx#L133``
- ``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/_app.orgs.%24organizationSlug.projects.%24projectParam.env.%24envParam.errors._index/route.tsx#L156``
- ``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/_app.orgs.%24organizationSlug.projects.%24projectParam.env.%24envParam.logs/route.tsx#L143``

**Positive fixture**
```diff
+interface DeferredDashboard {
+  environmentId: string
+  summaryPromise: Promise<string>
+}
+
+interface Environment {
+  id: string
+}
+
+function resolveEnvironment(orgId: string): Promise<Environment> {
+  return Promise.resolve({ id: orgId })
+}
+
+function fetchSummary(environmentId: string): Promise<string> {
+  return Promise.resolve(environmentId)
+}
+
+export async function loadDashboard(orgId: string): Promise<DeferredDashboard> {
+  const environment = await resolveEnvironment(orgId)
+  const summaryPromise = fetchSummary(environment.id)
+  return {
+    environmentId: environment.id,
+    summaryPromise,
+  }
+}
```

**Negative fixture**
```diff
+interface UserRecord {
+  name: string
+}
+
+function fetchUser(userId: string): Promise<UserRecord> {
+  return Promise.resolve({ name: userId })
+}
+
+export async function loadUserName(userId: string): Promise<string> {
+  // VIOLATION: bugs/deterministic/missing-await
+  const user = fetchUser(userId)
+  return user.name
+}
```

**Visitor fix:** Skip `missing-await` when the assigned variable name ends with `Promise`. A `...Promise` suffix is the explicit convention (used by the Remix / React Router `defer` streaming pattern) that the code intentionally holds an un-awaited promise to resolve later; adding `await` would defeat the pattern. Un-suffixed variables that forget `await` are still flagged.

## code-quality/deterministic/star-import

OSS sources (FP):
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/entry.server.tsx#L3 — Sentry namespace import convention
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/sentry.server.ts#L1 — Sentry namespace import convention
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/failedTaskRun.server.ts#L10 — `semver` is standardly imported as a namespace

**Positive fixture**
```diff
+import * as semver from 'semver';
+import * as Sentry from '@sentry/node';
+
+export function isCompatibleVersion(version: string): boolean {
+  return semver.satisfies(version, '>=1.0.0');
+}
+
+export function reportError(error: unknown): void {
+  Sentry.captureException(error);
+}
```
(Plus module declarations for `semver` and `@sentry/node` added to the fixture project's `externals.d.ts`.)

**Negative fixture**
```diff
+// VIOLATION: code-quality/deterministic/star-import
+import * as stringKit from 'string-kit-toolkit';
+
+export function shout(text: string): string {
+  return stringKit.toUpperCase(text);
+}
```

**Visitor fix:** Added `semver` and the Sentry SDK (`@sentry/*`) to the star-import idiomatic-namespace allowlist. Both libraries document namespace-alias consumption (`semver.satisfies(...)`, `Sentry.captureException(...)`) as their standard usage, so a namespace import is correct even when the alias is referenced only once or twice and wouldn't clear the existing ≥5-reference heuristic. Note: the issue also sampled two generated ANTLR files (`antlr4ts/misc/Utils` inside `// Generated from … by ANTLR` files). Those FPs stem from generated code and would need file-discovery-level handling to suppress, so they are out of scope for this rule-visitor fix; the star-import count therefore drops by the idiomatic-library occurrences rather than to zero.

## security/deterministic/timing-attack-comparison

OSS source (FP): ``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/admin/backOffice/RateLimitSection.tsx#L61`` — Comparing a config discriminator string (`'tokenBucket'`); `token` is a substring in the name but this is not a secret comparison.

**Positive fixture**
```diff
+interface TokenBucketConfig {
+  type: 'tokenBucket';
+  refillRate: number;
+}
+
+interface FixedWindowConfig {
+  type: 'fixedWindow';
+  limit: number;
+}
+
+type RateLimitConfig = TokenBucketConfig | FixedWindowConfig;
+
+export function selectRefillRate(config: RateLimitConfig): number {
+  return config.type === 'tokenBucket' ? config.refillRate : 0;
+}
```

**Negative fixture**
```diff
+export function tokenMatches(providedToken: string, storedToken: string): boolean {
+  // VIOLATION: security/deterministic/timing-attack-comparison
+  return providedToken === storedToken;
+}
```

**Visitor fix:** The sensitive-name check now ignores string/template-literal sides of a `===`/`!==` comparison. A string literal is a public, known value (e.g. a discriminated-union tag like `config.type === 'tokenBucket'`), and a timing attack requires the compared value to be secret to the attacker, so a literal never signals a secret comparison. Comparisons where a variable/property name (`userToken`, `apiKey`) signals a secret are still flagged.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a fresh `pnpm build:dist` (the exact artifact `publish.yml` ships), before vs after this batch's visitor fixes.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `security/deterministic/insecure-random` | 32 | 3 | -29 |
| `security/deterministic/process-signaling` | 7 | 6 | -1 |
| `bugs/deterministic/missing-await` | 9 | 3 | -6 |
| `code-quality/deterministic/star-import` | 32 | 26 | -6 |
| `security/deterministic/timing-attack-comparison` | 36 | 15 | -21 |
| **Total (these 5 rules)** | 116 | 53 | -63 |
| **All-rules total on target** | 34623 | 34560 | -63 |

The all-rules delta equals the five-rule subtotal, confirming these changes touched only the intended rules. The full analyzer test suite (`js-positive` / `js-negative` / per-rule unit tests) is green; the only remaining suite failures are pre-existing and environmental (the `@truecourse/ee-db` package not building in CI and the C# Roslyn host being unavailable), unrelated to these JS analyzer changes.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9LkfWPuZFGGyarFxQ9rGR)_