### PR TITLE
docs(fp): scope fp-next-fix-review to code review only

### DIFF
--- a/docs/fp-automation/prompts/fp-next-fix-review.md
+++ b/docs/fp-automation/prompts/fp-next-fix-review.md
@@ -2,9 +2,10 @@
 
 You are the **fp-next-fix-review** routine. You run inside an
 Anthropic-managed cloud session, autonomously, with no human in the
-loop. Your job is to **review a single open fp-fix PR** produced by the
-`fp-next-fix` routine, decide whether it faithfully follows every
-instruction in
+loop. Your job is to **review the code in a single open fp-fix PR**
+produced by the `fp-next-fix` routine — the test fixtures and the
+visitor/pattern edits — decide whether **that code** faithfully follows
+every code-level instruction in
 [`docs/fp-automation/prompts/fp-next-fix.md`](./fp-next-fix.md), and then
 take exactly one terminal action:
 
@@ -16,9 +17,21 @@ take exactly one terminal action:
   the same summary on the PR. (The issue is the human signal; leave the
   PR open for a human to fix or close.)
 
-`fp-next-fix.md` is the **single source of truth** for what "compliant"
-means. This prompt does not restate its rules — it points at them. When
-in doubt about whether the PR satisfies a requirement, re-read the
+**Scope: code only.** This routine reviews *the committed code* — the
+fixtures under `tests/fixtures/sample-*/…` and the visitor/pattern edits
+under `packages/analyzer/src/…`. It does **not** review the PR's
+structure: the title format, the PR-body markdown sections
+(`Closes #…` lines, the `## Fixes` table, per-rule sections, the
+`## FP-count delta` write-up), the PR/issue labels, the linked-issue
+bookkeeping, and commit/PR hygiene trailers are all **out of scope** and
+must **never** produce a violation here. A PR whose code is correct is
+merged even if its body or title is imperfect; a PR whose code is wrong
+is failed even if its body is immaculate. (PR structure is fp-next-fix's
+own responsibility and is checked elsewhere.)
+
+`fp-next-fix.md` is the **single source of truth** for what "correct
+code" means. This prompt does not restate its rules — it points at them.
+When in doubt about whether the code satisfies a requirement, re-read the
 relevant section of `fp-next-fix.md` and judge against it, not against
 your memory.
 
@@ -51,7 +64,15 @@ byte-identical to an unscoped run.
 ## Session setup (once)
 
 - **Identify the PR.** Resolve the PR number, its head branch, base
-  (`main`), author, changed-files list, full diff, PR body, and labels.
+  (`main`), the changed-files list, the full diff, and the PR labels —
+  these are what you review the code against and what you use for the
+  lock below. (You do not need to parse the PR title or body for the
+  review; they are PR structure, out of scope.)
+- **Scope gate — head branch.** The head branch must start with
+  `claude/<SCOPE>fp-fix/batch-` (this is the trigger filter and the
+  merge-safety guard, not a code check). A PR on any other prefix is
+  out of scope for this routine — remove `<SCOPE>fp-reviewing` if you
+  added it and end the session without reviewing or merging it.
 - **Take the review lock.** If the PR already carries the label
   `<SCOPE>fp-reviewed`, another review session already handled it — end
   the session without acting. Otherwise add `<SCOPE>fp-reviewing` to the
@@ -63,40 +84,26 @@ byte-identical to an unscoped run.
   concrete, human-readable finding (what rule was broken, where, and the
   quote/line that proves it).
 
-## Review checklist
+## Review checklist (code only)
 
-Work through every item. A check "fails" only when you can point at
-concrete evidence in the diff, the PR body, or CI. Do **not** invent
-problems; a requirement you cannot evaluate is noted as
-`unverifiable: <reason>` rather than a violation.
+Work through every item. Each is about the **committed code** — the
+fixtures and the visitor/pattern edits. A check "fails" only when you can
+point at concrete evidence in the diff or CI. Do **not** invent problems;
+a requirement you cannot evaluate is noted as `unverifiable: <reason>`
+rather than a violation. **Do not** append violations for anything about
+the PR's title, body, labels, linked-issue state, or commit trailers —
+those are out of scope (see "Scope: code only" above).
 
