### PR TITLE
Optimize fp-next-fix routines: work the human-review queue instead of parking it

### DIFF
--- a/.github/workflows/block-human-review.yml
+++ b/.github/workflows/block-human-review.yml
@@ -1,0 +1,38 @@
+name: Block human-review merges
+
+# Deterministic merge gate for the fp-automation loop: while a PR carries a
+# human-review-needed label, this check fails so the PR cannot be merged —
+# not by a human's merge button and not by the fp-next-fix-review routine's
+# API merge (a failing required check makes the REST merge return 405).
+#
+# To actually enforce it, mark the `block-human-review` check as a required
+# status check in the `main` branch protection rule / ruleset (and enable
+# "Do not allow bypassing the above settings"). See
+# docs/fp-automation/README.md for the setup steps.
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+# When labels change in quick succession, only the latest run matters.
+concurrency:
+  group: block-human-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  block-human-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail while a human-review-needed label is present
+        env:
+          # JSON array of the PR's current label names.
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          echo "PR labels: $LABELS"
+          # Substring match catches both the default `fp-human-review-needed`
+          # and the C# account's `cs-fp-human-review-needed` scoped label.
+          if echo "$LABELS" | grep -q 'fp-human-review-needed'; then
+            echo "::error::PR carries a human-review-needed label — a human must review and merge. Blocked until the label is removed."
+            exit 1
+          fi
+          echo "No human-review-needed label present — not blocking."

--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -694,6 +694,32 @@ there's almost nothing to configure:
    its own cadence. The `notify-stale-pr` job in
    `notify-routine-activity.yml` forwards the tracker issue to Telegram.
 
+## Deterministic merge gate: `block-human-review`
+
+`fp-next-fix-review` is instructed **not** to merge a PR carrying
+`<SCOPE>fp-human-review-needed` — but that's a prompt-level guarantee. The
+`.github/workflows/block-human-review.yml` workflow makes it deterministic:
+it runs on every PR (and on every label add/remove) and **fails** while a
+`*fp-human-review-needed` label is present (the substring match covers both
+the default and `cs-` scoped labels). A failing **required** check disables
+the merge button **and** makes the REST merge API return `405`, so neither a
+human nor the review routine can merge a flagged PR until the label is
+removed.
+
+The workflow alone doesn't block anything — it must be wired in as a
+required status check:
+
+1. Merge the workflow to `main`, then let it run once on any PR so GitHub
+   registers the `block-human-review` check name.
+2. **Settings → Branches → branch protection for `main`** (or a **Ruleset**):
+   enable **Require status checks to pass before merging** and add
+   **`block-human-review`**.
+3. Enable **Do not allow bypassing the above settings** — otherwise an admin
+   (or a routine running as one) can bypass the gate.
+
+Removing the `<SCOPE>fp-human-review-needed` label re-runs the check (on the
+`unlabeled` event), it goes green, and the human merge unlocks.
+
 ## Acceptance criteria
 
 An **fp-fix PR** is mergeable when:

--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -212,7 +212,7 @@ samples:                              # up to 5 representative FP locations
   - url: https://github.com/vercel/next.js/blob/abc1234/packages/next/src/server/lib/router-utils/filesystem.ts#L210
     why_fp: "promise is awaited inside Array.from(..., async fn) which we don't follow"
   - url: …
-status: open                          # open | in_review | merged | skipped | blocked
+status: open                          # open | in_review | merged | skipped | human-review-needed
 pr: null                              # filled when the fix PR is opened
 ```
 
@@ -222,7 +222,17 @@ Labels:
   "campaign done" (no open issues with this label and `fp-fix`).
 - `fp-in-progress` — concurrency lock; set by the routine the moment it
   picks an issue, before doing anything else.
-- `fp-skipped` / `fp-blocked` — set by the session when bailing out.
+- `fp-human-review-needed` — **defer** marker. Set when a normal-phase
+  fix would need to go over the in-bounds boundary (a cross-module
+  refactor, or the rule is broken beyond the FP). The issue isn't parked
+  for a human — a later **human-review-phase** session fixes it with
+  out-of-bounds access and opens a PR carrying this same label (which
+  `fp-next-fix-review` reviews but does not merge; a human merges).
+- `fp-skipped` — **terminal** marker. Set when an issue can't be fixed
+  even with out-of-bounds access (malformed issue data, an infeasible
+  refactor). These are the only genuinely-stuck issues; the queue-empty
+  path lists them on the `[fp-campaign-stuck]` tracking issue for a
+  human.
 
 The Claude session is the only writer. Ordering is "oldest open issue
 without `fp-in-progress` first".
@@ -396,32 +406,63 @@ cap. See the per-issue loop in
 (success vs attempt counters, skipped-issue handling, partial-batch
 revert rules).
 
+**Two phases, one PR per run**: each session runs in exactly one phase,
+fixed at session start by which queue has pickable work.
+- **Normal phase** (default): fix issues **without**
+  `fp-human-review-needed`, using only **in-bounds** changes (the rule's
+  visitor/pattern + fixtures). Opens a normal PR (label `fp-fix`) that
+  `fp-next-fix-review` may auto-merge. If a fix would need to cross the
+  in-bounds boundary, the issue is **deferred** with
+  `fp-human-review-needed` rather than dead-ended.
+- **Human-review phase**: entered only when the normal queue is empty but
+  `fp-human-review-needed` issues remain. The session is allowed to go
+  **over the boundary** (targeted cross-module refactors) to fix them,
+  and opens a PR carrying **both** `fp-fix` and `fp-human-review-needed`.
+  `fp-next-fix-review` reviews that PR but does **not** merge it — a human
+  reviews and merges. Merging it (branch prefix `claude/<SCOPE>fp-fix/`)
+  still fires the next session.
+
 **Session setup (once)**: `pnpm install && pnpm build:dist`; lazily
 clone target repo and run analyze on first issue. Counters:
 `successes`, `attempts`, `fixed_issues`.
 
-**Per-issue loop** (continues while `successes < 5 AND attempts < 10`):
-1. List open `fp-fix` issues (excluding `fp-in-progress`, `fp-blocked`,
-   `fp-skipped`, and any already in `fixed_issues`). Pick oldest. If
-   none → exit loop, go to "Open the batched PR".
+**Per-issue loop** (continues while `successes < 5 AND attempts < 10`,
+over the current phase's queue):
+1. List open `fp-fix` issues in the phase's queue (normal phase: **without**
+   `fp-human-review-needed`; human-review phase: **with** it). Both
+   exclude `fp-in-progress`, `fp-skipped`, and any already in
+   `fixed_issues`. Pick oldest. If none → exit loop, go to "Open the
+   batched PR".
 2. Add `fp-in-progress` label (concurrency lock; retry next-oldest on
    collision, max 3 retries).
-3. Parse YAML; on malformed → mark blocked, increment `attempts`,
-   continue loop.
+3. Parse YAML; on malformed → **terminal** (`fp-skipped`), increment
+   `attempts`, continue loop.
 4. Filter `LATEST.json` to this rule; on no-reproduce → close issue,
    increment `attempts`, continue.
 5. Add paraphrased FP to positive fixture (no annotation).
 6. Add true-bug to negative fixture (with `// VIOLATION: <rule-key>`).
