### PR TITLE
fix(fp): resolve 5 FPs from abpframework/abp

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/csharp/nested-type-publicly-visible.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/csharp/nested-type-publicly-visible.ts
@@ -23,11 +23,15 @@ function isNestedInType(node: SyntaxNode): boolean {
 }
 
 /**
- * A `static` class whose members are all constants (`const` / `static
- * readonly` fields) is an intentional namespacing idiom — grouping related
- * names (permission keys, bundle names, option names) under an owning type —
- * not a leaked implementation helper. Such a constant container is deliberately
- * public and should not be flagged.
+ * A `static` class whose members are all constant-like names — `const` /
+ * `static` fields — or nested classes that are themselves constant containers is
+ * an intentional namespacing idiom: grouping related names (permission keys,
+ * bundle names, option names, error codes) under an owning type, not a leaked
+ * implementation helper. Such a container is deliberately public and should not
+ * be flagged. Both the flat form (all const/static fields) and the grouped form
+ * (nested static holder classes, e.g. `Permissions { Blogs {…}, Posts {…} }`)
+ * qualify; a `static` field need not be `readonly`, since bundle-name holders
+ * often expose plain mutable `public static string` fields.
  */
 function isConstantContainer(node: SyntaxNode): boolean {
   if (node.type !== 'class_declaration') return false
@@ -36,12 +40,15 @@ function isConstantContainer(node: SyntaxNode): boolean {
   if (!body) return false
   const members = body.namedChildren.filter((c) => c && c.type !== 'comment')
   if (members.length === 0) return false
-  return members.every(
-    (m) =>
-      m?.type === 'field_declaration' &&
-      (hasCSharpModifier(m, 'const') ||
-        (hasCSharpModifier(m, 'static') && hasCSharpModifier(m, 'readonly'))),
-  )
+  return members.every((m) => {
+    if (!m) return false
+    if (m.type === 'field_declaration')
+      return hasCSharpModifier(m, 'const') || hasCSharpModifier(m, 'static')
+    // Nested grouping classes that are themselves constant containers keep the
+    // whole file a single cohesive constants namespace.
+    if (m.type === 'class_declaration') return isConstantContainer(m)
+    return false
+  })
 }
 
 export const csharpNestedTypePubliclyVisibleVisitor: CodeRuleVisitor = {

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/async-method-naming.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/async-method-naming.ts
@@ -1,3 +1,4 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { hasCSharpModifier } from '../../../_shared/csharp-helpers.js'
@@ -24,6 +25,28 @@ const HANDLER_ATTRIBUTES = new Set([
   'Route', 'Area', 'AcceptVerbs',
 ])
 
+/**
+ * CLR event handlers conventionally do NOT carry the `Async` suffix — the runtime
+ * invokes them through a delegate, not by name, and they are the standard use of
+ * `async void`. Recognize the two idioms so they aren't flagged:
+ *  - the canonical `(object sender, EventArgs e)` signature (first parameter typed
+ *    `object`, second a `…EventArgs` type), or
+ *  - a method subscribed to an event via `+=` somewhere in the same file
+ *    (`source.Changed += OnChanged;`), which covers parameterless handlers.
+ */
+function isEventHandler(node: SyntaxNode, name: string, sourceCode: string): boolean {
+  const params = node.childForFieldName('parameters')
+  if (params) {
+    const ps = params.namedChildren.filter((c) => c?.type === 'parameter')
+    if (ps.length === 2) {
+      const t0 = ps[0]?.childForFieldName('type')?.text ?? ''
+      const t1 = ps[1]?.childForFieldName('type')?.text ?? ''
+      if ((t0 === 'object' || t0 === 'object?') && /EventArgs$/.test(t1)) return true
+    }
+  }
+  return new RegExp('\\+=\\s*(this\\.)?' + name + '\\b').test(sourceCode)
+}
+
 export const csharpAsyncMethodNamingVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/async-method-naming',
   languages: ['csharp'],
@@ -37,6 +60,7 @@ export const csharpAsyncMethodNamingVisitor: CodeRuleVisitor = {
     if (name === 'Main') return null
     if (isCSharpTestMethod(node)) return null
     if (getCSharpDeclAttributeNames(node).some((a) => HANDLER_ATTRIBUTES.has(a))) return null
+    if (isEventHandler(node, name, sourceCode)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/nested-generic-parameter.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/nested-generic-parameter.ts
@@ -18,6 +18,18 @@ import { makeViolation } from '../../../types.js'
  */
 const DELEGATE_OR_EXPRESSION_GENERICS = new Set(['Func', 'Action', 'Predicate', 'Expression'])
 
+// Outer generics whose type argument is fixed by a framework/DI contract, not a
+// shape the caller constructs. `ILogger<T>` is a logger *category* type — the
+// category being itself generic (`ILogger<Repository<User>>`) is incidental, and
+// the value is dependency-injected, never built by the caller — so a "name it"
+// suggestion is noise.
+const FRAMEWORK_CONTAINER_GENERICS = new Set(['ILogger'])
+
+// Inner generics that are the canonical, idiomatic content of a collection and
+// can't be named away: `IEnumerable<KeyValuePair<K, V>>` is exactly what a
+// dictionary enumerates as.
+const IDIOMATIC_INNER_GENERICS = new Set(['KeyValuePair'])
+
 /** The simple identifier of a generic_name (`Func` for `Func<…>`). */
 function genericBaseName(generic: SyntaxNode): string {
   return generic.namedChildren.find((c) => c?.type === 'identifier')?.text ?? ''
@@ -38,11 +50,18 @@ function asGenericName(typeNode: SyntaxNode | null): SyntaxNode | null {
 function hasNestedGeneric(typeNode: SyntaxNode): boolean {
   const generic = asGenericName(typeNode)
   if (!generic) return false
+  const baseName = genericBaseName(generic)
   // Delegate/expression-tree generics nest by design and can't be named away.
-  if (DELEGATE_OR_EXPRESSION_GENERICS.has(genericBaseName(generic))) return false
+  if (DELEGATE_OR_EXPRESSION_GENERICS.has(baseName)) return false
+  // DI/framework container generics (e.g. `ILogger<T>`) are injected, not built.
+  if (FRAMEWORK_CONTAINER_GENERICS.has(baseName)) return false
   const args = generic.namedChildren.find((c) => c?.type === 'type_argument_list')
   if (!args) return false
-  return args.namedChildren.some((arg) => asGenericName(arg) !== null)
+  return args.namedChildren.some((arg) => {
+    const inner = asGenericName(arg)
+    // An idiomatic inner shape (e.g. `KeyValuePair<K, V>`) isn't a nesting smell.
+    return inner !== null && !IDIOMATIC_INNER_GENERICS.has(genericBaseName(inner))
+  })
 }
 
 export const csharpNestedGenericParameterVisitor: CodeRuleVisitor = {

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/too-many-classes-per-file.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/too-many-classes-per-file.ts
@@ -11,15 +11,28 @@ export const csharpTooManyClassesPerFileVisitor: CodeRuleVisitor = {
 
     // Records / structs / interfaces / enums are not counted — grouping small
     // record DTOs or an interface with its enum in one file is idiomatic C#.
-    function walk(n: SyntaxNode) {
-      if (n.type === 'class_declaration') classCount++
+    //
+    // Only TOP-LEVEL classes are counted: a nested class is part of its outer
+    // type, not a separate file-worth of code. Counting nested types flagged
+    // idiomatic single-purpose files — an outer holder whose nested static
+    // classes namespace constants/permissions/error-codes (e.g. `Foo { Bar {…},
+    // Baz {…} }`) — that cannot and should not be split into one file per class.
+    function walk(n: SyntaxNode, insideClass: boolean) {
+      if (n.type === 'class_declaration') {
+        if (!insideClass) classCount++
+        for (let i = 0; i < n.namedChildCount; i++) {
+          const child = n.namedChild(i)
+          if (child) walk(child, true)
+        }
+        return
+      }
       for (let i = 0; i < n.namedChildCount; i++) {
         const child = n.namedChild(i)
-        if (child) walk(child)
+        if (child) walk(child, insideClass)
       }
     }
 
-    walk(node)
+    walk(node, false)
 
     if (classCount > 3) {
       return makeViolation(

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/unnecessary-namespace-qualifier.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/unnecessary-namespace-qualifier.ts
@@ -47,6 +47,23 @@ export const csharpUnnecessaryNamespaceQualifierVisitor: CodeRuleVisitor = {
       // The using directives themselves obviously repeat their own target.
       if (n.type === 'using_directive') return
 
+      // A namespace declaration's OWN name is not a shortenable reference: even
+      // when `using Volo.Abp;` is present, `namespace Volo.Abp.X` must spell out
+      // its full name — a using can't shorten a declaration. Skip the name so the
+      // extremely common `using <parent>;` + `namespace <parent>.<child>` pairing
+      // isn't reported.
+      if (n.type === 'file_scoped_namespace_declaration') {
+        // Its only child is the namespace name; the members are siblings walked
+        // separately, so there is nothing further to descend into here.
+        return
+      }
+      if (n.type === 'namespace_declaration') {
+        // Skip the name node but still walk the block body.
+        const body = n.namedChildren.find((c) => c?.type === 'declaration_list')
+        if (body) walk(body)
+        return
+      }
+
       // Expression context: `System.Text.Json.JsonSerializer.Serialize(…)` —
       // the receiver chain that spells out an imported namespace.
       if (n.type === 'member_access_expression') {

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/CacheReader.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/CacheReader.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Demo.Caching;
+
+/// <summary>An entity repository, used here only as a logger category.</summary>
+/// <typeparam name="T">The entity type.</typeparam>
+public class Repository<T>
+{
+    /// <summary>Gets the entity count.</summary>
+    public int Count { get; init; }
+}
+
+/// <summary>Sums cache entries, logging through an injected category logger.</summary>
+public class CacheReader
+{
+    /// <summary>Sums the values of the supplied cache pairs.</summary>
+    public int SumValues(
+        ILogger<Repository<string>> logger,
+        IEnumerable<KeyValuePair<string, int>> pairs)
+    {
+        var total = 0;
+        foreach (var pair in pairs)
+        {
+            total += pair.Value;
+        }
+
+        logger.LogDebug("summed {Total}", total);
+        return total;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/DataChangeListener.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/DataChangeListener.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Demo.Events;
+
+/// <summary>Event payload describing a data change.</summary>
+public class DataChangedEventArgs : EventArgs
+{
+    /// <summary>Gets the number of changed rows.</summary>
+    public int ChangedCount { get; init; }
+}
+
+/// <summary>Handles data-change notifications raised by a source.</summary>
+public class DataChangeListener
+{
+    /// <summary>Handles a source change; event handlers omit the Async suffix.</summary>
+    public async Task OnSourceChanged(object? sender, DataChangedEventArgs e)
+    {
+        Console.WriteLine(sender);
+        await Task.Delay(e.ChangedCount);
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/OrderCatalog.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/OrderCatalog.cs
@@ -1,0 +1,29 @@
+namespace Demo.Sample;
+
+/// <summary>Groups related order lookup names under one owning type.</summary>
+public static class OrderCatalog
+{
+    /// <summary>Order lifecycle status names.</summary>
+    internal static class Statuses
+    {
+        internal const string Pending = "pending";
+    }
+
+    /// <summary>Sales channel names.</summary>
+    internal static class Channels
+    {
+        internal const string Web = "web";
+    }
+
+    /// <summary>Region names.</summary>
+    internal static class Regions
+    {
+        internal const string North = "north";
+    }
+
+    /// <summary>Fulfilment kind names.</summary>
+    internal static class Kinds
+    {
+        internal const string Retail = "retail";
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/PermissionRegistry.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/PermissionRegistry.cs
@@ -1,0 +1,22 @@
+namespace Demo.Authorization;
+
+/// <summary>Groups permission-name constants under one owning type.</summary>
+public static class PermissionRegistry
+{
+    /// <summary>Blog-area permission names, grouped by entity.</summary>
+    public static class Blog
+    {
+        /// <summary>Permission names for posts.</summary>
+        public static class Posts
+        {
+            internal const string Create = "Blog.Posts.Create";
+            internal const string Delete = "Blog.Posts.Delete";
+        }
+
+        /// <summary>Permission names for tags.</summary>
+        public static class Tags
+        {
+            internal const string Create = "Blog.Tags.Create";
+        }
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/Widget.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/Widget.cs
@@ -1,0 +1,10 @@
+using Acme.Platform.Core;
+
+namespace Acme.Platform.Core.Widgets;
+
+/// <summary>A dashboard widget descriptor.</summary>
+public class Widget
+{
+    /// <summary>Gets the widget identifier.</summary>
+    public string Id { get; init; } = string.Empty;
+}


### PR DESCRIPTION
Batch of 5 false-positive fixes for C# analyzer visitors, discovered against `abpframework/abp`.

Closes #744
Closes #745
Closes #746
Closes #747
Closes #748

## Fixes

| rule_key | issue | positive-fixture | negative-fixture (true-bug regression case) |
|---|---|---|---|
| code-quality/deterministic/too-many-classes-per-file | #744 | `tests/fixtures/sample-csharp-project-positive/src/FpRegression/OrderCatalog.cs` | `sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/RetryStrategy.cs` |
| code-quality/deterministic/async-method-naming | #745 | `.../FpRegression/DataChangeListener.cs` | `sample-csharp-project-negative/services/ApiGateway/Violations/Bugs/SyncRetryWorker.cs` |
| architecture/deterministic/nested-type-publicly-visible | #746 | `.../FpRegression/PermissionRegistry.cs` | `sample-csharp-project-negative/services/UserService/Violations/Architecture/PasswordHasher.cs` |
| code-quality/deterministic/unnecessary-namespace-qualifier | #747 | `.../FpRegression/Widget.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/DiagnosticsToolbox.cs` |
| code-quality/deterministic/nested-generic-parameter | #748 | `.../FpRegression/CacheReader.cs` | `sample-csharp-project-negative/services/UserService/Violations/Performance/MetricsAggregator.cs` |

> **Note on negative fixtures.** The C# negative fixture (`sample-csharp-project-negative`) already carries a marked true-bug case for every C#-capable rule (enforced by `csharp-negative.test.ts`), and its graph is asserted byte-for-byte by `csharp-graph-snapshot.test.ts` — adding new files there would break that snapshot. So each rule's regression guard is the **existing** marked negative case cited above (the suite staying green proves the fix didn't kill true-positive detection); the new artifact per fix is the paraphrased positive fixture that reproduced the false positive and is now clean.

## code-quality/deterministic/too-many-classes-per-file

Sources: [IdentitySettingNames.cs](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Settings/IdentitySettingNames.cs#L1),`` [BloggingPermissions.cs](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/blogging/src/Volo.Blogging.Application.Contracts.Shared/Volo/Blogging/BloggingPermissions.cs#L1),`` [CmsKitErrorCodes.cs](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/cms-kit/src/Volo.CmsKit.Domain.Shared/Volo/CmsKit/CmsKitErrorCodes.cs#L1)``

The visitor counted every `class_declaration` recursively, so a single cohesive constants/permissions file — one outer holder with several nested static classes namespacing const strings — was flagged as "too many classes." The walk now counts only **top-level** classes; nested types are part of their outer type. (Counts can only decrease, so existing true positives with >3 top-level classes still fire.)

## code-quality/deterministic/async-method-naming

Sources: [UiPageProgress.razor.cs](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.MudBlazorUI/Components/UiPageProgress.razor.cs#L28),`` ``[LoginDisplay.razor.cs](https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.MudBlazorBasicTheme/Themes/Basic/LoginDisplay.razor.cs#L36)``

CLR event handlers conventionally omit the `Async` suffix (the runtime invokes them by delegate), but the visitor flagged them. Added an event-handler exemption covering both idioms: the canonical `(object sender, EventArgs e)` signature, and any method subscribed to an event via `+=` in the same file (which also catches parameterless handlers).

## architecture/deterministic/nested-type-publicly-visible

Sources: [MauiBlazorStandardBundles.cs](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.AspNetCore.Components.MauiBlazor.Theming.Bundling/MauiBlazorStandardBundles.cs#L5),`` [SuiteCommand.cs](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/SuiteCommand.cs#L598``)

The constant-container exclusion only recognized `const`/`static readonly` fields, so public name-holder nested classes that use plain mutable `static` fields (bundle names) or nest further constant classes (option names) escaped it. `isConstantContainer` now also accepts mutable `static` fields and, recursively, nested constant-container classes.

## code-quality/deterministic/unnecessary-namespace-qualifier

Sources: [BlobStoringDatabaseTestBase.cs](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.TestBase/BlobStoringDatabaseTestBase.cs#L9),`` [AbpDefaultTokenProvider.cs](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpDefaultTokenProvider.cs#L8)``

The walk descended into namespace-declaration name nodes, so the extremely common `using Volo.Abp;` + `namespace Volo.Abp.X` pairing flagged the declaration's own qualifier as redundant — but a `using` cannot shorten a declaration. The walk now skips the name of `namespace_declaration` / `file_scoped_namespace_declaration` nodes while still descending into block-namespace bodies. (A second, semantic defect — textual-only qualifier matching that mis-fires on sub-namespace chains and local-member collisions — is out of scope and noted on #747 for a follow-up.)

## code-quality/deterministic/nested-generic-parameter

Sources: [LinkUserTokenProvider.cs](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/LinkUserTokenProvider.cs#L19),`` [IDistributedCache.cs](``https://github.com/abpframework/abp/blob/8665ce0a23622f658b531b0627c7c025935fdb3b/framework/src/Volo.Abp.Caching/Volo/Abp/Caching/IDistributedCache.cs#L214``)

Only `Func`/`Action`/`Predicate`/`Expression` were exempt, so DI/BCL fixed shapes were flagged even though the caller can't name them away. Added exemptions for `ILogger<…>` outer generics (an injected logger category whose `T` is incidentally generic) and `KeyValuePair<K,V>` inner generics (`IEnumerable<KeyValuePair<…>>` is the canonical dictionary-enumeration shape). A broader `IEnumerable<IConfigureOptions<T>>`-style DI-collection exemption is left for a follow-up (noted on #748).

## FP-count delta (vs `8665ce0a23622f658b531b0627c7c025935fdb3b` on `abpframework/abp`)

Measured with `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` from a fresh `pnpm build:dist` — the exact artifact publish.yml ships — before vs. after this batch's visitor edits.

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| code-quality/deterministic/too-many-classes-per-file | 66 | 29 | -37 |
| code-quality/deterministic/async-method-naming | 245 | 230 | -15 |
| architecture/deterministic/nested-type-publicly-visible | 166 | 129 | -37 |
| code-quality/deterministic/unnecessary-namespace-qualifier | 74 | 36 | -38 |
| code-quality/deterministic/nested-generic-parameter | 69 | 44 | -25 |
| **Total (these 5 rules)** | 620 | 468 | -152 |
| **All-rules total on target** | 76058 | 75906 | -152 |

The all-rules delta equals the 5-rule delta exactly, confirming the fixes affected only their targeted rules. Full C# test suite (positive/negative/coverage/graph, both tree-sitter and Roslyn-host engines) is green.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxGFrkj48nc3oSfbsgcvqm)_