### PR TITLE
fix(fp): provision + document the .NET toolchain for the C# (cs-) scope

### DIFF
--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -525,7 +525,28 @@ One-time, before the first run:
      it, and it opens `.slnx` solutions + modern targets at analyze time.
      The default (TS/JS/Python) account needs **no** .NET: the host build
      is tolerant — `build:dist` warns and skips it when `dotnet` is absent,
-     and C# analysis simply stays unavailable.
+     and C# analysis simply stays unavailable (fail-hard on the next analyze).
+
+     Provisioning the C# account has **two** required parts. The .NET SDK is
+     **not** on the Default environment (that image ships no `dotnet`, and
+     Default's Trusted allowlist covers npm/GitHub but **not** the Microsoft
+     .NET CDN — so a mid-session install returns 403 from the egress proxy):
+     1. **Setup script.** Give the C# account its **own** environment whose
+        setup script runs `docs/fp-automation/setup-csharp-env.sh` — it
+        installs the 10.x SDK plus a net8 runtime for the host, once per
+        container, and is idempotent. (The routine prompts also run it as a
+        fallback when `dotnet` is missing.)
+     2. **Network policy.** Widen that environment's egress allowlist to the
+        .NET download + NuGet hosts — at least `dot.net`,
+        `builds.dotnet.microsoft.com`, `dotnetcli.azureedge.net`,
+        `dotnetbuilds.azureedge.net`, and `api.nuget.org` / `*.nuget.org`
+        (the last for the `dotnet restore` the workspace-tier rule triggers
+        on the target solution). Without this, both the install **and** the
+        restore 403 — this is the most common C#-account failure.
+
+     If `dotnet` is still absent at session time the environment is
+     mis-provisioned: the routine posts the blocker and stops — it must
+     **not** route around the egress policy.
 4. **Bootstrap the first campaign** by clicking **Run now** on
    `fp-discover` (no campaign-close PR has merged yet, so the GitHub
    trigger has nothing to fire on). It reads `campaigns.yaml`, finds

--- a/docs/fp-automation/prompts/fp-discover.md
+++ b/docs/fp-automation/prompts/fp-discover.md
@@ -78,9 +78,15 @@ byte-identical to an unscoped run.
 - `git clone --depth=1 https://github.com/<target_repo>.git /tmp/target`.
 - Record the commit SHA as `target_ref` (full hash). Get it with
   `git -C /tmp/target rev-parse HEAD`.
-- **C# campaigns only** (`tech_stack: csharp`): `dotnet restore` the target's
+- **C# campaigns only** (`tech_stack: csharp`): the analyze needs the .NET
+  toolchain, and `build:dist` silently *skips* the Roslyn host when `dotnet` is
+  missing (a green build is not enough). If `dotnet` is not on PATH, run
+  `bash $TRUECOURSE_DIR/docs/fp-automation/setup-csharp-env.sh` to install it —
+  it fails with a clear message if this environment's egress policy blocks the
+  .NET hosts, which is an env-provisioning problem (post the blocker and stop;
+  do **not** route around the policy). Then `dotnet restore` the target's
   top-most `.sln`/`.slnx` **before** analyze. The project-aware (Roslyn
-  workspace) tier now **fails-hard** on an unrestored project or a missing SDK —
+  workspace) tier **fails-hard** on an unrestored project or a missing SDK —
   it aborts the whole run, it does not skip. This needs the .NET SDK in the
   session: **10.x** (or ≥ 9.0.2xx), which is what opens `.slnx` solutions and
   modern targets; the host is `net8.0` and runs on any ≥ 8 runtime. A target that

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -74,8 +74,14 @@ Before the per-issue loop:
   to `/tmp/target` and `git -C /tmp/target checkout <target_ref>`.
   All `<SCOPE>fp-fix` issues in a single campaign share `target_repo` +
   `target_ref`, so you only clone once per session.
