### PR TITLE
fix(fp): stop campaign-stuck tracker from double-notifying to Telegram

### DIFF
--- a/.github/workflows/notify-routine-activity.yml
+++ b/.github/workflows/notify-routine-activity.yml
@@ -105,13 +105,21 @@ jobs:
           fi
 
           since=$(date -u -d '10 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')
+          # Defence-in-depth: a campaign-level tracker ([<SCOPE>fp-campaign-stuck],
+          # [<SCOPE>fp-stale-pr], …) is handled by notify-campaign-alert /
+          # notify-stale-pr and must never appear in this fix-burst rollup. It
+          # only could if a routine mislabels it with a fix label (the
+          # fp-next-fix / drift-fp-next-fix prompts forbid this). Drop any such
+          # title here so a stray label can't double-notify: a genuine fix issue
+          # is titled [<SCOPE>fp-<rule-key>] and never contains these tokens.
           issues_json=$(gh issue list \
             --repo "$REPO" \
             --label "$LABEL" \
             --state open \
             --search "created:>${since}" \
             --json number,title \
-            --limit 200)
+            --limit 200 \
+            | jq '[.[] | select(.title | test("campaign-|stale-pr") | not)]')
 
           count=$(echo "$issues_json" | jq 'length')
           if [ "$count" -eq 0 ]; then

--- a/.github/workflows/notify-routine-activity.yml
+++ b/.github/workflows/notify-routine-activity.yml
@@ -105,13 +105,16 @@ jobs:
           fi
 
           since=$(date -u -d '10 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')
-          # Defence-in-depth: a campaign-level tracker ([<SCOPE>fp-campaign-stuck],
-          # [<SCOPE>fp-stale-pr], …) is handled by notify-campaign-alert /
-          # notify-stale-pr and must never appear in this fix-burst rollup. It
-          # only could if a routine mislabels it with a fix label (the
-          # fp-next-fix / drift-fp-next-fix prompts forbid this). Drop any such
-          # title here so a stray label can't double-notify: a genuine fix issue
-          # is titled [<SCOPE>fp-<rule-key>] and never contains these tokens.
+          # Defence-in-depth: a campaign-level tracker is handled by
+          # notify-campaign-alert / notify-stale-pr and must never appear in
+          # this fix-burst rollup. It only could if a routine mislabels it with
+          # a fix label (the fp-next-fix / drift-fp-next-fix prompts forbid
+          # this). Drop any tracker title here so a stray label can't
+          # double-notify. Match the exact title tags the sibling notifier jobs
+          # key on (anchored on the closing `]`) rather than loose substrings —
+          # a genuine fix issue is titled [<SCOPE>fp-<rule-key>] and some rule
+          # keys legitimately contain "stale" (e.g. .../stale-read-after-write),
+          # so a bare "stale" match would wrongly suppress real rollups.
           issues_json=$(gh issue list \
             --repo "$REPO" \
             --label "$LABEL" \
@@ -119,7 +122,7 @@ jobs:
             --search "created:>${since}" \
             --json number,title \
             --limit 200 \
-            | jq '[.[] | select(.title | test("campaign-|stale-pr") | not)]')
+            | jq '[.[] | select(.title | test("fp-campaign-close]|fp-campaign-stuck]|drift-campaign-broken]|fp-stale-pr]") | not)]')
 
           count=$(echo "$issues_json" | jq 'length')
           if [ "$count" -eq 0 ]; then

