### PR TITLE
fix(release): tag + publish from CI on campaign-close merge (#752)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,122 @@
 name: Publish to npm
 
+# Two ways in, one publish path:
+#
+#   1. push a `v*` tag        — manual / prerelease releases (unchanged).
+#   2. merge a campaign-close  — the fp-automation loop's release trigger.
+#      PR (label *fp-campaign-complete*)
+#
+# Why the PR-merge trigger exists: routine sessions run under a branch push
+# policy that only permits `claude/`-prefixed refs, so a routine can never
+# push a `v*` tag itself (that push is denied 403 — see issue #752). Instead,
+# merging the campaign-close PR lets THIS workflow — which runs with a token
+# that can write refs — create the tag and publish. The tag + publish happen
+# in the same run on purpose: a tag pushed by GITHUB_TOKEN does NOT start a
+# new workflow run (GitHub's recursion guard), so we must not rely on the
+# `push: tags` trigger firing for tags we create here.
+#
+# Everything runs top-level in this file (not a reusable `workflow_call`) so
+# the npm OIDC trusted-publisher config — pinned to `publish.yml` — matches on
+# both trigger paths.
+
 on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: write
   id-token: write
 
 jobs:
+  # Decide whether this event should release. Kept as a separate gate so the
+  # label check can substring-match (catching both the default
+  # `fp-campaign-complete` and the C# account's `cs-fp-campaign-complete`),
+  # which `if: contains(labels.*.name, …)` can't do (it's exact-match only).
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.decide.outputs.release }}
+    steps:
+      - id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          MERGED: ${{ github.event.pull_request.merged }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if [ "$EVENT" = "push" ]; then
+            echo "Tag push — releasing."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$MERGED" = "true" ] && echo "$LABELS" | grep -q 'fp-campaign-complete'; then
+            echo "Merged campaign-close PR — releasing."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Not a release event — skipping."
+          echo "release=false" >> "$GITHUB_OUTPUT"
+
   publish:
+    needs: gate
+    if: needs.gate.outputs.release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # PR-merge path: build + tag the merge commit. Tag path: default ref
+          # (the tag) is checked out. fetch-depth 0 brings tags so the
+          # "does the tag already exist" guard below is accurate.
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || '' }}
+
+      # Resolve the version to publish and the tag name. On the PR-merge path
+      # the tag doesn't exist yet, so we also assert the four version
+      # locations agree (CLAUDE.md "Releasing") — a mismatch fails the release
+      # here, the deterministic gate. (The fp-campaign-close routine performs
+      # the same check for human-facing alerting, but this is authoritative.)
+      - name: Resolve version and tag
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            CLI=$(jq -r .version tools/cli/package.json)
+            CORE=$(jq -r .version packages/core/package.json)
+            SRV=$(jq -r .version apps/dashboard/server/package.json)
+            IDX=$(grep -oE '\.version\("[^"]+"\)' tools/cli/src/index.ts | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+            echo "cli=$CLI core=$CORE server=$SRV index.ts=$IDX"
+            if [ "$CORE" != "$CLI" ] || [ "$SRV" != "$CLI" ] || [ "$IDX" != "$CLI" ]; then
+              echo "::error::Version mismatch across the four locations — refusing to release. cli=$CLI core=$CORE server=$SRV index.ts=$IDX"
+              exit 1
+            fi
+            VERSION="$CLI"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing v$VERSION"
+
+      # PR-merge path only: create + push the tag on the merge commit. The tag
+      # push path skips this (its tag already exists). Idempotent: if the tag
+      # is already present locally or on the remote, we leave it alone so a
+      # re-run can't fail here.
+      - name: Create and push release tag
+        if: github.event_name == 'pull_request'
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          if git rev-parse "$TAG" >/dev/null 2>&1 || \
+             git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists — skipping tag creation."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "Pushed $TAG."
+          fi
 
       - uses: pnpm/action-setup@v4
 
@@ -50,10 +153,11 @@ jobs:
       - name: Build dist
         run: pnpm build:dist
 
-      - name: Set version from tag
+      - name: Set version on the dist package
         id: version
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
           cd dist
           npm pkg set version="$VERSION"
           if [[ "$VERSION" == *-* ]]; then
@@ -71,6 +175,6 @@ jobs:
         working-directory: dist
 
       - name: Create GitHub Release
-        run: gh release create "${{ github.ref_name }}" --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ steps.meta.outputs.tag }}" --generate-notes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,17 +26,15 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: write
-  id-token: write
-
 jobs:
   # Decide whether this event should release. Kept as a separate gate so the
   # label check can substring-match (catching both the default
   # `fp-campaign-complete` and the C# account's `cs-fp-campaign-complete`),
   # which `if: contains(labels.*.name, …)` can't do (it's exact-match only).