-- **C# campaigns only** (`tech_stack: csharp`): `dotnet restore` the target's
-  top-most `.sln`/`.slnx` **before** analyze. The project-aware (Roslyn
+- **C# campaigns only** (`tech_stack: csharp`): the analyze needs the .NET
+  toolchain, and `build:dist` silently *skips* the Roslyn host when `dotnet` is
+  missing (so a green build is not enough). If `dotnet` is not on PATH, run
+  `bash $TRUECOURSE_DIR/docs/fp-automation/setup-csharp-env.sh` to install it —
+  it fails with a clear message if this environment's egress policy blocks the
+  .NET hosts, which is an env-provisioning problem (post the blocker and stop;
+  do **not** route around the policy). Then `dotnet restore` the target's
+  top-most `.sln`/`.slnx` **before** analyze: the project-aware (Roslyn
   workspace) tier **fails-hard** on an unrestored project / missing SDK — it
   aborts the run, it does not skip. Needs the .NET SDK in the session (**10.x**,
   or ≥ 9.0.2xx for `.slnx`); a target pinning an SDK via `global.json` needs it.

--- a/docs/fp-automation/setup-csharp-env.sh
+++ b/docs/fp-automation/setup-csharp-env.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Provision the .NET toolchain the C# (cs-) fp-automation scope needs.
+#
+# WHY: C# analyze is fail-hard on the Roslyn semantic host
+# (tools/csharp-roslyn-host, a net8.0 framework-dependent DLL). `pnpm build:dist`
+# only builds/publishes that host when `dotnet` is on PATH — otherwise it just
+# warns and SKIPS it (scripts/build.ts), so the build "succeeds" with no host and
+# the first C# `analyze` later throws RoslynHostUnavailableError. There is no
+# tree-sitter-only fallback, by design (see CLAUDE.md + violation-pipeline.service.ts).
+#
+# The default (TS/JS + Python) account does not need this. Only the cs- account,
+# whose campaigns analyze C#, does.
+#
+# WHERE THIS RUNS (two entry points, same script):
+#   1. The cs- environment's setup script points at this file, so it runs ONCE
+#      per container (fast path — dotnet is already present for every session).
+#   2. The routine prompts (fp-discover / fp-next-fix) run it as a FALLBACK when
+#      `dotnet` is missing, so a mis-provisioned environment still self-heals.
+# It is idempotent: if `dotnet` is already on PATH it exits immediately.
+#
+set -euo pipefail
+
+DOTNET_DIR="${DOTNET_ROOT:-$HOME/.dotnet}"
+
+if command -v dotnet >/dev/null 2>&1; then
+  echo "dotnet already on PATH ($(dotnet --version)) — nothing to do."
+  exit 0
+fi
+
+echo "=== Installing .NET for the C# (cs-) fp-automation scope into $DOTNET_DIR ==="
+
+# The .NET download hosts must be on this environment's egress allowlist. They are
+# NOT reachable under the default network policy (npm/pypi/crates/go are allowlisted,
+# the Microsoft CDN is not), so this download 403s unless the cs- environment's policy
+# permits at least: dot.net, builds.dotnet.microsoft.com, dotnetcli.azureedge.net,
+# dotnetbuilds.azureedge.net — plus api.nuget.org / *.nuget.org for `dotnet restore`.
+if ! curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh; then
+  echo "ERROR: could not download the .NET install script (likely a 403 from the egress proxy)." >&2
+  echo "The .NET download hosts are not on this environment's allowlist. Allowlist them on the" >&2
+  echo "cs- environment's network policy (see docs/fp-automation/README.md → 'C# account: .NET" >&2
+  echo "toolchain + egress'), then re-run. Do NOT route around the policy." >&2
+  exit 1
+fi
+chmod +x /tmp/dotnet-install.sh
+
+# .NET 10 SDK — abp's global.json pins 10.0.100 (rollForward latestFeature); the
+# roslyn-workspace tier restores abp's real solution with this SDK.
+/tmp/dotnet-install.sh --channel 10.0 --install-dir "$DOTNET_DIR"
+
+# .NET 8 runtime — the Roslyn host targets net8.0 and is launched framework-
+# dependent (`dotnet <dll>`); .NET does not roll forward across majors by default,
+# so a net8 app will not run on a net10-only runtime.
+/tmp/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir "$DOTNET_DIR"
+
+export DOTNET_ROOT="$DOTNET_DIR"
+export PATH="$DOTNET_DIR:$PATH"
+
+# Persist for the routine's subsequent shells. Each Bash step runs in a fresh
+# non-login shell initialized from the profile, so an in-shell `export` alone is
+# lost after this script returns — the routine would still see no `dotnet`.
+PROFILE="$HOME/.bashrc"
+if ! grep -q 'DOTNET_ROOT' "$PROFILE" 2>/dev/null; then
+  {
+    echo ''
+    echo '# .NET toolchain for the cs- fp-automation scope (added by setup-csharp-env.sh)'
+    echo "export DOTNET_ROOT=\"$DOTNET_DIR\""
+    echo "export PATH=\"$DOTNET_DIR:\$PATH\""
+  } >> "$PROFILE"
+fi
+
+echo "=== .NET ready ($(dotnet --version)); Roslyn host will build on the next 'pnpm build:dist' ==="


### PR DESCRIPTION
## Problem

The `cs-` fp-automation account blocks on **every** session: C# analyze is fail-hard on the Roslyn host, but the session never has the .NET SDK, so `build:dist` skips the host and the first `analyze` throws `RoslynHostUnavailableError`.

The README already said the C# account "needs the .NET SDK" — so it *looked* covered — but two things were missing, and the second is the actual blocker:

1. **No install mechanism.** The prompts assumed `dotnet` was already on PATH; nothing installed it.
2. **The .NET download hosts aren't on the egress allowlist.** I reproduced the install in-session and it 403'd. The agent proxy's own failure log names it:
   ```
   connect_rejected: gateway answered 403 to CONNECT (policy denial)
   host: builds.dotnet.microsoft.com:443
   ```
   Default's "Trusted" network access allowlists npm/GitHub/PyPI but **not** the Microsoft .NET CDN, so any install 403s. Per the proxy README, a 403 is an org egress-policy denial you must not route around — so this can only be fixed by widening the policy.

## Changes

- **`docs/fp-automation/setup-csharp-env.sh`** (new) — idempotent installer for the 10.x SDK + a net8 runtime (the host targets `net8.0`), installed once per container and persisted to the profile so later non-login tool shells see `dotnet`. If the .NET hosts are blocked it exits with a clear message pointing at the allowlist requirement instead of a raw `curl` error — and never routes around the policy.
- **README** — documents the two required provisioning parts for the C# account: (1) run the setup script from that environment's setup step, and (2) allowlist the .NET download + NuGet hosts (`dot.net`, `builds.dotnet.microsoft.com`, `dotnetcli.azureedge.net`, `dotnetbuilds.azureedge.net`, `api.nuget.org`/`*.nuget.org` — the last for `dotnet restore`). Corrects the "Default env, no customization" implication for the `cs-` scope.
- **`fp-discover.md` / `fp-next-fix.md`** — the existing C#-only bullets now point at the setup script when `dotnet` is missing, and state that a build that skips the host is not enough. If it still can't install, the environment is mis-provisioned: post the blocker and stop.

## Verification

- Ran `setup-csharp-env.sh` in this session — it reproduced the exact failure (`curl https://dot.net/... → 403`), which is what confirmed the root cause is the egress policy, not a missing script. `bash -n` passes.
- The install itself can't be verified here because these hosts are policy-blocked in this environment too — which is precisely the finding.

## Follow-up (not in this PR)

The `drift-fp` loop also verifies C# via the contract-verifier and will hit the same wall; if you want, I can apply the identical treatment to `docs/drift-fp-automation/`.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaC29nxSGNYW2qygioB2L)_