--- a/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
@@ -353,6 +353,14 @@ Enter when the **pickable** queue is empty AND `successes == 0` (includes all-re
      `[<SCOPE>drift-fp-campaign-stuck] <owner>/<repo>` tracking issue with the current state.
      Body carries: current `fp` count + `fp_rate`, the close gate `fp == 0`, a checklist
      of open `<SCOPE>drift-fp-blocked` issues. End with `cc @mushgev`.
+     - **Label the tracker with `drift-fp-target:<owner>-<repo>` ONLY. Do NOT apply the
+       `<SCOPE>drift-fp-fix` label to this tracker.** It is a campaign-level human-signal
+       issue, not a fix-queue item. Its Telegram alert comes from `notify-campaign-alert`,
+       which keys on the `fp-campaign-stuck]` **title** tag, not a label, so no extra label
+       is needed to notify. Applying the fix label would (1) sweep the tracker into the
+       `notify-fix-burst` rollup so the same issue fires a **second** Telegram message,
+       and (2) make it match the per-issue loop's `label:<SCOPE>drift-fp-fix` search so a
+       later run picks it up as a fixable FP issue and then blocks it.
 
      **Notify-on-change protocol** — the Telegram alert (`notify-campaign-alert`) only
      fires on `issues.opened` / `issues.reopened`, not on edits/comments. So:

--- a/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
+++ b/docs/drift-fp-automation/prompts/drift-fp-next-fix.md
@@ -94,6 +94,10 @@ Repeat while `successes < 5 AND attempts < 10`. Each iteration is one attempt.
 
 - List open issues with label `<SCOPE>drift-fp-fix`, excluding `<SCOPE>drift-fp-in-progress`,
   `<SCOPE>drift-fp-blocked`, `<SCOPE>drift-fp-skipped`, and any already in `fixed_issues`.
+- **Also exclude any campaign-level tracker** — an issue whose title contains a tracker tag
+  (`[<SCOPE>drift-fp-campaign-stuck]`). Trackers are human-signal issues, not fix-queue items,
+  and should never carry `<SCOPE>drift-fp-fix`; exclude by title here too so a stray mislabel
+  can't make you pick a tracker and needlessly block it.
 - If none (pickable queue empty — **including when all remaining open issues are blocked**):
   - `successes >= 1` → break, go to "Open the batched PR".
   - `successes == 0` → go to the **Queue-empty path** (re-measure the campaign; never end silently).

--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -467,7 +467,11 @@ and the session has 0 successes):
      the campaign can't self-progress. File/update a single
      `[fp-campaign-stuck] <owner>/<repo>` tracking issue (TP rate +
      checklist of blocked issues, `cc @mushgev`) — this fires the TG
-     alert — then end. **Never dead-end silently.**
+     alert — then end. **Never dead-end silently.** The tracker is
+     labelled `fp-target:<owner>-<repo>` only, **never `fp-fix`**: its
+     alert comes from `notify-campaign-alert` (title-tag driven), and a
+     `fp-fix` label would both double-notify via `notify-fix-burst` and
+     make the fix loop pick the tracker up as a fixable issue.
 5. End. The campaign-close PR merge fires `fp-campaign-close` and
    `fp-discover` in parallel.
 

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -106,6 +106,13 @@ iteration is one "attempt" (success or skip).
 - List open issues on `truecourse-ai/truecourse` with label `<SCOPE>fp-fix`,
   **excluding** any with label `<SCOPE>fp-in-progress`, `<SCOPE>fp-blocked`, or
   `<SCOPE>fp-skipped`.
+- **Also exclude any campaign-level tracker** — an issue whose title
+  contains a tracker tag (`[<SCOPE>fp-campaign-stuck]`,
+  `[<SCOPE>fp-stale-pr]`). These are human-signal issues, not fix-queue
+  items; they should never carry `<SCOPE>fp-fix` (see the Queue-empty path),
+  but exclude them by title here too so a stray mislabel can't make you pick
+  a tracker, parse its (non-existent) YAML, and needlessly `<SCOPE>fp-blocked`
+  it.
 - Also exclude any issue already in `fixed_issues` for this session.
 - If none (the **pickable** queue is empty — note this is also true
   when open issues remain but every one is `<SCOPE>fp-blocked`/`<SCOPE>fp-skipped`):

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -442,6 +442,21 @@ path in a session that already produced fixes.)
        `<SCOPE>fp-blocked` issue (number + rule_key) that must be resolved by
        a human before automation can proceed. End the body with
        `cc @mushgev`.
