### PR TITLE
fix(fp): resolve 4 FPs from abpframework/abp

### DIFF
--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -175,6 +175,12 @@
       "layer": "service"
     },
     {
+      "name": "CheckpointRecorder",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "Circle",
       "service": "ApiGateway",
       "kind": "class",
@@ -1279,6 +1285,12 @@
       "layer": "service"
     },
     {
+      "name": "RequestTagBag",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "RequestValidation",
       "service": "ApiGateway",
       "kind": "class",
@@ -1580,6 +1592,12 @@
     },
     {
       "name": "ThreadPoolSection",
+      "service": "ApiGateway",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "ThresholdReader",
       "service": "ApiGateway",
       "kind": "class",
       "layer": "service"
@@ -2060,6 +2078,12 @@
     },
     {
       "name": "ICache",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "IdentifierNormalizer",
       "service": "UserService",
       "kind": "class",
       "layer": "service"

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/ThresholdReader.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/ThresholdReader.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace ApiGateway.Violations.Bugs;
+
+/// <summary>
+/// Reads a configured numeric threshold from its raw text form. The parse omits an
+/// explicit IFormatProvider even though a culture-invariant overload exists, so the
+/// value is locale-dependent — a comma-decimal culture misreads "1.5" as 15.
+/// </summary>
+internal sealed class ThresholdReader
+{
+    private readonly string _rawLimit;
+
+    internal ThresholdReader(string rawLimit)
+    {
+        _rawLimit = rawLimit;
+    }
+
+    /// <summary>Parses the configured limit, dropping the invariant provider.</summary>
+    internal double Limit()
+    {
+        // VIOLATION: bugs/deterministic/missing-format-provider-overload
+        return double.Parse(_rawLimit);
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/CheckpointRecorder.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/CheckpointRecorder.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace ApiGateway.Violations.CodeQuality;
+
+/// <summary>Records processing checkpoints using the ambient clock read directly.</summary>
+internal sealed class CheckpointRecorder
+{
+    private DateTime _lastCheckpoint;
+
+    /// <summary>Advances the checkpoint to the current wall-clock time.</summary>
+    internal void Advance()
+    {
+        // Reads the ambient clock directly instead of an injected abstraction,
+        // making the checkpoint non-deterministic to test.
+        // VIOLATION: code-quality/deterministic/non-testable-datetime-provider
+        _lastCheckpoint = DateTime.Now;
+    }
+
+    /// <summary>The most recent checkpoint instant.</summary>
+    internal DateTime Last => _lastCheckpoint;
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/RequestTagBag.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/RequestTagBag.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace ApiGateway.Violations.CodeQuality;
+
+/// <summary>Holds request tags exposed with a replaceable setter.</summary>
+internal sealed class RequestTagBag
+{
+    // A raw List exposed with a public setter — callers can swap the whole
+    // collection wholesale and bypass any invariants (CA2227).
+    // VIOLATION: code-quality/deterministic/writable-collection-property
+    public List<string> Tags { get; set; } = new();
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/IdentifierNormalizer.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/IdentifierNormalizer.cs
@@ -1,0 +1,32 @@
+namespace UserServiceApp.Violations.CodeQuality;
+
+/// <summary>Builds prefixed identifiers; one private helper ignores the receiver.</summary>
+internal sealed class IdentifierNormalizer
+{
+    private readonly string _prefix;
+
+    internal IdentifierNormalizer(string prefix)
+    {
+        _prefix = prefix;
+    }
+
+    /// <summary>Combines the instance prefix with a normalized identifier.</summary>
+    internal string Build(string raw)
+    {
+        return _prefix + Normalize(raw);
+    }
+
+    // Takes an input, delegates only to a static helper, and never touches the
+    // receiver, so it should be declared static.
+    // VIOLATION: code-quality/deterministic/unused-this-parameter
+    // VIOLATION: code-quality/deterministic/static-method-candidate
+    private string Normalize(string raw)
+    {
+        return Collapse(raw);
+    }
+
+    private static string Collapse(string raw)
+    {
+        return raw.Trim();
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/MissingFormatProviderOverloadGuidParseSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/BugsSamples2/MissingFormatProviderOverloadGuidParseSafe.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Positive.Boundary.Bugs;
+
+/// <summary>
+/// Reads <see cref="System.Guid"/> identifiers from text. Guid parsing is
+/// culture-invariant: its <c>IParsable</c>/<c>ISpanParsable</c> overloads accept an
+/// <c>IFormatProvider</c> only to satisfy the interface and ignore it entirely, so
+/// <c>Guid.Parse</c>/<c>Guid.TryParse</c> without a provider is fully portable and the
+/// rule must not fire.
+/// </summary>
+public sealed class MissingFormatProviderOverloadGuidParseSafe
+{
+    /// <summary>Returns the parsed identifier, or null when the text is not a Guid.</summary>
+    public Guid? TryRead(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        // SAFE: bugs/deterministic/missing-format-provider-overload
+        return Guid.TryParse(text, out var parsed) ? parsed : (Guid?)null;
+    }
+
+    /// <summary>Parses a required identifier from its canonical text form.</summary>
+    public Guid Read(string text)
+    {
+        // SAFE: bugs/deterministic/missing-format-provider-overload
+        return Guid.Parse(text);
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/UnusedThisParameterInheritedConfigureSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/UnusedThisParameterInheritedConfigureSafe.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// A framework base that exposes a protected generic configuration helper, mirroring
+/// module base classes whose derived types call an inherited <c>Configure&lt;TOptions&gt;</c>
+/// with no qualifier.
+/// </summary>
+public class ConfigurableModuleBase
+{
+    private int _configuredCount;
+
+    /// <summary>Count of option types registered through this instance.</summary>
+    protected int ConfiguredCount => _configuredCount;
+
+    /// <summary>Registers options of the given type — a protected instance helper.</summary>
+    protected void Configure<TOptions>(Action<TOptions> setup)
+        where TOptions : new()
+    {
+        var options = new TOptions();
+        setup(options);
+        _configuredCount++;
+    }
+}
+
+/// <summary>
+/// A module whose private helper calls the inherited protected generic
+/// <c>Configure&lt;T&gt;</c> with no qualifier — a use of the receiver. The method is not
+/// static-eligible even though it only reads its parameter, so the rule must not fire
+/// on an unqualified generic instance-method call.
+/// </summary>
+public sealed class UnusedThisParameterInheritedConfigureSafe : ConfigurableModuleBase
+{
+    /// <summary>Delegates configuration to the private helper.</summary>
+    public void Initialize(string rootPath)
+    {
+        ApplyStoragePath(rootPath);
+    }
+
+    // Calls the inherited protected Configure<T>(...) with no qualifier — a use of the
+    // receiver — so it must not be reported as static-eligible.
+    // SAFE: code-quality/deterministic/unused-this-parameter
+    private void ApplyStoragePath(string rootPath)
+    {
+        Configure<StorageOptions>(options => options.RootPath = rootPath);
+    }
+}
+
+/// <summary>Options bag configured by the module.</summary>
+public sealed class StorageOptions
+{
+    /// <summary>Filesystem root the module serves from.</summary>
+    public string? RootPath { get; set; }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/NonTestableDateTimeProviderClockImplSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples2/NonTestableDateTimeProviderClockImplSafe.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>The clock abstraction callers inject instead of reading ambient time.</summary>
+public interface IClock
+{
+    /// <summary>The current instant.</summary>
+    DateTime Now { get; }
+
+    /// <summary>The current UTC instant.</summary>
+    DateTime UtcNow { get; }
+}
+
+/// <summary>
+/// The concrete clock implementation. A clock must read the ambient system time
+/// somewhere; this IS the injectable abstraction the rule recommends callers use, so
+/// non-testable-datetime-provider must not fire on the provider type itself.
+/// </summary>
+public sealed class NonTestableDateTimeProviderClockImplSafe : IClock
+{
+    /// <summary>The current instant, read from the system clock.</summary>
+    // SAFE: code-quality/deterministic/non-testable-datetime-provider
+    public DateTime Now => DateTime.Now;
+
+    /// <summary>The current UTC instant, read from the system clock.</summary>
+    // SAFE: code-quality/deterministic/non-testable-datetime-provider
+    public DateTime UtcNow => DateTime.UtcNow;
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples4/WritableCollectionPropertyDomainSubclassSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples4/WritableCollectionPropertyDomainSubclassSafe.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// A domain set of role names. It implements a mutable collection (via HashSet) but
+/// models a single named value with its own identity, so exposing it through a
+/// settable property is not the raw-collection replacement hazard CA2227 targets.
+/// </summary>
+public sealed class RoleSet : HashSet<string>
+{
+}
+
+/// <summary>
+/// Holds a default <see cref="RoleSet"/>. The property is settable because the set is
+/// a domain value assigned as a unit — not a raw collection exposed for wholesale
+/// replacement — so writable-collection-property must not fire on a user-defined type
+/// that merely derives from a collection.
+/// </summary>
+public sealed class WritableCollectionPropertyDomainSubclassSafe
+{
+    // SAFE: code-quality/deterministic/writable-collection-property
+    /// <summary>The default role set applied when none is specified.</summary>
+    public RoleSet? Default { get; set; }
+}

--- a/tools/csharp-roslyn-host/Rules/Bugs/MissingFormatProviderOverload.cs
+++ b/tools/csharp-roslyn-host/Rules/Bugs/MissingFormatProviderOverload.cs
@@ -43,6 +43,12 @@ internal sealed class MissingFormatProviderOverload : ISemanticRule
             // the formattable BCL surface). Restrict Format to System.String.Format.
             if (m.Name == "Format" && m.ContainingType?.SpecialType != SpecialType.System_String) continue;
 
+            // Some BCL types parse identically under every culture — their .NET 7
+            // IParsable/ISpanParsable IFormatProvider overloads exist only to satisfy
+            // the interface and ignore the provider entirely. Passing one changes
+            // nothing, so flagging Guid/bool/Version parsing is a false positive.
+            if (m.Name is "Parse" or "TryParse" && IsCultureInvariantParseType(m.ContainingType)) continue;
+
             var hasOverload = m.ContainingType?.GetMembers(m.Name).OfType<IMethodSymbol>()
                 .Any(o => o.Parameters.Any(IsFormatProvider)) == true;
             if (!hasOverload) continue;
@@ -53,6 +59,11 @@ internal sealed class MissingFormatProviderOverload : ISemanticRule
                 $"{m.ContainingType?.Name}.{m.Name} omits an IFormatProvider — pass CultureInfo.InvariantCulture (or the appropriate culture) for portable, predictable results.");
         }
     }
+
+    // Types whose Parse/TryParse ignore any IFormatProvider (culture-invariant by
+    // spec), even though a provider-taking overload exists via IParsable&lt;T&gt;.
+    private static bool IsCultureInvariantParseType(INamedTypeSymbol? t) =>
+        t is { ContainingNamespace.Name: "System" } && t.Name is "Guid" or "Boolean" or "Version";
 
     private static bool IsFormatProvider(IParameterSymbol p) =>
         p.Type is { Name: "IFormatProvider", ContainingNamespace.Name: "System" } ||

--- a/tools/csharp-roslyn-host/Rules/CodeQuality/NonTestableDateTimeProvider.cs
+++ b/tools/csharp-roslyn-host/Rules/CodeQuality/NonTestableDateTimeProvider.cs
@@ -38,10 +38,41 @@ internal sealed class NonTestableDateTimeProvider : ISemanticRule
             // DateTimeOffset has no `Today`; guard so we only report real members.
             if (owner == "DateTimeOffset" && name == "Today") continue;
 
+            // The clock abstraction itself is the sanctioned place to read ambient
+            // time — a clock must read DateTime.Now/UtcNow somewhere. Don't flag reads
+            // inside a type that IS the injectable clock (named like a clock, or
+            // implementing IClock / TimeProvider) — that is exactly what the rule tells
+            // callers to inject, so flagging the provider is self-defeating.
+            if (IsClockAbstraction(access.FirstAncestorOrSelf<TypeDeclarationSyntax>())) continue;
+
             var pos = access.GetLocation().GetLineSpan().StartLinePosition;
             yield return new Violation(
                 RuleKey, tree.FilePath, pos.Line + 1, pos.Character + 1,
                 $"Direct {owner}.{name} makes time-dependent code untestable; inject a clock abstraction (e.g. TimeProvider) instead.");
         }
+    }
+
+    // True when the enclosing type IS a clock abstraction — named like a clock, or
+    // implementing/deriving IClock / TimeProvider. Such a type is the single place a
+    // codebase reads the ambient clock; the rule recommends injecting it, so flagging
+    // it would be self-defeating. Syntax-based so it holds even in loose-text analysis
+    // where a project's own IClock interface is unresolved.
+    private static bool IsClockAbstraction(TypeDeclarationSyntax? decl)
+    {
+        if (decl is null) return false;
+        if (decl.Identifier.ValueText.EndsWith("Clock", StringComparison.Ordinal)) return true;
+        if (decl.BaseList is null) return false;
+        foreach (var baseType in decl.BaseList.Types)
+        {
+            var name = baseType.Type switch
+            {
+                GenericNameSyntax g => g.Identifier.ValueText,
+                IdentifierNameSyntax i => i.Identifier.ValueText,
+                QualifiedNameSyntax q => q.Right.Identifier.ValueText,
+                _ => null,
+            };
+            if (name is "IClock" or "TimeProvider" or "ITimeProvider") return true;
+        }
+        return false;
     }
 }

--- a/tools/csharp-roslyn-host/Rules/CodeQuality/UnusedThisParameter.cs
+++ b/tools/csharp-roslyn-host/Rules/CodeQuality/UnusedThisParameter.cs
@@ -72,7 +72,11 @@ internal sealed class UnusedThisParameter : ISemanticRule
                 case ThisExpressionSyntax:
                 case BaseExpressionSyntax:
                     return true;
-                case IdentifierNameSyntax id:
+                // SimpleNameSyntax covers both `Foo` (IdentifierNameSyntax) and the
+                // GENERIC form `Foo<T>` (GenericNameSyntax). Handling only the former
+                // missed unqualified inherited generic calls like `Configure<TOptions>(…)`
+                // — a use of the receiver the rule wrongly reported as static-eligible.
+                case SimpleNameSyntax id:
                     // Skip the right-hand name of a member access (`x.Foo`) — that's
                     // qualified and resolved via the receiver, not the implicit `this`.
                     if (id.Parent is MemberAccessExpressionSyntax ma && ma.Name == id) break;
@@ -81,9 +85,9 @@ internal sealed class UnusedThisParameter : ISemanticRule
                     // unresolved (loose-text analysis without the full reference set),
                     // overload resolution can fail to commit to a single symbol even
                     // though every candidate is an instance member of THIS type — e.g.
-                    // an unqualified call `Configure(option)` where `option`'s type lives
-                    // in an unreferenced assembly. Fall back to the candidate set so such
-                    // a call still counts as receiver use rather than a phantom "static".
+                    // an unqualified call `Configure<TOptions>(option)` where `option`'s
+                    // type lives in an unreferenced assembly. Fall back to the candidate
+                    // set so such a call still counts as receiver use, not a phantom "static".
                     foreach (var symbol in info.Symbol is { } resolved
                                  ? new[] { resolved }
                                  : info.CandidateSymbols.AsEnumerable())

--- a/tools/csharp-roslyn-host/Rules/CodeQuality/WritableCollectionProperty.cs
+++ b/tools/csharp-roslyn-host/Rules/CodeQuality/WritableCollectionProperty.cs
@@ -44,12 +44,35 @@ internal sealed class WritableCollectionProperty : ISemanticRule
             // to expose with a setter because callers can't mutate the elements anyway —
             // CA2227 targets the writable ones.
             if (!ImplementsMutableCollection(type)) continue;
+            // CA2227 targets a RAW collection exposed via a setter — a BCL collection
+            // type (List<T>, Dictionary<K,V>, HashSet<T>, …) or a collection interface.
+            // A user-defined type that merely DERIVES from a collection is a domain
+            // object with its own identity (e.g. a keyed config bag), not a collection
+            // the caller would replace wholesale, so it is not the invariant-bypass
+            // hazard — skip it.
+            if (!IsBclCollectionType(type)) continue;
 
             var pos = prop.Identifier.GetLocation().GetLineSpan().StartLinePosition;
             yield return new Violation(
                 RuleKey, tree.FilePath, pos.Line + 1, pos.Character + 1,
                 $"Collection property '{sym.Name}' has a public setter; expose it as get-only so callers cannot replace the whole collection.");
         }
+    }
+
+    // True when the property's DECLARED type is itself a framework collection (defined
+    // in a System.Collections* namespace) or a collection interface — the raw-collection
+    // surface CA2227 guards. A user-defined subclass has its own namespace and is
+    // excluded, so it is treated as a domain value rather than a raw collection.
+    private static bool IsBclCollectionType(ITypeSymbol type)
+    {
+        var ns = (type as INamedTypeSymbol)?.ContainingNamespace?.ToDisplayString();
+        return ns is "System.Collections.Generic"
+            or "System.Collections"
+            or "System.Collections.ObjectModel"
+            or "System.Collections.Concurrent"
+            or "System.Collections.Immutable"
+            or "System.Collections.Specialized"
+            or "System.Collections.Frozen";
     }
 
     private static bool ImplementsMutableCollection(ITypeSymbol type)


### PR DESCRIPTION
Resolves four re-discovered C# false-positive rules from the `abpframework/abp` campaign (SCOPE=`cs-`). Each fix is a principled exemption for a well-known C# idiom in the Roslyn semantic host (`tools/csharp-roslyn-host/Rules/`), paired with a paraphrased **positive** case (must-not-fire) and a **negative** true-bug case (must-fire) in the analyzer fixtures. All identifiers/filenames are domain-neutral; the OSS sources are linked below for review context only. (The committed fixture files are authoritative — see the "Files changed" tab; the inline snippets below may lose generic type arguments to Markdown sanitization.)

Closes #710
Closes #711
Closes #712
Closes #713

## Fixes

| rule_key | issue | Before | After | Delta |
|---|---|---:|---:|---:|
| bugs/deterministic/missing-format-provider-overload | #710 | 201 | 162 | -39 |
| code-quality/deterministic/unused-this-parameter | #711 | 298 | 226 | -72 |
| code-quality/deterministic/writable-collection-property | #712 | 275 | 246 | -29 |
| code-quality/deterministic/non-testable-datetime-provider | #713 | 113 | 111 | -2 |

Positive fixtures (must-not-fire) and negative fixtures (marked true-bug) per rule:

- **#710** `missing-format-provider-overload` — pos `…-positive/services/BugsSamples2/MissingFormatProviderOverloadGuidParseSafe.cs`, neg `…-negative/services/ApiGateway/Violations/Bugs/ThresholdReader.cs`
- **#711** `unused-this-parameter` — pos `…-positive/services/CodeQualitySamples1/UnusedThisParameterInheritedConfigureSafe.cs`, neg `…-negative/services/UserService/Violations/CodeQuality/IdentifierNormalizer.cs`
- **#712** `writable-collection-property` — pos `…-positive/services/CodeQualitySamples4/WritableCollectionPropertyDomainSubclassSafe.cs`, neg `…-negative/services/ApiGateway/Violations/CodeQuality/RequestTagBag.cs`
- **#713** `non-testable-datetime-provider` — pos `…-positive/services/CodeQualitySamples2/NonTestableDateTimeProviderClockImplSafe.cs`, neg `…-negative/services/ApiGateway/Violations/CodeQuality/CheckpointRecorder.cs`

## bugs/deterministic/missing-format-provider-overload (#710)

OSS sources (FP): `AbpClaimsIdentityExtensions.cs#L21` (`Guid.TryParse`), `IdentityUserStore.cs#L238` (`Guid.Parse`) — see [issue #710](https://github.com/truecourse-ai/truecourse/issues/710).

**Fix:** skip `Parse`/`TryParse` on the BCL types whose parsing is culture-invariant even though a .NET 7 `IParsable`/`ISpanParsable` provider overload exists — `Guid`, `bool`, `Version`. Those overloads accept a provider only to satisfy the interface and ignore it entirely, so parsing without a provider is fully portable. Culture-sensitive parses (`double`, `DateTime`, …) still fire.

## code-quality/deterministic/unused-this-parameter (#711)

OSS source (FP): `MyProjectNameBlazorModule.cs#L182` — see [issue #711](https://github.com/truecourse-ai/truecourse/issues/711).

**Fix:** the receiver-use scan only inspected `IdentifierNameSyntax` names, so an unqualified **generic** inherited call like `Configure<TOptions>(…)` (a `GenericNameSyntax`, a protected member of the base module) was never counted as a use of the receiver — the method was wrongly reported static-eligible. Broadening the case to `SimpleNameSyntax` (which covers both plain and generic names) makes the existing instance-member resolution handle generic calls too. Genuinely static-eligible private methods still fire.

## code-quality/deterministic/writable-collection-property (#712)

OSS source (FP): `RemoteServiceConfigurationDictionary.cs#L10` (`Default` is a `RemoteServiceConfiguration : Dictionary<…>`) — see [issue #712](https://github.com/truecourse-ai/truecourse/issues/712).

**Fix:** CA2227 targets a raw collection exposed via a setter. Require the property's declared type to itself be a framework collection (a `System.Collections*` type) or a collection interface. A user-defined type that merely derives from a collection is a domain value with its own identity, not a raw collection a caller would replace wholesale, so it no longer fires. Raw `List`/`Dictionary`/`HashSet` properties still fire.

## code-quality/deterministic/non-testable-datetime-provider (#713)

OSS source (FP): `Clock.cs#L23` (the `IClock` implementation itself) — see [issue #713](https://github.com/truecourse-ai/truecourse/issues/713).

**Fix:** exempt ambient-time reads inside the clock abstraction itself — a type named like a clock, or implementing/deriving `IClock` / `TimeProvider`. A clock must read the ambient time somewhere, and that type is exactly what the rule tells callers to inject, so flagging the provider is self-defeating. The check is syntax-based, so it holds in loose-text analysis where a project's own `IClock` is unresolved. Direct reads in ordinary services still fire.

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| bugs/deterministic/missing-format-provider-overload | 201 | 162 | -39 |
| code-quality/deterministic/unused-this-parameter | 298 | 226 | -72 |
| code-quality/deterministic/writable-collection-property | 275 | 246 | -29 |
| code-quality/deterministic/non-testable-datetime-provider | 113 | 111 | -2 |
| **Total (these 4 rules)** | **887** | **745** | **-142** |
| **All-rules total on target** | **82013** | **81871** | **-142** |

Measured with `node dist/cli.mjs analyze --no-llm` from a fresh `pnpm build:dist` (the exact artifact publish.yml ships), before vs after this batch's visitor fixes. The 4-rule subtotal (-142) equals the all-rules delta (-142) — this batch's four visitor changes are the only source of the difference.

cc @mushgev