-7. Run tests; if negative case fails too → revert this issue's
-   fixtures, mark blocked, increment `attempts`, continue.
-8. Edit the rule's visitor / pattern. If can't without a cross-module
-   refactor → revert this issue's fixtures, post `## Refactor needed`,
-   mark blocked, increment `attempts`, continue.
-9. Re-run full tests; on unrelated breakage → revert this issue's
-   visitor AND fixtures, mark blocked, increment `attempts`, continue.
+7. Run tests; if negative case fails too (rule broken beyond the FP) →
+   route per "Bail-out routing" (defer in normal phase; try broader fix
+   then terminal-skip in human-review phase), increment `attempts`,
+   continue.
+8. Fix the rule. **Normal phase:** in-bounds only; if it needs a
+   cross-module refactor → post `## Refactor needed`, **defer** with
+   `fp-human-review-needed`, increment `attempts`, continue.
+   **Human-review phase:** targeted cross-module refactors allowed; if
+   even that's infeasible → terminal-skip.
+9. Re-run full tests; on unrelated breakage → route per "Bail-out
+   routing" (defer in normal phase; extend-or-terminal in human-review
+   phase), increment `attempts`, continue.
 10. Record success: append to `fixed_issues`. Increment both
     `successes` AND `attempts`. Keep `fp-in-progress` label until the
     batch PR opens. If caps hit → exit loop.
+
+**Bail-out routing** (see the prompt for the full table): normal-phase
+**over-the-boundary** failures (refactor needed / rule broken beyond the
+FP / unrelated test fallout) **defer** the issue with
+`fp-human-review-needed`; **invalid-data** failures (malformed YAML,
+target mismatch) are **terminal** (`fp-skipped`); every human-review-phase
+failure is terminal (`fp-skipped`). A no-reproduce issue is simply closed.
 
 **After the loop — measure the FP-count delta** (only if
 `successes >= 1`): rebuild dist with the new fixes, re-run analyze
@@ -430,16 +471,18 @@ rule and total. Surfaces whether each fix actually reduced FPs on
 the target — a row with `Delta: 0` is a smell.
 
 **Open the batched PR**:
-- If `successes == 0` → end session, no PR.
+- If `successes == 0` → go to the queue-empty path (don't just end).
 - Else → push `claude/<SCOPE>fp-fix/batch-<YYYYMMDDHHMM>`, open one PR with
   one `Closes #N` per fixed issue, per-rule sections in body, optional
   "## Skipped this batch" section, a "## FP-count delta" table built
-  from the before/after measurements, label `fp-fix`. Comment + unlock
-  each fixed issue. End.
+  from the before/after measurements. Comment + unlock each fixed issue.
+  End. **Labels:** normal phase → `fp-fix`; human-review phase → `fp-fix`
+  **and** `fp-human-review-needed` (plus a `## Human review required`
+  body section listing what went over the boundary).
 
-**Queue empty path** (no *pickable* `fp-fix` issues — the queue is
-empty **or every remaining open issue is `fp-blocked`/`fp-skipped`**,
-and the session has 0 successes):
+**Queue empty path** (no *pickable* `fp-fix` issues in **either** queue —
+every remaining open issue is `fp-in-progress` or `fp-skipped`, or there
+are none — and the session has 0 successes):
 
 1. `pnpm install && pnpm build:dist` to rebuild dist with all merged
    fixes on `main`.
@@ -459,20 +502,29 @@ and the session has 0 successes):
      `node dist/cli.mjs` from the freshly-built dist).
 4. **If < 90 %**: file new `fp-fix` issues for FP-rules that **don't
    already have an open issue** (dedupe against existing, including
-   `fp-blocked`). Leave campaign `status: in_progress`. No
-   campaign-close PR.
+   `fp-human-review-needed` and `fp-skipped`). Leave campaign
+   `status: in_progress`. No campaign-close PR.
    - Filed ≥ 1 new issue → continue into the per-issue loop in the
-     same session and start fixing.
-   - Filed 0 (every FP-rule is already tracked and all are blocked) →
-     the campaign can't self-progress. File/update a single
+     same session (as a normal-phase run) and start fixing.
+   - Filed 0 (every FP-rule is already tracked) → the campaign can't
+     self-progress via new discovery. If any open `fp-skipped`
+     (terminally-stuck) issues exist, file/update a single
      `[fp-campaign-stuck] <owner>/<repo>` tracking issue (TP rate +
-     checklist of blocked issues, `cc @mushgev`) — this fires the TG
-     alert — then end. **Never dead-end silently.**
+     checklist of `fp-skipped` issues, `cc @mushgev`) — this fires the
+     TG alert — then end. If the only remaining open issues are
+     `fp-in-progress` in another session, end quietly (that session is
+     handling them). **Never dead-end on genuinely-stuck work
+     silently.**
 5. End. The campaign-close PR merge fires `fp-campaign-close` and
    `fp-discover` in parallel.
 
-**Refactor-required path**: comment on the issue with a `## Refactor
-needed` note, add `fp-blocked` label, end. The user triages later.
+**Over-the-boundary path**: when a normal-phase fix would need a
+cross-module refactor, comment on the issue with a `## Refactor needed`
+note, add the `fp-human-review-needed` label, and move on — a later
+human-review-phase session does the refactor with out-of-bounds access
+and opens a human-merged PR. Only issues that can't be fixed even
+out-of-bounds become terminal (`fp-skipped`) and land on the
+`[fp-campaign-stuck]` issue.
 
 ### 3. `fp-campaign-close` — tag and chain to the next campaign
 

--- a/docs/fp-automation/prompts/fp-next-fix-review.md
+++ b/docs/fp-automation/prompts/fp-next-fix-review.md
@@ -7,27 +7,28 @@ produced by the `fp-next-fix` routine — the test fixtures and the
 visitor/pattern edits — decide whether **that code** faithfully follows
 every code-level instruction in
 [`docs/fp-automation/prompts/fp-next-fix.md`](./fp-next-fix.md), and then
-take exactly one terminal action:
+take exactly one terminal action.
 
-- **Compliant** → **merge the PR**. The merge fires the next
-  `fp-next-fix` session (Trigger B), so the inner loop keeps running
-  with no human in the loop.
-- **Non-compliant** → **do not merge**. Open one issue on
-  `truecourse-ai/truecourse` describing every violation, and comment
-  the same summary on the PR. (The issue is the human signal; leave the
-  PR open for a human to fix or close.)
+**You review every fp-fix batch PR regardless of its labels.** But the
+`<SCOPE>fp-human-review-needed` label on the PR changes what you're
+allowed to do with it:
 