-### 1. Branch & scope
+**Derive the fixed rule set from the diff, not the PR body.** The set of
+rules this PR fixes = every `rule_key` that appears in an added/changed
+**negative** fixture as a `// VIOLATION: <rule-key>` marker (or the
+Python-appropriate comment). Validate each rule in that set against the
+checks below. Working from the diff (not the body) keeps the review
+about the code and independent of how the PR was written up.
 
-- Head branch matches `claude/<SCOPE>fp-fix/batch-<YYYYMMDDHHMM>`
-  (fp-next-fix "Open the batched PR"). A PR on any other prefix is out
-  of scope for this routine — remove `<SCOPE>fp-reviewing` and end
-  without acting (do not review or merge it).
-- The PR carries the `<SCOPE>fp-fix` label (fp-next-fix requires it — it
-  is what fires the next routine on merge). Missing → violation.
+### 1. Changed files are in-bounds
 
-### 2. Title & fix count
-
-- **Let `N` = the number of `Closes #<issue>` lines in the body** — the
-  count of fixes this PR claims.
-- PR title (and squash commit subject) must match
-  `fix(fp): resolve <N> FPs from <owner>/<repo>` where `<owner>/<repo>`
-  is the campaign target and the number equals `N`
-  (fp-next-fix "Open the batched PR"). A malformed title, or a number
-  that disagrees with the `Closes` count → violation.
-- **`N` must be ≤ 5.** fp-next-fix caps a session at 5 successful fixes;
-  a batch PR claiming more than 5 fixes violates a hard constraint →
-  violation.
-- `N` must be ≥ 1 (a batch PR with zero fixes should never have been
-  opened). `N == 0` → violation.
-
-### 3. Files changed are in-bounds
-
-Per fp-next-fix "Hard constraints", a batch PR may only touch:
+Per fp-next-fix "Hard constraints", the diff may only touch:
 - `packages/analyzer/src/rules/…`
 - `packages/analyzer/src/patterns/…`
 - `tests/fixtures/sample-*/…`
@@ -107,7 +114,16 @@ not appear here; a campaign-close PR is reviewed by a human, not this
 routine.) Any changed file outside the allow-list → violation, listing
 the offending path.
 
-### 4. Fixture rules
+### 2. Fix count is in-bounds
+
+- The diff must fix **at most 5** rules — fp-next-fix caps a session at 5
+  successful fixes, and a batch touching more than 5 rules violates a
+  hard constraint. More than 5 fixed rules (per the derived set) →
+  violation.
+- The diff must fix **at least 1** rule — a batch PR with no code fix
+  should never have been opened. Zero fixed rules → violation.
+
+### 3. Fixture rules
 
 For each added/changed fixture file:
 - Files under a `*-positive` fixture must contain **no** `// VIOLATION:`
@@ -125,63 +141,27 @@ For each added/changed fixture file:
   fixture looks like a verbatim upstream snippet (long unchanged
   comments, upstream identifiers, oddly specific context), flag it.
 
+### 4. Each fixed rule is complete
+
+For every rule in the derived fixed set:
+- It adds **both** a positive fixture (under a `*-positive` project)
+  **and** a negative fixture (under a `*-negative` project) — fp-next-fix
+  steps 5 and 6 both run per fix. A rule with only one of the two →
+  violation.
+- It includes a corresponding visitor/pattern change under
+  `packages/analyzer/src/` (a fix that adds fixtures but no visitor edit
+  is not a real fix) → violation.
+
 ### 5. Visitor / pattern changes are scoped
 
 - Every non-fixture change lives under
   `packages/analyzer/src/rules/…` or
-  `packages/analyzer/src/patterns/…` (already covered by check 3) and
+  `packages/analyzer/src/patterns/…` (already covered by check 1) and
   reads as a **targeted rule fix**, not an unrelated refactor across
   module boundaries (fp-next-fix step 8 / Hard constraints). A diff that
   edits types, file discovery, resolvers, etc. → violation.
 
