### PR TITLE
fix(fp): resolve 5 FPs from abpframework/abp

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/csharp/nested-type-publicly-visible.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/csharp/nested-type-publicly-visible.ts
@@ -22,6 +22,28 @@ function isNestedInType(node: SyntaxNode): boolean {
   return parent.parent != null && TYPE_DECL_TYPES.has(parent.parent.type)
 }
 
+/**
+ * A `static` class whose members are all constants (`const` / `static
+ * readonly` fields) is an intentional namespacing idiom — grouping related
+ * names (permission keys, bundle names, option names) under an owning type —
+ * not a leaked implementation helper. Such a constant container is deliberately
+ * public and should not be flagged.
+ */
+function isConstantContainer(node: SyntaxNode): boolean {
+  if (node.type !== 'class_declaration') return false
+  if (!hasCSharpModifier(node, 'static')) return false
+  const body = node.childForFieldName('body')
+  if (!body) return false
+  const members = body.namedChildren.filter((c) => c && c.type !== 'comment')
+  if (members.length === 0) return false
+  return members.every(
+    (m) =>
+      m?.type === 'field_declaration' &&
+      (hasCSharpModifier(m, 'const') ||
+        (hasCSharpModifier(m, 'static') && hasCSharpModifier(m, 'readonly'))),
+  )
+}
+
 export const csharpNestedTypePubliclyVisibleVisitor: CodeRuleVisitor = {
   ruleKey: 'architecture/deterministic/nested-type-publicly-visible',
   languages: ['csharp'],
@@ -30,6 +52,7 @@ export const csharpNestedTypePubliclyVisibleVisitor: CodeRuleVisitor = {
     if (!isNestedInType(node)) return null
     if (!hasCSharpModifier(node, 'public') && !hasCSharpModifier(node, 'protected')) return null
     if (getCSharpAttributeNames(node).length > 0) return null
+    if (isConstantContainer(node)) return null
 
     const name = node.childForFieldName('name')?.text ?? 'type'
     return makeViolation(

--- a/packages/analyzer/src/rules/bugs/visitors/csharp/fstring-missing-placeholders.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/csharp/fstring-missing-placeholders.ts
@@ -2,8 +2,18 @@ import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
-function hasInterpolation(node: SyntaxNode): boolean {
-  return node.namedChildren.some((c) => c?.type === 'interpolation')
+/**
+ * True when the string has a real `{expr}` interpolation hole. The normal case
+ * is an `interpolation` child node. But a hole wrapped in escaped braces —
+ * `$"{{{x}}}"`, which renders `{` + value + `}` — is parsed by
+ * tree-sitter-c-sharp as a single `string_content` run with no `interpolation`
+ * child, so also scan the raw text: after removing every escaped `{{`/`}}`
+ * pair, a remaining `{` marks a genuine hole.
+ */
+function hasRealHole(node: SyntaxNode): boolean {
+  if (node.namedChildren.some((c) => c?.type === 'interpolation')) return true
+  const stripped = node.text.replace(/\{\{/g, '').replace(/\}\}/g, '')
+  return stripped.includes('{')
 }
 
 /**
@@ -19,7 +29,7 @@ export const csharpFstringMissingPlaceholdersVisitor: CodeRuleVisitor = {
   languages: ['csharp'],
   nodeTypes: ['interpolated_string_expression'],
   visit(node, filePath, sourceCode) {
-    if (hasInterpolation(node)) return null
+    if (hasRealHole(node)) return null
 
     let top: SyntaxNode = node
     while (top.parent?.type === 'binary_expression' &&
@@ -30,7 +40,7 @@ export const csharpFstringMissingPlaceholdersVisitor: CodeRuleVisitor = {
       let siblingHasHoles = false
       const walk = (n: SyntaxNode): void => {
         if (siblingHasHoles) return
-        if (n.type === 'interpolated_string_expression' && n.id !== node.id && hasInterpolation(n)) {
+        if (n.type === 'interpolated_string_expression' && n.id !== node.id && hasRealHole(n)) {
           siblingHasHoles = true
           return
         }

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/identical-functions.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/identical-functions.ts
@@ -5,6 +5,50 @@ import { getCSharpFunctionName } from './_helpers.js'
 
 const COMPARED_TYPES = new Set(['method_declaration', 'local_function_statement', 'constructor_declaration'])
 
+/**
+ * A "trivial" returned expression carries no real computation: a literal,
+ * `default`, `this`, a bare identifier or member access, or a call whose
+ * arguments are themselves all trivial (`Task.FromResult(true)`,
+ * `Task.CompletedTask`). Two functions sharing such a body — framework
+ * default hooks, null-object stubs — are idiomatically identical with nothing
+ * worth extracting, so they must not be reported as duplication.
+ */
+function isTrivialExpr(e: SyntaxNode): boolean {
+  switch (e.type) {
+    case 'integer_literal':
+    case 'real_literal':
+    case 'boolean_literal':
+    case 'string_literal':
+    case 'verbatim_string_literal':
+    case 'null_literal':
+    case 'character_literal':
+    case 'identifier':
+    case 'this_expression':
+    case 'default_expression':
+    case 'member_access_expression':
+      return true
+    case 'invocation_expression': {
+      const args = e.childForFieldName('arguments')
+      if (!args) return true
+      return args.namedChildren.every((a) => {
+        if (a?.type !== 'argument') return true
+        const value = a.namedChildren.find((c) => c && c.type !== 'name_colon')
+        return !value || isTrivialExpr(value)
+      })
+    }
+    default:
+      return false
+  }
+}
+
+/** A block body that is a single `return` of a trivial expression (or bare `return;`). */
+function isTrivialReturnBody(body: SyntaxNode): boolean {
+  const stmts = body.namedChildren.filter((c) => c && c.type !== 'comment')
+  if (stmts.length !== 1 || stmts[0]?.type !== 'return_statement') return false
+  const expr = stmts[0].namedChildren.find((c) => c && c.type !== 'comment')
+  return !expr || isTrivialExpr(expr)
+}
+
 export const csharpIdenticalFunctionsVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/identical-functions',
   languages: ['csharp'],
@@ -21,7 +65,7 @@ export const csharpIdenticalFunctionsVisitor: CodeRuleVisitor = {
           // A single `throw` body is an intentional stub
           // (NotImplementedException etc.) — skip.
           const onlyThrow = body.namedChildCount === 1 && body.namedChildren[0]?.type === 'throw_statement'
-          if (!onlyThrow) {
+          if (!onlyThrow && !isTrivialReturnBody(body)) {
             const normalized = body.text.replace(/\s+/g, ' ').trim()
             bodies.push({ body: normalized, fnNode: n })
           }

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/magic-number.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/magic-number.ts
@@ -96,6 +96,11 @@ export const csharpMagicNumberVisitor: CodeRuleVisitor = {
     if (parentType !== 'binary_expression' && parentType !== 'argument') return null
     // Indexer access (`items[3]`) is excluded, like array subscripts in JS.
     if (parentType === 'argument' && parent.parent?.type === 'bracketed_argument_list') return null
+    // A named argument (`maxLength: 128`) documents the literal via the parameter
+    // name, so the number is already self-describing — not a magic number. This
+    // is the idiomatic shape of tool-generated code (EF migration column specs
+    // like `table.Column<string>(maxLength: 128, …)`).
+    if (parentType === 'argument' && parent.childForFieldName('name')) return null
 
     // Time conversion factor multiplied by another time factor — idiomatic.
     if (parentType === 'binary_expression' && TIME_FACTORS.has(val)) {

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/public-const-versioning-hazard.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/public-const-versioning-hazard.ts
@@ -1,6 +1,7 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
-import { hasCSharpModifier } from '../../../_shared/csharp-helpers.js'
+import { hasCSharpModifier, walkCSharp } from '../../../_shared/csharp-helpers.js'
 
 /**
  * A `public const` value is inlined into consuming assemblies at compile time,
@@ -10,6 +11,55 @@ import { hasCSharpModifier } from '../../../_shared/csharp-helpers.js'
  * `protected`) `const` `field_declaration` on a type. Private/internal consts
  * never cross an assembly boundary and are left alone.
  */
+
+/** The declared names of a `const` field (`public const string A = "x", B = "y";`). */
+function constFieldNames(fieldDecl: SyntaxNode): string[] {
+  const names: string[] = []
+  const varDecl = fieldDecl.namedChildren.find((c) => c?.type === 'variable_declaration')
+  if (!varDecl) return names
+  for (const vd of varDecl.namedChildren) {
+    if (vd?.type !== 'variable_declarator') continue
+    const n = vd.childForFieldName('name')?.text ?? vd.namedChildren.find((c) => c?.type === 'identifier')?.text
+    if (n) names.push(n)
+  }
+  return names
+}
+
+/**
+ * True when one of `names` is used inside another `const` field's initializer
+ * anywhere in the file. Such a constant is composed into a further compile-time
+ * constant, so it MUST stay `const` — a `static readonly` field is not a
+ * constant expression and would not compile in that position. Flagging it is a
+ * false positive.
+ */
+function referencedBySiblingConst(node: SyntaxNode, names: string[]): boolean {
+  let root: SyntaxNode = node
+  while (root.parent) root = root.parent
+
+  let found = false
+  const scan = (n: SyntaxNode): void => {
+    if (found) return
+    if (n.type === 'field_declaration' && n.id !== node.id && hasCSharpModifier(n, 'const')) {
+      const varDecl = n.namedChildren.find((c) => c?.type === 'variable_declaration')
+      if (varDecl) {
+        for (const vd of varDecl.namedChildren) {
+          if (vd?.type !== 'variable_declarator') continue
+          // Walk only the initializer value, not the declared name, for a name hit.
+          const declaredName = vd.childForFieldName('name')
+          walkCSharp(vd, (id) => {
+            if (id.type === 'identifier' && id.id !== declaredName?.id && names.includes(id.text)) {
+              found = true
+            }
+          })
+        }
+      }
+    }
+    for (const c of n.namedChildren) if (c) scan(c)
+  }
+  scan(root)
+  return found
+}
+
 export const csharpPublicConstVersioningHazardVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/public-const-versioning-hazard',
   languages: ['csharp'],
@@ -17,6 +67,10 @@ export const csharpPublicConstVersioningHazardVisitor: CodeRuleVisitor = {
   visit(node, filePath, sourceCode) {
     if (!hasCSharpModifier(node, 'const')) return null
     if (!hasCSharpModifier(node, 'public') && !hasCSharpModifier(node, 'protected')) return null
+
+    // A constant composed into another constant must remain `const`.
+    const names = constFieldNames(node)
+    if (names.length > 0 && referencedBySiblingConst(node, names)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -925,6 +925,12 @@
       "layer": "service"
     },
     {
+      "name": "NoticeFormatter",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "NotificationHub",
       "service": "ApiGateway",
       "kind": "class",
@@ -2167,6 +2173,12 @@
       "layer": "service"
     },
     {
+      "name": "MetricsCollector",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "MoneyAmount",
       "service": "UserService",
       "kind": "class",
@@ -2336,6 +2348,12 @@
     },
     {
       "name": "Program",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "QueueStats",
       "service": "UserService",
       "kind": "class",
       "layer": "service"
@@ -2558,6 +2576,12 @@
     },
     {
       "name": "TenantSnapshot",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "ThrottleWindow",
       "service": "UserService",
       "kind": "class",
       "layer": "service"

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/NoticeFormatter.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/NoticeFormatter.cs
@@ -1,0 +1,10 @@
+namespace ApiGatewayApp.Violations.Bugs;
+
+internal sealed class NoticeFormatter
+{
+    internal string Build()
+    {
+        // VIOLATION: bugs/deterministic/fstring-missing-placeholders
+        return $"no placeholders here";
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/MetricsCollector.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/MetricsCollector.cs
@@ -1,0 +1,12 @@
+namespace UserServiceApp.Violations.Architecture;
+
+internal sealed class MetricsCollector
+{
+    internal string Name => "metrics";
+
+    // VIOLATION: architecture/deterministic/nested-type-publicly-visible
+    public sealed class Sample
+    {
+        public long Value { get; set; }
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/QueueStats.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/QueueStats.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace UserServiceApp.Violations.CodeQuality;
+
+internal sealed class QueueStats
+{
+    private readonly List<int> _pending = new List<int>();
+    private readonly List<int> _deferred = new List<int>();
+
+    // VIOLATION: code-quality/deterministic/identical-functions
+    internal int CountPending()
+    {
+        return _pending.Count + _deferred.Count;
+    }
+
+    internal int CountDeferred()
+    {
+        return _pending.Count + _deferred.Count;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/ReleaseChannels.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/ReleaseChannels.cs
@@ -1,0 +1,7 @@
+namespace UserServiceApp.Violations.CodeQuality;
+
+internal static class ReleaseChannels
+{
+    // VIOLATION: code-quality/deterministic/public-const-versioning-hazard
+    public const string Stable = "stable";
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/ThrottleWindow.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/ThrottleWindow.cs
@@ -1,0 +1,10 @@
+namespace UserServiceApp.Violations.CodeQuality;
+
+internal sealed class ThrottleWindow
+{
+    internal int SlotFor(int requestId)
+    {
+        // VIOLATION: code-quality/deterministic/magic-number
+        return requestId % 47;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/NestedConstantContainer.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/NestedConstantContainer.cs
@@ -1,0 +1,24 @@
+namespace Positive.Boundary.Architecture;
+
+/// <summary>
+/// A <c>public static</c> nested class whose members are all constants is an
+/// intentional namespacing idiom (grouping related names under an owner), not a
+/// leaked implementation helper. The nested-type-publicly-visible rule must not
+/// flag such a constant container.
+/// </summary>
+public sealed class NestedConstantContainer
+{
+    /// <summary>Resolves a bundle by its declared name.</summary>
+    public string Resolve(string key) => key;
+
+    // SAFE: architecture/deterministic/nested-type-publicly-visible
+    /// <summary>Standard bundle names, grouped under their owner.</summary>
+    public static class StandardBundles
+    {
+        /// <summary>The primary bundle.</summary>
+        internal const string Primary = "primary";
+
+        /// <summary>The secondary bundle.</summary>
+        internal const string Secondary = "secondary";
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/BugsSamples1/EscapedBraceTemplate.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/BugsSamples1/EscapedBraceTemplate.cs
@@ -1,0 +1,17 @@
+namespace Positive.Boundary.Bugs;
+
+/// <summary>
+/// An interpolated string whose real <c>{expr}</c> hole is wrapped in escaped
+/// braces — <c>$"{{{segment}}}"</c> renders a literal <c>{</c>, the interpolated
+/// value, then a literal <c>}</c>. The <c>$</c> prefix is required, so the
+/// fstring-missing-placeholders rule must not flag it.
+/// </summary>
+public sealed class EscapedBraceTemplate
+{
+    /// <summary>Wraps a path segment in literal braces around its value.</summary>
+    public string Wrap(string segment)
+    {
+        // SAFE: bugs/deterministic/fstring-missing-placeholders
+        return $"{{{segment}}}";
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/NamedArgumentColumns.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/NamedArgumentColumns.cs
@@ -1,0 +1,33 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// Numeric literals passed as <em>named</em> call arguments
+/// (<c>maxLength: 128</c>) are self-documenting: the parameter name explains
+/// what the value means, so the magic-number rule must not flag them.
+/// </summary>
+public sealed class NamedArgumentColumns
+{
+    private readonly IColumnSink _sink;
+
+    /// <summary>Creates the plan over the given sink.</summary>
+    public NamedArgumentColumns(IColumnSink sink)
+    {
+        _sink = sink;
+    }
+
+    /// <summary>Declares the columns for a table.</summary>
+    public void Configure()
+    {
+        // SAFE: code-quality/deterministic/magic-number
+        // Every literal below is a named argument, so its meaning is explicit.
+        _sink.AddColumn(name: "title", maxLength: 128, nullable: false);
+        _sink.AddColumn(name: "summary", maxLength: 4000, nullable: true);
+    }
+}
+
+/// <summary>Receives column definitions.</summary>
+public interface IColumnSink
+{
+    /// <summary>Adds a column with the given constraints.</summary>
+    void AddColumn(string name, int maxLength, bool nullable);
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/DefaultAllowHooks.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/DefaultAllowHooks.cs
@@ -1,0 +1,28 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// Framework "default-allow" policy hooks each have a trivial single-return
+/// body (<c>return true;</c>). Being identical is intentional — they are
+/// distinct extension points that happen to share a default — and there is
+/// nothing worth extracting, so the identical-functions rule must not flag them.
+/// </summary>
+public class DefaultAllowHooks
+{
+    /// <summary>Whether reading is allowed by default.</summary>
+    public virtual bool CanRead()
+    {
+        return true;
+    }
+
+    /// <summary>Whether writing is allowed by default.</summary>
+    public virtual bool CanWrite()
+    {
+        return true;
+    }
+
+    /// <summary>Whether deleting is allowed by default.</summary>
+    public virtual bool CanDelete()
+    {
+        return true;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/ComposedPermissionKeys.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/ComposedPermissionKeys.cs
@@ -1,0 +1,22 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// A <c>public const</c> that is referenced inside another constant's
+/// initializer must stay <c>const</c> — a <c>static readonly</c> field is not a
+/// compile-time constant and cannot appear in a const expression. The
+/// public-const-versioning-hazard rule must not suggest converting such a
+/// composed-into constant.
+/// </summary>
+public static class ComposedPermissionKeys
+{
+    // SAFE: code-quality/deterministic/public-const-versioning-hazard
+    // Referenced by the composed constant below, so it must remain `const`.
+    public const string GroupName = "billing";
+
+    // Built from GroupName at compile time; kept private so it is not itself a
+    // public-surface constant.
+    private const string InvoicePaid = GroupName + ".InvoicePaid";
+
+    /// <summary>Returns the fully-qualified invoice-paid permission name.</summary>
+    public static string InvoicePaidPermission() => InvoicePaid;
+}


### PR DESCRIPTION
Resolves five C# deterministic false positives surfaced by the `cs-` FP-fix queue against **abpframework/abp** @ `8665ce0a23622f658b531b0627c7c025935fdb3b`. Each fix narrows one tree-sitter visitor and ships a paraphrased positive (zero-FP) fixture plus a true-bug negative fixture.

Closes #694
Closes #696
Closes #697
Closes #699
Closes #701

## Fixes

| rule_key | issue | positive fixture | negative fixture |
|---|---|---|---|
| `code-quality/deterministic/magic-number` | #694 | `NamedArgumentColumns.cs` | `ThrottleWindow.cs` |
| `architecture/deterministic/nested-type-publicly-visible` | #696 | `NestedConstantContainer.cs` | `MetricsCollector.cs` |
| `code-quality/deterministic/identical-functions` | #697 | `DefaultAllowHooks.cs` | `QueueStats.cs` |
| `code-quality/deterministic/public-const-versioning-hazard` | #699 | `ComposedPermissionKeys.cs` | `ReleaseChannels.cs` |
| `bugs/deterministic/fstring-missing-placeholders` | #701 | `EscapedBraceTemplate.cs` | `NoticeFormatter.cs` |

Full fixture paths are in the diff. See each file under `tests/fixtures/sample-csharp-project-positive/` (positive, asserts zero violations) and `tests/fixtures/sample-csharp-project-negative/.../Violations/` (negative, `// VIOLATION:` marker).

## code-quality/deterministic/magic-number — #694

FP source (abp): [OpenIddict.Demo.Server/Migrations/20260311061448_Initial.cs#L151](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/openiddict/app/OpenIddict.Demo.Server/Migrations/20260311061448_Initial.cs#L151),`` [Volo.CmsKit.IdentityServer/Migrations/20220504032505_Initial.cs#L924](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/cms-kit/host/Volo.CmsKit.IdentityServer/Migrations/20220504032505_Initial.cs#L924)``

A numeric literal that is the value of a **named argument** (`maxLength: 128`) is self-documenting — the parameter name explains it — and is the idiomatic shape of tool-generated code such as EF Core migration column specs. The visitor now skips `argument` nodes that carry a `name` (name-colon). Positional-argument and bare-expression magic numbers still fire (negative fixture `ThrottleWindow.cs`: `return requestId % 47;`).

## architecture/deterministic/nested-type-publicly-visible — #696

FP source (abp): [MauiBlazorStandardBundles.cs#L5](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Components.MauiBlazor.Theming.Bundling/MauiBlazorStandardBundles.cs#L5),`` [Cli/Commands/LoginCommand.cs#L204](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/LoginCommand.cs#L204``)

A `static` nested class whose members are all `const`/`static readonly` fields is an intentional namespacing idiom (grouping option/bundle/permission names under an owner), not a leaked implementation helper. Added an `isConstantContainer` guard. Nested types exposing properties, methods, or mutable state still fire (negative fixture `MetricsCollector.cs`: a nested public class with a mutable property).

## code-quality/deterministic/identical-functions — #697

FP source (abp): [Account/LoggedOut.cshtml.cs#L21](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/LoggedOut.cshtml.cs#L21),`` [NullInjectPropertiesService.cs#L6](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/NullInjectPropertiesService.cs#L6)``

Bodies that are a single `return` of a trivial expression (literal, `default`, bare identifier/member access, or a call with only trivial args such as `Task.FromResult(true)`) are excluded from duplicate comparison — framework default hooks and null-object stubs are idiomatically identical with nothing worth extracting. Duplicated bodies that contain real computation still fire (negative fixture `QueueStats.cs`: two methods returning `_pending.Count + _deferred.Count`).

## code-quality/deterministic/public-const-versioning-hazard — #699

FP source (abp): [Docs/DocsCommonPermissions.cs#L7](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/docs/src/Volo.Docs.Common.Application.Contracts/Volo/Docs/Common/DocsCommonPermissions.cs#L7),`` [CmsKit/Permissions/CmsKitAdminPermissions.cs#L51](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/cms-kit/src/Volo.CmsKit.Admin.Application.Contracts/Volo/CmsKit/Permissions/CmsKitAdminPermissions.cs#L51)``

A `public`/`protected const` referenced inside another const field's initializer is composed into a further compile-time constant, so it **must** remain `const` — a `static readonly` field is not a constant expression and would not compile in that position. The visitor now skips consts referenced by a sibling const. Standalone public consts still fire (negative fixture `ReleaseChannels.cs`: a lone `public const string Stable`).

## bugs/deterministic/fstring-missing-placeholders — #701

FP source (abp): [ClientProxyUrlBuilder.cs#L127](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/ClientProxying/ClientProxyUrlBuilder.cs#L127)``

`$"{{{x}}}"` renders a literal brace + the interpolated value + a literal brace; tree-sitter-c-sharp parses the whole run as a single `string_content` with **no** `interpolation` child, so the old check misfired. Replaced it with `hasRealHole`, which strips escaped `{{`/`}}` pairs and treats a remaining `{` as a genuine hole. Interpolated strings that truly have no holes still fire (negative fixture `NoticeFormatter.cs`: `$"no placeholders here"`).

## Skipped this batch

Attempted (oldest-first) but blocked as `cs-fp-blocked` — each needs semantic analysis / rule redesign, not a tree-sitter narrowing:

- #691 `generic-parameter-not-inferable` — FPs are idiomatic type-keyed APIs; no syntactic signal separates intended type-args from accidental non-inferable generics.
- #692 `abstract-class-without-abstract-members` — the FP shape is identical to the rule's own true-positive fixture; can't narrow one without killing the other.
- #695 `value-type-action-param-under-posting` — FPs are output DTOs, indistinguishable from request models without binding semantics.
- #698 `uri-property-as-string` — FPs depend on the runtime string value (bare host / relative URL), not syntax.
- #700 `commented-out-code` — FP is instructional prose; prose-vs-code needs a heuristic rethink.

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

Measured with `node dist/cli.mjs analyze --no-llm` from a freshly-built `pnpm build:dist` (the exact artifact `publish.yml` ships), same target ref before and after.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/magic-number` | 3501 | 1787 | -1714 |
| `architecture/deterministic/nested-type-publicly-visible` | 322 | 166 | -156 |
| `code-quality/deterministic/identical-functions` | 112 | 74 | -38 |
| `code-quality/deterministic/public-const-versioning-hazard` | 1238 | 1188 | -50 |
| `bugs/deterministic/fstring-missing-placeholders` | 95 | 84 | -11 |
| **Total (these 5 rules)** | 5268 | 3299 | **-1969** |
| **All-rules total on target** | 86421 | 84452 | **-1969** |

The all-rules total dropped by exactly the sum of the five rule reductions, confirming the fixes touched only these rules and introduced no new violations elsewhere.

cc @mushgev