+       - **Label the tracker with `fp-target:<owner>-<repo>` ONLY. Do NOT
+         apply the `<SCOPE>fp-fix` label to this tracker.** It is a
+         campaign-level human-signal issue, not an FP-fix queue item. The
+         Telegram alert for it comes from `notify-campaign-alert`, which keys
+         on the `fp-campaign-stuck]` **title** tag, not on a label — so no
+         extra label is needed to notify. The `<SCOPE>fp-fix` label is not
+         just unnecessary, it is actively harmful here:
+         (1) it sweeps the tracker into the `notify-fix-burst` rollup, so the
+         same issue fires a **second** Telegram message ("N new
+         `<SCOPE>fp-fix` issue(s) filed"); and (2) it makes the tracker match
+         step 1's `label:<SCOPE>fp-fix` search, so the next fp-next-fix run
+         would pick it up as a fixable FP issue and then `<SCOPE>fp-blocked`
+         it on the missing YAML. This mirrors the `fp-stale-pr-notify`
+         tracker, which carries its own `<SCOPE>fp-stale-pr` label and never
+         the fix-queue label.
      - If one already exists → add a comment refreshing the `tp_rate`
        and the current blocked list (don't open a duplicate).
      - Then end the session. Opening/commenting the tracking issue is


### PR DESCRIPTION
Surfaced by #735. This PR fixes the **double-Telegram-notification bug** that #735 exposed. It does **not** resolve #735's underlying campaign-stuck condition (the abp blocked-rule fixes) — that stays open.

## Problem

Issue #735 (`[cs-fp-campaign-stuck] abpframework/abp`) sent **two** Telegram messages on open instead of one:

| Message | Job in `notify-routine-activity.yml` | Fired because |
|---|---|---|
| ⚠️ Campaign needs attention: #735 | `notify-campaign-alert` | **Title** contains `fp-campaign-stuck]` ✅ intended |
| 📋 1 new cs-fp-fix issue filed • #735 | `notify-fix-burst` | Issue carried the **`cs-fp-fix` label** ❌ spurious |

## Root cause

The campaign-stuck tracker is a campaign-level human-signal issue, not an FP-fix queue item — its alert should come only from `notify-campaign-alert` (keyed on the title tag). The queue-empty path in `fp-next-fix.md` never specified the tracker's labels, so the routine defaulted to the campaign's fix-queue label `cs-fp-fix`, which swept the tracker into the `notify-fix-burst` rollup.

The same mislabel had a second, latent effect: `cs-fp-fix` makes the tracker match step 1's `label:cs-fp-fix` search, so the next `fp-next-fix` run would have picked it up as a fixable FP issue, commented "malformed YAML", and blocked it.

`fp-stale-pr-notify` already avoids this by giving its tracker a dedicated `fp-stale-pr` label — this change brings the campaign-stuck tracker in line, and hardens both consumers (notifier + fix loop) against a future mislabel.

## Changes

**Root cause — don't mislabel the tracker**
- `docs/fp-automation/prompts/fp-next-fix.md` / `docs/drift-fp-automation/prompts/drift-fp-next-fix.md`: the campaign-stuck tracker is labelled `fp-target:<owner>-<repo>` **only**, never the fix-queue label.

**Defence-in-depth — notifier ignores mislabeled trackers**
- `.github/workflows/notify-routine-activity.yml`: the fix-burst rollup filters trackers out of its count by matching the **exact tracker title tags** the sibling notifier jobs key on (`fp-campaign-close]` / `fp-campaign-stuck]` / `drift-campaign-broken]` / `fp-stale-pr]`), anchored on the closing `]`. (An earlier loose `stale` substring would have wrongly suppressed real rollups for rule keys like `database/llm/stale-read-after-write`.)

**Defence-in-depth — fix loop ignores mislabeled trackers**
- `fp-next-fix.md` / `drift-fp-next-fix.md` step 1: exclude any issue whose title contains a tracker tag from the pickup search, so a stray fix label can't make a session grab a tracker and block it.

**Docs**
- `docs/fp-automation/README.md`: document the label constraint.

## Out-of-band cleanup (not in this diff)

Removed the erroneous `cs-fp-fix` label from the live issue #735, so it now carries `fp-target:abpframework-abp` only and won't be re-picked by the fix loop.

cc @mushgev

🤖 Generated with [Claude Code](https://claude.com/claude-code)