### PR TITLE
feat(dashboard): add directory picker for adding repositories

### DIFF
--- a/apps/dashboard/client/src/components/repo/DirectoryPicker.tsx
+++ b/apps/dashboard/client/src/components/repo/DirectoryPicker.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useRef, useState } from 'react';
+import { ArrowUp, Folder, FolderGit2, Loader2 } from 'lucide-react';
+import type { BrowseDirResponse } from '@truecourse/shared';
+import { browseDir } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+type DirectoryPickerProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called with the currently-browsed absolute directory when the user confirms. */
+  onSelect: (path: string) => void;
+};
+
+/**
+ * Local-only directory picker. Enumerates subdirectories via the server's
+ * `/api/repos/browse` endpoint (browsers can't expose absolute paths). Single
+ * click navigates into a folder; "Use this folder" confirms whatever directory
+ * is currently being browsed, so picking a repo means navigating into it first.
+ */
+export function DirectoryPicker({ open, onOpenChange, onSelect }: DirectoryPickerProps) {
+  const [data, setData] = useState<BrowseDirResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Guards against a slow earlier request resolving after a newer navigation.
+  const requestId = useRef(0);
+
+  async function load(path?: string) {
+    const id = ++requestId.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await browseDir(path);
+      if (id !== requestId.current) return;
+      setData(result);
+    } catch (err) {
+      if (id !== requestId.current) return;
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (id === requestId.current) setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    // Seed with the home dir each time the dialog opens (no path → server default).
+    if (open) void load(undefined);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Select a folder</DialogTitle>
+          <DialogDescription className="truncate">
+            {data?.path ?? 'Loading...'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            aria-label="Up"
+            disabled={loading || !data || data.parent === null}
+            onClick={() => data?.parent && void load(data.parent)}
+          >
+            <ArrowUp />
+          </Button>
+        </div>
+
+        <ScrollArea className="h-64 rounded-md border">
+          {loading ? (
+            <div className="flex h-64 items-center justify-center">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : error ? (
+            <div className="p-3">
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            </div>
+          ) : data && data.entries.length === 0 ? (
+            <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+              No subfolders
+            </div>
+          ) : (
+            <div className="flex flex-col p-1">
+              {data?.entries.map((entry) => (
+                <button
+                  key={entry.path}
+                  type="button"
+                  // Accessible name is exactly the folder name; the "repo" tag is
+                  // decorative, so it must not leak into the button's label.
+                  aria-label={entry.name}
+                  onClick={() => void load(entry.path)}
+                  className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted"
+                >
+                  <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="flex-1 truncate">{entry.name}</span>
+                  {entry.isRepo && (
+                    <span
+                      aria-hidden="true"
+                      className="inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-xs text-primary"
+                    >
+                      <FolderGit2 className="h-3 w-3" />
+                      repo
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!data}
+            onClick={() => {
+              if (data) {
+                onSelect(data.path);
+                onOpenChange(false);
+              }
+            }}
+          >
+            Use this folder
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/client/src/components/repo/RepoSelector.tsx
+++ b/apps/dashboard/client/src/components/repo/RepoSelector.tsx
@@ -1,8 +1,10 @@
 
 import { useState } from 'react';
-import { FolderOpen, Plus, Loader2 } from 'lucide-react';
+import { FolderOpen, FolderSearch, Plus, Loader2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { useCapability } from '@/contexts/CapabilityContext';
+import { DirectoryPicker } from './DirectoryPicker';
 
 type RepoSelectorProps = {
   onAdd: (path: string) => Promise<unknown>;
@@ -11,6 +13,8 @@ type RepoSelectorProps = {
 export function RepoSelector({ onAdd }: RepoSelectorProps) {
   const [path, setPath] = useState('');
   const [isAdding, setIsAdding] = useState(false);
+  const canBrowse = useCapability('local-filesystem');
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -28,30 +32,45 @@ export function RepoSelector({ onAdd }: RepoSelectorProps) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="w-full">
-      <div className="flex gap-2">
-        <div className="relative flex-1">
-          <FolderOpen className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            value={path}
-            onChange={(e) => setPath(e.target.value)}
-            placeholder="Paste repository path..."
-            className="pl-10"
-          />
-        </div>
-        <Button
-          type="submit"
-          disabled={isAdding || !path.trim()}
-        >
-          {isAdding ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Plus className="h-4 w-4" />
+    <>
+      <form onSubmit={handleSubmit} className="w-full">
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <FolderOpen className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="text"
+              value={path}
+              onChange={(e) => setPath(e.target.value)}
+              placeholder="Paste repository path..."
+              className="pl-10"
+            />
+          </div>
+          {canBrowse && (
+            <Button type="button" variant="outline" onClick={() => setPickerOpen(true)}>
+              <FolderSearch className="h-4 w-4" />
+              Browse
+            </Button>
           )}
-          Add Repository
-        </Button>
-      </div>
-    </form>
+          <Button
+            type="submit"
+            disabled={isAdding || !path.trim()}
+          >
+            {isAdding ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Plus className="h-4 w-4" />
+            )}
+            Add Repository
+          </Button>
+        </div>
+      </form>
+      {canBrowse && (
+        <DirectoryPicker
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          onSelect={(p) => setPath(p)}
+        />
+      )}
+    </>
   );
 }

--- a/apps/dashboard/client/src/lib/api.ts
+++ b/apps/dashboard/client/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { CapabilitiesResponse } from '@truecourse/shared';
+import type { BrowseDirResponse, CapabilitiesResponse } from '@truecourse/shared';
 import { getServerUrl } from './server-url';
 
 const BASE_URL = getServerUrl();
@@ -172,6 +172,16 @@ export function addRepo(path: string): Promise<RepoResponse> {
 
 export function deleteRepo(id: string): Promise<void> {
   return fetchApi<void>(`/api/repos/${id}`, { method: 'DELETE' });
+}
+
+/**
+ * List subdirectories of `path` (defaults to the server user's home dir) for the
+ * directory picker. Local-only — the server 404s this when the local-filesystem
+ * capability is off, so callers must gate the UI on `useCapability('local-filesystem')`.
+ */
+export function browseDir(path?: string): Promise<BrowseDirResponse> {
+  const qs = path ? `?path=${encodeURIComponent(path)}` : '';
+  return fetchApi<BrowseDirResponse>(`/api/repos/browse${qs}`);
 }
 
 export function analyzeRepo(

--- a/apps/dashboard/server/src/routes/repos.ts
+++ b/apps/dashboard/server/src/routes/repos.ts
@@ -1,6 +1,9 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
 import * as fs from 'fs';
-import { CreateRepoSchema } from '@truecourse/shared';
+import * as path from 'path';
+import * as os from 'os';
+import { CreateRepoSchema, BrowseDirQuerySchema } from '@truecourse/shared';
+import { getCapabilities } from '../ee-loader.js';
 import { createAppError } from '@truecourse/core/lib/errors';
 import { getGit } from '@truecourse/core/lib/git';
 import { getRepoTruecourseDir } from '@truecourse/core/config/paths';
@@ -64,6 +67,84 @@ router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
         lastAnalyzed: e.lastAnalyzed ?? null,
       })),
     );
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/repos/browse?path=<abs> — list subdirectories for the directory picker.
+// LOCAL-ONLY: gated on the 'local-filesystem' capability (present in OSS, absent
+// in hosted EE where there is no per-user disk). MUST be declared before GET '/:id'
+// so 'browse' is not captured as a project id.
+router.get('/browse', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    // Capability gate — hidden entirely (404) when local-filesystem is off.
+    if (!getCapabilities().includes('local-filesystem')) {
+      throw createAppError('Not found', 404);
+    }
+
+    const parsed = BrowseDirQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      throw createAppError('Invalid query: path must be a string', 400);
+    }
+
+    const raw = parsed.data.path;
+    // Reject a relative path BEFORE resolving (realpath would resolve it against
+    // the server cwd, silently browsing somewhere the caller didn't ask for).
+    if (raw && raw.length > 0 && !path.isAbsolute(raw)) {
+      throw createAppError('Path must be absolute', 400);
+    }
+    const target = raw && raw.length > 0 ? raw : os.homedir();
+
+    // Resolve symlinks; map fs errors to 4xx, never let them surface as a 500.
+    let resolved: string;
+    try {
+      resolved = fs.realpathSync(target);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ELOOP' || code === 'ENOTDIR') {
+        throw createAppError(`Path does not exist: ${target}`, 404);
+      }
+      if (code === 'EACCES' || code === 'EPERM') {
+        throw createAppError(`Permission denied: ${target}`, 403);
+      }
+      throw err; // unexpected — let the error handler 500 it
+    }
+
+    const stat = fs.statSync(resolved);
+    if (!stat.isDirectory()) {
+      throw createAppError(`Path is not a directory: ${target}`, 400);
+    }
+
+    let dirents: fs.Dirent[];
+    try {
+      dirents = fs.readdirSync(resolved, { withFileTypes: true });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EACCES' || code === 'EPERM') {
+        throw createAppError(`Permission denied: ${resolved}`, 403);
+      }
+      throw err;
+    }
+
+    const entries = dirents
+      .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+      .map((d) => {
+        const childPath = path.join(resolved, d.name);
+        let isRepo = false;
+        try {
+          isRepo = fs.statSync(path.join(childPath, '.git')).isDirectory();
+        } catch {
+          isRepo = false; // no .git, or unreadable
+        }
+        return { name: d.name, path: childPath, isRepo };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    const parentPath = path.dirname(resolved);
+    const parent = parentPath === resolved ? null : parentPath;
+
+    res.json({ path: resolved, parent, entries });
   } catch (error) {
     next(error);
   }

--- a/apps/dashboard/server/src/routes/repos.ts
+++ b/apps/dashboard/server/src/routes/repos.ts
@@ -72,12 +72,38 @@ router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
   }
 });
 
+// The app-level CORS config reflects any origin with credentials and community
+// mode has no auth, so /browse — a general filesystem-read primitive, unlike the
+// other GETs which only expose registered-repo data — needs its own origin gate:
+// any website open in the user's browser could otherwise read arbitrary directory
+// listings cross-origin. Trusted: no Origin at all (same-origin GETs, curl), a
+// loopback hostname on any port (dev client on :3000 → server on :3001), or an
+// Origin host matching the request's own Host (same-site on a LAN IP).
+function isTrustedBrowseOrigin(origin: string | undefined, host: string | undefined): boolean {
+  if (!origin) return true;
+  let parsed: URL;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    return false; // malformed Origin — reject
+  }
+  // WHATWG URL keeps the brackets on an IPv6 hostname ('[::1]').
+  if (['localhost', '127.0.0.1', '[::1]'].includes(parsed.hostname)) return true;
+  return host !== undefined && parsed.host === host;
+}
+
 // GET /api/repos/browse?path=<abs> — list subdirectories for the directory picker.
 // LOCAL-ONLY: gated on the 'local-filesystem' capability (present in OSS, absent
-// in hosted EE where there is no per-user disk). MUST be declared before GET '/:id'
-// so 'browse' is not captured as a project id.
+// in hosted EE where there is no per-user disk) and on a trusted Origin (see
+// isTrustedBrowseOrigin above). MUST be declared before GET '/:id' so 'browse'
+// is not captured as a project id.
 router.get('/browse', async (req: Request, res: Response, next: NextFunction) => {
   try {
+    // Origin gate — reject cross-origin reads before anything else.
+    if (!isTrustedBrowseOrigin(req.headers.origin, req.headers.host)) {
+      throw createAppError('Cross-origin requests are not allowed', 403);
+    }
+
     // Capability gate — hidden entirely (404) when local-filesystem is off.
     if (!getCapabilities().includes('local-filesystem')) {
       throw createAppError('Not found', 404);
@@ -96,10 +122,14 @@ router.get('/browse', async (req: Request, res: Response, next: NextFunction) =>
     }
     const target = raw && raw.length > 0 ? raw : os.homedir();
 
-    // Resolve symlinks; map fs errors to 4xx, never let them surface as a 500.
+    // Resolve symlinks and stat in one guarded block — the dir can vanish or
+    // become unreadable between the two calls; map fs errors to 4xx, never let
+    // them surface as a 500.
     let resolved: string;
+    let stat: fs.Stats;
     try {
       resolved = fs.realpathSync(target);
+      stat = fs.statSync(resolved);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code === 'ENOENT' || code === 'ELOOP' || code === 'ENOTDIR') {
@@ -111,7 +141,6 @@ router.get('/browse', async (req: Request, res: Response, next: NextFunction) =>
       throw err; // unexpected — let the error handler 500 it
     }
 
-    const stat = fs.statSync(resolved);
     if (!stat.isDirectory()) {
       throw createAppError(`Path is not a directory: ${target}`, 400);
     }

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -27,3 +27,34 @@ export const GenerateViolationsSchema = z.object({
 })
 
 export type GenerateViolationsInput = z.infer<typeof GenerateViolationsSchema>
+
+// ---------------------------------------------------------------------------
+// Directory browse (local-filesystem picker) — issue #41
+// ---------------------------------------------------------------------------
+
+/** Query for GET /api/repos/browse. `path` optional; server defaults to os.homedir(). */
+export const BrowseDirQuerySchema = z.object({
+  path: z.string().optional(),
+})
+export type BrowseDirQuery = z.infer<typeof BrowseDirQuerySchema>
+
+/** One non-hidden subdirectory of the browsed path. */
+export const BrowseEntrySchema = z.object({
+  /** Basename, e.g. "my-service". */
+  name: z.string(),
+  /** Absolute path to this subdirectory. */
+  path: z.string(),
+  /** True when the subdirectory contains a `.git` directory (a git repo). */
+  isRepo: z.boolean(),
+})
+export type BrowseEntry = z.infer<typeof BrowseEntrySchema>
+
+export const BrowseDirResponseSchema = z.object({
+  /** The (realpath-resolved) absolute directory being listed. */
+  path: z.string(),
+  /** Absolute parent path, or null when `path` is the filesystem root. */
+  parent: z.string().nullable(),
+  /** Non-hidden subdirectories, sorted alphabetically by name. */
+  entries: z.array(BrowseEntrySchema),
+})
+export type BrowseDirResponse = z.infer<typeof BrowseDirResponseSchema>

--- a/tests/dashboard-client/directory-picker.test.tsx
+++ b/tests/dashboard-client/directory-picker.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * The directory picker is a local-only, capability-gated dialog for the
+ * "Add Repository" flow. RepoSelector shows a Browse button only when the
+ * `local-filesystem` capability is on; the dialog lists server-enumerated
+ * subdirectories and fills the manual input on confirm.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppProvider } from '@/contexts/CapabilityContext';
+import { RepoSelector } from '@/components/repo/RepoSelector';
+import { DirectoryPicker } from '@/components/repo/DirectoryPicker';
+
+const HOME = {
+  path: '/home/user',
+  parent: null,
+  entries: [
+    { name: 'proj', path: '/home/user/proj', isRepo: true },
+    { name: 'docs', path: '/home/user/docs', isRepo: false },
+  ],
+};
+const CHILD = {
+  path: '/home/user/proj',
+  parent: '/home/user',
+  entries: [{ name: 'src', path: '/home/user/proj/src', isRepo: false }],
+};
+
+function stubBrowseFetch() {
+  const fetchMock = vi.fn(async (url: string) => {
+    const p = new URL(url, 'http://localhost').searchParams.get('path');
+    const body = p === '/home/user/proj' ? CHILD : HOME;
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('RepoSelector Browse gating', () => {
+  beforeEach(() => stubBrowseFetch());
+
+  it('shows a Browse button when local-filesystem is enabled', () => {
+    render(
+      <AppProvider initial={{ edition: 'community', capabilities: ['local-filesystem'] }}>
+        <RepoSelector onAdd={vi.fn()} />
+      </AppProvider>,
+    );
+    expect(screen.getByRole('button', { name: /Browse/ })).toBeInTheDocument();
+  });
+
+  it('hides the Browse button when the capability is absent', () => {
+    render(
+      <AppProvider initial={{ edition: 'community', capabilities: [] }}>
+        <RepoSelector onAdd={vi.fn()} />
+      </AppProvider>,
+    );
+    expect(screen.queryByRole('button', { name: /Browse/ })).toBeNull();
+    expect(screen.getByPlaceholderText('Paste repository path...')).toBeInTheDocument();
+  });
+});
+
+describe('DirectoryPicker', () => {
+  it('lists the home directory subdirectories on open', async () => {
+    const fetchMock = stubBrowseFetch();
+    render(<DirectoryPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />);
+
+    expect(await screen.findByText('proj')).toBeInTheDocument();
+    expect(screen.getByText('docs')).toBeInTheDocument();
+
+    // Seeds with the home default → no `path` query param on the first call.
+    const firstUrl = fetchMock.mock.calls[0][0] as string;
+    expect(new URL(firstUrl, 'http://localhost').searchParams.get('path')).toBeNull();
+  });
+
+  it('navigates into an entry on click; Up is disabled at the root', async () => {
+    stubBrowseFetch();
+    const user = userEvent.setup();
+    render(<DirectoryPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />);
+
+    await screen.findByText('proj');
+    expect(screen.getByRole('button', { name: /Up/ })).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: 'proj' }));
+
+    expect(await screen.findByText('src')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Up/ })).toBeEnabled();
+  });
+});
+
+describe('DirectoryPicker confirm flow', () => {
+  beforeEach(() => stubBrowseFetch());
+
+  it('"Use this folder" confirms the current path and fills the RepoSelector input', async () => {
+    const user = userEvent.setup();
+    render(
+      <AppProvider initial={{ edition: 'community', capabilities: ['local-filesystem'] }}>
+        <RepoSelector onAdd={vi.fn()} />
+      </AppProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Browse/ }));
+    await screen.findByText('proj');
+    await user.click(screen.getByRole('button', { name: /Use this folder/ }));
+
+    expect(screen.getByPlaceholderText('Paste repository path...')).toHaveValue('/home/user');
+    expect(screen.queryByText('proj')).toBeNull();
+  });
+});

--- a/tests/dashboard-server/browse-routes.test.ts
+++ b/tests/dashboard-server/browse-routes.test.ts
@@ -144,6 +144,57 @@ describe('GET /api/repos/browse', () => {
     expect(res.body.error).toBeTruthy();
   });
 
+  // Origin gate: the global CORS config reflects any origin with credentials and
+  // community mode has no auth, so without this gate any website open in the
+  // user's browser could read arbitrary directory listings cross-origin.
+  describe('origin gate', () => {
+    it('403 for a non-loopback cross-site Origin', async () => {
+      const root = makeTmpRoot();
+
+      const res = await request(app)
+        .get('/api/repos/browse')
+        .set('Origin', 'https://evil.example')
+        .query({ path: root });
+
+      expect(res.status).toBe(403);
+      expect(typeof res.body.error).toBe('string');
+    });
+
+    it('200 for a localhost Origin on any port (dev client on :3000)', async () => {
+      const root = makeTmpRoot();
+
+      const res = await request(app)
+        .get('/api/repos/browse')
+        .set('Origin', 'http://localhost:3000')
+        .query({ path: root });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('200 for a 127.0.0.1 Origin on any port', async () => {
+      const root = makeTmpRoot();
+
+      const res = await request(app)
+        .get('/api/repos/browse')
+        .set('Origin', 'http://127.0.0.1:5173')
+        .query({ path: root });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('403 for a malformed Origin', async () => {
+      const root = makeTmpRoot();
+
+      const res = await request(app)
+        .get('/api/repos/browse')
+        .set('Origin', 'not-a-url')
+        .query({ path: root });
+
+      expect(res.status).toBe(403);
+      expect(typeof res.body.error).toBe('string');
+    });
+  });
+
   it('404 when the local-filesystem capability is absent', async () => {
     mockCaps = [];
     const root = makeTmpRoot();

--- a/tests/dashboard-server/browse-routes.test.ts
+++ b/tests/dashboard-server/browse-routes.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import request from 'supertest';
+import type { Express } from 'express';
+
+// app.ts pulls the analyses router which imports the socket-handlers module;
+// mirror dashboard-routes.test.ts's stub so nothing tries to open a real socket.
+vi.mock('../../apps/dashboard/server/src/socket/handlers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../apps/dashboard/server/src/socket/handlers')>();
+  class NoopTracker {
+    start() {}
+    done() {}
+    error() {}
+    detail() {}
+  }
+  return {
+    ...actual,
+    emitAnalysisProgress: vi.fn(),
+    emitAnalysisComplete: vi.fn(),
+    emitViolationsReady: vi.fn(),
+    emitFilesChanged: vi.fn(),
+    emitAnalysisCanceled: vi.fn(),
+    createSocketTracker: () => new NoopTracker(),
+    createSocketLlmEstimateHandler: () => () => Promise.resolve(true),
+    createSocketStashConfirmHandler: () => () => Promise.resolve('stash'),
+  };
+});
+
+// Switchable capability set — reset to OSS default before each case; only the
+// last case flips it off to prove the gate.
+let mockCaps: string[] = ['local-filesystem'];
+vi.mock('../../apps/dashboard/server/src/ee-loader', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../apps/dashboard/server/src/ee-loader')>();
+  return { ...actual, getCapabilities: () => mockCaps };
+});
+
+import { createApp } from '../../apps/dashboard/server/src/app';
+
+let app: Express;
+let tmpRoots: string[] = [];
+
+function makeTmpRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-browse-'));
+  tmpRoots.push(root);
+  // realpath because macOS /tmp is a symlink to /private/tmp — the handler
+  // returns realpath-resolved paths, so tests must compare against realpath too.
+  return fs.realpathSync(root);
+}
+
+beforeEach(() => {
+  mockCaps = ['local-filesystem'];
+  app = createApp({ serveStatic: false });
+});
+
+afterEach(() => {
+  for (const root of tmpRoots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  tmpRoots = [];
+});
+
+describe('GET /api/repos/browse', () => {
+  it('lists non-hidden subdirectories sorted alphabetically, excluding files and dotfiles', async () => {
+    const root = makeTmpRoot();
+    fs.mkdirSync(path.join(root, 'beta'));
+    fs.mkdirSync(path.join(root, 'alpha'));
+    fs.mkdirSync(path.join(root, '.hidden'));
+    fs.writeFileSync(path.join(root, 'readme.txt'), 'hi');
+
+    const res = await request(app).get('/api/repos/browse').query({ path: root });
+
+    expect(res.status).toBe(200);
+    expect(res.body.entries.map((e: { name: string }) => e.name)).toEqual(['alpha', 'beta']);
+    for (const entry of res.body.entries) {
+      expect(entry.path).toBe(path.join(root, entry.name));
+      expect(entry.isRepo).toBe(false);
+    }
+  });
+
+  it('marks a subdirectory containing a .git dir as isRepo:true', async () => {
+    const root = makeTmpRoot();
+    fs.mkdirSync(path.join(root, 'proj', '.git'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'plain'));
+
+    const res = await request(app).get('/api/repos/browse').query({ path: root });
+
+    expect(res.status).toBe(200);
+    const byName = Object.fromEntries(
+      res.body.entries.map((e: { name: string; isRepo: boolean }) => [e.name, e.isRepo]),
+    );
+    expect(byName.proj).toBe(true);
+    expect(byName.plain).toBe(false);
+  });
+
+  it('defaults to the home directory when path is omitted', async () => {
+    const res = await request(app).get('/api/repos/browse');
+
+    expect(res.status).toBe(200);
+    expect(res.body.path).toBe(fs.realpathSync(os.homedir()));
+    expect(Array.isArray(res.body.entries)).toBe(true);
+  });
+
+  it('returns the parent for a nested dir, and null at the filesystem root', async () => {
+    const root = makeTmpRoot();
+    const nested = path.join(root, 'a', 'b');
+    fs.mkdirSync(nested, { recursive: true });
+
+    const nestedRes = await request(app).get('/api/repos/browse').query({ path: nested });
+    expect(nestedRes.status).toBe(200);
+    expect(nestedRes.body.parent).toBe(fs.realpathSync(path.join(root, 'a')));
+
+    const rootRes = await request(app).get('/api/repos/browse').query({ path: '/' });
+    expect(rootRes.status).toBe(200);
+    expect(rootRes.body.parent).toBeNull();
+  });
+
+  it('404 {error} for a non-existent path', async () => {
+    const res = await request(app)
+      .get('/api/repos/browse')
+      .query({ path: '/definitely/not/here/xyz' });
+
+    expect(res.status).toBe(404);
+    expect(typeof res.body.error).toBe('string');
+  });
+
+  it('400 {error} when path points to a file', async () => {
+    const root = makeTmpRoot();
+    const file = path.join(root, 'a-file.txt');
+    fs.writeFileSync(file, 'contents');
+
+    const res = await request(app).get('/api/repos/browse').query({ path: file });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it('400 {error} for a relative path', async () => {
+    const res = await request(app).get('/api/repos/browse').query({ path: 'relative/dir' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it('404 when the local-filesystem capability is absent', async () => {
+    mockCaps = [];
+    const root = makeTmpRoot();
+
+    const res = await request(app).get('/api/repos/browse').query({ path: root });
+
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Closes #41.

Adding a repository previously required typing or pasting the full path. Browsers never expose absolute filesystem paths, but the dashboard server runs on the same machine as the repos — so this adds a server-backed directory browser instead of a native `webkitdirectory` picker.

## Server

- **`GET /api/repos/browse?path=<abs>`** in `apps/dashboard/server/src/routes/repos.ts` — lists non-hidden subdirectories of an absolute path (defaults to the home directory), sorted alphabetically, each flagged `isRepo` when it contains a `.git` directory, plus a `parent` for upward navigation (`null` at the filesystem root).
- Declared **before** `GET /:id` — route order is load-bearing (`browse` would otherwise match as a project id); a comment marks this.
- Gated on the `local-filesystem` capability (404 when absent), so it is off in hosted EE where there is no per-user disk. In community mode it matches the existing trust boundary of `POST /api/repos`, which already accepts arbitrary absolute paths.
- Error mapping: relative path / path-is-a-file → 400, nonexistent → 404, `EACCES`/`EPERM` → 403 — fs errors never leak as 500s.

## Client

- New `DirectoryPicker.tsx` dialog: seeds at the home dir on open, single-click navigation into entries, Up button (disabled at root), git-repo badge, loading/error/empty states, stale-response guard.
- `RepoSelector.tsx` gains a **Browse** button behind the same `local-filesystem` capability gate. "Use this folder" fills the existing path input — manual entry keeps working unchanged, and adding still goes through the same submit flow.
- Shared zod schemas (`BrowseDirQuerySchema`, `BrowseEntrySchema`, `BrowseDirResponseSchema`) in `packages/shared`; `browseDir()` in the client API layer.

## Tests (TDD — written first, red, then green)

- `tests/dashboard-server/browse-routes.test.ts` — 8 cases: listing/sorting/hidden-dir filtering, `isRepo` detection, home-dir default, parent navigation incl. fs root, 404/400/400 error paths, capability-off 404.
- `tests/dashboard-client/directory-picker.test.tsx` — 5 cases: capability-gated Browse button (shown/hidden), home listing on open, navigation + Up state, "Use this folder" filling the input.

Full suite: 6214 passed, 0 regressions (8 pre-existing environment failures on the dev machine: 7 from forced `commit.gpgsign` with no signing key in temp-repo tests, 1 from the .NET-requiring C# Roslyn host test).

## Notes for review

- `isRepo` deliberately means `.git` **directory** — git worktrees/submodules (`.git` file) read as `false`; trivially relaxable later if wanted.
- Symlinked subdirectories are not listed (`dirent.isDirectory()` is false for symlinks); symlinked paths can still be typed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)