### PR TITLE
fix(fp): resolve 1 FP from abpframework/abp

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/class-prototype-assignment.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/class-prototype-assignment.ts
@@ -1,6 +1,35 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
+// Collect the names bound to an ES6 `class` in this file — both
+// `class Foo {}` declarations and `const Foo = class {}` expressions. The rule
+// only makes sense when the `.prototype` receiver is actually one of these:
+// grafting a method onto a real class's prototype is inconsistent with class
+// syntax, whereas the same shape on an ES5 constructor function is idiomatic.
+function collectClassNames(root: import('web-tree-sitter').Node): Set<string> {
+  const names = new Set<string>()
+  const stack: (import('web-tree-sitter').Node)[] = [root]
+  while (stack.length > 0) {
+    const n = stack.pop()!
+    if (n.type === 'class_declaration') {
+      const name = n.childForFieldName('name')
+      if (name?.text) names.add(name.text)
+    } else if (n.type === 'variable_declarator') {
+      const name = n.childForFieldName('name')
+      const value = n.childForFieldName('value')
+      if (name?.type === 'identifier' && value &&
+          (value.type === 'class' || value.type === 'class_expression')) {
+        names.add(name.text)
+      }
+    }
+    for (let i = 0; i < n.namedChildCount; i++) {
+      const c = n.namedChild(i)
+      if (c) stack.push(c)
+    }
+  }
+  return names
+}
+
 export const classPrototypeAssignmentVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/class-prototype-assignment',
   languages: ['typescript', 'tsx', 'javascript'],
