### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/missing-error-boundary.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/missing-error-boundary.ts
@@ -25,14 +25,20 @@ export const missingErrorBoundaryVisitor: CodeRuleVisitor = {
     // we exclude member-expression calls like `trpc.x.useQuery(...)`,
     // which delegate to TanStack Query under abstractions that surface
     // errors via the returned `error`/`isError` state (no boundary
-    // required). Suspense and the suspense-* query variants always throw
-    // during render and need a boundary upstream.
+    // required). The suspense-* query variants always throw during render
+    // and need a boundary upstream.
+    //
+    // The bare `<Suspense>` component is NOT a signal on its own: it is a
+    // *loading* boundary for pending state, not evidence of an unhandled
+    // throwing fetch in this file. Leaf components frequently render a
+    // <Suspense> fallback while error handling is defined on the route
+    // (Remix / React Router), so keying off `Suspense` presence produced
+    // false positives across ordinary presentational components.
     const hasAsyncData =
       /(?<![.\w])useQuery\b/.test(sourceCode) ||
       /(?<![.\w])useSWR\b/.test(sourceCode) ||
       /\buseSuspenseQuery\b/.test(sourceCode) ||
-      /\buseSuspenseInfiniteQuery\b/.test(sourceCode) ||
-      /\bSuspense\b/.test(sourceCode)
+      /\buseSuspenseInfiniteQuery\b/.test(sourceCode)
 
     if (!hasAsyncData) return null
 

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/for-in-without-filter.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/for-in-without-filter.ts
@@ -31,6 +31,14 @@ export const forInWithoutFilterVisitor: CodeRuleVisitor = {
           if (prop?.text === 'hasOwnProperty' || prop?.text === 'hasOwn') return true
         }
       }