-**Scope: code only.** This routine reviews *the committed code* — the
-fixtures under `tests/fixtures/sample-*/…` and the visitor/pattern edits
-under `packages/analyzer/src/…`. It does **not** review the PR's
-structure: the title format, the PR-body markdown sections
-(`Closes #…` lines, the `## Fixes` table, per-rule sections, the
-`## FP-count delta` write-up), the PR/issue labels, the linked-issue
-bookkeeping, and commit/PR hygiene trailers are all **out of scope** and
-must **never** produce a violation here. A PR whose code is correct is
-merged even if its body or title is imperfect; a PR whose code is wrong
-is failed even if its body is immaculate. (PR structure is fp-next-fix's
-own responsibility and is checked elsewhere.)
+- **Normal PR** (no `<SCOPE>fp-human-review-needed` label) — the fix is
+  in-bounds and auto-mergeable:
+  - **Compliant** → **merge the PR**. The merge fires the next
+    `fp-next-fix` session (Trigger B), so the inner loop keeps running
+    with no human in the loop.
+  - **Non-compliant** → **do not merge**. Open one issue on
+    `truecourse-ai/truecourse` describing every violation, and comment
+    the same summary on the PR. (The issue is the human signal; leave the
+    PR open for a human to fix or close.)
+- **Human-review PR** (carries `<SCOPE>fp-human-review-needed`) — the fix
+  deliberately went **over the in-bounds boundary** (cross-module
+  refactor), so a human must review and merge it. You **never merge**
+  this PR. You still review the code and **post your review as a PR
+  comment** to help the human, then stop. You do **not** open a
+  review-failed issue for these — the human is already in the loop, and
+  the `cc @mushgev` on the PR already pinged them.
 
 `fp-next-fix.md` is the **single source of truth** for what "correct
 code" means. This prompt does not restate its rules — it points at them.
@@ -57,17 +58,24 @@ byte-identical to an unscoped run.
 - The repository `truecourse-ai/truecourse` is cloned.
 - The triggering event is `pull_request.opened` (and `reopened`) whose
   **head branch starts with `claude/<SCOPE>fp-fix/batch-`** — i.e. a
-  batch PR just opened by `fp-next-fix`. The open event is the cue that
-  a PR is waiting for review. Determine the PR number from the trigger
-  payload.
+  batch PR just opened by `fp-next-fix`. Both normal and human-review
+  batch PRs share this branch prefix, so you review both. The open event
+  is the cue that a PR is waiting for review. Determine the PR number
+  from the trigger payload.
 
 ## Session setup (once)
 
 - **Identify the PR.** Resolve the PR number, its head branch, base
   (`main`), the changed-files list, the full diff, and the PR labels —
   these are what you review the code against and what you use for the
-  lock below. (You do not need to parse the PR title or body for the
-  review; they are PR structure, out of scope.)
+  lock and the merge gate below. (You do not need to parse the PR title
+  or body for the review; they are PR structure, out of scope. The one
+  label you **must** read is `<SCOPE>fp-human-review-needed`, because it
+  decides whether you may merge.)
+- **Classify the PR.** If the PR carries `<SCOPE>fp-human-review-needed`
+  it is a **human-review PR** (never merge; review-only). Otherwise it is
+  a **normal PR** (mergeable when compliant). Hold this classification —
+  it drives the "Decision" section.
 - **Scope gate — head branch.** The head branch must start with
   `claude/<SCOPE>fp-fix/batch-` (this is the trigger filter and the
   merge-safety guard, not a code check). A PR on any other prefix is
@@ -92,7 +100,7 @@ point at concrete evidence in the diff or CI. Do **not** invent problems;
 a requirement you cannot evaluate is noted as `unverifiable: <reason>`
 rather than a violation. **Do not** append violations for anything about
 the PR's title, body, labels, linked-issue state, or commit trailers —
-those are out of scope (see "Scope: code only" above).
+those are out of scope (see "Scope: code only" below).
 
 **Derive the fixed rule set from the diff, not the PR body.** The set of
 rules this PR fixes = every `rule_key` that appears in an added/changed
@@ -101,18 +109,35 @@ Python-appropriate comment). Validate each rule in that set against the
 checks below. Working from the diff (not the body) keeps the review
 about the code and independent of how the PR was written up.
 