@@ -19,10 +48,25 @@ export const classPrototypeAssignmentVisitor: CodeRuleVisitor = {
 
     const right = node.childForFieldName('right')
     if (right?.type === 'function_expression' || right?.type === 'arrow_function') {
-      const builtinObj = obj.childForFieldName('object')
+      const receiver = obj.childForFieldName('object')
+
+      // A simple identifier receiver is required to reason about whether it is
+      // a class. `X.prototype.m = fn` where `X` is anything else (a member
+      // expression, a call, etc.) is not the ES6-class inconsistency this rule
+      // targets.
+      if (receiver?.type !== 'identifier') return null
+
       const BUILTINS = new Set(['Array', 'Object', 'String', 'Number', 'Boolean', 'Function',
         'RegExp', 'Date', 'Error', 'Map', 'Set', 'Promise', 'Symbol'])
-      if (builtinObj?.type === 'identifier' && BUILTINS.has(builtinObj.text)) return null
+      if (BUILTINS.has(receiver.text)) return null
+
+      // Only fire when the receiver is actually declared as an ES6 class in the
+      // same file. Assigning `.prototype` methods on a plain ES5 constructor
+      // function is idiomatic ES5, not an inconsistency with class syntax.
+      let root = node
+      while (root.parent) root = root.parent
+      const classNames = collectClassNames(root)
+      if (!classNames.has(receiver.text)) return null
 
       return makeViolation(
         this.ruleKey, node, filePath, 'low',

--- a/tests/analyzer/code-quality-rules.test.ts
+++ b/tests/analyzer/code-quality-rules.test.ts
@@ -2581,13 +2581,24 @@ describe('code-quality/deterministic/require-yield', () => {
 });
 
 describe('code-quality/deterministic/class-prototype-assignment', () => {
-  it('detects prototype method assignment', () => {
+  it('detects prototype method assignment on an ES6 class', () => {
+    const violations = check(`
+      class Animal { constructor(name) { this.name = name; } }
+      Animal.prototype.speak = function() { return this.name; };
+    `, 'javascript');
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/class-prototype-assignment');
+    expect(matches).toHaveLength(1);
+  });
+
+  it('does not flag prototype assignment on an ES5 constructor function', () => {
+    // Idiomatic ES5 — the receiver is a plain constructor function, not a
+    // `class`, so this is not "inconsistent with class syntax" (issue #734).
     const violations = check(`
       function Animal(name) { this.name = name; }
       Animal.prototype.speak = function() { return this.name; };
     `, 'javascript');
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/class-prototype-assignment');
-    expect(matches).toHaveLength(1);
+    expect(matches).toHaveLength(0);
   });
 
   it('does not flag extend-native (handled by separate rule)', () => {

--- a/tests/fixtures/sample-js-project-negative/class-prototype-assignment-es6-class.js
+++ b/tests/fixtures/sample-js-project-negative/class-prototype-assignment-es6-class.js
@@ -1,0 +1,13 @@
+// An ES6 class whose method is grafted on externally via `.prototype`. This
+// IS the inconsistent pattern the rule targets: the receiver is a real `class`
+// declared in the same file, so the method belongs in the class body.
+export class Toast {
+  constructor() {
+    this.queue = [];
+  }
+}
+
+// VIOLATION: code-quality/deterministic/class-prototype-assignment
+Toast.prototype.show = function (message) {
+  this.queue.push(message);
+};

--- a/tests/fixtures/sample-js-project-positive/class-prototype-assignment-es5-constructor.js
+++ b/tests/fixtures/sample-js-project-positive/class-prototype-assignment-es5-constructor.js
@@ -1,0 +1,16 @@
+// An ES5 constructor function with methods assigned onto its `.prototype`.
+// This is the idiomatic ES5 pattern — there is no `class` declaration for the
+// receiver, so it is not "inconsistent with class syntax" and must not be
+// flagged. (`export` keeps it a module so the top-level function isn't
+// separately flagged as an implicit global.)
+export function ToastService() {
+  this.queue = [];
+}
+
+ToastService.prototype.show = function (message) {
+  this.queue.push(message);
+};
+
+ToastService.prototype.dismiss = function (id) {
+  this.queue = this.queue.filter((toast) => toast.id !== id);
+};


### PR DESCRIPTION
## Human review required

This PR was produced in the **human-review phase** of `fp-next-fix` (SCOPE=`cs-`): the only pickable `cs-fp-fix` issue, #734, carried `cs-fp-human-review-needed`, so this batch is reviewed by `fp-next-fix-review` but **merged by a human**.

What to focus on:
- The rule fix itself is **in-bounds** (only edits the rule visitor under `packages/analyzer/src/rules/…` + fixtures).
- One change goes **over the normal in-bounds boundary**: `tests/analyzer/code-quality-rules.test.ts`. The existing `detects prototype method assignment` unit test asserted the **pre-fix (buggy)** behavior — that an ES5 constructor's `.prototype` assignment fires — which is exactly the false positive #734 reports. It's updated to the corrected semantics (fire on an ES6 `class` receiver) plus a regression guard for the ES5 case. This test edit is why the PR is human-merged.

Closes #734

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/class-prototype-assignment` | #734 | `sample-js-project-positive/class-prototype-assignment-es5-constructor.js` | `sample-js-project-negative/class-prototype-assignment-es6-class.js` |

## code-quality/deterministic/class-prototype-assignment (#734)

OSS sources (abp @ `8665ce0a23622f658b531b0627c7c025935fdb3b`):
- ``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/toast/abp-toast.js#L43``
- https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/index.js#L406
- https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/npm/packs/jquery/src/abp.jquery.js#L300

Summary: the rule flagged **any** `X.prototype.method = function(){}` regardless of whether `X` is an ES6 `class`, so it misfired on ordinary ES5 constructor-function code (abp's idiom). Added a `collectClassNames` helper that walks the file AST for `class Foo {}` declarations and `const Foo = class {}` expressions; the rule now fires only when the `.prototype` receiver is a **simple identifier declared as a class in the same file**. Non-class (builtin or ES5 constructor) receivers are skipped. Grafting a method onto a real class's prototype — the actual "inconsistent with class syntax" pattern — still fires (see negative fixture).

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/class-prototype-assignment` | 138 | 0 | -138 |
| **Total (these 1 rules)** | **138** | **0** | **-138** |
| **All-rules total on target** | — | — | `unavailable: see note` |

**Measurement note.** The standard `node dist/cli.mjs analyze --no-llm` could not complete on this session: the project-aware **C# Roslyn tier fail-hard'd** loading `framework/Volo.Abp.slnx` (`No instances of MSBuild could be detected` — a net8 host / SDK-10 MSBuild mismatch), even after `dotnet restore` and installing the .NET 10 SDK. That aborts the whole run before results are saved, so the all-rules total is unavailable. This is an environment/toolchain limitation and is **unrelated to this rule**, which is a pure tree-sitter JS rule. The per-rule delta above was measured by running only this rule over abp's analyzer-discovered `.js` files (299 files — the same set the real analyze scans): **138 → 0**, exactly matching the count in #734. The full JS/TS analyzer suite is green (`js-positive`, `js-negative`, `code-quality-rules`).

cc @mushgev