### PR TITLE
test(setup): hide host git config from the suite + document test prereqs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ npm publishing is automated: push a git tag `vX.Y.Z` after merging to `main` and
 ## Testing
 
 - When running tests, save the full output to a file and read from it — do NOT run tests multiple times with different grep patterns. For example: `pnpm test 2>&1 | tee /tmp/test-output.txt` then read the file.
+- The full suite needs `pnpm build` run once first (tests resolve workspace packages from `dist/`) and the C# Roslyn host built (`dotnet build -c Release tools/csharp-roslyn-host`, once per checkout/worktree) — without the host the C# e2e test fails hard and the Roslyn semantic-rule tests skip.
+- `tests/setup.ts` hides the developer's global/system git config from the whole suite (`GIT_CONFIG_GLOBAL=/dev/null`), so host settings like `commit.gpgsign` can't leak into temp fixture repos. Tests that commit must set `user.name`/`user.email` per-repo.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -423,12 +423,15 @@ Or set `TRUECOURSE_TELEMETRY=0` to opt out.
 git clone https://github.com/truecourse-ai/truecourse.git
 cd truecourse
 pnpm install
+pnpm build              # Build all packages — required before the first `pnpm test` (tests resolve workspace packages from their dist/)
+dotnet build -c Release tools/csharp-roslyn-host   # One-time, needs the .NET 8 SDK — see note below
 pnpm dev                # Start dashboard at http://localhost:3000 (server on :3001, Vite on :3000)
 pnpm test               # Run tests
-pnpm build              # Build all packages
 ```
 
 `pnpm dev` expects a `.truecourse/` folder at the repo root — created automatically on the first `truecourse analyze` against the repo (or simply `mkdir -p .truecourse`).
+
+The full test suite requires the C# Roslyn host to be built (same requirement as [analyzing C#](#prerequisites)): the C# e2e test fails without it, and the Roslyn semantic-rule tests silently skip. CI builds it before running tests (`.github/workflows/test.yml`); do the same locally, once per checkout/worktree.
 
 ## Community
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,4 @@
+import os from 'node:os'
 import { initParsers } from '../packages/analyzer/src/parser'
 
 // Never emit usage telemetry from the test suite — analyze and the
@@ -5,6 +6,15 @@ import { initParsers } from '../packages/analyzer/src/parser'
 // want tests hitting PostHog. (`spec-telemetry.test.ts` mocks trackEvent
 // directly to assert it's called.)
 process.env.TRUECOURSE_TELEMETRY = '0'
+
+// Make git hermetic: hide the developer's global/system git config from every
+// git invocation in the suite (tests and the code under test alike). Otherwise
+// host settings leak in — e.g. `commit.gpgsign=true` makes commits in temp
+// fixture repos die with "user.signingkey needs to be configured". This mirrors
+// CI, which has no global config. Tests that commit must set user.name/email
+// per-repo (or via GIT_AUTHOR_*/GIT_COMMITTER_* env), as CI already requires.
+process.env.GIT_CONFIG_GLOBAL = os.devNull
+process.env.GIT_CONFIG_NOSYSTEM = '1'
 
 // Load tree-sitter WASM grammars once before any test runs.
 // initParsers() is idempotent (returns cached promise), so repeated imports


### PR DESCRIPTION
## Problem

Running `pnpm test` on a machine with `commit.gpgsign=true` in the global git config (and the signing key configured per-repo rather than globally) fails 7 tests across `tests/core/verify-store.test.ts`, `tests/dashboard-server/oss-diff-routes.test.ts`, and `tests/dashboard-server/spec-routes.test.ts`:

```
fatal: either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured
```

These tests commit inside temp fixture repos, which inherit the developer's global/system git config. Five other test files had already hit this and worked around it locally with `git -c commit.gpgsign=false commit …` — the workaround just wasn't applied everywhere, and any new test that commits would trip over it again.

Separately, two local-run prerequisites weren't documented where you'd look: the suite needs `pnpm build` first (tests resolve workspace packages from `dist/`), and the C# Roslyn host must be built or the C# e2e test fails hard while the Roslyn semantic-rule tests silently skip. CI does both (`.github/workflows/test.yml`), but README's Development section only said `pnpm install` / `pnpm test`.

## Fix

- **`tests/setup.ts`** — set `GIT_CONFIG_GLOBAL=os.devNull` and `GIT_CONFIG_NOSYSTEM=1` for the whole node suite. Every git invocation (test helpers and code under test alike) now ignores the host's global/system config, exactly mirroring CI. No per-test workarounds needed; the existing `-c commit.gpgsign=false` guards become harmless redundancy.
- **`README.md`** — Development section now lists the real sequence: `pnpm install` → `pnpm build` → `dotnet build -c Release tools/csharp-roslyn-host` (once per checkout/worktree) → `pnpm test`, with a note on what breaks/skips without the host.
- **`CLAUDE.md`** — Testing section documents the same prereqs and the hermetic-git setup.

## Verification

Full suite on a machine with global `commit.gpgsign=true` + `gpg.format=ssh`: **248 files / 6743 tests passed, 0 failed** (previously 8 failed: 7 signing + 1 missing Roslyn host), with the per-test-file behavior otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)