+**Two checks are scoped differently for a human-review PR.** Checks 1 and
+5 below enforce the **in-bounds boundary** — but a human-review PR is
+*expected* to cross that boundary (that's why a human merges it). For a
+human-review PR, do **not** raise a violation merely because the diff
+touches files outside `packages/analyzer/src/rules|patterns/` or refactors
+across modules; instead evaluate whether the broader change is a
+**targeted, sound** fix and surface any concerns as review notes for the
+human. The two things that are **still hard violations even on a
+human-review PR**: touching `docs/fp-automation/campaigns.yaml` or the
+four version-bump locations (those never belong in an fp-fix batch), and
+changes that are plainly unrelated to any fixed rule.
+
 ### 1. Changed files are in-bounds
 
-Per fp-next-fix "Hard constraints", the diff may only touch:
+**Normal PR.** Per fp-next-fix "Hard constraints" (normal phase), the
+diff may only touch:
 - `packages/analyzer/src/rules/…`
 - `packages/analyzer/src/patterns/…`
 - `tests/fixtures/sample-*/…`
 
-(The queue-empty / campaign-close paths — `campaigns.yaml` and the four
-version-bump locations — are **not** part of an fp-fix batch PR and must
-not appear here; a campaign-close PR is reviewed by a human, not this
-routine.) Any changed file outside the allow-list → violation, listing
-the offending path.
+Any changed file outside that allow-list → violation, listing the
+offending path.
+
+**Human-review PR.** Cross-boundary files (types, file discovery,
+resolvers, data-flow, shared helpers under `packages/analyzer/src/…` or
+adjacent packages) are **allowed** and must **not** be flagged. Still a
+violation, on either PR kind: `docs/fp-automation/campaigns.yaml` or any
+of the four version-bump locations appearing in the diff (those belong to
+a campaign-close PR, reviewed by a human, not an fp-fix batch).
 
 ### 2. Fix count is in-bounds
 
@@ -149,17 +174,26 @@ For every rule in the derived fixed set:
   steps 5 and 6 both run per fix. A rule with only one of the two →
   violation.
 - It includes a corresponding visitor/pattern change under
-  `packages/analyzer/src/` (a fix that adds fixtures but no visitor edit
-  is not a real fix) → violation.
+  `packages/analyzer/src/` (a fix that adds fixtures but no code change
+  is not a real fix) → violation. (On a human-review PR that change may
+  legitimately live outside `rules/`/`patterns/` — see check 5.)
 
-### 5. Visitor / pattern changes are scoped
+### 5. Code changes are scoped
 
-- Every non-fixture change lives under
-  `packages/analyzer/src/rules/…` or
-  `packages/analyzer/src/patterns/…` (already covered by check 1) and
-  reads as a **targeted rule fix**, not an unrelated refactor across
-  module boundaries (fp-next-fix step 8 / Hard constraints). A diff that
-  edits types, file discovery, resolvers, etc. → violation.
+**Normal PR.** Every non-fixture change lives under
+`packages/analyzer/src/rules/…` or `packages/analyzer/src/patterns/…`
+(already covered by check 1) and reads as a **targeted rule fix**, not an
+unrelated refactor across module boundaries (fp-next-fix step 8 / Hard
+constraints). A diff that edits types, file discovery, resolvers, etc. →
+violation.
+
+**Human-review PR.** Cross-module edits are expected. The bar here is
+**targeted, not sprawling**: every non-fixture change must be traceable
+to one of the fixed rules. Flag (as a review note, and as a violation
+only if egregious) any change that is a drive-by cleanup or an unrelated
+refactor with no connection to a fixed rule. Genuine refactors that a
+fixed rule requires are fine — that's the whole point of a human-review
+PR.
 
 ### 6. Tests / CI are green
 
@@ -175,7 +209,28 @@ For every rule in the derived fixed set:
 
 ## Decision
 
-### If `violations` is empty → MERGE
+First branch on the PR classification from session setup.
+
+### Human-review PR (carries `<SCOPE>fp-human-review-needed`) → REVIEW, never merge
+
+- **Do not merge and do not close the PR** under any circumstance — a
+  human owns the merge decision on these.
+- Post your review as a comment on the PR:
+  - If `violations` is empty and you have no concerns → a short
+    approval-style note (e.g. "fp-next-fix-review: code review passed;
+    out-of-bounds changes look targeted. Held for human merge per
+    `<SCOPE>fp-human-review-needed`.").
+  - Otherwise → a checklist of every entry in `violations` plus any
+    review notes about the cross-boundary changes, so the human can act
+    on them before merging.
+- Do **not** open a review-failed issue — the human is already the
+  reviewer/merger here; a separate issue is redundant noise.
+- Remove `<SCOPE>fp-reviewing`; add `<SCOPE>fp-reviewed` (so a re-fire
+  doesn't re-review the same unchanged PR — a human reopening the review
+  removes the label). Leave `<SCOPE>fp-human-review-needed` in place.
+- End the session.
+
+### Normal PR — `violations` is empty → MERGE
 
 - Merge the PR into `main` using the repository's standard merge method
   (squash). Rely on `Closes #…` in the body to auto-close the linked
@@ -187,7 +242,7 @@ For every rule in the derived fixed set:
 - Remove `<SCOPE>fp-reviewing`; add `<SCOPE>fp-reviewed`.
 - End the session.
 
-### If `violations` is non-empty → OPEN AN ISSUE, do NOT merge
+### Normal PR — `violations` is non-empty → OPEN AN ISSUE, do NOT merge
 
 - **Do not merge or close the PR.** Leave it open for a human.
 - First search for an existing open issue titled
@@ -212,26 +267,38 @@ For every rule in the derived fixed set:
   a missing/extra body section, a label, linked-issue bookkeeping, or a
   commit/PR hygiene trailer — those are PR structure, not this routine's
   concern.
-- **At most one terminal action per session**: either one merge, or one
-  issue (open or refreshed). Never both, never two.
+- **Review every batch PR, but never merge a `<SCOPE>fp-human-review-needed`
+  one.** A PR carrying that label is merged by a human; your terminal
+  action on it is a review comment, nothing more. Merging one would
+  defeat the whole point of flagging it.
+- **At most one terminal action per session**: for a normal PR, either
+  one merge or one issue (open or refreshed); for a human-review PR, one
+  review comment. Never two.
 - **Review, never edit.** This routine does not push commits, change
   fixtures/visitors, or touch the PR's files. If the code is wrong, it
-  files an issue — it does not fix it.
+  files an issue (normal PR) or notes it in the review comment
+  (human-review PR) — it does not fix it.
 - Only ever merge a PR whose head branch starts with
-  `claude/<SCOPE>fp-fix/batch-`. Never merge any other branch.
-- Never merge with a non-empty `violations` list, and never merge while
-  CI is still running or failing.
+  `claude/<SCOPE>fp-fix/batch-` **and** that does **not** carry
+  `<SCOPE>fp-human-review-needed`. Never merge any other branch, and never
+  merge a human-review PR.
+- Never merge a normal PR with a non-empty `violations` list, and never
+  merge while CI is still running or failing.
+- **The in-bounds boundary is phase-aware.** On a normal PR, out-of-bounds
+  files / cross-module refactors are violations (checks 1 and 5). On a
+  human-review PR they are expected and must not be flagged — evaluate
+  them for being targeted and sound, and surface concerns as review
+  notes. In both cases, touching `campaigns.yaml` or the version-bump
+  locations is always a violation.
 - `fp-next-fix.md` is authoritative. If this prompt and `fp-next-fix.md`
   ever disagree about what correct code looks like, `fp-next-fix.md`
   wins — file the discrepancy as an `unverifiable` note, don't guess.
 - If anything is genuinely ambiguous (a requirement you cannot evaluate
-  from the diff / CI), record it as `unverifiable: <reason>` in the issue
-  rather than merging on assumption. When unsure, prefer **not** merging.
+  from the diff / CI), record it as `unverifiable: <reason>` rather than
+  merging on assumption. When unsure, prefer **not** merging.
 
 ## Commit & PR hygiene — no Claude Code session details
 
 **Never include Claude Code session details in anything you create or push.** No commit message,
 PR body, or issue body may contain a `Claude-Session:` trailer or any `https://claude.ai/code/session…`
 URL — strip them before committing or opening the PR/issue. Default commit/PR formatting is otherwise fine.
-</content>
-</invoke>

--- a/docs/fp-automation/prompts/fp-next-fix-review.md
+++ b/docs/fp-automation/prompts/fp-next-fix-review.md
@@ -100,7 +100,8 @@ point at concrete evidence in the diff or CI. Do **not** invent problems;
 a requirement you cannot evaluate is noted as `unverifiable: <reason>`
 rather than a violation. **Do not** append violations for anything about
 the PR's title, body, labels, linked-issue state, or commit trailers —
-those are out of scope (see "Scope: code only" below).
+those are PR structure, not this routine's concern (see the **Code only.**
+bullet under "Hard constraints").
 
 **Derive the fixed rule set from the diff, not the PR body.** The set of
 rules this PR fixes = every `rule_key` that appears in an added/changed
@@ -200,12 +201,21 @@ PR.
 - The full test suite must pass (fp-next-fix step 9 requires a green
   suite before success). Check the PR's CI: all required checks
   completed and passing.
-  - If checks are still **running**, do not merge and do not fail the
-    PR — remove `<SCOPE>fp-reviewing` and end the session; the next
+- **Ignore the `block-human-review` gate — it is not a test.** The
+  `block-human-review` check (`.github/workflows/block-human-review.yml`)
+  is a merge gate, not a CI signal: it is **designed to fail** on any PR
+  carrying `<SCOPE>fp-human-review-needed`, purely to stop the merge. On a
+  **human-review PR it will always be red, and that is expected** — never
+  treat it as a failed check or a violation. Evaluate only the *real* CI
+  checks (tests, build, etc.) below; exclude `block-human-review` from
+  that set on either PR kind.
+  - If the real checks are still **running**, do not merge and do not fail
+    the PR — remove `<SCOPE>fp-reviewing` and end the session; the next
     trigger fire (or a re-open) will pick it up once CI settles. Note
     this as the reason in the session log.
-  - If any required check **failed**, that is a violation (attach the
-    failing check name / a link to its log).
+  - If any real (non-gate) required check **failed**, that is a violation
+    (attach the failing check name / a link to its log). A red
+    `block-human-review` is **not** such a failure.
 
 ## Decision
 