+      // `hasOwnProperty` / `hasOwn` accessed as a member anywhere in the body is
+      // a filter too — this catches `Object.prototype.hasOwnProperty.call(obj,
+      // key)` / `.apply(...)`, where the invoked method is `call`/`apply` and
+      // `hasOwnProperty` is only the receiver, not the called property.
+      if (n.type === 'member_expression') {
+        const prop = n.childForFieldName('property')
+        if (prop?.text === 'hasOwnProperty' || prop?.text === 'hasOwn') return true
+      }
       if (n.type === 'string' && (n.text.includes('hasOwnProperty') || n.text.includes('hasOwn'))) return true
       for (let i = 0; i < n.childCount; i++) {
         const child = n.child(i)

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/test-with-hardcoded-timeout.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/test-with-hardcoded-timeout.ts
@@ -1,13 +1,26 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
+// A genuine test file, not merely a path that contains the substring "test"
+// (which matches route modules like `tests.sse.stream.ts`, reference apps
+// under `test-tasks/`, and infra like `testcontainers/`). Recognised shapes:
+//   - a `*.test.*` / `*.spec.*` basename (foo.test.ts, foo.spec.tsx, …)
+//   - a `__tests__` / `__test__` directory in the path
+function isTestFile(filePath: string): boolean {
+  const norm = filePath.replace(/\\/g, '/')
+  const base = norm.slice(norm.lastIndexOf('/') + 1)
+  if (/\.(test|spec)\.[cm]?[jt]sx?$/i.test(base)) return true
+  if (/(^|\/)__tests?__\//.test(norm)) return true
+  return false
+}
+
 export const testWithHardcodedTimeoutVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/test-with-hardcoded-timeout',
   languages: ['typescript', 'tsx', 'javascript'],
   nodeTypes: ['call_expression'],
   visit(node, filePath, sourceCode) {
-    // Only flag in test files
-    if (!filePath.includes('test') && !filePath.includes('spec') && !filePath.includes('.test.') && !filePath.includes('.spec.')) return null
+    // Only flag in genuine test files.
+    if (!isTestFile(filePath)) return null
 
     const fn = node.childForFieldName('function')
     if (!fn) return null

--- a/packages/analyzer/src/rules/security/visitors/javascript/unverified-cross-origin-message.ts
+++ b/packages/analyzer/src/rules/security/visitors/javascript/unverified-cross-origin-message.ts
@@ -19,6 +19,17 @@ export const unverifiedCrossOriginMessageVisitor: CodeRuleVisitor = {
 
     if (methodName !== 'addEventListener') return null
 
+    // Only the browser `window` message event carries cross-origin risk
+    // (window.postMessage from another window/iframe/opener). A `message`
+    // event on some other receiver — e.g. a server-side `ws` WebSocket
+    // (`ws.addEventListener('message', …)`) — has no notion of window origin,
+    // so flagging it is a false positive. A bare `addEventListener(...)` call
+    // is `window.addEventListener` in browser scope, so keep flagging that.
+    if (fn.type === 'member_expression') {
+      const receiver = fn.childForFieldName('object')?.text ?? ''
+      if (receiver !== 'window' && receiver !== 'self' && receiver !== 'globalThis') return null
+    }
+
     const args = node.childForFieldName('arguments')
     if (!args) return null
 

--- a/packages/analyzer/src/rules/security/visitors/universal.ts
+++ b/packages/analyzer/src/rules/security/visitors/universal.ts
@@ -2,6 +2,7 @@
  * Security domain language-agnostic visitors.
  */
 
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../types.js'
 import { makeViolation } from '../../types.js'
 import { scanForSecrets, isSensitiveFile } from '../secret-scanner.js'
@@ -544,6 +545,59 @@ const HASH_FUNCTIONS_NEEDING_SALT = new Set([
   'createHash', 'md5', 'sha1', 'sha256', 'sha512',
 ])
 
+// Node types that bound a single statement across the JS/TS, Python and C#
+// grammars. The password signal is scoped to the statement performing the
+// hash so that an unrelated `password` token in a *sibling* statement (e.g. a
+// cache/redis connection option) does not turn a request-fingerprinting hash
+// into a false "unsalted password hash".
+const STATEMENT_NODE_TYPES = new Set([
+  'expression_statement', 'return_statement', 'lexical_declaration',
+  'variable_declaration', 'variable_declarator', 'local_declaration_statement',
+  'assignment', 'augmented_assignment', 'assignment_expression',
+  'augmented_assignment_expression',
+])
+
+// Function/method node types across the three grammars.
+const FUNCTION_NODE_TYPES = new Set([
+  'function_declaration', 'function_expression', 'arrow_function',
+  'generator_function_declaration', 'method_definition', 'function_definition',
+  'method_declaration', 'local_function_statement', 'constructor_declaration',
+])
+
+function hasPasswordToken(text: string): boolean {
+  const lower = text.toLowerCase()
+  return lower.includes('password') || lower.includes('passwd')
+}
+
+/**
+ * Decide whether a hash call sits in a password-hashing context. Two signals
+ * count, and only these two — scanning the whole enclosing function's text is
+ * too coarse and produces false positives:
+ *   1. the statement that performs the hash (e.g. `.update(password)`), and
+ *   2. the enclosing function's signature — its name and parameters
+ *      (e.g. `hashPassword(string password)`), never its body.
+ */
+function isPasswordHashingContext(node: SyntaxNode): boolean {
+  // (1) the statement performing the hash
+  let stmt: SyntaxNode | null = node.parent
+  while (stmt && !STATEMENT_NODE_TYPES.has(stmt.type) && !FUNCTION_NODE_TYPES.has(stmt.type)) {
+    stmt = stmt.parent
+  }
+  if (stmt && STATEMENT_NODE_TYPES.has(stmt.type) && hasPasswordToken(stmt.text)) return true
+
+  // (2) the enclosing function's signature (name + parameters only)
+  let fnNode: SyntaxNode | null = node.parent
+  while (fnNode && !FUNCTION_NODE_TYPES.has(fnNode.type)) fnNode = fnNode.parent
+  if (fnNode) {
+    const nameNode = fnNode.childForFieldName('name')
+    const paramsNode = fnNode.childForFieldName('parameters') ?? fnNode.childForFieldName('parameter_list')
+    const signature = `${nameNode?.text ?? ''} ${paramsNode?.text ?? ''}`
+    if (hasPasswordToken(signature)) return true
+  }
+
+  return false
+}
+
 export const unpredictableSaltMissingVisitor: CodeRuleVisitor = {
   ruleKey: 'security/deterministic/unpredictable-salt-missing',
   nodeTypes: ['call_expression', 'call', 'invocation_expression'],
@@ -561,30 +615,20 @@ export const unpredictableSaltMissingVisitor: CodeRuleVisitor = {
 
     if (!HASH_FUNCTIONS_NEEDING_SALT.has(methodName)) return null
 
-    // Only flag if this is in a password-hashing context
-    let parent = node.parent
-    while (parent) {
-      const parentText = parent.text.toLowerCase()
-      if (parentText.includes('password') || parentText.includes('passwd')) {
-        const args = node.childForFieldName('arguments')
-        if (args && args.namedChildren.length < 2) {
-          return makeViolation(
-            this.ruleKey, node, filePath, 'high',
-            'Missing salt in hash',
-            `${methodName}() called without a salt in a password context. This allows rainbow table attacks.`,
-            sourceCode,
-            'Use a password hashing function like bcrypt, argon2, or PBKDF2 which handle salting automatically.',
-          )
-        }
-        return null
-      }
-      if (parent.type === 'function_declaration' || parent.type === 'function_definition' ||
-          parent.type === 'method_definition' || parent.type === 'program' ||
-          parent.type === 'method_declaration' || parent.type === 'compilation_unit') break
-      parent = parent.parent
-    }
+    // A bare, single-argument hash call is the candidate; a second argument is
+    // typically the salt/encoding that makes it safe.
+    const args = node.childForFieldName('arguments')
+    if (!args || args.namedChildren.length >= 2) return null
 
-    return null
+    if (!isPasswordHashingContext(node)) return null
+
+    return makeViolation(
+      this.ruleKey, node, filePath, 'high',
+      'Missing salt in hash',
+      `${methodName}() called without a salt in a password context. This allows rainbow table attacks.`,
+      sourceCode,
+      'Use a password hashing function like bcrypt, argon2, or PBKDF2 which handle salting automatically.',
+    )
   },
 }
 

--- a/tests/fixtures/sample-js-project-negative/for-in-without-filter-collect-keys.ts
+++ b/tests/fixtures/sample-js-project-negative/for-in-without-filter-collect-keys.ts
@@ -1,0 +1,11 @@
+// A true bug: for…in over an untyped object with no own-property filter, so
+// inherited enumerable keys are collected alongside the object's own keys.
+
+export function collectKeys(source: object): string[] {
+  const keys: string[] = [];
+  // VIOLATION: code-quality/deterministic/for-in-without-filter
+  for (const key in source) {
+    keys.push(key);
+  }
+  return keys;
+}

--- a/tests/fixtures/sample-js-project-negative/missing-error-boundary-swr.tsx
+++ b/tests/fixtures/sample-js-project-negative/missing-error-boundary-swr.tsx
@@ -1,0 +1,18 @@
+// A React component that fetches async data with a bare useSWR hook whose
+// promise can reject during render, yet nothing upstream catches a render
+// failure. A failed fetch will crash the whole component tree.
+
+import type { ReactElement } from "react";
+
+declare function useSWR<T>(
+  key: string,
+  fetcher: (key: string) => Promise<T>,
+): { data: T | undefined };
+
+// VIOLATION: bugs/deterministic/missing-error-boundary
+export function DashboardStats(): ReactElement {
+  const { data } = useSWR<{ total: number }>("/api/stats", (k) =>
+    fetch(k).then((r) => r.json() as Promise<{ total: number }>),
+  );
+  return <div>{data?.total}</div>;
+}

--- a/tests/fixtures/sample-js-project-negative/test-with-hardcoded-timeout.test.ts
+++ b/tests/fixtures/sample-js-project-negative/test-with-hardcoded-timeout.test.ts
@@ -1,0 +1,8 @@
+// A real test file (`.test.ts`) that blocks on a fixed wall-clock timeout to
+// "wait" for async work to settle. This is fragile and slow; deterministic
+// waiting (await, polling, waitFor) should be used instead.
+
+export async function waitForQueueToDrain(): Promise<void> {
+  // VIOLATION: code-quality/deterministic/test-with-hardcoded-timeout
+  await new Promise<void>((resolve) => setTimeout(resolve, 500));
+}

--- a/tests/fixtures/sample-js-project-negative/unpredictable-salt-missing.ts
+++ b/tests/fixtures/sample-js-project-negative/unpredictable-salt-missing.ts
@@ -1,0 +1,15 @@
+// A genuine unsalted password hash: the user's password is fed straight into
+// a bare SHA-256 digest with no per-user salt, leaving it open to rainbow
+// table attacks. A password-safe KDF (bcrypt/argon2/PBKDF2) should be used.
+
+interface Hash {
+  update(_input: string): Hash;
+  digest(_encoding: string): string;
+}
+
+declare function createHash(_algorithm: string): Hash;
+
+export function fingerprintCredential(password: string): string {
+  // VIOLATION: security/deterministic/unpredictable-salt-missing
+  return createHash("sha256").update(password).digest("hex");
+}

--- a/tests/fixtures/sample-js-project-negative/unverified-cross-origin-message.ts
+++ b/tests/fixtures/sample-js-project-negative/unverified-cross-origin-message.ts
@@ -1,0 +1,10 @@
+// A browser message listener that trusts any origin: it reads event.data and
+// acts on it without checking event.origin against a trusted list, so any
+// window (a malicious iframe or opener) can drive it.
+
+export function registerMessageBridge(handle: (data: unknown) => void): void {
+  // VIOLATION: security/deterministic/unverified-cross-origin-message
+  window.addEventListener("message", (event) => {
+    handle(event.data);
+  });
+}

--- a/tests/fixtures/sample-js-project-positive/for-in-without-filter-prototype-hasown.ts
+++ b/tests/fixtures/sample-js-project-positive/for-in-without-filter-prototype-hasown.ts
@@ -1,0 +1,14 @@
+// A for…in loop that DOES filter inherited keys: it captures the own-property
+// predicate from the prototype and applies it to each key before acting. The
+// filter is present, so this must not be flagged as a for…in missing an
+// own-property check.
+
+export function hasNoOwnKeys(record: object): boolean {
+  for (const key in record) {
+    const ownProperty = Object.prototype.hasOwnProperty;
+    if (ownProperty.call(record, key)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/tests/fixtures/sample-js-project-positive/missing-error-boundary-suspense.tsx
+++ b/tests/fixtures/sample-js-project-positive/missing-error-boundary-suspense.tsx
@@ -1,0 +1,21 @@
+// A presentational React component that renders a <Suspense> loading boundary
+// around streamed children. <Suspense> is itself a boundary for the pending
+// state; in a Remix / React Router app the route-level error handling catches
+// render failures, so this leaf component must not be flagged just because it
+// renders a Suspense fallback.
+
+import { Suspense } from "react";
+import type { ReactNode } from "react";
+
+interface StreamPanelProps {
+  readonly fallbackText: string;
+  readonly children: ReactNode;
+}
+
+export function StreamPanel({ fallbackText, children }: StreamPanelProps): JSX.Element {
+  return (
+    <Suspense fallback={<p>{fallbackText}</p>}>
+      {children}
+    </Suspense>
+  );
+}

--- a/tests/fixtures/sample-js-project-positive/test-with-hardcoded-timeout.ts
+++ b/tests/fixtures/sample-js-project-positive/test-with-hardcoded-timeout.ts
@@ -1,0 +1,10 @@
+// A route-style helper whose filename merely contains the substring "test"
+// (like a `tests.*` route module) — it is NOT a unit/integration test.
+// Scheduling a delay with setTimeout is perfectly normal in production code
+// and must not be flagged as a "hardcoded timeout in a test".
+
+export function delayFor(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/tests/fixtures/sample-js-project-positive/unpredictable-salt-missing.ts
+++ b/tests/fixtures/sample-js-project-positive/unpredictable-salt-missing.ts
@@ -1,0 +1,33 @@
+// A request-throttling helper. The incoming authorization header is reduced
+// to a fast digest purely to build a cache key — the digest is never stored
+// or treated as a credential, so salting would add nothing here. An unrelated
+// connection option in the same function happens to be named `password`; that
+// must not be mistaken for a password-hashing context.
+
+interface Hash {
+  update(_input: string): Hash;
+  digest(_encoding: string): string;
+}
+
+interface CacheConnectionOptions {
+  readonly host: string;
+  readonly password: string;
+}
+
+interface ThrottledRequest {
+  readonly authorization: string;
+}
+
+declare function createHash(_algorithm: string): Hash;
+declare function openCacheConnection(_options: CacheConnectionOptions): void;
+
+export function buildThrottleCacheKey(
+  request: ThrottledRequest,
+  connection: CacheConnectionOptions,
+): string {
+  openCacheConnection({ host: connection.host, password: connection.password });
+
+  const digest = createHash("sha256");
+  digest.update(request.authorization);
+  return digest.digest("hex");
+}

--- a/tests/fixtures/sample-js-project-positive/unverified-cross-origin-message.ts
+++ b/tests/fixtures/sample-js-project-positive/unverified-cross-origin-message.ts
@@ -1,0 +1,15 @@
+// A server-side WebSocket connection (the Node `ws` library) attaching a
+// `message` handler. This is not a browser `window.postMessage` channel — the
+// socket is already authenticated and there is no window origin to verify — so
+// flagging it as an unverified cross-origin message is a false positive.
+
+interface ServerSocket {
+  addEventListener(_event: string, _handler: (payload: unknown) => void): void;
+}
+
+export function attachSocketHandlers(
+  socket: ServerSocket,
+  onMessage: (payload: unknown) => void,
+): void {
+  socket.addEventListener("message", onMessage);
+}


### PR DESCRIPTION
Closes #429
Closes #430
Closes #431
Closes #432
Closes #433

Resolves a batch of false positives found by analyzing [`triggerdotdev/trigger.dev`](https://github.com/triggerdotdev/trigger.dev) at `2dd9f37b4045d2a414c0a300995d068f28926d50`. Each fix adds a paraphrased positive-fixture case (asserts zero violations) and a paraphrased true-bug negative-fixture case (asserts the rule still fires), then narrows the rule visitor. Full `tests/analyzer` suite is green.

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `security/deterministic/unpredictable-salt-missing` | #429 | `tests/fixtures/sample-js-project-positive/unpredictable-salt-missing.ts` | `tests/fixtures/sample-js-project-negative/unpredictable-salt-missing.ts` |
| `code-quality/deterministic/test-with-hardcoded-timeout` | #430 | `tests/fixtures/sample-js-project-positive/test-with-hardcoded-timeout.ts` | `tests/fixtures/sample-js-project-negative/test-with-hardcoded-timeout.test.ts` |
| `security/deterministic/unverified-cross-origin-message` | #431 | `tests/fixtures/sample-js-project-positive/unverified-cross-origin-message.ts` | `tests/fixtures/sample-js-project-negative/unverified-cross-origin-message.ts` |
| `bugs/deterministic/missing-error-boundary` | #432 | `tests/fixtures/sample-js-project-positive/missing-error-boundary-suspense.tsx` | `tests/fixtures/sample-js-project-negative/missing-error-boundary-swr.tsx` |
| `code-quality/deterministic/for-in-without-filter` | #433 | `tests/fixtures/sample-js-project-positive/for-in-without-filter-prototype-hasown.ts` | `tests/fixtures/sample-js-project-negative/for-in-without-filter-collect-keys.ts` |

## security/deterministic/unpredictable-salt-missing

**Upstream source (false positive):**
- ``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/services/authorizationRateLimitMiddleware.server.ts#L248``

**Positive fixture** (`tests/fixtures/sample-js-project-positive/unpredictable-salt-missing.ts`) — asserts zero violations:
```ts
// A request-throttling helper. The incoming authorization header is reduced
// to a fast digest purely to build a cache key — the digest is never stored
// or treated as a credential, so salting would add nothing here. An unrelated
// connection option in the same function happens to be named `password`; that
// must not be mistaken for a password-hashing context.

interface Hash {
  update(_input: string): Hash;
  digest(_encoding: string): string;
}

interface CacheConnectionOptions {
  readonly host: string;
  readonly password: string;
}

interface ThrottledRequest {
  readonly authorization: string;
}

declare function createHash(_algorithm: string): Hash;
declare function openCacheConnection(_options: CacheConnectionOptions): void;

export function buildThrottleCacheKey(
  request: ThrottledRequest,
  connection: CacheConnectionOptions,
): string {
  openCacheConnection({ host: connection.host, password: connection.password });

  const digest = createHash("sha256");
  digest.update(request.authorization);
  return digest.digest("hex");
}
```

**Negative fixture** (`tests/fixtures/sample-js-project-negative/unpredictable-salt-missing.ts`) — asserts the rule still fires:
```ts
// A genuine unsalted password hash: the user's password is fed straight into
// a bare SHA-256 digest with no per-user salt, leaving it open to rainbow
// table attacks. A password-safe KDF (bcrypt/argon2/PBKDF2) should be used.

interface Hash {
  update(_input: string): Hash;
  digest(_encoding: string): string;
}

declare function createHash(_algorithm: string): Hash;

export function fingerprintCredential(password: string): string {
  // VIOLATION: security/deterministic/unpredictable-salt-missing
  return createHash("sha256").update(password).digest("hex");
}
```

**Fix:** Previously the rule scanned the entire enclosing function's text for the word `password`, so an unrelated token — here a Redis `password` connection option in a sibling statement — turned a request-fingerprinting `createHash('sha256')` into a false unsalted-password-hash finding. The password signal is now restricted to (1) the single statement performing the hash (e.g. `.update(password)`) and (2) the enclosing function's signature — its name and parameters (e.g. `hashPassword(password)`) — never the whole body. This is strictly narrower than before, so it can only remove violations; both the JS and C# true-positive cases still fire.

## code-quality/deterministic/test-with-hardcoded-timeout

**Upstream source (false positive):**
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/routes/tests.sse.stream.ts#L49

**Positive fixture** (`tests/fixtures/sample-js-project-positive/test-with-hardcoded-timeout.ts`) — asserts zero violations:
```ts
// A route-style helper whose filename merely contains the substring "test"
// (like a `tests.*` route module) — it is NOT a unit/integration test.
// Scheduling a delay with setTimeout is perfectly normal in production code
// and must not be flagged as a "hardcoded timeout in a test".

export function delayFor(ms: number): Promise<void> {
  return new Promise<void>((resolve) => {
    setTimeout(resolve, ms);
  });
}
```

**Negative fixture** (`tests/fixtures/sample-js-project-negative/test-with-hardcoded-timeout.test.ts`) — asserts the rule still fires:
```ts
// A real test file (`.test.ts`) that blocks on a fixed wall-clock timeout to
// "wait" for async work to settle. This is fragile and slow; deterministic
// waiting (await, polling, waitFor) should be used instead.

export async function waitForQueueToDrain(): Promise<void> {
  // VIOLATION: code-quality/deterministic/test-with-hardcoded-timeout
  await new Promise<void>((resolve) => setTimeout(resolve, 500));
}
```

**Fix:** Replaced the loose `filePath.includes('test')` guard — which matched any path containing the substring `test`, including Remix route modules like `tests.sse.stream.ts`, reference apps under `test-tasks/`, and infra like `testcontainers/` — with an `isTestFile()` helper that recognises only genuine test files: a `*.test.*` / `*.spec.*` basename or a `__tests__` / `__test__` directory. Removed all 25 hits on this target while the real test-file case still fires.

## security/deterministic/unverified-cross-origin-message

**Upstream source (false positive):**
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/authenticatedSocketConnection.server.ts#L58

**Positive fixture** (`tests/fixtures/sample-js-project-positive/unverified-cross-origin-message.ts`) — asserts zero violations:
```ts
// A server-side WebSocket connection (the Node `ws` library) attaching a
// `message` handler. This is not a browser `window.postMessage` channel — the
// socket is already authenticated and there is no window origin to verify — so
// flagging it as an unverified cross-origin message is a false positive.

interface ServerSocket {
  addEventListener(_event: string, _handler: (payload: unknown) => void): void;
}

export function attachSocketHandlers(
  socket: ServerSocket,
  onMessage: (payload: unknown) => void,
): void {
  socket.addEventListener("message", onMessage);
}
```

**Negative fixture** (`tests/fixtures/sample-js-project-negative/unverified-cross-origin-message.ts`) — asserts the rule still fires:
```ts
// A browser message listener that trusts any origin: it reads event.data and
// acts on it without checking event.origin against a trusted list, so any
// window (a malicious iframe or opener) can drive it.

export function registerMessageBridge(handle: (data: unknown) => void): void {
  // VIOLATION: security/deterministic/unverified-cross-origin-message
  window.addEventListener("message", (event) => {
    handle(event.data);
  });
}
```

**Fix:** The rule flagged any `x.addEventListener('message', …)` whose handler didn't reference `origin`, regardless of receiver, so a server-side `ws` WebSocket handler (`ws.addEventListener('message', …)`) was a false positive. Added a receiver check: for a member call, only fire when the receiver is a browser global (`window` / `self` / `globalThis`); a bare `addEventListener(...)` identifier (implicitly `window`) still fires.

## bugs/deterministic/missing-error-boundary

**Upstream source (false positive):**
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/AIQueryInput.tsx#L1
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/runs/v3/PromptSpanDetails.tsx#L1
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/runs/v3/ai/AIChatMessages.tsx#L1
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/runs/v3/ai/AISpanDetails.tsx#L1

**Positive fixture** (`tests/fixtures/sample-js-project-positive/missing-error-boundary-suspense.tsx`) — asserts zero violations:
```tsx
// A presentational React component that renders a <Suspense> loading boundary
// around streamed children. <Suspense> is itself a boundary for the pending
// state; in a Remix / React Router app the route-level error handling catches
// render failures, so this leaf component must not be flagged just because it
// renders a Suspense fallback.

import { Suspense } from "react";
import type { ReactNode } from "react";

interface StreamPanelProps {
  readonly fallbackText: string;
  readonly children: ReactNode;
}

export function StreamPanel({ fallbackText, children }: StreamPanelProps): JSX.Element {
  return (
    <Suspense fallback={<p>{fallbackText}</p>}>
      {children}
    </Suspense>
  );
}
```

**Negative fixture** (`tests/fixtures/sample-js-project-negative/missing-error-boundary-swr.tsx`) — asserts the rule still fires:
```tsx
// A React component that fetches async data with a bare useSWR hook whose
// promise can reject during render, yet nothing upstream catches a render
// failure. A failed fetch will crash the whole component tree.

import type { ReactElement } from "react";

declare function useSWR<T>(
  key: string,
  fetcher: (key: string) => Promise<T>,
): { data: T | undefined };

// VIOLATION: bugs/deterministic/missing-error-boundary
export function DashboardStats(): ReactElement {
  const { data } = useSWR<{ total: number }>("/api/stats", (k) =>
    fetch(k).then((r) => r.json() as Promise<{ total: number }>),
  );
  return <div>{data?.total}</div>;
}
```

**Fix:** The rule treated the mere presence of a `<Suspense>` component as an unhandled async-data signal, so ordinary presentational components that render a `<Suspense>` loading fallback (with error handling defined on the Remix route) were flagged. Removed bare `Suspense` from the async-data triggers; the throwing query hooks (`useQuery` / `useSWR` / `useSuspenseQuery` / `useSuspenseInfiniteQuery`) remain triggers, so genuine unhandled fetches are still caught.

## code-quality/deterministic/for-in-without-filter

**Upstream source (false positive):**
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/eventRepository/common.server.ts#L170
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/server.ts#L39

**Positive fixture** (`tests/fixtures/sample-js-project-positive/for-in-without-filter-prototype-hasown.ts`) — asserts zero violations:
```ts
// A for…in loop that DOES filter inherited keys: it captures the own-property
// predicate from the prototype and applies it to each key before acting. The
// filter is present, so this must not be flagged as a for…in missing an
// own-property check.

export function hasNoOwnKeys(record: object): boolean {
  for (const key in record) {
    const ownProperty = Object.prototype.hasOwnProperty;
    if (ownProperty.call(record, key)) {
      return false;
    }
  }
  return true;
}
```

**Negative fixture** (`tests/fixtures/sample-js-project-negative/for-in-without-filter-collect-keys.ts`) — asserts the rule still fires:
```ts
// A true bug: for…in over an untyped object with no own-property filter, so
// inherited enumerable keys are collected alongside the object's own keys.

export function collectKeys(source: object): string[] {
  const keys: string[] = [];
  // VIOLATION: code-quality/deterministic/for-in-without-filter
  for (const key in source) {
    keys.push(key);
  }
  return keys;
}
```

**Fix:** `hasOwnPropertyCheck` only recognised `hasOwnProperty` / `hasOwn` when it was the directly-called method (e.g. `obj.hasOwnProperty(key)`), so the canonical safe form `Object.prototype.hasOwnProperty.call(obj, key)` — where the invoked method is `call` and `hasOwnProperty` is only the receiver — went undetected and produced a false positive. Added a branch that treats `hasOwnProperty` / `hasOwn` accessed as a member anywhere in the loop body as a filter, covering the `.call` / `.apply` forms.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

Measured with `node dist/cli.mjs analyze --no-llm` from a fresh `pnpm build:dist` (the exact artifact publish.yml ships), before vs. after this batch's visitor edits.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `security/deterministic/unpredictable-salt-missing` | 1 | 0 | -1 |
| `code-quality/deterministic/test-with-hardcoded-timeout` | 25 | 0 | -25 |
| `security/deterministic/unverified-cross-origin-message` | 1 | 0 | -1 |
| `bugs/deterministic/missing-error-boundary` | 13 | 1 | -12 |
| `code-quality/deterministic/for-in-without-filter` | 6 | 5 | -1 |
| **Total (these 5 rules)** | 46 | 6 | -40 |
| **All-rules total on target** | 34560 | 34520 | -40 |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgVDARW4MuTVKqVYCL2zCn)_