### PR TITLE
fix(fp): resolve 5 FPs from triggerdotdev/trigger.dev

### DIFF
--- a/packages/analyzer/src/rules/bugs/visitors/javascript/misused-promise.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/misused-promise.ts
@@ -3,6 +3,35 @@ import { makeViolation } from '../../../types.js'
 import { TS_LANGUAGES } from './_helpers.js'
 
 /**
+ * Returns true when the top-level union of a type string contains a `null` or
+ * `undefined` member — e.g. `Promise<void> | undefined`. A nullable value in a
+ * boolean condition is a legitimate *existence* check ("has this been assigned
+ * yet?"), not the always-truthy bug this rule targets. Nested nullish inside a
+ * generic argument (`Promise<string | null>`) is ignored: that promise object
+ * is still always truthy, so `if (p)` on it is still a bug.
+ */
+function topLevelUnionHasNullish(typeStr: string): boolean {
+  let depth = 0
+  let member = ''
+  const members: string[] = []
+  for (const ch of typeStr) {
+    if (ch === '<' || ch === '(' || ch === '[' || ch === '{') depth++
+    else if (ch === '>' || ch === ')' || ch === ']' || ch === '}') depth--
+    if (ch === '|' && depth === 0) {
+      members.push(member)
+      member = ''
+      continue
+    }
+    member += ch
+  }
+  members.push(member)
+  return members.some((m) => {
+    const t = m.trim()
+    return t === 'null' || t === 'undefined'
+  })
+}
+
+/**
  * Detect: Promise used in boolean context without await (if, while, ternary, &&, ||).
  * Corresponds to @typescript-eslint/no-misused-promises.
  */
