### PR TITLE
fix(fp): resolve 1 FP from abpframework/abp

### DIFF
--- a/packages/analyzer/src/rules/_shared/csharp-helpers.ts
+++ b/packages/analyzer/src/rules/_shared/csharp-helpers.ts
@@ -145,3 +145,20 @@ export function walkCSharp(node: SyntaxNode, visit: (n: SyntaxNode) => void): vo
     if (child) walkCSharp(child, visit)
   }
 }
+
+/**
+ * True when `filePath` lives in a C# test project, matched by the .NET
+ * test-project directory naming convention: `Acme.Foo.Tests` / `Acme.Foo.Test`,
+ * a shared `Acme.Foo.TestBase`, or an integration test-app (`Acme.FooTestApp`).
+ * Rules whose signal is a real bug only in production code (e.g. hardcoded
+ * endpoints) use this to exempt test seed/fixture data, where sample URLs and
+ * constants are intentional. Keyed on the project-dir name rather than a bare
+ * `test`/`tests` folder so unrelated paths (e.g. a repo's own test tree) don't
+ * falsely match.
+ */
+export function isCSharpTestPath(filePath: string): boolean {
+  return filePath.split(/[\\/]/).some((segment) => {
+    const s = segment.toLowerCase()
+    return /\.tests?$/.test(s) || s.endsWith('.testbase') || s.endsWith('testapp')
+  })
+}

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/hardcoded-url.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/hardcoded-url.ts
@@ -1,6 +1,7 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { isCSharpTestPath } from '../../../_shared/csharp-helpers.js'
 
 // XML/SOAP/schema namespace hosts — fixed identifiers, not service endpoints.
 // `tempuri.org` and `schemas.microsoft.com` are the .NET-specific additions.
