### PR TITLE
fix(fp): resolve 2 FPs from abpframework/abp

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/global-this-usage.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/global-this-usage.ts
@@ -14,6 +14,14 @@ export const globalThisUsageVisitor: CodeRuleVisitor = {
       if (
         t === 'function_declaration' ||
         t === 'function' ||
+        // Modern tree-sitter-javascript names a `function () {}` expression
+        // `function_expression` (only the legacy grammar used bare `function`).
+        // Without it, `this` inside any function-expression callback / IIFE /
+        // prototype-assigned method walks up to program scope and is wrongly
+        // reported as a global reference.
+        t === 'function_expression' ||
+        t === 'generator_function' ||
+        t === 'generator_function_declaration' ||
         t === 'method_definition' ||
         t === 'class_declaration' ||
         t === 'class'

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/unbound-method.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/unbound-method.ts
@@ -72,37 +72,40 @@ export const unboundMethodVisitor: CodeRuleVisitor = {
 
     const methodName = property.text
 
-    // Walk the enclosing class body to figure out whether `methodName` refers
-    // to an actual method (callable, has `this` binding) or just a data field.
-    // Fields whose value/type isn't a function never had `this` bound to
-    // begin with, so referencing them as values is not an unbound-method risk.
+    // Only a reference to an actual method loses its `this` when detached, so
+    // require positive evidence: `methodName` must resolve to a `method_definition`
+    // in an enclosing class body. Without a class context (plain functions,
+    // prototype-style objects) `this.<name>` is far more likely a data-property
+    // read — e.g. `widget(this.checked)`, `closest(this.element)` — than a
+    // method reference, and flagging those is the dominant false positive.
     let classBody: SyntaxNode | null = node.parent
     while (classBody && classBody.type !== 'class_body') classBody = classBody.parent
-    if (classBody) {
-      for (const member of classBody.namedChildren) {
-        if (member.type === 'public_field_definition' || member.type === 'field_definition') {
-          // Private fields use `#name` and parse as `private_property_identifier`,
-          // not `property_identifier`. Include both so `this.#x` references can
-          // be resolved against their declaring field.
-          const nameNode = member.children.find(
-            (c) => c.type === 'property_identifier' || c.type === 'private_property_identifier',
-          )
-          if (nameNode?.text !== methodName) continue
-          const value = member.childForFieldName('value')
-          // Arrow / function field — bound by construction.
-          if (value?.type === 'arrow_function' || value?.type === 'function_expression') return null
-          // Field with any other initializer — data, not a method.
-          if (value) return null
-          // No initializer: look at the type annotation. Anything that isn't
-          // a function type means it's a data field assigned later.
-          const typeAnnot = member.namedChildren.find((c) => c.type === 'type_annotation')
-          const typeChild = typeAnnot?.namedChildren[0]
-          if (typeChild && typeChild.type !== 'function_type' && typeChild.type !== 'constructor_type') {
-            return null
-          }
-        }
+    if (!classBody) return null
+
+    let resolvesToMethod = false
+    for (const member of classBody.namedChildren) {
+      if (member.type === 'method_definition') {
+        const nameNode = member.childForFieldName('name')
+        if (nameNode?.text !== methodName) continue
+        // A getter/setter is accessed as a value, not invoked as a callback —
+        // reading `this.x` runs the accessor, it does not detach a method.
+        const isAccessor = member.children.some(
+          (c) => (c.text === 'get' || c.text === 'set') && c.type !== 'property_identifier',
+        )
+        resolvesToMethod = !isAccessor
+        break
+      }
+      if (member.type === 'public_field_definition' || member.type === 'field_definition') {
+        // A same-named field is data (or a bound arrow/function field) — never an
+        // unbound-method risk. Private fields use `#name`, which parses as
+        // `private_property_identifier`; include both.
+        const nameNode = member.children.find(
+          (c) => c.type === 'property_identifier' || c.type === 'private_property_identifier',
+        )
+        if (nameNode?.text === methodName) return null
       }
     }
+    if (!resolvesToMethod) return null
 
     return makeViolation(
       this.ruleKey,

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/global-this-usage-top-level.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/global-this-usage-top-level.ts
@@ -1,0 +1,10 @@
+/**
+ * True-bug fixture for bugs/deterministic/global-this-usage.
+ *
+ * At the top level of a module `this` is `undefined` under strict mode (or the
+ * global object otherwise) — capturing it as a value is the portability hazard
+ * the rule targets. It is lexically outside any function/class scope.
+ */
+
+// VIOLATION: bugs/deterministic/global-this-usage
+export const moduleScopeRef = this;

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/unbound-method-callback.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/unbound-method-callback.ts
@@ -15,6 +15,14 @@ export class BatchProcessor {
     items.forEach(this.handleItem);
   }
 
+  // Second paraphrased true-bug at a distinct call site: `this.handleItem`
+  // resolves to a real method_definition, so detaching it as a bare callback
+  // value loses the receiver — the case the rule must keep catching.
+  dispatch(batch: readonly string[]): void {
+    // VIOLATION: bugs/deterministic/unbound-method
+    batch.forEach(this.handleItem);
+  }
+
   handleItem(item: string): void {
     console.log(`${this.tag}: ${item}`);
   }

--- a/tests/fixtures/sample-js-project-positive/src/global-this-usage-function-expression.js
+++ b/tests/fixtures/sample-js-project-positive/src/global-this-usage-function-expression.js
@@ -1,0 +1,16 @@
+// Positive fixture for bugs/deterministic/global-this-usage.
+//
+// `this` written inside a classic `function () {}` expression — here a method
+// attached to an object after construction — is the call-time receiver, not the
+// global object. Modern tree-sitter-javascript types such a `function(){}` as a
+// `function_expression`; the visitor's scope-boundary walk must treat that as an
+// enclosing scope, or every `this` inside a function expression is misreported
+// as a top-level/global reference.
+
+const service = { label: 'idle' };
+
+service.describe = function () {
+  return this.label;
+};
+
+export { service };

--- a/tests/fixtures/sample-js-project-positive/src/unbound-method-plain-function-data-prop.ts
+++ b/tests/fixtures/sample-js-project-positive/src/unbound-method-plain-function-data-prop.ts
@@ -1,0 +1,23 @@
+/**
+ * Positive fixture for bugs/deterministic/unbound-method.
+ *
+ * `this.<name>` used as a value is only an unbound-method hazard when `<name>`
+ * is an actual method that loses its receiver when detached. Here `this` is the
+ * receiver of a plain `function` expression (no class) and `flag` is a boolean
+ * data property — reading it and passing it as an argument detaches nothing, so
+ * the rule must not fire.
+ */
+
+interface Toggle {
+  flag: boolean;
+}
+
+declare function applyState(name: string, value: boolean): void;
+
+export function attach(toggle: Toggle): void {
+  const onChange = function (this: Toggle): void {
+    applyState('checked', this.flag);
+  };
+
+  Reflect.apply(onChange, toggle, []);
+}


### PR DESCRIPTION
Two false-positive fixes surfaced by the fp-next-fix queue-empty re-measurement of `abpframework/abp` (SCOPE=cs-). Both are tree-sitter visitor bugs that misfire on hand-written JavaScript in the target.

Closes #727
Closes #728

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `bugs/deterministic/global-this-usage` | #727 | `tests/fixtures/sample-js-project-positive/src/global-this-usage-function-expression.js` | `tests/fixtures/sample-js-project-negative/shared/utils/src/global-this-usage-top-level.ts` |
| `bugs/deterministic/unbound-method` | #728 | `tests/fixtures/sample-js-project-positive/src/unbound-method-plain-function-data-prop.ts` | `tests/fixtures/sample-js-project-negative/shared/utils/src/unbound-method-callback.ts` |

## bugs/deterministic/global-this-usage

OSS source (false positives):
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/toast/abp-toast.js#L47``
- https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.MudBlazorUI/wwwroot/abp-mud-popover-patch.js#L11
- https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.js#L3

The scope-boundary walk recognized `function` / `function_declaration` / `method_definition` / `class` but not `function_expression`, which is how modern tree-sitter-javascript names a classic `function () {}` expression. As a result, a `this` inside any function-expression callback, IIFE, or prototype-assigned method (e.g. `AbpToastService.prototype.extend = function () { … this.extend … }`) walked up past the function to program scope and was wrongly flagged as a global reference. Added `function_expression` plus the `generator_function` / `generator_function_declaration` variants to the set of enclosing scopes, so only a genuinely top-level `this` is reported.

## bugs/deterministic/unbound-method

OSS source (false positives):
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Pages/AbpPermissionManagement/add-resource-permission-management-modal.js#L6``
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/date-range-picker/date-range-picker-extensions.js#L268``

The rule flagged any `this.<name>` used as a value unless it could positively resolve `<name>` to a *data field* in an enclosing `class_body`. In plain functions and prototype-style objects (no class), it could not, so ordinary data-property reads passed as arguments — `$items.prop("checked", this.checked)`, `target.closest(this.element)` — were misreported as detached method references. Inverted the check to require positive evidence: only flag when `<name>` resolves to a real `method_definition` (non-accessor) in an enclosing class, which is the sole case where detaching the reference actually loses `this`. A same-named field, or the absence of a class context, now short-circuits to no violation. The existing class-method true-bug fixtures (a method passed to `forEach`) still fire.

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `bugs/deterministic/global-this-usage` | 3694 | 11 | -3683 |
| `bugs/deterministic/unbound-method` | 1416 | 35 | -1381 |
| **Total (these 2 rules)** | 5110 | 46 | -5064 |
| **All-rules total on target** | 81871 | 76807 | -5064 |

The remaining hits for each rule are genuine true positives (top-level `this`; real class methods passed as detached callbacks). The all-rules total fell by exactly the same 5064, confirming no other rule's output changed.

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a fresh `pnpm build:dist` (the exact artifact publish.yml ships), before vs. after this batch's visitor edits, on the same target ref.

cc @mushgev