### PR TITLE
fix(fp): resolve 5 FPs from abpframework/abp

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/csharp-filename-type-mismatch.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/csharp-filename-type-mismatch.ts
@@ -29,11 +29,18 @@ export const csharpFilenameTypeMismatchVisitor: CodeRuleVisitor = {
       : base.replace(/\.[^.]*$/, '')
     if (!fileName) return null
 
+    // EF Core migrations are generated as `<14-digit-timestamp>_<MigrationName>.cs`
+    // and the type is named after the migration, not the numeric prefix. Accept the
+    // name with that leading timestamp prefix stripped so the type still matches.
+    const migrationName = fileName.match(/^\d{14}_(.+)$/)?.[1]
+    const candidateNames = migrationName ? [fileName, migrationName] : [fileName]
+
     const identifiers = topLevelTypeIdentifiers(node)
     if (identifiers.length === 0) return null
     // For code-behind files the conventional `Model` suffix is an accepted match.
     const matches = (id: SyntaxNode): boolean =>
-      nameMatches(fileName, id.text) || (compoundExt !== undefined && id.text === `${fileName}Model`)
+      candidateNames.some((fn) => nameMatches(fn, id.text)) ||
+      (compoundExt !== undefined && id.text === `${fileName}Model`)
     if (identifiers.some(matches)) return null
 
     const first = identifiers[0]
@@ -71,6 +78,9 @@ function topLevelTypeIdentifiers(root: SyntaxNode): SyntaxNode[] {
 
 function nameMatches(fileName: string, typeName: string): boolean {
   if (fileName === typeName) return true
+  // C# `Attribute` suffix convention: the attribute `[Foo]` is the class
+  // `FooAttribute`, and the file is conventionally named after the usage (`Foo.cs`).
+  if (typeName === `${fileName}Attribute`) return true
   const brace = fileName.indexOf('{')
   if (brace > 0 && fileName.slice(0, brace) === typeName) return true
   const dot = fileName.indexOf('.')

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -787,6 +787,24 @@
       "layer": "service"
     },
     {
+      "name": "LabelStage",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "LabelStageBase",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "LabelTruncator",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "LedgerProjection",
       "service": "ApiGateway",
       "kind": "class",
@@ -1156,6 +1174,12 @@
       "name": "ReflectionAndUnsafe",
       "service": "ApiGateway",
       "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "RefundLedger",
+      "service": "ApiGateway",
+      "kind": "interface",
       "layer": "service"
     },
     {
@@ -2455,7 +2479,19 @@
       "layer": "data"
     },
     {
+      "name": "ReportFormatter",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "ReportSectionBase",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "RetryOptionsBuilder",
       "service": "UserService",
       "kind": "class",
       "layer": "service"
@@ -2755,6 +2791,18 @@
       "layer": "external"
     },
     {
+      "name": "BackgroundSyncer",
+      "service": "Utils",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "ComponentBase",
+      "service": "Utils",
+      "kind": "interface",
+      "layer": "service"
+    },
+    {
       "name": "Formatters",
       "service": "Utils",
       "kind": "standalone",
@@ -2770,6 +2818,12 @@
       "name": "ModuleBootstrap",
       "service": "Utils",
       "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "NotificationPanel",
+      "service": "Utils",
+      "kind": "class",
       "layer": "service"
     },
     {
@@ -3075,6 +3129,10 @@
     {
       "source": "services/UserService/Services/UserService.cs",
       "target": "services/UserService/Repositories/UserRepository.cs"
+    },
+    {
+      "source": "shared/Utils/Violations/Reliability/NotificationPanel.cs",
+      "target": "shared/Utils/Components/ComponentBase.cs"
     }
   ],
   "routes": [

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Architecture/LabelStage.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Architecture/LabelStage.cs
@@ -1,0 +1,27 @@
+#nullable disable
+namespace ApiGateway.Violations.Architecture;
+
+// A pipeline stage base that declares a boundary method the host always invokes
+// with a non-null argument (a pre-nullable type: nullable context disabled).
+public abstract class LabelStageBase
+{
+    // Measures the given label; the host always passes a non-null value.
+    public abstract int Measure(string label);
+}
+
+// An override cannot tighten the base method's argument contract, and the caller
+// (the pipeline host) controls the argument — so a missing null-guard on an
+// overridden parameter is not actionable. This must NOT be flagged (no marker):
+// the line stays clean after the fix.
+public sealed class LabelStage : LabelStageBase
+{
+    public override int Measure(string label) => label.Length;
+}
+
+// An ordinary public method that owns its own signature and dereferences a
+// reference-type argument without a guard — the genuine bug this rule catches.
+public sealed class LabelTruncator
+{
+    // VIOLATION: architecture/deterministic/missing-public-argument-validation
+    public int Truncate(string label) => label.Length;
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Style/PaymentRouting.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Style/PaymentRouting.cs
@@ -1,0 +1,9 @@
+namespace ApiGateway.Violations.Style;
+
+// The file is named PaymentRouting but the only type is RefundLedger, with no
+// attribute-suffix or migration-timestamp convention to explain the difference —
+// a genuine "name the file after its type" miss.
+// VIOLATION: code-quality/deterministic/csharp-filename-type-mismatch
+internal sealed class RefundLedger
+{
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/ReportFormatter.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/ReportFormatter.cs
@@ -1,0 +1,10 @@
+namespace UserService.Violations.CodeQuality;
+
+// A standalone formatter that owns its own signature (implements no interface).
+public sealed class ReportFormatter
+{
+    // A public method with a parameter that is never read — a genuine unused
+    // parameter, not fixed by any interface contract.
+    // VIOLATION: code-quality/deterministic/unused-function-parameter
+    public int Format(string text, int unusedWidth) => text.Length;
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/RetryOptionsBuilder.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/RetryOptionsBuilder.cs
@@ -1,0 +1,10 @@
+namespace UserService.Violations.CodeQuality;
+
+// A builder exposing a public API whose default value is a versioning hazard.
+public sealed class RetryOptionsBuilder
+{
+    // A public method with an optional value-type parameter whose default is
+    // compiled into every call site — changing it later silently strands callers.
+    // VIOLATION: code-quality/deterministic/optional-parameter-hazard
+    public int Build(int maxAttempts = 3) => maxAttempts;
+}

--- a/tests/fixtures/sample-csharp-project-negative/shared/Utils/Components/ComponentBase.cs
+++ b/tests/fixtures/sample-csharp-project-negative/shared/Utils/Components/ComponentBase.cs
@@ -1,0 +1,8 @@
+namespace Microsoft.AspNetCore.Components;
+
+// Minimal stand-in for the Blazor base type, so the fixture can model a UI
+// component without a reference to the ASP.NET Core framework. The rule matches
+// the base type by name + namespace, which this reproduces exactly.
+public class ComponentBase
+{
+}

--- a/tests/fixtures/sample-csharp-project-negative/shared/Utils/Violations/Reliability/NotificationPanel.cs
+++ b/tests/fixtures/sample-csharp-project-negative/shared/Utils/Violations/Reliability/NotificationPanel.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace Utils.Violations.Reliability;
+
+// A Blazor UI component: awaits that mutate component state must resume on the
+// captured SynchronizationContext, so ConfigureAwait(false) is the wrong advice
+// here — detaching from the UI context is a bug, not a fix. The rule must NOT
+// fire on a component await (no marker).
+public class NotificationPanel : ComponentBase
+{
+    // Refreshes the panel; the continuation must run back on the UI context.
+    public async Task RefreshAsync()
+    {
+        await Task.Delay(1);
+    }
+}
+
+// Plain shared-library code (not a UI component): a captured context can deadlock
+// a caller that blocks on the returned task, so the missing ConfigureAwait(false)
+// is a genuine bug here.
+public sealed class BackgroundSyncer
+{
+    // Runs one background synchronization step.
+    public async Task RunAsync()
+    {
+        // VIOLATION: reliability/deterministic/missing-configureawait
+        await Task.Delay(2);
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/20240115090000_AddAuditColumns.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/20240115090000_AddAuditColumns.cs
@@ -1,0 +1,9 @@
+namespace Positive.Boundary.CodeQuality.Migrations;
+
+// SAFE: code-quality/deterministic/csharp-filename-type-mismatch
+// A tool-generated migration file: the type is named after the migration and the
+// file carries the generator's 14-digit numeric timestamp prefix (20240115090000_),
+// so the type matches the file once that prefix is disregarded.
+internal sealed class AddAuditColumns
+{
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/RetentionPolicy.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/RetentionPolicy.cs
@@ -1,0 +1,10 @@
+namespace Positive.Boundary.CodeQuality;
+
+// SAFE: code-quality/deterministic/csharp-filename-type-mismatch
+// The file is named after the attribute's usage name (RetentionPolicy); by the
+// standard C# 'Attribute' suffix convention the declared type is
+// RetentionPolicyAttribute, so the file is correctly located — not a mismatch.
+[System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method)]
+internal sealed class RetentionPolicyAttribute : System.Attribute
+{
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/OptionalParameterCancellationTokenSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/OptionalParameterCancellationTokenSafe.cs
@@ -1,0 +1,16 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// A public method whose only optional parameter is a CancellationToken defaulting
+/// to `default` (CancellationToken.None) — the universal async-cancellation idiom.
+/// The default is an immutable, well-known value, so there is no cross-version
+/// call-site-baking hazard and the rule must not fire.
+/// </summary>
+public class OptionalParameterCancellationTokenSafe
+{
+    // SAFE: code-quality/deterministic/optional-parameter-hazard
+    public void Cancel(System.Threading.CancellationToken token = default)
+    {
+        token.ThrowIfCancellationRequested();
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/UnusedParamInterfaceImplSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/UnusedParamInterfaceImplSafe.cs
@@ -1,0 +1,14 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// Implicitly implements an interface method whose declaring interface lives in an
+/// assembly this loose-text pass cannot resolve (mirrors implementing ASP.NET Core's
+/// IAsyncPageFilter / IAuthorizationService). The signature is contract-fixed by that
+/// interface, so an unreferenced parameter must NOT be flagged — renaming or removing
+/// it would break the implementation.
+/// </summary>
+public class UnusedParamInterfaceImplSafe : IExternalHandlerContract
+{
+    // SAFE: code-quality/deterministic/unused-function-parameter
+    public int Handle(string request) => 0;
+}

--- a/tools/csharp-roslyn-host/Rules/Architecture/MissingPublicArgumentValidation.cs
+++ b/tools/csharp-roslyn-host/Rules/Architecture/MissingPublicArgumentValidation.cs
@@ -31,6 +31,18 @@ internal sealed class MissingPublicArgumentValidation : ISemanticRule
             if (!IsExternallyVisible(sym) || sym.ContainingType is null || !IsExternallyVisible(sym.ContainingType))
                 continue;
 
+            // Overrides and interface implementations inherit their argument contract
+            // from the base method / interface member: the parameter's nullability and
+            // any guard obligation are dictated there, and the caller — very often a
+            // framework that always supplies a non-null argument (an overridden
+            // `ConfigureServices(context)` / `Execute(context)` hook) — controls the
+            // value. A missing guard on such a signature is not actionable here, so
+            // flagging it is a false positive. This mirrors the other public-surface
+            // rules, which likewise exempt inherited signatures.
+            if (sym.IsOverride || sym.ExplicitInterfaceImplementations.Length > 0 ||
+                IsImplicitInterfaceImplementation(sym))
+                continue;
+
             foreach (var p in method.ParameterList.Parameters)
             {
                 if (model.GetDeclaredSymbol(p) is not IParameterSymbol ps) continue;
@@ -58,6 +70,20 @@ internal sealed class MissingPublicArgumentValidation : ISemanticRule
 
     private static bool IsExternallyVisible(ISymbol s) =>
         s.DeclaredAccessibility is Accessibility.Public or Accessibility.Protected or Accessibility.ProtectedOrInternal;
+
+    // An implicit interface implementation (`void Configure(context)` satisfying
+    // `IFoo.Configure(context)` without the explicit `IFoo.` prefix) has a
+    // contract-fixed signature just like an override, so it carries the same
+    // inherited argument contract.
+    private static bool IsImplicitInterfaceImplementation(IMethodSymbol method)
+    {
+        var containingType = method.ContainingType;
+        if (containingType is null) return false;
+        return containingType.AllInterfaces
+            .SelectMany(i => i.GetMembers(method.Name).OfType<IMethodSymbol>())
+            .Any(im => SymbolEqualityComparer.Default.Equals(
+                containingType.FindImplementationForInterfaceMember(im), method));
+    }
 
     private static bool IsGuardableReferenceParameter(IParameterSymbol p)
     {

--- a/tools/csharp-roslyn-host/Rules/CodeQuality/OptionalParameterHazard.cs
+++ b/tools/csharp-roslyn-host/Rules/CodeQuality/OptionalParameterHazard.cs
@@ -32,6 +32,12 @@ internal sealed class OptionalParameterHazard : ISemanticRule
             foreach (var p in node.ParameterList.Parameters)
             {
                 if (p.Default is null) continue;
+                // A `CancellationToken token = default` tail is the universal async
+                // cancellation idiom: the default is the immutable, well-known
+                // CancellationToken.None, so there is no per-call-site baking hazard
+                // and no confusing overload-resolution surprise across assemblies.
+                if (model.GetDeclaredSymbol(p) is IParameterSymbol ps && IsCancellationToken(ps.Type))
+                    continue;
                 var pos = p.Identifier.GetLocation().GetLineSpan().StartLinePosition;
                 yield return new Violation(
                     RuleKey, tree.FilePath, pos.Line + 1, pos.Character + 1,
@@ -39,6 +45,10 @@ internal sealed class OptionalParameterHazard : ISemanticRule
             }
         }
     }
+
+    private static bool IsCancellationToken(ITypeSymbol type) =>
+        type.Name == "CancellationToken" &&
+        type.ContainingNamespace?.ToDisplayString() == "System.Threading";
 
     private static bool IsExternallyVisible(IMethodSymbol method)
     {

--- a/tools/csharp-roslyn-host/Rules/CodeQuality/UnusedFunctionParameter.cs
+++ b/tools/csharp-roslyn-host/Rules/CodeQuality/UnusedFunctionParameter.cs
@@ -39,6 +39,15 @@ internal sealed class UnusedFunctionParameter : ISemanticRule
             // can choose to do explicitly; we do not flag.
             if (IsImplicitInterfaceImplementation(method)) continue;
 
+            // Loose-text analysis can leave an implemented interface (or a base type)
+            // unresolved when its assembly is not in the reference set — e.g. a class
+            // implementing ASP.NET Core's IAsyncPageFilter / IAuthorizationService. In
+            // that case IsImplicitInterfaceImplementation cannot see the contract
+            // member, so we cannot prove this method is NOT a contract-fixed
+            // implementation whose parameter names/types are mandated. Be conservative
+            // and do not flag parameters on such a type.
+            if (HasUnresolvedContract(method.ContainingType)) continue;
+
             if (method.Name == "Main") continue;
             if (method.Parameters.IsEmpty) continue;
 
@@ -84,6 +93,18 @@ internal sealed class UnusedFunctionParameter : ISemanticRule
                 }
             }
         }
+    }
+
+    // True when the type implements an interface — or derives from a base — that the
+    // compilation could not resolve (an error type), so its inherited contract is
+    // unknown to this pass.
+    private static bool HasUnresolvedContract(INamedTypeSymbol type)
+    {
+        if (type.Interfaces.Any(i => i.TypeKind == TypeKind.Error)) return true;
+        if (type.AllInterfaces.Any(i => i.TypeKind == TypeKind.Error)) return true;
+        for (var b = type.BaseType; b is not null; b = b.BaseType)
+            if (b.TypeKind == TypeKind.Error) return true;
+        return false;
     }
 
     private static bool IsImplicitInterfaceImplementation(IMethodSymbol method)

--- a/tools/csharp-roslyn-host/Rules/Reliability/MissingConfigureAwait.cs
+++ b/tools/csharp-roslyn-host/Rules/Reliability/MissingConfigureAwait.cs
@@ -37,10 +37,29 @@ internal sealed class MissingConfigureAwait : IProjectAwareRule
             if (type is null || type.TypeKind == TypeKind.Error) continue;
             if (!type.GetMembers("ConfigureAwait").OfType<IMethodSymbol>().Any()) continue;
 
+            // Blazor components (types deriving from Microsoft.AspNetCore.Components.
+            // ComponentBase) run on the renderer's SynchronizationContext, and their
+            // awaits frequently mutate component state (StateHasChanged, bound fields).
+            // Those continuations MUST resume on the captured context, so
+            // ConfigureAwait(false) is the wrong advice — flagging it is a false
+            // positive even though the assembly is a library.
+            if (IsInBlazorComponent(awaitExpr, model)) continue;
+
             var pos = expr.GetLocation().GetLineSpan().StartLinePosition;
             yield return new Violation(
                 RuleKey, tree.FilePath, pos.Line + 1, pos.Character + 1,
                 "await in library code without ConfigureAwait(false) captures the caller's synchronization context and can deadlock callers that block on the task; add .ConfigureAwait(false).");
         }
+    }
+
+    private static bool IsInBlazorComponent(SyntaxNode node, SemanticModel model)
+    {
+        var typeDecl = node.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+        if (typeDecl is null) return false;
+        for (var t = model.GetDeclaredSymbol(typeDecl) as INamedTypeSymbol; t is not null; t = t.BaseType)
+            if (t.Name == "ComponentBase" &&
+                t.ContainingNamespace?.ToDisplayString() == "Microsoft.AspNetCore.Components")
+                return true;
+        return false;
     }
 }


### PR DESCRIPTION
Resolves five re-discovered C# false-positive rules from the `abpframework/abp` campaign (SCOPE=`cs-`). Each fix is a principled exemption for a well-known C# idiom, paired with a paraphrased **positive** case (must-not-fire) and a **negative** true-bug case (must-fire) in the analyzer fixtures. All identifiers/filenames are domain-neutral; the OSS sources are linked below for review context only.

Closes #704
Closes #706
Closes #707
Closes #708
Closes #709

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| architecture/deterministic/missing-public-argument-validation | #704 | `…-negative/services/ApiGateway/Violations/Architecture/LabelStage.cs` (override, unmarked) | same file (`LabelTruncator`) |
| code-quality/deterministic/csharp-filename-type-mismatch | #706 | `…-positive/services/CodeQualitySamples1/RetentionPolicy.cs`, `…/20240115090000_AddAuditColumns.cs` | `…-negative/services/ApiGateway/Violations/Style/PaymentRouting.cs` |
| code-quality/deterministic/optional-parameter-hazard | #707 | `…-positive/services/CodeQualitySamples2/OptionalParameterCancellationTokenSafe.cs` | `…-negative/services/UserService/Violations/CodeQuality/RetryOptionsBuilder.cs` |
| code-quality/deterministic/unused-function-parameter | #708 | `…-positive/services/CodeQualitySamples2/UnusedParamInterfaceImplSafe.cs` | `…-negative/services/UserService/Violations/CodeQuality/ReportFormatter.cs` |
| reliability/deterministic/missing-configureawait | #709 | `…-negative/shared/Utils/Violations/Reliability/NotificationPanel.cs` (component, unmarked) + `…/shared/Utils/Components/ComponentBase.cs` | same file (`BackgroundSyncer`) |

> Note: #704 and #709 are `roslyn-workspace`/project-aware rules whose only executing harness is `csharp-negative-project.test.ts`. Their positive (must-not-fire) case therefore lives in the negative-project fixture as an **unmarked** declaration inside a `/Violations/` folder — the "no unexpected violations" assertion is what pins the no-false-positive regression there.

## architecture/deterministic/missing-public-argument-validation (#704)

OSS sources (FP):
- https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/AbpCliCoreModule.cs#L40
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Building/Steps/ReplaceCommonPropsStep.cs#L12``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/ExceptionHandling/AbpAuthorizationExceptionTestPage_Tests.cs#L32``

Positive (must NOT fire) + negative (marked) — `LabelStage.cs`:
```diff
+#nullable disable
+namespace ApiGateway.Violations.Architecture;
+
+public abstract class LabelStageBase
+{
+    // Measures the given label; the host always passes a non-null value.
+    public abstract int Measure(string label);
+}
+
+public sealed class LabelStage : LabelStageBase
+{
+    public override int Measure(string label) => label.Length;   // override → must NOT fire
+}
+
+public sealed class LabelTruncator
+{
+    // VIOLATION: architecture/deterministic/missing-public-argument-validation
+    public int Truncate(string label) => label.Length;           // ordinary public method → fires
+}
```

**Fix:** exempt `override` methods, explicit interface implementations, and implicit interface implementations. Such a method inherits its parameter contract (nullability + guard obligation) from the base method / interface member, and its argument is supplied by the caller — very often a framework passing a guaranteed non-null context (`ConfigureServices(context)`, `Execute(context)`). A missing null-guard there is not actionable, and this mirrors the exemptions the other public-surface rules already apply.

## code-quality/deterministic/csharp-filename-type-mismatch (#706)

OSS sources (FP):
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/IgnoreAbpSecurityHeader.cs#L6``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/blogging/app/Volo.BloggingTestApp.EntityFrameworkCore/Migrations/20180817055949_ReplyComment_Nullable.cs#L5``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/docs/app/VoloDocs.EntityFrameworkCore/Migrations/20250425082043_add_pdf_file.cs#L9``

Positive (must NOT fire) — `RetentionPolicy.cs` (Attribute suffix) and `20240115090000_AddAuditColumns.cs` (migration timestamp):
```diff
+// RetentionPolicy.cs
+[System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method)]
+internal sealed class RetentionPolicyAttribute : System.Attribute { }   // file RetentionPolicy.cs ↔ FooAttribute
+
+// 20240115090000_AddAuditColumns.cs
+internal sealed class AddAuditColumns { }   // type matches once the 14-digit timestamp prefix is stripped
```
Negative (marked) — `PaymentRouting.cs`:
```diff
+// VIOLATION: code-quality/deterministic/csharp-filename-type-mismatch
+internal sealed class RefundLedger { }   // file PaymentRouting.cs, no convention explains the mismatch → fires
```

**Fix:** teach the visitor two standard C# conventions — (1) the `Attribute` suffix, so a file named after the attribute's usage (`Foo.cs`) correctly houses `FooAttribute`; (2) EF Core migrations named `<14-digit-timestamp>_<Name>.cs`, whose type is named after the migration, not the numeric prefix.

## code-quality/deterministic/optional-parameter-hazard (#707)

OSS sources (FP):
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/audit-logging/src/Volo.Abp.AuditLogging.EntityFrameworkCore/Volo/Abp/AuditLogging/EntityFrameworkCore/EfCoreAuditLogRepository.cs#L230``
- https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Caching/Volo/Abp/Caching/DistributedCache.cs#L118

Positive (must NOT fire) — `OptionalParameterCancellationTokenSafe.cs`:
```diff
+public class OptionalParameterCancellationTokenSafe
+{
+    // SAFE: code-quality/deterministic/optional-parameter-hazard
+    public void Cancel(System.Threading.CancellationToken token = default)
+    {
+        token.ThrowIfCancellationRequested();
+    }
+}
```
Negative (marked) — `RetryOptionsBuilder.cs`:
```diff
+public sealed class RetryOptionsBuilder
+{
+    // VIOLATION: code-quality/deterministic/optional-parameter-hazard
+    public int Build(int maxAttempts = 3) => maxAttempts;   // genuine baked-in default
+}
```

**Fix:** exempt optional parameters of type `System.Threading.CancellationToken`. `CancellationToken token = default` is the universal async-cancellation idiom; its default is the immutable, well-known `CancellationToken.None`, so it carries no per-call-site default-baking or cross-assembly overload-resolution hazard.

## code-quality/deterministic/unused-function-parameter (#708)

OSS sources (FP):
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Features/AbpFeaturePageFilter.cs#L13``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/AlwaysAllowAuthorizationService.cs#L29``

Positive (must NOT fire) — `UnusedParamInterfaceImplSafe.cs`:
```diff
+public class UnusedParamInterfaceImplSafe : IExternalHandlerContract   // interface unresolved in loose-text pass
+{
+    // SAFE: code-quality/deterministic/unused-function-parameter
+    public int Handle(string request) => 0;   // signature is contract-fixed → must NOT fire
+}
```
Negative (marked) — `ReportFormatter.cs`:
```diff
+public sealed class ReportFormatter   // implements no interface
+{
+    // VIOLATION: code-quality/deterministic/unused-function-parameter
+    public int Format(string text, int unusedWidth) => text.Length;   // genuinely unused param → fires
+}
```

**Fix:** when the containing type implements an interface (or derives from a base) that the loose-text pass could not resolve — e.g. a class implementing ASP.NET Core's `IAsyncPageFilter` / `IAuthorizationService`, whose assembly is not in the reference set — `IsImplicitInterfaceImplementation` cannot see the contract member. In that case we cannot prove the method is not a contract-fixed implementation, so we conservatively do not flag its parameters. (Targets the implicit-interface-implementation FP class — the majority of the sample.)

## reliability/deterministic/missing-configureawait (#709)

OSS sources (FP):
- https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.BlazoriseUI/AbpCrudPageBase.cs#L525
- https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.MudBlazorUI/AbpMudCrudPageBase.cs#L349

Positive (must NOT fire) + negative (marked) — `NotificationPanel.cs` (+ a local `ComponentBase` stand-in so the fixture models a component without an ASP.NET Core framework reference):
```diff
+public class NotificationPanel : ComponentBase   // Microsoft.AspNetCore.Components.ComponentBase
+{
+    public async Task RefreshAsync()
+    {
+        await Task.Delay(1);   // UI component await → must NOT fire (no marker)
+    }
+}
+
+public sealed class BackgroundSyncer   // plain library code
+{
+    public async Task RunAsync()
+    {
+        // VIOLATION: reliability/deterministic/missing-configureawait
+        await Task.Delay(2);   // genuine missing ConfigureAwait(false) → fires
+    }
+}
```

**Fix:** exempt awaits inside Blazor components (types deriving from `Microsoft.AspNetCore.Components.ComponentBase`). Components run on the renderer's `SynchronizationContext` and their awaits frequently mutate component state, so those continuations MUST resume on the captured context — `ConfigureAwait(false)` is the wrong advice there, even though the assembly is a library.

## Skipped this batch

- #705 `bugs/deterministic/normalize-to-lower-not-upper` — **refactor needed** (labeled `cs-fp-blocked`). The FP reproduces (138 hits) but spans several distinct intent-driven sub-patterns (externally-mandated lowercase contracts, casing-transform methods, boolean/enum-to-token serialization, display/markup output) with no shared local AST/semantic signal. A correct fix restricts the rule to the genuine normalize-then-compare anti-pattern, which is a usage/dataflow-context redesign beyond a single-call visitor tweak. Details on the issue.

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

Measured with `node dist/cli.mjs analyze --no-llm` from a fresh `pnpm build:dist` (the exact artifact publish.yml ships), before vs after this batch's visitor fixes.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| architecture/deterministic/missing-public-argument-validation | 600 | 194 | -406 |
| code-quality/deterministic/csharp-filename-type-mismatch | 120 | 71 | -49 |
| code-quality/deterministic/optional-parameter-hazard | 4602 | 2941 | -1661 |
| code-quality/deterministic/unused-function-parameter | 302 | 248 | -54 |
| reliability/deterministic/missing-configureawait | 2854 | 2665 | -189 |
| **Total (these 5 rules)** | **8478** | **6119** | **-2359** |
| **All-rules total on target** | **84372** | **82013** | **-2359** |

cc @mushgev

🤖 Generated with [Claude Code](https://claude.com/claude-code)