+  # Needs no write access — permissions are scoped to the publish job below.
   gate:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       release: ${{ steps.decide.outputs.release }}
     steps:
@@ -44,6 +42,7 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
           MERGED: ${{ github.event.pull_request.merged }}
+          BASE: ${{ github.event.pull_request.base.ref }}
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           if [ "$EVENT" = "push" ]; then
@@ -51,8 +50,14 @@ jobs:
             echo "release=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ "$MERGED" = "true" ] && echo "$LABELS" | grep -q 'fp-campaign-complete'; then
-            echo "Merged campaign-close PR — releasing."
+          # PR-merge path: must be merged, into `main`, and carry a
+          # campaign-complete label. The label regex anchors on the quotes in
+          # the JSON array so it matches `fp-campaign-complete` or a scoped
+          # `<scope>-fp-campaign-complete` exactly — never a longer label like
+          # `fp-campaign-complete-docs`.
+          if [ "$MERGED" = "true" ] && [ "$BASE" = "main" ] && \
+             echo "$LABELS" | grep -Eq '"([a-z]+-)?fp-campaign-complete"'; then
+            echo "Merged campaign-close PR into main — releasing."
             echo "release=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -63,6 +68,15 @@ jobs:
     needs: gate
     if: needs.gate.outputs.release == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # push the tag + create the GitHub Release
+      id-token: write    # npm OIDC trusted publishing
+    # Serialize releases: if two labeled PRs merge back-to-back, the second
+    # publish waits for the first rather than racing it. Never cancel an
+    # in-progress publish (a half-published release is worse than a queue).
+    concurrency:
+      group: publish
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -107,7 +121,7 @@ jobs:
         env:
           TAG: ${{ steps.meta.outputs.tag }}
         run: |
-          if git rev-parse "$TAG" >/dev/null 2>&1 || \
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1 || \
              git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists — skipping tag creation."
           else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,12 +98,12 @@ jobs:
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing v$VERSION"
 
-      # PR-merge path only: create + push the tag on the merge commit. The tag
-      # push path skips this (its tag already exists). Idempotent: if the tag
-      # is already present locally or on the remote, we leave it alone so a
-      # re-run can't fail here.
+      # Ensure the release tag exists on both trigger paths — a `v*` tag is
+      # itself a release for this repo, so the workflow always guarantees it.
+      # Idempotent: if the tag is already present locally or on the remote we
+      # leave it alone, so on the tag-push path (where the triggering tag
+      # already exists) this is a safe no-op, and a re-run can't fail here.
       - name: Create and push release tag
-        if: github.event_name == 'pull_request'
         env:
           TAG: ${{ steps.meta.outputs.tag }}
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,9 @@ When bumping the package version, update all four places — `package.json` alon
 
 The internal packages (`@truecourse/dashboard-client`, `@truecourse/analyzer`, `@truecourse/shared`) are marked `private: true` and never published — leave their versions at `0.1.0`.
 