--- a/docs/fp-automation/prompts/fp-next-fix.md
+++ b/docs/fp-automation/prompts/fp-next-fix.md
@@ -10,13 +10,44 @@ The 15-sessions-per-day routine cap is the binding constraint, so each
 session does meaningful batch work instead of one fix at a time. With
 N = 5, 15 sessions/day = ~75 fixes/day instead of 15.
 
+## Two phases, one PR per run
+
+fp-next-fix works the fix queue in **two phases**, and each session runs
+in exactly **one** of them (at most one PR per run):
+
+- **Normal phase** — the default. Fix issues that do **not** carry the
+  `<SCOPE>fp-human-review-needed` label, using only **in-bounds** changes
+  (the rule's visitor/pattern + the fixtures). Open a normal PR (label
+  `<SCOPE>fp-fix`) that `fp-next-fix-review` may auto-merge.
+- **Human-review phase** — entered only when the normal queue is empty
+  but issues carrying `<SCOPE>fp-human-review-needed` remain. In this
+  phase you are **allowed to go over the boundary** — targeted
+  cross-module refactors, type changes, etc. — to fix issues that a plain
+  in-bounds fix couldn't. Open a PR carrying **both** `<SCOPE>fp-fix` and
+  `<SCOPE>fp-human-review-needed`; `fp-next-fix-review` reviews it but does
+  **not** merge it — a human reviews and merges those.
+
+**The boundary is what routes an issue between phases.** When a
+normal-phase fix would require going over the in-bounds boundary (a
+cross-module refactor, or the rule is broken in more ways than the FP),
+you don't dead-end it: you **defer** the issue by adding
+`<SCOPE>fp-human-review-needed` and moving on. A later human-review-phase
+session fixes it with the broader access. This replaces the old
+"block-and-wait" behavior — the flagged queue is now worked, not parked.
+
+Only issues that **can't be fixed even with out-of-bounds access** (e.g.
+malformed issue data, or a refactor that turns out infeasible) become
+terminally stuck: they are marked `<SCOPE>fp-skipped` and surfaced to a
+human via the single `[<SCOPE>fp-campaign-stuck]` tracking issue.
+
 Per invocation:
-- Process issues until you've accumulated **5 successful fixes**, OR
-  you've attempted **10 issues**, OR the queue is empty.
-- Issues that can't produce a fix (malformed YAML / FP no longer
-  reproduces / broken-beyond-FP / refactor required) are skipped per
-  their respective paths; they count toward the 10-attempt cap but
-  not the 5-success cap.
+- Determine the phase up front (see "Determine the run phase"). Then
+  process issues from that phase's queue until you've accumulated
+  **5 successful fixes**, OR you've attempted **10 issues**, OR the
+  phase's queue is empty.
+- Issues that can't produce a fix are routed per "Bail-out routing"
+  below (defer to human-review, terminal-skip, or close); they count
+  toward the 10-attempt cap but not the 5-success cap.
 - Open ONE PR at the end with all successful fixes (or end with no PR
   if zero successes).
 
@@ -43,7 +74,10 @@ byte-identical to an unscoped run.
 - The triggering event is `pull_request.closed` (merged) on either a
   previous fp-fix PR (Trigger B) or the campaign's discovery PR
   (Trigger A, fp-next-fix-bootstrap). Either way, the merge is just
-  the cue that a new session should run.
+  the cue that a new session should run. Both normal and human-review
+  batch PRs live on `claude/<SCOPE>fp-fix/batch-…` branches, so merging
+  either kind (a human merges the human-review ones) fires the next
+  session.
 
 ## Session setup (once)
 
@@ -96,26 +130,53 @@ Before the per-issue loop:
   `.violations[]` by `ruleKey` and counting; populate `before_total`
   as the total length of `.violations[]`.
 
+## Determine the run phase (once, up front)
+
+After session setup, list open `<SCOPE>fp-fix` issues and split them into
+two **pickable** queues:
+
+- **normal-pickable** = open `<SCOPE>fp-fix` issues that lack
+  `<SCOPE>fp-human-review-needed`, `<SCOPE>fp-in-progress`, and
+  `<SCOPE>fp-skipped`.
+- **review-pickable** = open `<SCOPE>fp-fix` issues that **carry**
+  `<SCOPE>fp-human-review-needed` and lack `<SCOPE>fp-in-progress` and
+  `<SCOPE>fp-skipped`.
+
+Then:
+
+- **normal-pickable non-empty** → **phase = normal**. Work only the
+  normal queue this session.
+- **normal-pickable empty, review-pickable non-empty** → **phase =
+  human-review**. Work only the human-review queue this session, with
+  out-of-bounds access.
+- **both empty** → go to the **Queue-empty path**.
+
+**The phase is fixed for the whole session.** Every issue you pick comes
+from the chosen phase's queue, and you open at most one PR (normal, or
+human-review-labeled). If a normal-phase queue drains after only 2
+successes, you ship a normal PR with 2 fixes — you do **not** then start
+a human-review batch in the same session; the next session's phase check
+will pick up the human-review queue.
+
 ## Per-issue loop
 
 Repeat the steps below while `successes < 5 AND attempts < 10`. Each
-iteration is one "attempt" (success or skip).
+iteration is one "attempt" (success or skip). The steps are the same in
+both phases; the two differences are called out at step 8 (fix scope)
+and in "Bail-out routing" (how failures are handled).
 
 ### 1. Pick the next issue
 
-- List open issues on `truecourse-ai/truecourse` with label `<SCOPE>fp-fix`,
-  **excluding** any with label `<SCOPE>fp-in-progress`, `<SCOPE>fp-blocked`, or
-  `<SCOPE>fp-skipped`.
-- Also exclude any issue already in `fixed_issues` for this session.
-- If none (the **pickable** queue is empty — note this is also true
-  when open issues remain but every one is `<SCOPE>fp-blocked`/`<SCOPE>fp-skipped`):
+- From the current phase's queue (normal-pickable in normal phase,
+  review-pickable in human-review phase), exclude any issue already in
+  `fixed_issues` for this session.
+- If the phase's pickable queue is empty:
   - If `successes >= 1` → break out of the loop and go to "Open the
     batched PR" (ship the batch you've built).
   - If `successes == 0` → go to the **Queue-empty path**. Do **not**
     just end the session — an empty pickable queue is the cue to
     re-measure the campaign (re-analyze, recompute TP, then close /
-    re-discover / flag-stuck). This holds even when the only remaining
-    issues are blocked.
+    re-discover / flag-stuck).
 - Otherwise: pick the **oldest** by `created_at`.
 
 ### 2. Take the concurrency lock
@@ -131,24 +192,25 @@ iteration is one "attempt" (success or skip).
 
 - Parse the YAML block from the issue body. Extract `target_repo`,
   `target_ref`, `rule_key`, `samples[]`.