@@ -39,6 +68,19 @@ export const misusedPromiseVisitor: CodeRuleVisitor = {
       condition.endPosition.column,
     )
     if (isPromise) {
+      // Skip nullable promises (`Promise<T> | undefined`): a condition like
+      // `if (maybePromise)` is an intentional existence/init guard, not the
+      // always-truthy mistake this rule flags. A bare `Promise<T>` has no
+      // nullish member and still fires.
+      const condType = typeQuery.getTypeAtPosition(
+        filePath,
+        condition.startPosition.row,
+        condition.startPosition.column,
+        condition.endPosition.row,
+        condition.endPosition.column,
+      )
+      if (condType && topLevelUnionHasNullish(condType)) return null
+
       return makeViolation(
         this.ruleKey, node, filePath, 'high',
         'Promise used in conditional without await',

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/prototype-pollution.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/prototype-pollution.ts
@@ -28,6 +28,15 @@ export const prototypePollutionVisitor: CodeRuleVisitor = {
       if (objProp?.text === 'current') return null
     }
 
+    // Skip when the target is a freshly-declared local container in the same
+    // scope — `const state = {}`, `const merged = { ...base }`,
+    // `const next = [...items]`. Writing an app-controlled key into a
+    // throwaway object/array the function just built is not the
+    // user-input → shared/global-object pollution vector this rule targets;
+    // the container is not a shared prototype root. True bugs write into a
+    // *parameter* or otherwise externally-supplied object (`target[key] = …`).
+    if (obj.type === 'identifier' && isFreshLocalContainer(node, obj.text)) return null
+
     // Resolve `const typedKey = key (as T)?` chains so checks downstream see
     // the underlying iteration / counter / param name. Example:
     //   for (const key in obj) {
@@ -96,6 +105,69 @@ export const prototypePollutionVisitor: CodeRuleVisitor = {
       `Validate that \`${index.text}\` is not "__proto__", "constructor", or "prototype" before assignment, or use Map instead.`,
     )
   },
+}
+
+/**
+ * True if `objName` is declared in the enclosing function/program scope as a
+ * `const`/`let`/`var` initialised directly from an object or array literal —
+ * `const state = {}`, `const merged = { ...base }`, `const next = [...items]`.
+ * Such a value is a fresh container the function just built, not a shared or
+ * externally-supplied object, so an app-controlled dynamic key on it is not a
+ * prototype-pollution vector.
+ */
+function isFreshLocalContainer(assignmentNode: SyntaxNode, objName: string): boolean {
+  const isScope = (n: SyntaxNode): boolean =>
+    n.type === 'function_declaration' ||
+    n.type === 'function_expression' ||
+    n.type === 'arrow_function' ||
+    n.type === 'method_definition' ||
+    n.type === 'program'
+
+  // Search each enclosing scope from innermost outward — the container is often
+  // declared in an outer function while the write happens inside a nested
+  // callback (`ids.forEach((id) => state[id] = …)`).
+  let scope: SyntaxNode | null = assignmentNode.parent
+  while (scope) {
+    if (isScope(scope)) {
+      if (scopeDeclaresContainer(scope, objName)) return true
+      if (scope.type === 'program') break
+    }
+    scope = scope.parent
+  }
+  return false
+}
+
+function scopeDeclaresContainer(scope: SyntaxNode, objName: string): boolean {
+  let found = false
+  function walk(n: SyntaxNode): void {
+    if (found) return
+    if (n.type === 'variable_declarator') {
+      const name = n.childForFieldName('name')
+      const value = n.childForFieldName('value')
+      if (
+        name?.type === 'identifier' && name.text === objName &&
+        (value?.type === 'object' || value?.type === 'array')
+      ) {
+        found = true
+        return
+      }
+    }
+    // Don't descend into nested functions — declarations there belong to a
+    // different scope than the one we're inspecting.
+    if (
+      n !== scope &&
+      (n.type === 'function_declaration' ||
+        n.type === 'function_expression' ||
+        n.type === 'arrow_function' ||
+        n.type === 'method_definition')
+    ) return
+    for (let i = 0; i < n.childCount; i++) {
+      const ch = n.child(i)
+      if (ch) walk(ch)
+    }
+  }
+  walk(scope)
+  return found
 }
 
 /**

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/reduce-missing-initial.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/reduce-missing-initial.ts
@@ -1,6 +1,69 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { JS_LANGUAGES } from './_helpers.js'
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * True if the enclosing function has an emptiness guard clause on the reduce
+ * receiver — an `if` that tests `<receiver>.length` and early-exits
+ * (`return` / `throw` / `break` / `continue`). e.g.
+ *
+ *   if (workers.length === 0) return;
+ *   return workers.reduce((a, b) => …);   // ← safe: array is non-empty here
+ *
+ * A `reduce` without an initial value only throws on an *empty* array, so a
+ * preceding length guard makes the missing initial value intentional, not a bug.
+ */
+function hasEmptinessGuard(node: SyntaxNode, receiver: string): boolean {
+  let scope: SyntaxNode | null = node.parent
+  while (scope) {
+    if (
+      scope.type === 'function_declaration' ||
+      scope.type === 'function_expression' ||
+      scope.type === 'arrow_function' ||
+      scope.type === 'method_definition' ||
+      scope.type === 'program'
+    ) break
+    scope = scope.parent
+  }
+  if (!scope) return false
+
+  // `<receiver>.length` or `<receiver>?.length`, not a substring of another name.
+  const lengthRef = new RegExp(`(^|[^\\w$.])${escapeRegExp(receiver)}(?:\\?\\.|\\.)length\\b`)
+
+  let found = false
+  function walk(n: SyntaxNode): void {
+    if (found) return
+    if (n.type === 'if_statement') {
+      const cond = n.childForFieldName('condition')
+      const cons = n.childForFieldName('consequence')
+      if (
+        cond && lengthRef.test(cond.text) &&
+        cons && /\b(return|throw|break|continue)\b/.test(cons.text)
+      ) {
+        found = true
+        return
+      }
+    }
+    if (
+      n !== scope &&
+      (n.type === 'function_declaration' ||
+        n.type === 'function_expression' ||
+        n.type === 'arrow_function' ||
+        n.type === 'method_definition')
+    ) return
+    for (let i = 0; i < n.childCount; i++) {
+      const ch = n.child(i)
+      if (ch) walk(ch)
+    }
+  }
+  walk(scope)
+  return found
+}
 
 export const reduceMissingInitialVisitor: CodeRuleVisitor = {
   ruleKey: 'bugs/deterministic/reduce-missing-initial',
@@ -19,6 +82,11 @@ export const reduceMissingInitialVisitor: CodeRuleVisitor = {
     const argNodes = args.namedChildren
     // reduce(fn) — only one argument, no initial value
     if (argNodes.length === 1) {
+      // Skip when the receiver array is guarded against emptiness above — a
+      // length-check guard clause makes the missing initial value intentional.
+      const receiver = fn.childForFieldName('object')
+      if (receiver && hasEmptinessGuard(node, receiver.text)) return null
+
       return makeViolation(
         this.ruleKey, node, filePath, 'medium',
         'Array.reduce missing initial value',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/hardcoded-url.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/hardcoded-url.ts
@@ -43,6 +43,13 @@ export const hardcodedUrlVisitor: CodeRuleVisitor = {
     // paths are owned by the identity provider and have no env-specific form.
     if (/\.well-known\/(openid-configuration|oauth-authorization-server|jwks(?:\.json)?)/.test(text)) return null
 
+    // Skip loopback / unspecified hosts — `0.0.0.0` (all-interfaces / unspecified),
+    // the `127.0.0.0/8` loopback range, and the IPv6 loopback/unspecified
+    // (`[::1]`, `[::]`). Like `localhost`, these are local dev defaults (e.g.
+    // OTEL exporter fallbacks such as `process.env.X ?? "http://0.0.0.0:4318"`),
+    // not environment-specific production endpoints worth hoisting to config.
+    if (/\/\/(?:0\.0\.0\.0|127(?:\.\d{1,3}){3}|\[::1?\])(?::\d+)?(?:[/?#"'`]|$)/.test(text)) return null
+
     // Skip URLs assigned to variables whose names suggest placeholder/example/default values
     if (parent?.type === 'variable_declarator' || parent?.type === 'assignment_expression' || parent?.type === 'pair') {
       const nameNode2 = parent.type === 'pair'

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/type-guard-preference.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/type-guard-preference.ts
@@ -22,11 +22,20 @@ function returnTypeIsBoolish(node: SyntaxNode): boolean {
   return t === 'boolean' || t === 'Boolean'
 }
 
+function isNestedFunction(n: SyntaxNode): boolean {
+  return n.type === 'arrow_function' || n.type === 'function_declaration'
+    || n.type === 'function_expression' || n.type === 'function'
+    || n.type === 'method_definition'
+}
+
 function containsTypeNarrowingCheck(bodyNode: SyntaxNode): boolean {
   let found = false
 
   function walk(n: SyntaxNode) {
     if (found) return
+    // Don't recurse into nested functions — an inner callback's `instanceof`/
+    // `typeof` check belongs to that callback, not the function we're judging.
+    if (n !== bodyNode && isNestedFunction(n)) return
     if (n.type === 'binary_expression') {
       const op = n.children.find((c) => c.type === 'instanceof' || c.text === 'instanceof')
       if (op) { found = true; return }
@@ -66,6 +75,9 @@ function hasBooleanReturn(bodyNode: SyntaxNode): boolean {
 
   function walk(n: SyntaxNode) {
     if (found) return
+    // Don't recurse into nested functions — a `return false` inside an inner
+    // callback is not this function's return value.
+    if (n !== bodyNode && isNestedFunction(n)) return
     if (n.type === 'return_statement') {
       let val: SyntaxNode | undefined = n.namedChildren[0]
       // Unwrap parenthesized expressions so `return (typeof x === 'string')`

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/misc-bugs.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/misc-bugs.ts
@@ -279,4 +279,48 @@ export function squaredOnly(nums: readonly number[]): number[] {
   });
 }
 
+// True bug: a non-nullable Promise placed directly in a condition. The promise
+// object is always truthy, so the branch runs regardless of the resolved
+// value — the author almost certainly meant to `await` it first.
+export function decideFromResult(): string {
+  const settled = Promise.resolve(1);
+  // VIOLATION: bugs/deterministic/misused-promise
+  if (settled) {
+    return "done";
+  }
+  return "pending";
+}
+
+// True bug: a real, routable production endpoint hardcoded in source — it
+// should be an environment variable so staging/prod/local can differ without a
+// redeploy. Unlike a loopback dev default, this host is not localhost-equivalent.
+export async function pushMetrics(payload: string): Promise<unknown> {
+  // VIOLATION: code-quality/deterministic/hardcoded-url
+  const response = await fetch("https://metrics.acme-telemetry.io/v1/ingest", {
+    method: "POST",
+    body: payload,
+  });
+  return response.json();
+}
+
+// True bug: writes an arbitrary caller-supplied key into an externally-supplied
+// object. A caller passing "__proto__" pollutes the object's prototype chain —
+// unlike a fresh local container, `target` is not built here.
+export function assignInto(
+  target: Record<string, unknown>,
+  dynamicKey: string,
+  value: unknown,
+): void {
+  // VIOLATION: bugs/deterministic/prototype-pollution
+  target[dynamicKey] = value;
+}
+
+// True bug: reduce without an initial value and no emptiness guard — throws
+// `TypeError: Reduce of empty array with no initial value` when the array is
+// empty.
+export function sumAll(values: number[]): number {
+  // VIOLATION: bugs/deterministic/reduce-missing-initial
+  return values.reduce((acc, val) => acc + val);
+}
+
 export { readFile };

--- a/tests/fixtures/sample-js-project-negative/shared/utils/src/type-guard-preference-typeof.ts
+++ b/tests/fixtures/sample-js-project-negative/shared/utils/src/type-guard-preference-typeof.ts
@@ -12,3 +12,10 @@ export function isStringValue(input: unknown): boolean {
 export function isNumberValue(input: unknown): boolean {
   return typeof input === 'number';
 }
+
+// True bug: narrows with `instanceof` directly in its own body but returns a
+// bare `boolean` — callers get no narrowing. It should return `err is Error`.
+// VIOLATION: code-quality/deterministic/type-guard-preference
+export function isTimeoutError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'TimeoutError';
+}

--- a/tests/fixtures/sample-js-project-positive/hardcoded-url-loopback-default.ts
+++ b/tests/fixtures/sample-js-project-positive/hardcoded-url-loopback-default.ts
@@ -1,0 +1,11 @@
+// Loopback / unspecified-host endpoints used as env-var fallbacks. `0.0.0.0`
+// (all-interfaces) and `127.0.0.1` (loopback) are localhost-equivalent local
+// dev defaults, not production endpoints, so they must NOT trip
+// code-quality/deterministic/hardcoded-url.
+export function resolveEndpoints(
+  env: Record<string, string | undefined>,
+): { otlp: string; admin: string } {
+  const otlpEndpoint = env.OTLP_ENDPOINT ?? "http://0.0.0.0:4318";
+  const adminEndpoint = env.ADMIN_URL ?? "http://127.0.0.1:9000";
+  return { otlp: otlpEndpoint, admin: adminEndpoint };
+}

--- a/tests/fixtures/sample-js-project-positive/misused-promise-nullable-guard.ts
+++ b/tests/fixtures/sample-js-project-positive/misused-promise-nullable-guard.ts
@@ -1,0 +1,27 @@
+// Existence guards on possibly-undefined promises. `if (x)` here asks "has
+// this promise been created yet?", not "is the resolved value truthy?" — the
+// value can legitimately be `undefined`, so the check is meaningful and must
+// NOT trip bugs/deterministic/misused-promise.
+
+interface LoaderState {
+  pending?: Promise<void>
+}
+
+export function ensureLoaded(state: LoaderState): Promise<void> {
+  if (state.pending) {
+    return state.pending
+  }
+  const started = Promise.resolve()
+  state.pending = started
+  return started
+}
+
+export function pickPending(
+  primary: Promise<number> | undefined,
+  fallback: Promise<number>,
+): Promise<number> {
+  if (primary) {
+    return primary
+  }
+  return fallback
+}

--- a/tests/fixtures/sample-js-project-positive/prototype-pollution-fresh-local-container.ts
+++ b/tests/fixtures/sample-js-project-positive/prototype-pollution-fresh-local-container.ts
@@ -1,0 +1,25 @@
+// Writing an app-controlled dynamic key into a freshly-built local container is
+// not a prototype-pollution vector: the object/array is created in this
+// function and is not a shared or externally-supplied prototype root. These
+// must NOT trip bugs/deterministic/prototype-pollution.
+export function buildStateMap(
+  ids: readonly string[],
+  selectedId: string,
+): Record<string, { selected: boolean }> {
+  const state: Record<string, { selected: boolean }> = {};
+  ids.forEach((id) => {
+    state[id] = { selected: false };
+  });
+  state[selectedId] = { selected: true };
+  return state;
+}
+
+export function withRenamedField(
+  base: Record<string, string>,
+  toKey: string,
+  value: string,
+): Record<string, string> {
+  const merged = { ...base };
+  merged[toKey] = value;
+  return merged;
+}

--- a/tests/fixtures/sample-js-project-positive/reduce-missing-initial-length-guard.ts
+++ b/tests/fixtures/sample-js-project-positive/reduce-missing-initial-length-guard.ts
@@ -1,0 +1,10 @@
+// The array is guarded against emptiness before the reduce, so calling reduce
+// without an initial value can never throw on an empty array — the missing
+// initial is intentional and must NOT trip
+// bugs/deterministic/reduce-missing-initial.
+export function total(values: readonly number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((acc, curr) => acc + curr);
+}

--- a/tests/fixtures/sample-js-project-positive/type-guard-preference-nested-callback.ts
+++ b/tests/fixtures/sample-js-project-positive/type-guard-preference-nested-callback.ts
@@ -1,0 +1,12 @@
+// The `instanceof`/`typeof` checks and boolean returns here live inside a
+// nested callback, not in the outer function's own body. The outer function
+// delegates its narrowing to `.some(...)`, so it is NOT a type-guard candidate
+// and must NOT trip code-quality/deterministic/type-guard-preference.
+export function anyLooksTransient(items: readonly unknown[]): boolean {
+  return items.some((result) => {
+    if (result instanceof Error) {
+      return result.message === "timeout";
+    }
+    return String(result).length === 0;
+  });
+}


### PR DESCRIPTION
Batch of 5 false-positive fixes from analyzing [`triggerdotdev/trigger.dev`](https://github.com/triggerdotdev/trigger.dev) at `2dd9f37b4045d2a414c0a300995d068f28926d50`. Each fix edits only the rule's visitor and adds a paraphrased positive (must-not-fire) fixture plus a negative (true-bug) fixture. Full JS/TS analyzer suite (`js-positive`, `js-negative`, `bugs-rules`, `code-quality-rules`) is green.

Closes #438
Closes #440
Closes #441
Closes #443
Closes #445

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `bugs/deterministic/misused-promise` | #438 | `sample-js-project-positive/misused-promise-nullable-guard.ts` | `…-negative/shared/utils/src/misc-bugs.ts` |
| `code-quality/deterministic/type-guard-preference` | #440 | `sample-js-project-positive/type-guard-preference-nested-callback.ts` | `…-negative/shared/utils/src/type-guard-preference-typeof.ts` |
| `code-quality/deterministic/hardcoded-url` | #441 | `sample-js-project-positive/hardcoded-url-loopback-default.ts` | `…-negative/shared/utils/src/misc-bugs.ts` |
| `bugs/deterministic/prototype-pollution` | #443 | `sample-js-project-positive/prototype-pollution-fresh-local-container.ts` | `…-negative/shared/utils/src/misc-bugs.ts` |
| `bugs/deterministic/reduce-missing-initial` | #445 | `sample-js-project-positive/reduce-missing-initial-length-guard.ts` | `…-negative/shared/utils/src/misc-bugs.ts` |

## bugs/deterministic/misused-promise (#438)

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/TriggerRotatingLogo.tsx#L33
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/mollifier/mollifierStaleSweep.server.ts#L240
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/run-engine/src/engine/locking.ts#L521
- ``https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/internal-packages/run-engine/src/engine/systems/raceSimulationSystem.ts#L9``

Summary: the rule flagged `if (promiseVar)` existence guards on possibly-undefined promises (`Promise<T> | undefined`), which are intentional "has this been created yet?" checks, not the always-truthy mistake the rule targets. After confirming the condition is promise-like, it now also reads the condition's type and skips when the **top-level** union contains a `null`/`undefined` member (a new `topLevelUnionHasNullish` helper that ignores nullish nested inside generic args, so `Promise<string | null>` still fires). A bare non-nullable `Promise<T>` in a condition still fires.

Positive fixture (must NOT fire):
```ts
export function ensureLoaded(state: LoaderState): Promise<void> {
  if (state.pending) {          // state.pending: Promise<void> | undefined
    return state.pending
  }
  const started = Promise.resolve()
  state.pending = started
  return started
}
```

Negative fixture (true bug):
```diff
+export function decideFromResult(): string {
+  const settled = Promise.resolve(1);
+  // VIOLATION: bugs/deterministic/misused-promise
+  if (settled) {              // settled: Promise<number> — always truthy
+    return "done";
+  }
+  return "pending";
+}
```

## code-quality/deterministic/type-guard-preference (#440)

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/models/vercelIntegration.server.ts#L1204
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/packages/cli-v3/src/build/plugins.ts#L106
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/references/ai-chat/src/components/chat.tsx#L618

Summary: `containsTypeNarrowingCheck` and `hasBooleanReturn` walked into nested functions, so a large outer function (e.g. a 287-line `(client) => …andThen(…)` chain, or an esbuild `setup: (build) => {…}`) was flagged for `instanceof`/`typeof` checks and boolean returns that actually belonged to inner callbacks. Both walks now stop at nested-function boundaries (matching the existing `collectReturns` behavior). A genuine type-guard whose narrowing is in its own body still fires.

Positive fixture (must NOT fire):
```ts
export function anyLooksTransient(items: readonly unknown[]): boolean {
  return items.some((result) => {          // narrowing lives in the callback
    if (result instanceof Error) {
      return result.message === "timeout";
    }
    return String(result).length === 0;
  });
}
```

Negative fixture (true bug):
```diff
+// VIOLATION: code-quality/deterministic/type-guard-preference
+export function isTimeoutError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'TimeoutError';
+}
```

## code-quality/deterministic/hardcoded-url (#441)

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/docker-provider/src/index.ts#L21
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/kubernetes-provider/src/index.ts#L26

Summary: OTEL exporter fallbacks like `process.env.X ?? "http://0.0.0.0:4318"` were flagged. `0.0.0.0` (all-interfaces / unspecified), the `127.0.0.0/8` loopback range, and IPv6 `[::1]`/`[::]` are localhost-equivalent local dev defaults, not environment-specific production endpoints. The rule already skipped `localhost`; it now skips these loopback/unspecified hosts too. Real routable production URLs still fire.

Positive fixture (must NOT fire):
```ts
export function resolveEndpoints(env: Record<string, string | undefined>): { otlp: string; admin: string } {
  const otlpEndpoint = env.OTLP_ENDPOINT ?? "http://0.0.0.0:4318";
  const adminEndpoint = env.ADMIN_URL ?? "http://127.0.0.1:9000";
  return { otlp: otlpEndpoint, admin: adminEndpoint };
}
```

Negative fixture (true bug):
```diff
+export async function pushMetrics(payload: string): Promise<unknown> {
+  // VIOLATION: code-quality/deterministic/hardcoded-url
+  const response = await fetch("https://metrics.acme-telemetry.io/v1/ingest", {
+    method: "POST", body: payload,
+  });
+  return response.json();
+}
```

## bugs/deterministic/prototype-pollution (#443)

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/ChartConfigPanel.tsx#L339
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/code/QueryResultsChart.tsx#L894
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/components/primitives/TreeView/utils.ts#L24

Summary: writes of an app-controlled dynamic key into a **freshly-declared local container** (`const state = {}`, `const merged = { ...base }`, `const next = [...items]`) were flagged. A throwaway object/array the function just built is not a shared or externally-supplied prototype root, so it is not the user-input → shared-object pollution vector this rule targets. A new `isFreshLocalContainer` helper searches each enclosing scope for such a declarator (the write is often inside a nested callback while the container is declared in the outer function). Writes into a **parameter** or otherwise externally-supplied object still fire.

Positive fixture (must NOT fire):
```ts
export function buildStateMap(ids: readonly string[], selectedId: string): Record<string, { selected: boolean }> {
  const state: Record<string, { selected: boolean }> = {};
  ids.forEach((id) => { state[id] = { selected: false }; });
  state[selectedId] = { selected: true };
  return state;
}
```

Negative fixture (true bug):
```diff
+export function assignInto(target: Record<string, unknown>, dynamicKey: string, value: unknown): void {
+  // VIOLATION: bugs/deterministic/prototype-pollution
+  target[dynamicKey] = value;      // target is a parameter, not built here
+}
```

## bugs/deterministic/reduce-missing-initial (#445)

OSS sources:
- https://github.com/triggerdotdev/trigger.dev/blob/2dd9f37b4045d2a414c0a300995d068f28926d50/apps/webapp/app/v3/marqs/devQueueConsumer.server.ts#L601

Summary: `arr.reduce(fn)` without an initial value only throws on an *empty* array. The rule flagged reduces that are preceded by an emptiness guard clause (`if (workers.length === 0) return; … return workers.reduce(...)`), where the missing initial is intentional. A new `hasEmptinessGuard` helper skips the reduce when the enclosing function has an `if` that tests `<receiver>.length` and early-exits (`return`/`throw`/`break`/`continue`). An unguarded reduce still fires.

Positive fixture (must NOT fire):
```ts
export function total(values: readonly number[]): number {
  if (values.length === 0) { return 0; }
  return values.reduce((acc, curr) => acc + curr);
}
```

Negative fixture (true bug):
```diff
+export function sumAll(values: number[]): number {
+  // VIOLATION: bugs/deterministic/reduce-missing-initial
+  return values.reduce((acc, val) => acc + val);   // no emptiness guard
+}
```

## Skipped this batch

- #437 `global-statement` — broken-beyond-FP: the JS visitor's entire behavior is flagging any `var` inside a function, which is exactly the reported FP, and its existing true-bug fixture asserts the same pattern. Needs a rule redefinition (human).
- #439 `non-number-arithmetic` — not reproducible in the type-query fixture harness; the FP is an artifact of degraded type inference under incomplete type context (untyped `Map` operand). Needs a resolver/type-service change (out of scope).
- #442 `undefined-passed-as-optional` — distinguishing a redundant trailing `undefined` from a meaningful one requires the callee's signature (optional vs required param); not derivable syntactically.
- #444 `identical-functions` — the natural fix (require ≥2 statements) is blocked by a committed unit test (`tests/analyzer/code-quality-rules.test.ts`, outside this routine's editable scope) that asserts single-statement identical bodies fire.

## FP-count delta (vs `2dd9f37b4045d2a414c0a300995d068f28926d50` on `triggerdotdev/trigger.dev`)

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a freshly-built `pnpm build:dist` (the exact artifact `publish.yml` ships).

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `bugs/deterministic/misused-promise` | 14 | 4 | -10 |
| `code-quality/deterministic/type-guard-preference` | 3 | 0 | -3 |
| `code-quality/deterministic/hardcoded-url` | 178 | 172 | -6 |
| `bugs/deterministic/prototype-pollution` | 63 | 43 | -20 |
| `bugs/deterministic/reduce-missing-initial` | 5 | 0 | -5 |
| **Total (these 5 rules)** | **263** | **219** | **-44** |
| **All-rules total on target** | **34520** | **34476** | **-44** |

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoXC3paVTNgdS81X6ARN2o)_