### PR TITLE
fix(guard): make the package-under-test resolvable by name in scenario sandboxes

### DIFF
--- a/packages/guard-runner/src/index.ts
+++ b/packages/guard-runner/src/index.ts
@@ -25,6 +25,9 @@ export type { RunScenarioContext } from './run-scenario.js'
 export { createSandbox, SandboxError, listSandboxFiles, DETERMINISM_PINS } from './sandbox.js'
 export type { Sandbox, SandboxOptions } from './sandbox.js'
 
+export { discoverPackageLinks } from './package-links.js'
+export type { PackageLink } from './package-links.js'
+
 export { applyCapabilities, CapabilityError } from './capabilities/index.js'
 export type { CapabilityContext } from './capabilities/index.js'
 export { materializeGit } from './capabilities/git.js'

--- a/packages/guard-runner/src/package-links.ts
+++ b/packages/guard-runner/src/package-links.ts
@@ -1,0 +1,176 @@
+/**
+ * Package-under-test resolution links. Scenario `setup.files` import the target
+ * package the way its docs tell users to — by published name (`import 'tsx'`,
+ * `require('tsx/cjs/api')`). The sandbox cwd is a bare temp dir, so without help
+ * Node rejects those bare specifiers (MODULE_NOT_FOUND) before any behavior of
+ * the package runs, and every programmatic-API scenario dies at birth.
+ *
+ * The engine therefore links each discovered package into the sandbox at
+ * `node_modules/<name>` → its real directory — `npm link` semantics. Node
+ * resolves through the link's realpath, so the package's own dependencies come
+ * from the repo's real `node_modules` and subpaths (`pkg/sub`) resolve through
+ * its actual `exports` map. Discovery covers the repo-root package and, for
+ * monorepos, every workspace package (npm/yarn `workspaces` globs and
+ * `pnpm-workspace.yaml`). A repo with no linkable package (non-Node targets)
+ * yields an empty list and the sandbox is unchanged.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import yaml from 'js-yaml'
+
+export interface PackageLink {
+  /** The package's published name (`name` from its package.json). */
+  name: string
+  /** Absolute directory the sandbox `node_modules/<name>` link points at. */
+  dir: string
+}
+
+interface PackageJson {
+  name?: unknown
+  workspaces?: unknown
+}
+
+/**
+ * All packages a sandbox should make resolvable by name: the repo-root package
+ * plus every workspace package. Deduplicated by name (root first), sorted
+ * workspace order, packages without a valid name skipped.
+ */
+export function discoverPackageLinks(repoRoot: string): PackageLink[] {
+  const links: PackageLink[] = []
+  const seen = new Set<string>()
+  const add = (pkg: PackageJson | null, dir: string): void => {
+    const name = pkg?.name
+    if (typeof name !== 'string' || !isLinkableName(name) || seen.has(name)) return
+    seen.add(name)
+    links.push({ name, dir })
+  }
+  const rootPkg = readPackageJson(repoRoot)
+  add(rootPkg, repoRoot)
+  for (const dir of workspaceDirs(repoRoot, rootPkg)) add(readPackageJson(dir), dir)
+  return links
+}
+
+/**
+ * A name is linkable when `node_modules/<name>` stays inside `node_modules`: a
+ * bare name or a single-scope `@scope/name`, with no empty, `.`/`..`, or
+ * backslash segments. Anything else is an invalid npm name anyway.
+ */
+function isLinkableName(name: string): boolean {
+  const segs = name.split('/')
+  if (segs.length > 2 || (segs.length === 2 && !segs[0].startsWith('@'))) return false
+  return segs.every((s) => s.length > 0 && s !== '.' && s !== '..' && !s.includes('\\'))
+}
+
+/** Parse `<dir>/package.json`, or `null` when absent/unreadable/invalid JSON. */
+function readPackageJson(dir: string): PackageJson | null {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf-8'))
+    return typeof parsed === 'object' && parsed !== null ? (parsed as PackageJson) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Expand the repo's workspace globs into existing package directories.
+ * Patterns come from the root package.json `workspaces` (array or `{ packages }`
+ * form) plus `pnpm-workspace.yaml` `packages`; `!`-prefixed patterns exclude.
+ */
+function workspaceDirs(repoRoot: string, rootPkg: PackageJson | null): string[] {
+  const patterns = workspacePatterns(repoRoot, rootPkg)
+  const include = new Set<string>()
+  for (const p of patterns.filter((p) => !p.startsWith('!'))) {
+    for (const dir of expandPattern(repoRoot, p)) include.add(dir)
+  }
+  const exclude = new Set<string>()
+  for (const p of patterns.filter((p) => p.startsWith('!'))) {
+    for (const dir of expandPattern(repoRoot, p.slice(1))) exclude.add(dir)
+  }
+  return [...include].filter((d) => !exclude.has(d) && d !== repoRoot).sort()
+}
+
+function workspacePatterns(repoRoot: string, rootPkg: PackageJson | null): string[] {
+  const patterns: string[] = []
+  const ws = rootPkg?.workspaces
+  if (Array.isArray(ws)) {
+    patterns.push(...ws.filter((p): p is string => typeof p === 'string'))
+  } else if (ws && typeof ws === 'object') {
+    const pkgs = (ws as { packages?: unknown }).packages
+    if (Array.isArray(pkgs)) patterns.push(...pkgs.filter((p): p is string => typeof p === 'string'))
+  }
+  const pnpmFile = path.join(repoRoot, 'pnpm-workspace.yaml')
+  if (fs.existsSync(pnpmFile)) {
+    try {
+      const doc = yaml.load(fs.readFileSync(pnpmFile, 'utf-8'))
+      const pkgs = (doc as { packages?: unknown } | null)?.packages
+      if (Array.isArray(pkgs)) patterns.push(...pkgs.filter((p): p is string => typeof p === 'string'))
+    } catch {
+      // Malformed workspace file — the target repo's defect; workspace packages
+      // simply stay unlinked (the pre-discovery state), never a crashed run.
+    }
+  }
+  return patterns
+}
+
+/**
+ * Expand one workspace glob into existing directories. Supports literal
+ * segments, `*` (any name within one level), and `**` (any depth, including
+ * none). `node_modules` and dot-directories are never traversed.
+ */
+function expandPattern(root: string, pattern: string): string[] {
+  const segs = pattern.split('/').filter((s) => s !== '' && s !== '.')
+  let dirs: string[] = [root]
+  for (const seg of segs) {
+    const next = new Set<string>()
+    if (seg === '**') {
+      for (const dir of dirs) for (const sub of descendantDirs(dir)) next.add(sub)
+    } else if (seg.includes('*')) {
+      const re = segmentRegex(seg)
+      for (const dir of dirs) {
+        for (const name of childDirs(dir)) if (re.test(name)) next.add(path.join(dir, name))
+      }
+    } else if (seg !== '..') {
+      for (const dir of dirs) {
+        const candidate = path.join(dir, seg)
+        if (isDir(candidate)) next.add(candidate)
+      }
+    }
+    dirs = [...next]
+    if (dirs.length === 0) break
+  }
+  return dirs
+}
+
+/** `dir` plus every traversable descendant directory (the `**` expansion). */
+function descendantDirs(dir: string): string[] {
+  const out: string[] = [dir]
+  for (const name of childDirs(dir)) out.push(...descendantDirs(path.join(dir, name)))
+  return out
+}
+
+function childDirs(dir: string): string[] {
+  let entries: fs.Dirent[]
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  return entries
+    .filter((e) => e.isDirectory() && e.name !== 'node_modules' && !e.name.startsWith('.'))
+    .map((e) => e.name)
+}
+
+function isDir(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/** One glob segment → an anchored regex; `*` matches within the segment only. */
+function segmentRegex(seg: string): RegExp {
+  const escaped = seg.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*')
+  return new RegExp(`^${escaped}$`)
+}

--- a/packages/guard-runner/src/run-scenario.ts
+++ b/packages/guard-runner/src/run-scenario.ts
@@ -9,6 +9,7 @@
 
 import type { GuardScenario, GuardScenarioResult } from '@truecourse/shared'
 import { createSandbox, SandboxError, DETERMINISM_PINS } from './sandbox.js'
+import type { PackageLink } from './package-links.js'
 import { applyCapabilities, CapabilityError } from './capabilities/index.js'
 import { executeStep, type StepCapture } from './executor.js'
 import { normalize, type NormalizerContext } from './normalizers.js'
@@ -24,6 +25,8 @@ export interface RunScenarioContext {
   runId: string
   resolvedEntry: string[]
   recipeEnv?: Record<string, string>
+  /** The package(s) under test, linked into every sandbox's `node_modules`. */
+  packageLinks?: readonly PackageLink[]
   stepTimeoutMs: number
   /**
    * Write the evidence transcript for a `pass` too (proof of what executed). A
@@ -76,6 +79,7 @@ export async function runScenario(
       recipeEnv: ctx.recipeEnv,
       scenarioEnv: scenario.setup?.env,
       setupFiles: scenario.setup?.files,
+      packageLinks: ctx.packageLinks,
     })
   } catch (e) {
     // Setup failure (e.g. a path escape) — infra error before any step ran.

--- a/packages/guard-runner/src/run.ts
+++ b/packages/guard-runner/src/run.ts
@@ -18,6 +18,7 @@ import {
   type GuardSummary,
 } from '@truecourse/shared'
 import { loadRecipe, resolveEntry, RecipeError } from './recipe.js'
+import { discoverPackageLinks } from './package-links.js'
 import { loadScenarios, type ScenarioLoadError } from './scenario-loader.js'
 import { runBuild, type BuildResult } from './build.js'
 import { preflightEntry, type EntryPreflightResult } from './preflight.js'
@@ -172,12 +173,15 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
   // Pass evidence is part of the persisted run baseline; a non-persisted (birth
   // validation) run captures none for its passing candidates — the next real run does.
   const capturePassEvidence = opts.persist !== false
+  // Discovered once per run — every sandbox links the same package(s) under test.
+  const packageLinks = discoverPackageLinks(repoRoot)
   const executed = await mapWithConcurrency(executable, concurrency, async ({ scenario, resolution }) => {
     const outcome = await runScenario(scenario, {
       repoRoot,
       runId,
       resolvedEntry,
       recipeEnv: loaded.recipe.env,
+      packageLinks,
       stepTimeoutMs,
       capturePassEvidence,
     })

--- a/packages/guard-runner/src/sandbox.ts
+++ b/packages/guard-runner/src/sandbox.ts
@@ -1,7 +1,9 @@
 /**
  * Per-scenario sandbox: a fresh temp `cwd`, an isolated `HOME`/`XDG_*` inside the
  * sandbox (the user's real machine state never leaks in or gets touched), a pinned
- * deterministic env, and declaratively seeded `setup.files`.
+ * deterministic env, declaratively seeded `setup.files`, and the package(s) under
+ * test linked into `node_modules` so bare-specifier imports of the target resolve
+ * (see `package-links.ts`).
  *
  * The child env is built from an ALLOWLIST, not from `process.env`. Only what a
  * program legitimately needs to run — `PATH`, the sandbox-redirected HOME/XDG/TMP,
@@ -17,6 +19,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import type { PackageLink } from './package-links.js'
 
 /**
  * Determinism pins applied to every sandbox — the single source for both the
@@ -47,6 +50,8 @@ export interface SandboxOptions {
   recipeEnv?: Record<string, string>
   scenarioEnv?: Record<string, string>
   setupFiles?: Record<string, string>
+  /** Packages to link into `node_modules` by name (the package(s) under test). */
+  packageLinks?: readonly PackageLink[]
 }
 
 export function createSandbox(opts: SandboxOptions = {}): Sandbox {
@@ -84,6 +89,7 @@ export function createSandbox(opts: SandboxOptions = {}): Sandbox {
   if (opts.scenarioEnv) Object.assign(env, opts.scenarioEnv)
 
   if (opts.setupFiles) seedFiles(cwd, opts.setupFiles)
+  if (opts.packageLinks) linkPackages(cwd, opts.packageLinks)
 
   return {
     cwd,
@@ -92,6 +98,37 @@ export function createSandbox(opts: SandboxOptions = {}): Sandbox {
     cleanup() {
       fs.rmSync(root, { recursive: true, force: true })
     },
+  }
+}
+
+/**
+ * Symlink each package into `cwd/node_modules/<name>` — `npm link` semantics, so
+ * a scenario can import the package-under-test by its published name. Runs AFTER
+ * `setup.files` seeding and never over an existing path: a scenario that seeds
+ * its own `node_modules/<name>` stub keeps it, and seeded files can never be
+ * written THROUGH a link into the real repo. `junction` keeps Windows
+ * privilege-free (the type is ignored elsewhere).
+ */
+function linkPackages(cwd: string, links: readonly PackageLink[]): void {
+  const nodeModules = path.join(cwd, 'node_modules')
+  for (const { name, dir } of links) {
+    const target = path.resolve(nodeModules, name)
+    if (!target.startsWith(nodeModules + path.sep)) {
+      throw new SandboxError(`package link name escapes node_modules: ${name}`)
+    }
+    if (lexists(target)) continue
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    fs.symlinkSync(dir, target, 'junction')
+  }
+}
+
+/** lstat-based existence — a seeded dangling symlink still counts as present. */
+function lexists(p: string): boolean {
+  try {
+    fs.lstatSync(p)
+    return true
+  } catch {
+    return false
   }
 }
 

--- a/tests/guard-runner/package-links.test.ts
+++ b/tests/guard-runner/package-links.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { discoverPackageLinks } from '@truecourse/guard-runner'
+import { rmrf } from './helpers.js'
+
+const repos: string[] = []
+afterEach(() => {
+  while (repos.length) rmrf(repos.pop()!)
+})
+
+function repo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-pkg-links-'))
+  repos.push(dir)
+  return dir
+}
+
+function writePkg(dir: string, pkg: Record<string, unknown>): void {
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg))
+}
+
+describe('discoverPackageLinks — root package', () => {
+  it('links a single-package repo by its name', () => {
+    const r = repo()
+    writePkg(r, { name: 'tsx', version: '1.0.0' })
+    expect(discoverPackageLinks(r)).toEqual([{ name: 'tsx', dir: r }])
+  })
+
+  it('links a scoped root name', () => {
+    const r = repo()
+    writePkg(r, { name: '@scope/pkg' })
+    expect(discoverPackageLinks(r)).toEqual([{ name: '@scope/pkg', dir: r }])
+  })
+
+  it('returns nothing for a repo without package.json (non-Node target)', () => {
+    expect(discoverPackageLinks(repo())).toEqual([])
+  })
+
+  it('skips a package.json without a name, and invalid JSON', () => {
+    const unnamed = repo()
+    writePkg(unnamed, { private: true })
+    expect(discoverPackageLinks(unnamed)).toEqual([])
+
+    const broken = repo()
+    fs.writeFileSync(path.join(broken, 'package.json'), '{ not json')
+    expect(discoverPackageLinks(broken)).toEqual([])
+  })
+
+  it('rejects names that would escape node_modules', () => {
+    for (const name of ['../evil', '/abs', 'a/b/c', '@scope/..', 'plain/other']) {
+      const r = repo()
+      writePkg(r, { name })
+      expect(discoverPackageLinks(r)).toEqual([])
+    }
+  })
+})
+
+describe('discoverPackageLinks — workspaces', () => {
+  it('expands npm/yarn `workspaces` array globs', () => {
+    const r = repo()
+    writePkg(r, { name: 'root', workspaces: ['packages/*'] })
+    writePkg(path.join(r, 'packages', 'a'), { name: '@acme/a' })
+    writePkg(path.join(r, 'packages', 'b'), { name: '@acme/b' })
+    // A workspace dir without a package.json is not a package.
+    fs.mkdirSync(path.join(r, 'packages', 'empty'), { recursive: true })
+
+    expect(discoverPackageLinks(r)).toEqual([
+      { name: 'root', dir: r },
+      { name: '@acme/a', dir: path.join(r, 'packages', 'a') },
+      { name: '@acme/b', dir: path.join(r, 'packages', 'b') },
+    ])
+  })
+
+  it('supports the `workspaces.packages` object form', () => {
+    const r = repo()
+    writePkg(r, { name: 'root', workspaces: { packages: ['libs/*'] } })
+    writePkg(path.join(r, 'libs', 'x'), { name: 'x' })
+    expect(discoverPackageLinks(r)).toContainEqual({ name: 'x', dir: path.join(r, 'libs', 'x') })
+  })
+
+  it('reads pnpm-workspace.yaml, honoring `!` exclusions', () => {
+    const r = repo()
+    writePkg(r, { name: 'root' })
+    fs.writeFileSync(
+      path.join(r, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'packages/*'\n  - '!packages/skipme'\n",
+    )
+    writePkg(path.join(r, 'packages', 'keep'), { name: 'keep' })
+    writePkg(path.join(r, 'packages', 'skipme'), { name: 'skipme' })
+
+    const links = discoverPackageLinks(r)
+    expect(links).toContainEqual({ name: 'keep', dir: path.join(r, 'packages', 'keep') })
+    expect(links.map((l) => l.name)).not.toContain('skipme')
+  })
+
+  it('expands `**` patterns without descending into node_modules or dot-dirs', () => {
+    const r = repo()
+    writePkg(r, { name: 'root', workspaces: ['packages/**'] })
+    writePkg(path.join(r, 'packages', 'group', 'deep'), { name: 'deep' })
+    writePkg(path.join(r, 'packages', 'node_modules', 'trap'), { name: 'trap' })
+    writePkg(path.join(r, 'packages', '.hidden', 'trap2'), { name: 'trap2' })
+
+    const names = discoverPackageLinks(r).map((l) => l.name)
+    expect(names).toContain('deep')
+    expect(names).not.toContain('trap')
+    expect(names).not.toContain('trap2')
+  })
+
+  it('dedupes by name — first discovery wins', () => {
+    const r = repo()
+    writePkg(r, { name: 'dup', workspaces: ['packages/*'] })
+    writePkg(path.join(r, 'packages', 'a'), { name: 'dup' })
+    expect(discoverPackageLinks(r)).toEqual([{ name: 'dup', dir: r }])
+  })
+
+  it('a malformed pnpm-workspace.yaml yields no workspace links, not a crash', () => {
+    const r = repo()
+    writePkg(r, { name: 'root' })
+    fs.writeFileSync(path.join(r, 'pnpm-workspace.yaml'), 'packages: [unclosed')
+    expect(discoverPackageLinks(r)).toEqual([{ name: 'root', dir: r }])
+  })
+})

--- a/tests/guard-runner/run.test.ts
+++ b/tests/guard-runner/run.test.ts
@@ -414,6 +414,70 @@ describe('runGuard — end to end', () => {
     expect(res.latest.scenarios[0].outcome).toBe('pass')
   })
 
+  it('resolves the package-under-test by bare name inside the sandbox (#754)', async () => {
+    // The tsx failure mode: a scenario's seeded entry file imports the target
+    // package by its published name. The sandbox cwd is a bare temp dir, so
+    // without the node_modules link Node dies with ERR_MODULE_NOT_FOUND before
+    // any behavior runs. The temp repo IS the package (`tmp-fixture-repo`).
+    const r = repo()
+    fs.writeFileSync(path.join(r, 'index.js'), "module.exports = { greeting: require('dep-of-pkg')() }\n")
+    fs.writeFileSync(path.join(r, 'extra.js'), "module.exports = { tag: 'via-subpath' }\n")
+    // The package's own dependency, installed only in the REPO's node_modules —
+    // it resolves through the link's realpath, exactly like `npm link`.
+    const depDir = path.join(r, 'node_modules', 'dep-of-pkg')
+    fs.mkdirSync(depDir, { recursive: true })
+    fs.writeFileSync(path.join(depDir, 'package.json'), JSON.stringify({ name: 'dep-of-pkg', main: 'index.js' }))
+    fs.writeFileSync(path.join(depDir, 'index.js'), "module.exports = () => 'hello-from-package'\n")
+
+    writeRecipe(r, { entry: ['node'] })
+    writeScenario(
+      r,
+      'byname.yaml',
+      scenario({
+        id: 'byname',
+        setup: {
+          files: {
+            'entry.mjs': "import pkg from 'tmp-fixture-repo'\nconsole.log('by-name:', pkg.greeting)\n",
+            'sub.cjs': "const extra = require('tmp-fixture-repo/extra.js')\nconsole.log('subpath:', extra.tag)\n",
+          },
+        },
+        steps: [
+          { run: ['entry.mjs'], expect: { exit: 0, stdout: { contains: 'by-name: hello-from-package' } } },
+          { run: ['sub.cjs'], expect: { exit: 0, stdout: { contains: 'subpath: via-subpath' } } },
+        ],
+      }),
+    )
+
+    const res = await runGuard({ repoRoot: r, skipBuild: true, scenarioId: 'byname' })
+    if (res.status !== 'ok') throw new Error('expected ok')
+    expect(res.latest.scenarios[0].outcome).toBe('pass')
+    expect(res.latest.scenarios[0].failure).toBeUndefined()
+  })
+
+  it('resolves workspace packages by name too (monorepo target)', async () => {
+    const r = repo()
+    fs.writeFileSync(path.join(r, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n")
+    const lib = path.join(r, 'packages', 'lib')
+    fs.mkdirSync(lib, { recursive: true })
+    fs.writeFileSync(path.join(lib, 'package.json'), JSON.stringify({ name: '@acme/lib', main: 'index.js' }))
+    fs.writeFileSync(path.join(lib, 'index.js'), "module.exports = { answer: 42 }\n")
+
+    writeRecipe(r, { entry: ['node'] })
+    writeScenario(
+      r,
+      'ws.yaml',
+      scenario({
+        id: 'ws',
+        setup: { files: { 'entry.cjs': "console.log('answer:', require('@acme/lib').answer)\n" } },
+        steps: [{ run: ['entry.cjs'], expect: { exit: 0, stdout: { contains: 'answer: 42' } } }],
+      }),
+    )
+
+    const res = await runGuard({ repoRoot: r, skipBuild: true, scenarioId: 'ws' })
+    if (res.status !== 'ok') throw new Error('expected ok')
+    expect(res.latest.scenarios[0].outcome).toBe('pass')
+  })
+
   it('opts.concurrency overrides TRUECOURSE_MAX_CONCURRENCY (barrier scenarios pair up in parallel)', async () => {
     // Two scenarios each write a sentinel and block until the other's appears, with
     // a 5s poll cap. Concurrency ≥ 2 → both pair instantly; serial (concurrency 1) →

--- a/tests/guard-runner/sandbox.test.ts
+++ b/tests/guard-runner/sandbox.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { createSandbox, SandboxError, listSandboxFiles } from '@truecourse/guard-runner'
 
@@ -105,6 +106,49 @@ describe('createSandbox — setup.files', () => {
   it('rejects a path that escapes the sandbox', () => {
     expect(() => make({ setupFiles: { '../escape.txt': 'x' } })).toThrow(SandboxError)
     expect(() => make({ setupFiles: { '/etc/passwd': 'x' } })).toThrow(SandboxError)
+  })
+})
+
+describe('createSandbox — packageLinks', () => {
+  const pkgDirs: string[] = []
+  afterEach(() => {
+    while (pkgDirs.length) fs.rmSync(pkgDirs.pop()!, { recursive: true, force: true })
+  })
+  function pkgDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-sbx-pkg-'))
+    pkgDirs.push(dir)
+    return dir
+  }
+
+  it('links a package into node_modules by name', () => {
+    const dir = pkgDir()
+    const sb = make({ packageLinks: [{ name: 'mypkg', dir }] })
+    const link = path.join(sb.cwd, 'node_modules', 'mypkg')
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(true)
+    expect(fs.realpathSync(link)).toBe(fs.realpathSync(dir))
+  })
+
+  it('creates the scope parent for a scoped name', () => {
+    const dir = pkgDir()
+    const sb = make({ packageLinks: [{ name: '@scope/pkg', dir }] })
+    const link = path.join(sb.cwd, 'node_modules', '@scope', 'pkg')
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(true)
+  })
+
+  it('never overwrites a path the scenario seeded — the seeded stub wins', () => {
+    const dir = pkgDir()
+    const sb = make({
+      setupFiles: { 'node_modules/mypkg/index.js': 'module.exports = "stub"' },
+      packageLinks: [{ name: 'mypkg', dir }],
+    })
+    const target = path.join(sb.cwd, 'node_modules', 'mypkg')
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(false)
+    expect(fs.readFileSync(path.join(target, 'index.js'), 'utf-8')).toBe('module.exports = "stub"')
+  })
+
+  it('rejects a link name that escapes node_modules', () => {
+    const dir = pkgDir()
+    expect(() => make({ packageLinks: [{ name: '../evil', dir }] })).toThrow(SandboxError)
   })
 })
 


### PR DESCRIPTION
Fixes #754

## Problem

During `guard generate`, birth-validation runs each scenario in a bare temp work dir. Any scenario whose `setup.files` import the package-under-test by its published name (`import 'tsx'`, `require('tsx/cjs/api')`) — exactly how the docs tell users to consume it — died at Node module resolution (`MODULE_NOT_FOUND`) before any behavior ran, and was discarded as a spurious birth finding. For tsx this threw away the entire `docs/dev-api/*` surface (18 of 20 birth findings), leaving guard blind to the programmatic API.

## Fix

`npm link` semantics, applied per sandbox:

- **`package-links.ts`** (new): `discoverPackageLinks(repoRoot)` finds the repo-root package by name plus, for monorepos, every workspace package — npm/yarn `workspaces` (array and `{ packages }` forms) and `pnpm-workspace.yaml`, with `*`/`**` glob and `!` exclusion support. Non-Node repos yield an empty list (no-op).
- **`sandbox.ts`**: each discovered package is symlinked into the sandbox at `node_modules/<name>` (junction type — privilege-free on Windows). Node resolves through the link's realpath, so the package's own dependencies resolve from the repo's real `node_modules` and subpaths (`tsx/cjs/api`) resolve through its actual `exports` map.
- **`run.ts` / `run-scenario.ts`**: discovery runs once per `runGuard` and reaches every sandbox. Birth-validation calls `runGuard` too, so birth and real `guard run` are fixed by the same path.

Safety: links are created **after** `setup.files` seeding and never over an existing path — a scenario that seeds its own `node_modules/<name>` stub keeps it, and seeded files can never be written *through* a link into the real repo. A link name that would escape `node_modules` throws `SandboxError`.

## Tests

- 11 discovery unit tests (`package-links.test.ts`): root/scoped names, both workspace forms, pnpm yaml + `!` exclusions, `**` traversal guards, dedup, malformed inputs, escape rejection.
- 4 sandbox tests: link creation, scoped parent dirs, seeded-stub-wins, escape rejection.
- 2 end-to-end regressions in `run.test.ts`: the exact #754 failure mode (bare-name ESM import + CJS subpath require + a dependency that only resolves through the link's realpath), and a pnpm-workspace monorepo importing `@acme/lib`.

Full suite: 288 files / 7360 tests green.

The other 2 of 20 tsx findings (CJS resolution-order scenarios) are unrelated and tracked separately per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U8xzfBwVuuHafRPpug6P5