-- If the YAML is malformed: comment on the issue ("malformed YAML in
-  body — needs human review"), add label `<SCOPE>fp-blocked`, remove
-  `<SCOPE>fp-in-progress`, increment `attempts`, **continue to next iteration**.
+- If the YAML is malformed: this is **invalid issue data** — see
+  "Bail-out routing / Invalid issue data (terminal)". Increment
+  `attempts`, **continue to next iteration**.
 
 ### 4. Confirm the FP still reproduces
 
 - If `target_repo`/`target_ref` differs from any earlier issue in this
   session, that's surprising — all fp-fix issues in a campaign should
-  share the same target. Comment on the issue noting the mismatch,
-  add `<SCOPE>fp-blocked`, remove `<SCOPE>fp-in-progress`, increment `attempts`,
-  continue.
+  share the same target. This is **invalid issue data** — route it per
+  "Bail-out routing / Invalid issue data (terminal)", increment
+  `attempts`, continue.
 - Filter `/tmp/target/.truecourse/LATEST.json` `.violations[]` to
   entries with `ruleKey == <rule_key>`. Cross-reference at least one
   of the URLs in `samples[].url`.
 - If no violations remain for this rule at this ref (upstream changed
   or an earlier fix in this batch already resolved it): close the
   issue with comment "FP no longer reproduces at `<target_ref>`",
-  remove `<SCOPE>fp-in-progress`, increment `attempts`, continue.
+  remove `<SCOPE>fp-in-progress`, increment `attempts`, continue. (This
+  is a clean close, not a failure — no defer, no skip.)
 
 ### 5. Add a paraphrased FP to the positive fixture
 
@@ -204,13 +266,15 @@ or `tests/analyzer/python-positive.test.ts` is a false positive.
   fire because their visitors haven't been fixed yet — that's fine,
   tolerated until step 9 below.
 - If the new negative case fails: the rule is broken in more ways
-  than the FP — comment on the issue with the test output, add
-  `<SCOPE>fp-blocked`, remove `<SCOPE>fp-in-progress`, **revert** this issue's
-  positive and negative fixture files (keep earlier-batch files
-  intact), increment `attempts`, continue.
+  than the FP. This is **over-the-boundary** work — route it per
+  "Bail-out routing / Over-the-boundary" (defer in normal phase; try
+  the broader fix, then terminal-skip if infeasible, in human-review
+  phase). Attach the test output to your comment. Increment `attempts`,
+  continue.
 
-### 8. Fix the visitor
+### 8. Fix the rule
 
+**Normal phase — in-bounds only.**
 - Edit only the rule's visitor / pattern under
   `packages/analyzer/src/rules/<domain>/…` (and/or
   `packages/analyzer/src/patterns/<domain>-patterns.ts` if the fix
@@ -218,9 +282,24 @@ or `tests/analyzer/python-positive.test.ts` is a false positive.
 - No unrelated refactors. Do not touch types, file discovery,
   resolvers, etc. unless the rule lives there.
 - If you can't fix it without a refactor that crosses module
-  boundaries: revert this issue's fixture additions, post a
-  `## Refactor needed` comment on the issue, add `<SCOPE>fp-blocked` label,
-  remove `<SCOPE>fp-in-progress`, increment `attempts`, continue.
+  boundaries: this is **over-the-boundary** work — route it per
+  "Bail-out routing / Over-the-boundary" (post a `## Refactor needed`
+  comment describing what's required, defer with
+  `<SCOPE>fp-human-review-needed`), increment `attempts`, continue. A
+  later human-review-phase session will do the refactor.
+
+**Human-review phase — over-the-boundary allowed.**
+- You are permitted to make the changes the rule genuinely needs to be
+  correct, **including** cross-module refactors: types, file discovery,
+  resolvers, data-flow, shared helpers. This is exactly why these PRs
+  are merged by a human, not auto-merged.
+- Keep the change **targeted**: only what this specific fix requires, no
+  unrelated refactors, no drive-by cleanups. **Never** touch
+  `docs/fp-automation/campaigns.yaml` or any of the four version-bump
+  locations — those belong to campaign-close, not an fp-fix batch.
+- If even an out-of-bounds fix isn't feasible (the refactor is too
+  large / would change the rule's contract in ways that need a human
+  design decision): route it per "Bail-out routing / Terminal (skip)".
 
 ### 9. Re-run tests, confirm green
 
@@ -228,23 +307,59 @@ or `tests/analyzer/python-positive.test.ts` is a false positive.
 - Required state: full test suite green, including all earlier-batch
   fixes (their visitors are fixed too, so their positive cases now
   pass).
-- If anything other than expected cases fails: revert this issue's
-  visitor change AND fixture files, comment on the issue with the
-  failure, add `<SCOPE>fp-blocked`, remove `<SCOPE>fp-in-progress`, increment
-  `attempts`, continue.
+- If anything other than expected cases fails: the fix has unintended
+  fallout. Route it per "Bail-out routing / Over-the-boundary" (defer
+  in normal phase; in human-review phase, either extend the fix to make
+  the suite green or terminal-skip if you can't). Revert as that routing
+  specifies, attach the failure, increment `attempts`, continue.
 
 ### 10. Mark success
 
 - Append `(issue_number, rule_key, positive_fixture_path,
   negative_fixture_path, visitor_summary)` to `fixed_issues`.
   `visitor_summary` is a 2–3 sentence summary of what you changed
-  and why.
+  and why. In human-review phase, also note **what went over the
+  boundary** (which non-rule files/modules you touched and why) so the
+  human reviewer knows where to focus.
 - Increment `successes` AND `attempts`.
 - **Do not** remove `<SCOPE>fp-in-progress` yet — the issue stays locked
   until the batch PR opens (in case the loop breaks early due to
   attempts cap or queue empty).
 - If `successes == 5` or `attempts == 10`: break out of the loop.
 - Otherwise: continue to next iteration.
+
+## Bail-out routing (defer vs terminal vs close)
+
+When step 3–9 can't produce a clean in-batch fix, route the issue by
+**cause** and **phase**. In every case, revert **only this issue's** own
+fixture/visitor changes (keep earlier-batch changes intact) before
+continuing.
+
+- **Over-the-boundary** (a cross-module refactor is required — step 8;
+  the rule is broken beyond the FP — step 7; or the fix causes unrelated
+  test fallout you can't contain in-bounds — step 9):
+  - **Normal phase → DEFER.** Comment on the issue explaining what's
+    needed (for the refactor case, a `## Refactor needed` section), add
+    label `<SCOPE>fp-human-review-needed`, remove `<SCOPE>fp-in-progress`.
+    Do **not** open any issue and do **not** mark it skipped — a later
+    human-review session will fix it.
+  - **Human-review phase → try the broader fix first** (you have
+    out-of-bounds access). Only if it's still infeasible, fall through
+    to **Terminal (skip)** below.
+- **Invalid issue data** (malformed YAML — step 3; `target_repo`/
+  `target_ref` mismatch — step 4): out-of-bounds access can't
+  manufacture missing/valid data, so this is **Terminal (skip)** in
+  either phase.
+- **Terminal (skip)** — the issue can't be fixed even with out-of-bounds
+  access: comment on the issue with the concrete blocker, add label
+  `<SCOPE>fp-skipped`, remove `<SCOPE>fp-in-progress`. (In human-review
+  phase, leave the `<SCOPE>fp-human-review-needed` label in place — the
+  `<SCOPE>fp-skipped` marker is what pulls it out of every pickable queue
+  and lands it on the campaign-stuck checklist.) These terminally-stuck
+  issues are surfaced to a human via `[<SCOPE>fp-campaign-stuck]` in the
+  Queue-empty path.
+- **No longer reproduces** (step 4): **close** the issue — not a
+  failure, no defer, no skip.
 
 ## After the loop: measure the FP-count delta on the target (REQUIRED)
 
@@ -295,10 +410,10 @@ After the loop:
 
 - If `successes == 0`: do **not** end here. You only reach this section
   with zero successes if you attempted issues that all failed
-  (blocked / no-reproduce / refactor) — the pickable queue ran out
+  (deferred / terminal / no-reproduce) — the pickable queue ran out
   mid-session. Go to the **Queue-empty path** to re-measure the
-  campaign. (Step 1 already routes a start-empty queue straight there;
-  this catches the case where the queue drained during the loop.)
+  campaign. (The phase check already routes a start-empty queue straight
+  there; this catches the case where the queue drained during the loop.)
 - If `successes >= 1`:
   - **Verify your branch.** Run `git rev-parse --abbrev-ref HEAD` and
     confirm it starts with `claude/<SCOPE>fp-fix/batch-`. If it doesn't —
@@ -326,11 +441,16 @@ After the loop:
     - One "## <rule_key>" section per fixed issue, each containing:
       - OSS source URLs from the issue's `samples[].url`.
       - The `visitor_summary` for that issue.
+    - **Human-review phase only** — a "## Human review required"
+      section at the top of the body: state that these fixes went
+      **over the in-bounds boundary** (list the non-rule files/modules
+      touched per fix), that `fp-next-fix-review` will review but not
+      merge, and that a human must review and merge. This is the signal
+      that distinguishes the two PR kinds in the body.
     - A "## Skipped this batch" section (only if any `attempts >
-      successes`): brief list of issues that were attempted but
-      skipped, with reason (malformed YAML / no-reproduces /
-      broken-beyond-FP / refactor-required). One line each, link
-      to the issue.
+      successes`): brief list of issues that were attempted but not
+      fixed, with routing (deferred-to-human-review / terminal-skip /
+      no-reproduce / invalid-data). One line each, link to the issue.
     - A "## FP-count delta (vs `<target_ref>` on `<target_repo>`)"
       section with a markdown table built from the after-loop
       measurements:
@@ -351,8 +471,14 @@ After the loop:
       a one-line note: `unavailable: <reason>`.
     - End the body with a line `cc @mushgev` so the reviewer gets a
       notification email on PR creation.
-  - Labels: `<SCOPE>fp-fix` (this label must be on the PR — it's what fires
-    the next routine invocation on merge).
+  - Labels:
+    - **Normal phase:** `<SCOPE>fp-fix` (this label must be on the PR —
+      it's what fires the next routine invocation on merge).
+    - **Human-review phase:** both `<SCOPE>fp-fix` **and**
+      `<SCOPE>fp-human-review-needed`. The `<SCOPE>fp-fix` label + the
+      `claude/<SCOPE>fp-fix/batch-…` branch still fire the next
+      invocation once a human merges; the `<SCOPE>fp-human-review-needed`
+      label is what tells `fp-next-fix-review` to review-but-not-merge.
   - For each fixed issue: comment on the issue with the PR URL, then
     remove the `<SCOPE>fp-in-progress` label (the merge will auto-close the
     issue via `Closes #N`).
@@ -360,14 +486,21 @@ After the loop:
 
 ## Queue-empty path
 
-Enter this path when the **pickable** queue is empty AND
-`successes == 0` this session. "Pickable empty" means step 1 found no
-open `<SCOPE>fp-fix` issue that lacks `<SCOPE>fp-in-progress`/`<SCOPE>fp-blocked`/`<SCOPE>fp-skipped`
-— **including the case where open issues remain but all are blocked.**
-Do not require "zero issues exist at all"; all-blocked counts.
+Enter this path when **both** pickable queues are empty AND
+`successes == 0` this session. "Both empty" means the phase check (and
+step 1) found no open `<SCOPE>fp-fix` issue that lacks
+`<SCOPE>fp-in-progress`/`<SCOPE>fp-skipped` in either the normal **or** the
+human-review queue — i.e. every remaining open issue is already
+in-progress (another session) or `<SCOPE>fp-skipped` (terminally stuck),
+or there are no open issues at all.
 
 (If `successes >= 1`, you ship the batch PR instead — never run this
 path in a session that already produced fixes.)
+
+Note the change from the old design: an all-`<SCOPE>fp-human-review-needed`
+queue is **no longer** a reason to enter this path — that's a
+human-review-phase run, and you'd be fixing those issues, not parking
+them here.
 
 1. Find the campaign in `docs/fp-automation/campaigns.yaml` with
    `status: in_progress` or `status: discovering`. There should be
@@ -414,47 +547,58 @@ path in a session that already produced fixes.)
 
    **File new issues, but dedupe first.** For each rule that still
    shows FPs, check whether an **open** `<SCOPE>fp-fix` issue for that
-   `rule_key` already exists (any label — `<SCOPE>fp-blocked` counts).
+   `rule_key` already exists (any label — `<SCOPE>fp-human-review-needed`
+   and `<SCOPE>fp-skipped` both count).
    - Rule has no open issue → file a new fp-fix issue (same shape as
-     discovery).
+     discovery). New issues are unflagged, so they land in the normal
+     queue.
    - Rule already has an open issue → **skip it**. Re-filing a rule
-     that's already tracked (especially one that's `<SCOPE>fp-blocked`) just
-     creates duplicates.
+     that's already tracked (especially one that's
+     `<SCOPE>fp-human-review-needed` or `<SCOPE>fp-skipped`) just creates
+     duplicates.
 
    **Then branch on what you filed:**
    - **Filed ≥ 1 new issue** → continue into the per-issue loop in