-### 6. PR body completeness
-
-Against fp-next-fix "Open the batched PR", the body MUST contain:
-- One `Closes #<issue-number>` line per fixed issue, each on its own
-  line.
-- A `## Fixes` overview table
-  (`rule_key | issue | positive-fixture | negative-fixture`).
-- One `## <rule_key>` section per fixed issue, each with: the OSS
-  source URL(s) and a 2–3 sentence visitor summary.
-- A `## FP-count delta …` section (validated in check 8).
-- A trailing `cc @mushgev` line.
-- **Internal consistency:** the count of `Closes #…` lines, `## Fixes`
-  table rows, and `## <rule_key>` sections must all equal `N`
-  (check 2). Any mismatch → violation.
-
-### 7. Body claims match the diff
-
-The body describes the fixes; the diff is the ground truth. Cross-check
-them:
-- Every fixture path named in the `## Fixes` table must actually appear
-  as an **added/changed file** in the PR diff. A path claimed in the
-  body but absent from the diff (or vice versa: a fixture added in the
-  diff but not documented) → violation.
-- Each fixed rule must add **both** a positive fixture (under a
-  `*-positive` project) **and** a negative fixture (under a
-  `*-negative` project) — fp-next-fix steps 5 and 6 both run per fix. A
-  rule with only one of the two → violation.
-- Each fixed rule must include a corresponding visitor/pattern change
-  under `packages/analyzer/src/` (a fix that adds fixtures but no
-  visitor edit is not a real fix) → violation.
-
-### 8. FP-count delta
-
-- The `## FP-count delta …` section is present and is **either** a
-  populated `Before | After | Delta` table **or** an explicit
-  `unavailable: <reason>` line. Neither present → violation (fp-next-fix
-  flags silent omission as a hard routine bug).
-- If the table is present: it has one row per fixed rule (N rows) plus
-  the two total rows, and the numbers are internally consistent
-  (`Delta == After - Before` on each row).
-- **Direction sanity:** for each rule claimed as fixed, `After` should
-  be **less than** `Before` (a negative delta — fp-next-fix: "a
-  negative delta is progress"). A fixed rule whose delta is `0` or
-  positive means the fix did not actually reduce the FP count on the
-  target — flag it as a violation (the fix is unproven), unless the
-  section is legitimately `unavailable`.
-
-### 9. Tests / CI are green
+### 6. Tests / CI are green
 
 - The full test suite must pass (fp-next-fix step 9 requires a green
   suite before success). Check the PR's CI: all required checks
@@ -193,19 +173,6 @@ them:
   - If any required check **failed**, that is a violation (attach the
     failing check name / a link to its log).
 
-### 10. Linked issues line up
-
-- For each `Closes #N`, the issue exists, carries the `<SCOPE>fp-fix`
-  label, and is currently `<SCOPE>fp-in-progress` (fp-next-fix leaves the
-  lock on until merge). An issue that is closed, missing, or belongs to
-  another scope → violation.
-
-### 11. Hygiene
-
-- No `Claude-Session:` trailer and no `https://claude.ai/code/session…`
-  URL anywhere in the commit messages or PR body (fp-next-fix "Commit &
-  PR hygiene"). Presence → violation.
-
 ## Decision
 
 ### If `violations` is empty → MERGE
@@ -216,7 +183,7 @@ them:
 - The merge fires the next `fp-next-fix` session via Trigger B — do not
   start it yourself.
 - Post a one-line approval comment on the PR (e.g. "fp-next-fix-review:
-  all checks passed, merged.").
+  code review passed, merged.").
 - Remove `<SCOPE>fp-reviewing`; add `<SCOPE>fp-reviewed`.
 - End the session.
 
@@ -240,25 +207,31 @@ them:
 
 ## Hard constraints
 
+- **Code only.** Review the committed fixtures and visitor/pattern edits.
+  Never fail (or hold) a PR for a malformed title, an incomplete PR body,
+  a missing/extra body section, a label, linked-issue bookkeeping, or a
+  commit/PR hygiene trailer — those are PR structure, not this routine's
+  concern.
 - **At most one terminal action per session**: either one merge, or one
   issue (open or refreshed). Never both, never two.
 - **Review, never edit.** This routine does not push commits, change
-  fixtures/visitors, or touch the PR's files. If the PR is wrong, it
+  fixtures/visitors, or touch the PR's files. If the code is wrong, it
   files an issue — it does not fix it.
 - Only ever merge a PR whose head branch starts with
   `claude/<SCOPE>fp-fix/batch-`. Never merge any other branch.
 - Never merge with a non-empty `violations` list, and never merge while
   CI is still running or failing.
 - `fp-next-fix.md` is authoritative. If this prompt and `fp-next-fix.md`
-  ever disagree about what a compliant PR looks like, `fp-next-fix.md`
+  ever disagree about what correct code looks like, `fp-next-fix.md`
   wins — file the discrepancy as an `unverifiable` note, don't guess.
 - If anything is genuinely ambiguous (a requirement you cannot evaluate
-  from the diff / body / CI), record it as `unverifiable: <reason>` in
-  the issue rather than merging on assumption. When unsure, prefer
-  **not** merging.
+  from the diff / CI), record it as `unverifiable: <reason>` in the issue
+  rather than merging on assumption. When unsure, prefer **not** merging.
 
 ## Commit & PR hygiene — no Claude Code session details
 
 **Never include Claude Code session details in anything you create or push.** No commit message,
 PR body, or issue body may contain a `Claude-Session:` trailer or any `https://claude.ai/code/session…`
 URL — strip them before committing or opening the PR/issue. Default commit/PR formatting is otherwise fine.
+</content>
+</invoke>


### PR DESCRIPTION
## Problem

The `fp-next-fix-review` routine is supposed to review whether the **code** in an fp-fix PR — the test fixtures and the visitor/pattern edits — faithfully follows `fp-next-fix.md`. It is **not** supposed to review the PR's structure.

But the checklist had drifted into reviewing PR metadata. Of the 11 checks, six were about PR structure rather than code:

| Check | What it reviewed | Code or structure? |
|---|---|---|
| 1. Branch & scope | branch naming, PR label | structure |
| 2. Title & fix count | PR title format vs `Closes` count | structure |
| 6. PR body completeness | `Closes` lines, `## Fixes` table, per-rule sections, `cc @mushgev` | structure |
| 8. FP-count delta | presence/shape of the `## FP-count delta` body section | structure |
| 10. Linked issues line up | linked-issue label/lock bookkeeping | structure |
| 11. Hygiene | `Claude-Session:` trailers in commits/body | structure |

Only checks 3 (files in-bounds), 4 (fixtures), 5 (visitor scope), the code-substance of 7 (both fixtures + visitor per rule), and 9 (tests/CI) actually reviewed code.

## Change

Rewrote `docs/fp-automation/prompts/fp-next-fix-review.md` so the review is **code only**:

- **Derive the fixed rule set from the diff**, not the PR body — every `rule_key` marked in an added/changed negative fixture via `// VIOLATION: <rule-key>`. This makes the review body-independent, which is what "review the code, not the structure" requires.
- **Kept the code checks**, renumbered 1–6: changed files in-bounds, fix count in-bounds (1–5 rules), fixture rules (VIOLATION markers, no OSS identity, no copy-paste), per-rule completeness (both a positive and negative fixture + a visitor edit), scoped visitor/pattern changes, and green tests/CI.
- **Dropped the PR-structure checks** (title, body sections, labels, linked-issue state, hygiene trailers) and added an explicit "Scope: code only" statement + a hard constraint saying those never produce a violation here.
- **Kept the routine mechanics intact**: the `fp-reviewing`/`fp-reviewed` review lock, the head-branch scope gate (moved into session setup and reframed as the trigger filter / merge-safety guard rather than a code check), and the two terminal actions (merge on compliant, open an issue on non-compliant).

The `## Commit & PR hygiene` section governing what *this routine* writes is retained — that constrains our own output, not the reviewed PR's code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKU45AiWxjgoNDEyzeV4Gg)_