-npm publishing is automated: push a git tag `vX.Y.Z` after merging to `main` and the GitHub Actions workflow publishes `truecourse` to npm. Never `npm publish` manually.
+npm publishing is automated via `.github/workflows/publish.yml`, which has two triggers — both run the same publish steps, so never `npm publish` manually:
+- **Push a git tag `vX.Y.Z`** (after merging to `main`) — the manual / prerelease path.
+- **Merge a campaign-close PR** (labelled `*fp-campaign-complete`) — the fp-automation path. The workflow verifies the four version locations agree, then creates the `vX.Y.Z` tag on the merge commit and publishes. The `fp-campaign-close` routine does **not** push the tag (routine sessions can't push `v*` refs — issue #752); CI owns tagging. See `docs/fp-automation/README.md` → "Release on merge".
 
 ## Testing
 

--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -62,10 +62,13 @@ For each target OSS repo:
    (see below) that bumps the version and flips campaign `status: done`.
    If TP < 90 %, it files new `fp-fix` issues; the campaign continues
    without a release.
-7. When the campaign-close PR merges, two routines fire in parallel:
-   `fp-campaign-close` pushes `vX.Y.Z` (publish.yml ships from dist —
-   byte-equal to what fp-next-fix just verified), and `fp-discover`
-   starts the next pending campaign.
+7. When the campaign-close PR merges, the release happens automatically:
+   `.github/workflows/publish.yml` (triggered by that merge) creates the
+   `vX.Y.Z` tag and ships from dist — byte-equal to what fp-next-fix just
+   verified. Two routines also fire in parallel: `fp-campaign-close`
+   confirms the version and alerts a human on mismatch (it does **not**
+   push the tag — see below), and `fp-discover` starts the next pending
+   campaign.
 
 ### Campaign-close PR
 
@@ -84,9 +87,11 @@ the freshly-built dist, it opens a campaign-close PR that:
 - Carries the **`fp-campaign-complete`** label.
 - Branch name `claude/<SCOPE>fp-campaign-close/<owner>-<repo>`.
 
-On merge, `fp-campaign-close` pushes the tag (publish.yml ships to npm)
-and `fp-discover` fires on the same event to start the next pending
-campaign — both routines run in parallel, each doing one job.
+On merge, `publish.yml` creates the tag and ships to npm (see
+["Release on merge"](#release-on-merge-publishyml) below);
+`fp-campaign-close` verifies the version and alerts on mismatch, and
+`fp-discover` fires on the same event to start the next pending
+campaign — the routines run in parallel, each doing one job.
 
 ### Borderline FPs
 
@@ -181,17 +186,17 @@ So an FP fix means:
 │ Routine: fp-campaign-close (parallel with fp-discover)   │
 │ trigger: pull_request.closed                             │
 │   Is merged=true, Head Branch starts-with                │
-│   claude/<SCOPE>fp-campaign-close/,                      │
+│   claude/<SCOPE>fp-campaign-close/                       │
 │                                                          │
+│ Release is automatic: publish.yml (on this same PR       │
+│ merge) tags vX.Y.Z + ships dist/ to npm + GH Release.    │
 │                                                          │
-│ 1. Read new version from tools/cli/package.json,         │
-│    sanity-check the 4 locations agree                    │
-│ 2. git tag vX.Y.Z, git push origin vX.Y.Z                │
-│    (publish.yml ships dist/ to npm + creates GH Release) │
-│                                                          │
-│ No analyze, no verification — fp-next-fix already        │
-│ measured TP ≥ 90% against the same dist artifact         │
-│ publish.yml is about to ship.                            │
+│ This routine does NOT push the tag (routine sessions     │
+│ can't push v* refs — issue #752). It only:               │
+│ 1. Reads version from tools/cli/package.json,            │
+│    checks the 4 locations agree                          │
+│ 2. On mismatch -> opens an alert issue (cc @mushgev);    │
+│    otherwise posts a summary and ends.                   │
 └──────────────────────────────────────────────────────────┘
 ```
 
@@ -526,28 +531,70 @@ and opens a human-merged PR. Only issues that can't be fixed even
 out-of-bounds become terminal (`fp-skipped`) and land on the
 `[fp-campaign-stuck]` issue.
 
-### 3. `fp-campaign-close` — tag and chain to the next campaign
+### 3. `fp-campaign-close` — confirm the release and chain to the next campaign
 
 | Field | Value |
 |---|---|
 | **Trigger** | GitHub event: `pull_request.closed` on `truecourse-ai/truecourse` |
 | **Filters** | `Is merged` equals `true` AND `Head Branch` starts with `claude/<SCOPE>fp-campaign-close/` |
 | **Repositories** | `truecourse-ai/truecourse` |
-| **Branch push policy** | Default — only needs to push a tag, not a branch |
+| **Branch push policy** | Default — this routine pushes **nothing** (no tag, no branch) |
 | **Environment** | **Default** |
 | **Prompt** | Bootstrap pointer (see [Prompt convention](#triggers-three-routines)) → `docs/fp-automation/prompts/fp-campaign-close.md` |
+
+**The routine does not push the tag** — `publish.yml` does, on the same
+merge event (see ["Release on merge"](#release-on-merge-publishyml)). A
+routine session runs under a branch push policy that only permits
+`claude/`-prefixed refs, so pushing `v<version>` is denied `403` — this is
+exactly what [issue #752](https://github.com/truecourse-ai/truecourse/issues/752)
+hit. Tagging therefore lives in CI, which runs with a token that can write
+refs. The routine is now a **human-facing safety net** on top of CI.
 
 Steps the session takes:
 1. Read new version from `tools/cli/package.json`. Sanity-check the
    other three locations agree (CLAUDE.md "Releasing").
-2. `git tag v<version> && git push origin v<version>`. The existing
-   `.github/workflows/publish.yml` triggers, ships `dist/` to npm,
-   creates the GitHub Release.
-3. End. No verification step — fp-next-fix already measured TP ≥ 90 %
-   against the same dist artifact publish.yml is shipping.
+2. If the four disagree → open a `[<SCOPE>fp-campaign-close] version
+   mismatch after merge` issue (`cc @mushgev`) so a human is notified.
+   `publish.yml` performs the same check and **fails the release** on a
+   mismatch, so nothing ships either way.
+3. If they agree → the routine does nothing to the repo (no tag, no push,
+   no build); `publish.yml` is already creating the tag and publishing.
+   Post a one-line summary and end. No verification step — fp-next-fix
+   already measured TP ≥ 90 % against the same dist artifact publish.yml
+   is shipping.
 
 `fp-discover` listens to the same merge event and runs in parallel,
 starting the next pending campaign from `campaigns.yaml`.
+
+### Release on merge (`publish.yml`)
+
+`.github/workflows/publish.yml` is the single place that publishes. It has
+two entry points, both running the same steps top-level so npm's OIDC
+trusted-publisher config (pinned to `publish.yml`) matches either way:
+
+- **`push` of a `v*` tag** — manual / prerelease releases (unchanged). The
+  version comes from the tag; the tag already exists, so no tag is created.
+- **`pull_request.closed`** where the merged PR carries a
+  `*fp-campaign-complete` label (substring match, so both the default
+  `fp-campaign-complete` and the `cs-`-scoped label are caught) — the
+  fp-automation release path. Here the workflow:
+  1. reads the version from `tools/cli/package.json` and asserts the four
+     version locations agree (fails the release on mismatch — the
+     authoritative gate);
+  2. creates and pushes the `v<version>` tag on the merge commit
+     (idempotent — skips if it already exists);
+  3. builds, tests, and publishes to npm + creates the GitHub Release.
+
+The tag is created **and** published in one run on purpose: a tag pushed by
+`GITHUB_TOKEN` does **not** start a new workflow run (GitHub's recursion
+guard), so the `push: tags` trigger can't be relied on for tags the workflow
+creates itself.
+
+> **One-time setup:** if a repository/organization **tag ruleset** protects
+> `v*` tags, add this workflow's actor (the GitHub Actions bot) to the
+> ruleset's bypass list, or the CI tag push will `403` too. This grants tag
+> creation to **one** trusted, auditable workflow — not to every ephemeral
+> routine session.
 
 ## Auxiliary routine: `fp-stale-pr-notify` (monitoring)
 
@@ -673,11 +720,11 @@ One-time, before the first run:
    empty.
 6. **Outer loop is fully automatic**: when the queue empties,
    fp-next-fix re-analyzes against the freshly-built dist; if TP ≥ 90 %
-   it opens a campaign-close PR. Merging that PR fires
-   `fp-campaign-close` (tags + publishes) and `fp-discover` (starts
-   the next pending campaign's discovery) in parallel — and merging
-   *that* next discovery PR restarts the inner loop. No "Run now"
-   needed after the very first campaign.
+   it opens a campaign-close PR. Merging that PR triggers `publish.yml`
+   (tags + publishes) and fires `fp-campaign-close` (confirms the version)
+   and `fp-discover` (starts the next pending campaign's discovery) in
+   parallel — and merging *that* next discovery PR restarts the inner loop.
+   No "Run now" needed after the very first campaign.
 
 **Optional — the `fp-stale-pr-notify` monitor** (see "Auxiliary routine"
 above). Independent of the loop; set up only if you want Telegram alerts
@@ -747,7 +794,10 @@ A **campaign-close PR** is mergeable when:
   label `fp-campaign-complete`.
 
 A repo is "done" when its campaign-close PR is merged and `vX.Y.Z` is
-tagged. The 90 % gate was verified pre-merge by fp-next-fix against the
+tagged + published by `publish.yml` (the merge triggers it — the
+`fp-campaign-close` routine no longer pushes the tag; see
+["Release on merge"](#release-on-merge-publishyml)). The 90 % gate was
+verified pre-merge by fp-next-fix against the
 dist artifact; `fp-discover` fires on the same merge event to start the
 next pending campaign automatically. The campaigns file is the audit
 trail.
@@ -806,9 +856,9 @@ If green-lit:
    From there:
    - **Inner loop** (auto): fp-fix PR merges drive `fp-next-fix` until
      the campaign queue is empty.
-   - **Outer loop** (auto): campaign-close PR merges fire
-     `fp-campaign-close`, which tags + publishes + verifies against the
-     just-published version. If TP < 90 % it files new fp-fix issues
-     and the inner loop resumes.
+   - **Outer loop** (auto): a campaign-close PR merge triggers
+     `publish.yml` (tags + publishes) and fires `fp-campaign-close`
+     (confirms the version, alerts on mismatch). If TP < 90 % the
+     queue-empty path files new fp-fix issues and the inner loop resumes.
    - **Next campaign** (manual): once a campaign reaches
      `status: done`, click **Run now** on `fp-discover` again.

--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -574,9 +574,10 @@ trusted-publisher config (pinned to `publish.yml`) matches either way:
 
 - **`push` of a `v*` tag** — manual / prerelease releases (unchanged). The
   version comes from the tag; the tag already exists, so no tag is created.
-- **`pull_request.closed`** where the merged PR carries a
-  `*fp-campaign-complete` label (substring match, so both the default
-  `fp-campaign-complete` and the `cs-`-scoped label are caught) — the
+- **`pull_request.closed`** where the PR was **merged into `main`** and
+  carries a `*fp-campaign-complete` label (anchored match, so both the
+  default `fp-campaign-complete` and a `<scope>-fp-campaign-complete` are
+  caught but a longer label like `fp-campaign-complete-docs` is not) — the
   fp-automation release path. Here the workflow:
   1. reads the version from `tools/cli/package.json` and asserts the four
      version locations agree (fails the release on mismatch — the

--- a/docs/fp-automation/prompts/fp-campaign-close.md
+++ b/docs/fp-automation/prompts/fp-campaign-close.md
@@ -3,12 +3,25 @@
 You are the **fp-campaign-close** routine. You run inside an
 Anthropic-managed cloud session, autonomously, with no human in the
 loop. Your job is small and well-defined: when a `<SCOPE>fp-campaign-complete`
-PR merges to `main`, push a release tag.
+PR merges to `main`, **confirm the release is in good shape** and alert a
+human if it is not.
+
+**You do not push the tag.** The release (tag + npm publish + GitHub
+Release) is created automatically by `.github/workflows/publish.yml`, which
+triggers on the campaign-close PR merge — it verifies the version, creates
+the `v<version>` tag on the merge commit, and publishes. Routine sessions run
+under a branch push policy that only allows `claude/`-prefixed refs, so a
+routine can never push a `v*` tag (the push is denied `403` — this is what
+issue #752 hit). Tagging therefore lives in CI, which runs with a token that
+can write refs.
+
+Your remaining job is a **human-facing safety net**: independently
+sanity-check the version, and if something is wrong, open an issue so a
+person is notified (CI failing a check is easy to miss).
 
 The 90 % TP gate was already checked **pre-merge** by fp-next-fix
-against the local dist build — the artifact publish.yml is about to
-ship. So merging the campaign-close PR is the campaign's "done"
-signal, and your only remaining job is tagging.
+against the local dist build. So merging the campaign-close PR is the
+campaign's "done" signal.
 
 `<SCOPE>fp-discover` fires on the same merge event in parallel and starts
 the next pending campaign — you don't chain to it.
@@ -37,7 +50,7 @@ byte-identical to an unscoped run.
 
 ## Step-by-step
 
-### 1. Read the new version
+### 1. Read the new version and sanity-check it
 
 - From the working copy, read `version` out of `tools/cli/package.json`.
   This is the version the merged PR bumped to.
@@ -46,52 +59,54 @@ byte-identical to an unscoped run.
   - `apps/dashboard/server/package.json` — must match.
   - `tools/cli/src/index.ts` — the `.version("X.Y.Z")` argument must
     match.
-- If any of the four disagree: do **not** push the tag. Open an issue
-  on `truecourse-ai/truecourse` titled `[<SCOPE>fp-campaign-close] version
-  mismatch after merge` with the four observed values and the merge
-  commit SHA. End the issue body with `cc @mushgev` so the reviewer
-  is notified. End the session.
+- If any of the four disagree: the release must not ship. `publish.yml`
+  performs the same check and will **fail the release** on a mismatch, but
+  open an issue anyway so a human is notified — titled
+  `[<SCOPE>fp-campaign-close] version mismatch after merge` with the four
+  observed values and the merge commit SHA. End the issue body with
+  `cc @mushgev`. End the session.
 
-### 2. Push the tag
+### 2. Confirm the release, don't perform it
 
-- Verify the tag `v<version>` does **not** already exist:
-  `git tag -l "v<version>"` should be empty. If it exists, end without
-  pushing.
-- Create and push the tag:
-  ```
-  git tag v<version>
-  git push origin v<version>
-  ```
-- The existing `.github/workflows/publish.yml` triggers on tag push,
-  ships `dist/` to npm, and creates the GitHub Release.
+- The four versions agree. **Do nothing to the repository** — do not tag,
+  do not push, do not run builds. `publish.yml` is already creating the
+  `v<version>` tag and publishing from the same merge commit.
+- Optionally confirm the release path is progressing: the tag `v<version>`
+  should not already exist from a prior run (`git tag -l "v<version>"`); if
+  it already exists, the release has run — just note that and end.
 
 ### 3. End
 
 - Post a brief end-of-run summary in the session log:
   ```
-  Released v<version>. publish.yml is handling npm + GitHub Release.
+  Campaign closed at v<version>. Release is handled automatically by
+  publish.yml on the campaign-close PR merge (tag + npm + GitHub Release);
+  no tag push from this routine.
   ```
 - End.
 
 ## Failure modes
 
-- **Tag push fails** (e.g. permissions): do not retry. Open an issue
-  titled `[<SCOPE>fp-campaign-close] tag push failed for v<version>` with
-  the error. End the issue body with `cc @mushgev`. End the session.
 - **Version mismatch across the four locations**: see step 1. Do not
-  push; open the mismatch issue and end.
+  tag or push (you never do); open the mismatch issue and end. CI also
+  blocks the release.
+- **Anything unexpected**: open an issue titled
+  `[<SCOPE>fp-campaign-close] campaign-close anomaly for v<version>` with the
+  details, end the body with `cc @mushgev`, and end the session. Do not
+  invent state.
 
 ## Hard constraints
 
-- Never modify files in this session. Push only the tag.
-- Never push to a branch.
+- **Never push a tag or a branch, and never modify files in this session.**
+  This routine only reads and, at most, opens an issue. The release is CI's
+  job — do not attempt `git tag`/`git push` (it will be denied `403` and is
+  not your responsibility).
 - Never run `truecourse analyze`, tests, builds, or any verification.
   The pre-merge fp-next-fix queue-empty path already verified the
   campaign hit ≥ 90 % against the exact dist artifact publish.yml will
   ship.
 - **Never use `npx truecourse` or `npm install truecourse`.** This
   routine doesn't run truecourse at all — there's no analyze step.
-- One tag push per session. Never push two tags.
 - If anything is unexpected, open an issue and end. Do not invent
   state.
 


### PR DESCRIPTION
## Summary

Fixes #752. The `fp-campaign-close` routine's whole job was to push the release tag (`git push origin v<version>`), but **routine sessions run under a branch push policy that only permits `claude/`-prefixed refs** — so a tag push is denied `403` and the release never ships. This wasn't a transient permissions hiccup: the routine could **never** have pushed a tag, so the first campaign to reach release was always going to hit this wall.

The fix moves tagging into CI, where the token can write refs. The routine no longer pushes anything.

## Root cause

| | Before | After |
|---|---|---|
| **Who creates the tag** | `fp-campaign-close` routine session (`git push`) — ❌ blocked `403` | `publish.yml` in GitHub Actions — ✅ has ref-write token |
| **Trigger** | routine fires on campaign-close PR merge | `publish.yml` fires on the same merge |
| **Routine's job** | push tag `v<version>` | verify version + alert a human on mismatch |

## What changed

### `.github/workflows/publish.yml` — the one place that publishes
Now has **two entry points**, both running the same steps top-level (so npm's OIDC trusted-publisher config, pinned to `publish.yml`, keeps matching):

1. **`push` of a `v*` tag** — manual / prerelease releases. **Unchanged.**
2. **`pull_request.closed`** where the merged PR carries a `*fp-campaign-complete` label (substring match → catches both the default and the `cs-`-scoped label). The workflow:
   - reads the version from `tools/cli/package.json` and asserts the **four version locations agree** — a mismatch fails the release (the authoritative gate);
   - creates + pushes the `v<version>` tag on the merge commit (idempotent — skips if it already exists);
   - builds, tests, publishes to npm, and creates the GitHub Release.

> **Why tag + publish in one run:** a tag pushed by `GITHUB_TOKEN` does **not** start a new workflow run (GitHub's recursion guard), so we can't rely on the `push: tags` trigger firing for tags CI creates itself. Doing both in one job sidesteps that entirely — and means no double-publish.

### `docs/fp-automation/prompts/fp-campaign-close.md` — routine reduced to a safety net
- **Removed** the `git tag` / `git push` step.
- Routine now: reads the version, checks the four locations, and on mismatch opens a `[<SCOPE>fp-campaign-close] version mismatch after merge` issue (`cc @mushgev`) so a human is notified (a red CI check alone is easy to miss). On success it posts a one-line summary and ends.
- Hard constraint added: **never push a tag or branch, never modify files.**

### Docs
- `docs/fp-automation/README.md` — updated the loop steps, the ASCII architecture diagram, the routine table (`Branch push policy` → "pushes **nothing**"), and added a new **"Release on merge (`publish.yml`)"** section.
- `CLAUDE.md` "Releasing" — documents both triggers.

## ⚠️ One-time setup to verify after merge
If a repository/org **tag ruleset** protects `v*` tags, add this workflow's actor (the GitHub Actions bot) to the ruleset's **bypass list**, or the CI tag push will `403` too. This grants tag creation to **one** trusted, auditable workflow — far better than granting every ephemeral routine session tag-push rights. (Documented inline in the new README section.)

## Note on v0.7.1
`v0.7.1` is **already released** — a maintainer manually pushed the tag ~23 min after #752 was filed (tag `v0.7.1` on `0733eec`, GitHub Release published by `github-actions[bot]`, npm publish succeeded). This PR is the durable fix so the **next** campaign releases automatically; it does not re-release 0.7.1.

## Testing
- `publish.yml` parses as valid YAML; both jobs (`gate`, `publish`) and triggers (`push`, `pull_request`) load.
- Verified the version-extraction (`jq` for the package.jsons, `grep`/`sed` for `index.ts` `.version(...)`) resolves `0.7.1` from all four locations.
- Verified the label gate: `fp-campaign-complete` and `cs-fp-campaign-complete` → release; `fp-fix` → skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018RU6RqcfvZCmhD5B9C6LeK)_