-     this same session. The target clone, dist build, `before_counts`,
-     and counters are all still valid; only the issue list needs
+     this same session as a **normal-phase** run (the new issues are
+     unflagged). The target clone, dist build, `before_counts`, and
+     counters are all still valid; only the issue list needs
      re-fetching. If the budget allows at least one success, the
      session ends with a normal batched PR (carrying the FP-count
-     delta, firing Trigger B on merge). This removes the old manual
-     "Run now" hand-off.
-   - **Filed 0 new issues** (every FP-rule already has an open issue,
-     and all pickable ones are blocked) → the campaign **cannot
-     self-progress**: the only thing standing between it and 0.90 is
-     human-gated work. Do not end silently. Instead **file or update a
-     single tracking issue**:
-     - First search for an open issue titled
-       `[<SCOPE>fp-campaign-stuck] <owner>/<repo>`.
-     - If none exists → open one. Title:
-       `[<SCOPE>fp-campaign-stuck] <owner>/<repo>`. Body: current `tp_rate`,
-       the close threshold (0.90), and a checklist of every open
-       `<SCOPE>fp-blocked` issue (number + rule_key) that must be resolved by
-       a human before automation can proceed. End the body with
-       `cc @mushgev`.
-     - If one already exists → add a comment refreshing the `tp_rate`
-       and the current blocked list (don't open a duplicate).
-     - Then end the session. Opening/commenting the tracking issue is
-       the human signal — never dead-end without it.
+     delta, firing Trigger B on merge).
+   - **Filed 0 new issues** (every FP-rule already has an open issue) →
+     the campaign **cannot self-progress via new discovery**. Two
+     sub-cases:
+     - If any open `<SCOPE>fp-skipped` issues exist → these are the
+       terminally-stuck ones that need a human. **File or update a
+       single tracking issue:**
+       - First search for an open issue titled
+         `[<SCOPE>fp-campaign-stuck] <owner>/<repo>`.
+       - If none exists → open one. Title:
+         `[<SCOPE>fp-campaign-stuck] <owner>/<repo>`. Body: current
+         `tp_rate`, the close threshold (0.90), and a checklist of every
+         open `<SCOPE>fp-skipped` issue (number + rule_key + the blocker
+         reason) that a human must resolve before automation can
+         proceed. End the body with `cc @mushgev`.
+       - If one already exists → add a comment refreshing the `tp_rate`
+         and the current `<SCOPE>fp-skipped` list (don't open a
+         duplicate).
+       - Then end the session. Opening/commenting the tracking issue is
+         the human signal — never dead-end without it.
+     - If there are **no** `<SCOPE>fp-skipped` issues (the only remaining
+       open issues are `<SCOPE>fp-in-progress` in another session) →
+       another session is actively handling the queue. End quietly; the
+       next fire will re-check. Don't open a tracking issue for
+       in-flight work.
 
 If the queue empties during the per-issue loop **after** at least one
 success, go to "Open the batched PR" with what you have — don't run