@@ -44,6 +45,9 @@ export const csharpHardcodedUrlVisitor: CodeRuleVisitor = {
     const text = node.text
 
     if (!/https?:\/\/[a-zA-Z0-9]/.test(text)) return null
+    // Test seed/fixture data intentionally hardcodes sample URLs (mock avatars,
+    // example endpoints); they are not configurable production endpoints.
+    if (isCSharpTestPath(filePath)) return null
     if (text.includes('example.com') || text.includes('localhost')
       || text.includes('127.0.0.1') || text.includes('placeholder')) return null
     if (NAMESPACE_URI_HOSTS.test(text)) return null

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -2269,6 +2269,12 @@
       "layer": "service"
     },
     {
+      "name": "PaymentGatewayClient",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "external"
+    },
+    {
       "name": "PaymentReconciler",
       "service": "UserService",
       "kind": "class",

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/PaymentGatewayClient.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/PaymentGatewayClient.cs
@@ -1,0 +1,18 @@
+namespace UserServiceApp.Violations.CodeQuality;
+
+/// <summary>
+/// A production client that hardcodes its base endpoint in source instead of
+/// reading it from configuration. Unlike test seed data, this is a genuine
+/// smell — the URL belongs in appsettings/IOptions. The rule must still fire.
+/// </summary>
+internal sealed class PaymentGatewayClient
+{
+    // VIOLATION: code-quality/deterministic/hardcoded-url
+    private const string ApiBase = "https://api.acme-payments.net/v2";
+
+    /// <summary>True when the configured base matches the compiled-in default.</summary>
+    public bool UsesDefaultBase(string configured)
+    {
+        return configured == ApiBase;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/test/Acme.Seeding.TestBase/SeedDataFixture.cs
+++ b/tests/fixtures/sample-csharp-project-positive/test/Acme.Seeding.TestBase/SeedDataFixture.cs
@@ -1,0 +1,19 @@
+namespace Positive.Boundary.CodeQuality.Seeding;
+
+/// <summary>
+/// Test seed data. Hardcoded sample URLs in test fixtures are mock values (mock
+/// avatars, example profile links), not configurable production endpoints, so
+/// the hardcoded-url rule must not flag them.
+/// </summary>
+public sealed class SeedDataFixture
+{
+    /// <summary>Builds the set of sample contributor links used by tests.</summary>
+    public System.Collections.Generic.List<string> SampleContributorLinks()
+    {
+        return new System.Collections.Generic.List<string>
+        {
+            "https://media.contoso-profiles.net/u/1",
+            "https://media.contoso-profiles.net/u/1/avatar?v=4",
+        };
+    }
+}


### PR DESCRIPTION
Closes #703

This batch resolves 1 false-positive rule from the `abpframework/abp` C# campaign.

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/hardcoded-url` | #703 | `tests/fixtures/sample-csharp-project-positive/test/Acme.Seeding.TestBase/SeedDataFixture.cs` | `tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/PaymentGatewayClient.cs` |

## code-quality/deterministic/hardcoded-url

**OSS sources (FP):**
- [`.../test/Volo.Docs.TestBase/Volo/Docs/DocsTestBase.cs#L49`](https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/docs/test/Volo.Docs.TestBase/Volo/Docs/DocsTestBase.cs#L49) — mock GitHub avatar/profile URLs in test seed data
- [`.../test/Volo.Abp.OpenIddict.TestBase/.../OpenIddictDataSeedContributor.cs#L102`](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/openiddict/test/Volo.Abp.OpenIddict.TestBase/Volo/Abp/OpenIddict/OpenIddictDataSeedContributor.cs#L102)`` — `new Uri("https://abp.io")` seed value

The rule fired on hardcoded URLs in C# **test projects**, where sample URLs (mock
avatars, example endpoints, seed data) are intentional, not configurable
production endpoints. Test seed/fixture data is the clear FP category addressed
here.

**Positive fixture** (in a `*.TestBase` project — asserts zero violations after the fix):

```
namespace Positive.Boundary.CodeQuality.Seeding;

/// <summary>Test seed data — hardcoded sample URLs are intentional mock values.</summary>
public sealed class SeedDataFixture
{
    /// <summary>Builds the set of sample contributor links used by tests.</summary>
    public System.Collections.Generic.List<string> SampleContributorLinks()
    {
        return new System.Collections.Generic.List<string>
        {
            "https://media.contoso-profiles.net/u/1",
            "https://media.contoso-profiles.net/u/1/avatar?v=4",
        };
    }
}
```

**Negative fixture** (a production client hardcoding its endpoint — the rule must still fire):

```
internal sealed class PaymentGatewayClient
{
    // VIOLATION: code-quality/deterministic/hardcoded-url
    private const string ApiBase = "https://api.acme-payments.net/v2";

    /// <summary>True when the configured base matches the compiled-in default.</summary>
    public bool UsesDefaultBase(string configured) => configured == ApiBase;
}
```

**Visitor change:** Added an `isCSharpTestPath` helper keyed on the .NET
test-project directory naming convention (`Acme.Foo.Tests` / `.Test` / `.TestBase`,
or `Acme.FooTestApp`) and skip such files in the C# `hardcoded-url` visitor. The
helper matches on the project-dir name rather than a bare `test`/`tests` folder,
so unrelated paths don't falsely match. The rule continues to fire on hardcoded
endpoints in production code (verified by the negative fixture; the existing
`TenantResolver.cs` marker still fires). The C# graph-snapshot baseline
(`expected-graph.json`) was updated for the new negative-fixture class.

Scope note: the test-seed-data category is the unambiguous FP class. The separate
CLI-help doc-link URLs (e.g. `AddPackageCommand.cs` help text) are a more
subjective sub-pattern and are intentionally left for a dedicated follow-up.

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a
freshly-built `dist` (the exact artifact `publish.yml` ships), before vs. after
this batch's visitor change, against the same restored `framework/Volo.Abp.slnx`.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/hardcoded-url` | 94 | 77 | -17 |
| **Total (these 1 rules)** | 94 | 77 | -17 |
| **All-rules total on target** | 84436 | 84419 | -17 |

The all-rules total moved by exactly the per-rule delta, confirming the change
removed 17 test-project false positives and affected no other rule.

cc @mushgev