-the queue-empty path in the same session. The next session's loop will
-hit a true empty queue and run the close logic.
+the queue-empty path in the same session. The next session's phase
+check will hit a truly empty queue and run the close logic.
 
 ## Hard constraints
 
-- At most one **PR-opening** per session.
+- At most one **PR-opening** per session — normal **or**
+  human-review-labeled, never both. The phase is fixed at session start.
 - At most **5 successful fixes** and **10 total attempts** per session.
 - **Every PR body must contain a `## FP-count delta` section** —
   either a populated `Before | After | Delta` table or an explicit
@@ -474,14 +618,27 @@ hit a true empty queue and run the close logic.
   OSS owner/repo, the upstream's source filenames, or upstream-themed
   identifiers. The committed fixture should look like generic
   domain-agnostic code that happens to trigger the rule.
-- Never change anything outside `packages/analyzer/src/rules/`,
-  `packages/analyzer/src/patterns/`, `tests/fixtures/sample-*/`, and
-  (in the queue-empty path) `docs/fp-automation/campaigns.yaml` +
-  the four version-bump locations.
-- A skipped (blocked / no-reproduces / refactor) issue only reverts
-  **its own** fixture and visitor changes, never earlier-batch
-  changes. The session's working tree is the accumulating draft of
-  the batch PR.
+- **Change scope depends on phase:**
+  - **Normal phase** — only in-bounds:
+    `packages/analyzer/src/rules/`, `packages/analyzer/src/patterns/`,
+    and `tests/fixtures/sample-*/`. A fix that needs to go over that
+    boundary is **deferred** with `<SCOPE>fp-human-review-needed`, never
+    forced.
+  - **Human-review phase** — you may go **over the boundary** with
+    **targeted** cross-module changes (types, file discovery, resolvers,
+    data-flow, shared helpers) as the flagged fix requires. This is why
+    those PRs are human-merged.
+  - **Neither phase** ever touches `docs/fp-automation/campaigns.yaml` or
+    the four version-bump locations — those belong to the queue-empty /
+    campaign-close path only.
+- **Bail-out routing** (see the section above): normal-phase
+  over-the-boundary failures **defer** (`<SCOPE>fp-human-review-needed`);
+  invalid-data failures are **terminal** (`<SCOPE>fp-skipped`);
+  human-review-phase failures are **terminal** (`<SCOPE>fp-skipped`, kept
+  alongside `<SCOPE>fp-human-review-needed`). A deferred/terminal/close
+  issue reverts only **its own** fixture and visitor changes, never
+  earlier-batch changes. The session's working tree is the accumulating
+  draft of the batch PR.
 - If anything is ambiguous, document it on the issue and continue the
   loop (or end the loop if it's session-wide). Do not invent state,
   do not skip steps, do not "try one more thing."


### PR DESCRIPTION
## What & why

Today `fp-next-fix` treats a hard-to-fix false positive as a dead end: it labels the issue `fp-blocked` and, once only blocked issues remain, files a "needs human input" tracking issue and stops. Since we're now using Claude to work those harder fixes too, this PR turns that dead-end into a **worked queue**.

## Changes

**Label rename:** `fp-blocked` → `fp-human-review-needed` (scoped: default `fp-human-review-needed`, C# account `cs-fp-human-review-needed`).

**`fp-next-fix` — two phases, one PR per run** (the "at most one PR per session" constraint is preserved). The phase is fixed at session start by which queue has pickable work:

- **Normal phase** (default): fix up to 5 issues that **don't** carry `fp-human-review-needed`, using only **in-bounds** changes (the rule's visitor/pattern + fixtures). Opens a normal PR (label `fp-fix`) that `fp-next-fix-review` may auto-merge. Fewer than 5 pickable → fix that many. When a fix would need to cross the in-bounds boundary (cross-module refactor, or the rule is broken beyond the FP), the issue is **deferred** with `fp-human-review-needed` instead of being dead-blocked.
- **Human-review phase**: entered only once the normal queue is empty but `fp-human-review-needed` issues remain. The session is allowed to **go over the boundary** (targeted cross-module refactors) to fix up to 5 of them, and opens a PR carrying **both** `fp-fix` and `fp-human-review-needed` (plus a `## Human review required` body section listing what went over the boundary).

**Terminal handling retained:** issues that can't be fixed even with out-of-bounds access (malformed issue data, an infeasible refactor) are marked `fp-skipped` and surfaced to a human via the retained `[fp-campaign-stuck]` tracking issue. Bail-out routing is spelled out explicitly (defer vs terminal vs close).

**`fp-next-fix-review` — reviews every PR, merges only the safe ones:**

- Reviews **every** batch PR regardless of label.
- **Normal PR:** unchanged — compliant → merge (fires the next session); non-compliant → open a `[fp-review-failed]` issue, don't merge.
- **`fp-human-review-needed` PR:** **never merges.** It posts its review as a PR comment to help the human and stops — no review-failed issue (the human is already in the loop). A human reviews and merges.
- The in-bounds/scoped checks (checks 1 & 5) are **phase-aware**: cross-boundary changes are expected on a human-review PR and aren't flagged, while touching `campaigns.yaml` or the four version-bump locations stays a hard violation on either PR kind.

**Docs:** `docs/fp-automation/README.md` updated to match (label list, issue-status enum, per-issue-loop summary, queue-empty/stuck path, two-phase description).

## Not touched (by design)

- `fp-stale-pr-notify` — it keys on the presence of the `fp-reviewed` label, which the review routine now also adds to human-review PRs after reviewing, so those aren't falsely flagged as stuck. Functionally correct as-is; left out of this PR's two-prompt scope.
- The separate `drift-fp-automation` chain — a parallel system, not in scope.

cc @mushgev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtZ8sQ7ZL6yJeqBMwicJxR)_