### PR TITLE
fix(fp): resolve 4 FPs from OrchardCMS/OrchardCore

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/csharp/action-missing-producesresponsetype.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/csharp/action-missing-producesresponsetype.ts
@@ -7,11 +7,16 @@ const VERB_ATTRS = new Set([
 ])
 
 /**
- * An MVC/Web-API controller action — a method on a <c>*Controller</c> carrying an
+ * An API controller action — a method on a <c>*Controller</c> carrying an
  * HTTP-verb attribute — with no <c>[ProducesResponseType]</c>. Without it the
  * generated OpenAPI document cannot describe the response shapes or status codes the
- * action returns, so clients and codegen see an untyped <c>200</c> only. Matched by
- * name (ASP.NET types are not in scope at this analysis layer); a class-level
+ * action returns, so clients and codegen see an untyped <c>200</c> only.
+ * Server-rendered MVC view controllers — those deriving from <c>Controller</c> (the
+ * view-supporting base) without an explicit <c>[ApiController]</c> — are excluded:
+ * their actions return rendered views, not an API surface, so [ProducesResponseType]
+ * is not meaningful for them. Controllers on <c>ControllerBase</c> (the API base) or
+ * marked <c>[ApiController]</c> are still checked. Matched by name (ASP.NET types are
+ * not in scope at this analysis layer); a class-level
  * <c>[ProducesResponseType]</c>/<c>[ProducesDefaultResponseType]</c> that covers
  * every action clears it.
  */
@@ -24,11 +29,19 @@ export const csharpActionMissingProducesResponseTypeVisitor: CodeRuleVisitor = {
     if (cls?.type !== 'class_declaration') return null
     if (!(cls.childForFieldName('name')?.text ?? '').endsWith('Controller')) return null
 
+    // [ProducesResponseType] only shapes the generated OpenAPI/API description, which
+    // covers the API surface. A server-rendered MVC view controller — one deriving
+    // from `Controller` (the view-supporting base) without an explicit [ApiController]
+    // — returns rendered views and never appears in the API description, so requiring
+    // [ProducesResponseType] on its actions is a false positive. Controllers on
+    // `ControllerBase` (the API base) or marked [ApiController] stay in scope.
+    const classAttrs = attributeNames(cls)
+    if (!classAttrs.includes('ApiController') && baseClassName(cls) === 'Controller') return null
+
     const attrs = attributeNames(node)
     if (!attrs.some((a) => VERB_ATTRS.has(a))) return null
     if (attrs.some((a) => a.startsWith('ProducesResponseType'))) return null
 
-    const classAttrs = attributeNames(cls)
     if (classAttrs.some((a) => a.startsWith('ProducesResponseType') || a === 'ProducesDefaultResponseType')) return null
 
     // An action (or whole controller) marked [ApiExplorerSettings(IgnoreApi = true)]
@@ -64,6 +77,26 @@ function excludedFromApiExplorer(node: SyntaxNode): boolean {
     }
   }
   return false
+}
+
+/**
+ * The last-segment name of a class's base *type* (the first entry in the
+ * <c>base_list</c>, which in C# is the base class when one is present), or null when
+ * the class has no base list. Used to tell an MVC view controller (<c>Controller</c>)
+ * from an API controller (<c>ControllerBase</c>). Name-based: ASP.NET types are not
+ * resolved at this layer.
+ */
+function baseClassName(cls: SyntaxNode): string | null {
+  for (const child of cls.children) {
+    if (child?.type !== 'base_list') continue
+    const first = child.namedChildren[0]
+    if (!first) return null
+    const text = first.type === 'generic_name'
+      ? (first.childForFieldName('name')?.text ?? first.text)
+      : first.text
+    return text.split('.').pop() ?? text
+  }
+  return null
 }
 
 /** Attribute names (last segment) applied directly to a declaration node. */

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/async-method-naming.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/async-method-naming.ts
@@ -17,7 +17,9 @@ import { isCSharpTestMethod, getCSharpDeclAttributeNames } from './_helpers.js'
  *  - framework handler methods bound by attribute — ASP.NET controller actions
  *    (`[HttpGet]`/`[Route]`/…), minimal-API/SignalR handlers — must NOT carry
  *    the `Async` suffix (the framework strips it from routing), so any method
- *    with a routing/handler attribute is exempt.
+ *    with a routing/handler attribute is exempt;
+ *  - ASP.NET Core middleware `Invoke(HttpContext …)` — bound by convention name,
+ *    not by attribute, so it cannot take the `Async` suffix either.
  * Anonymous async lambdas have no name and are never the subject of this rule.
  */
 const HANDLER_ATTRIBUTES = new Set([
@@ -34,6 +36,20 @@ const HANDLER_ATTRIBUTES = new Set([
  *  - a method subscribed to an event via `+=` somewhere in the same file
  *    (`source.Changed += OnChanged;`), which covers parameterless handlers.
  */
+/**
+ * ASP.NET Core middleware convention: the pipeline invokes a middleware component
+ * through a method named `Invoke` (or `InvokeAsync`) whose first parameter is the
+ * `HttpContext`. `UseMiddleware<T>` binds this method by that exact name, so the
+ * `Async` suffix cannot be added to `Invoke` without breaking the convention.
+ */
+function isMiddlewareInvoke(node: SyntaxNode, name: string): boolean {
+  if (name !== 'Invoke' && name !== 'InvokeAsync') return false
+  const params = node.childForFieldName('parameters')
+  const first = params?.namedChildren.find((c) => c?.type === 'parameter')
+  const type = (first?.childForFieldName('type')?.text ?? '').split('.').pop()
+  return type === 'HttpContext'
+}
+
 function isEventHandler(node: SyntaxNode, name: string, sourceCode: string): boolean {
   const params = node.childForFieldName('parameters')
   if (params) {
@@ -61,6 +77,7 @@ export const csharpAsyncMethodNamingVisitor: CodeRuleVisitor = {
     if (isCSharpTestMethod(node)) return null
     if (getCSharpDeclAttributeNames(node).some((a) => HANDLER_ATTRIBUTES.has(a))) return null
     if (isEventHandler(node, name, sourceCode)) return null
+    if (isMiddlewareInvoke(node, name)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/if-else-instead-of-ternary.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/if-else-instead-of-ternary.ts
@@ -42,6 +42,13 @@ export const csharpIfElseInsteadOfTernaryVisitor: CodeRuleVisitor = {
   languages: ['csharp'],
   nodeTypes: ['if_statement'],
   visit(node, filePath, sourceCode) {
+    // An `else if` branch: this if_statement is the `alternative` of an enclosing
+    // if, so it belongs to a multi-arm if/else-if/else chain. Collapsing only its
+    // tail into a two-arm ternary silently drops the earlier arm(s), producing a
+    // wrong suggestion — such chains are out of scope for this rule.
+    const parent = node.parent
+    if (parent?.type === 'if_statement' && parent.childForFieldName('alternative')?.id === node.id) return null
+
     const alternative = node.childForFieldName('alternative')
     if (!alternative || alternative.type === 'if_statement') return null
 

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/typeof-name-over-typeof-name.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/typeof-name-over-typeof-name.ts
@@ -1,5 +1,30 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+
+/**
+ * True when `name` matches a generic type parameter declared on any enclosing
+ * method, local function, or type declaration — e.g. `TPart` in
+ * `TResult Foo<TPart>()`. For such a parameter `nameof(TPart)` is the literal
+ * string "TPart", not the runtime type-argument name that `typeof(TPart).Name`
+ * returns, so the two are not interchangeable and the rule must not fire.
+ */
+function isGenericTypeParameterInScope(node: SyntaxNode, name: string): boolean {
+  let cur: SyntaxNode | null = node.parent
+  while (cur) {
+    for (const child of cur.namedChildren) {
+      if (child?.type !== 'type_parameter_list') continue
+      for (const tp of child.namedChildren) {
+        if (tp?.type !== 'type_parameter') continue
+        const tpName = tp.childForFieldName('name')?.text
+          ?? tp.namedChildren.find((c) => c?.type === 'identifier')?.text
+        if (tpName === name) return true
+      }
+    }
+    cur = cur.parent
+  }
+  return false
+}
 
 /**
  * `typeof(X).Name` performs a runtime reflection lookup to recover a name the
@@ -22,6 +47,10 @@ export const csharpTypeofNameOverTypeofNameVisitor: CodeRuleVisitor = {
     if (receiver?.type !== 'typeof_expression') return null
 
     const typeArg = receiver.namedChildren.find(Boolean)?.text ?? 'X'
+    // `nameof(T)` on a generic type parameter yields the literal parameter name
+    // ("T"), not the runtime type argument's name, so it is not equivalent to
+    // `typeof(T).Name`. Suggesting the swap there would be wrong.
+    if (isGenericTypeParameterInScope(node, typeArg)) return null
     return makeViolation(
       this.ruleKey, node, filePath, 'low',
       'Convert typeof().Name to nameof',

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -1861,6 +1861,12 @@
       "layer": "service"
     },
     {
+      "name": "CatalogApiController",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "api"
+    },
+    {
       "name": "ChangeNotifier",
       "service": "UserService",
       "kind": "class",
@@ -1925,6 +1931,12 @@
       "service": "UserService",
       "kind": "standalone",
       "layer": "data"
+    },
+    {
+      "name": "DiagnosticLabel",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
     },
     {
       "name": "Diagnostics",
@@ -2641,6 +2653,12 @@
       "layer": "service"
     },
     {
+      "name": "TelemetryPublisher",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "TenantResolver",
       "service": "UserService",
       "kind": "class",
@@ -2648,6 +2666,12 @@
     },
     {
       "name": "TenantSnapshot",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
+      "name": "ThresholdSelector",
       "service": "UserService",
       "kind": "class",
       "layer": "service"
@@ -3234,6 +3258,11 @@
       "method": "GET",
       "path": "/users/{userId}",
       "file": "services/UserService/Program.cs"
+    },
+    {
+      "method": "GET",
+      "path": "/api/catalog",
+      "file": "services/UserService/Violations/Architecture/CatalogApiController.cs"
     },
     {
       "method": "GET",

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/CatalogApiController.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/CatalogApiController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace UserServiceApp.Violations.Architecture;
+
+/// <summary>Serves catalog data over HTTP as a JSON API.</summary>
+[ApiController]
+[Route("api/catalog")]
+public sealed class CatalogApiController : ControllerBase
+{
+    /// <summary>Returns all catalog entries.</summary>
+    [HttpGet]
+    // VIOLATION: architecture/deterministic/action-missing-producesresponsetype
+    public IActionResult List() => Ok();
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/RegistrationController.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/RegistrationController.cs
@@ -16,7 +16,9 @@ public class RegistrationController : Controller
     /// <summary>Create an account from the posted form.</summary>
     [HttpPost]
     // VIOLATION: architecture/deterministic/missing-modelstate-validation
-    // VIOLATION: architecture/deterministic/action-missing-producesresponsetype
+    // A server-rendered MVC view controller (base `Controller`, no [ApiController])
+    // is not part of the API description, so action-missing-producesresponsetype
+    // intentionally does not fire here.
     public IActionResult Create(RegistrationInput model)
     {
         return RedirectToAction("Index", model);

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/DiagnosticLabel.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/DiagnosticLabel.cs
@@ -1,0 +1,7 @@
+namespace UserServiceApp.Violations.CodeQuality;
+
+internal class DiagnosticLabel
+{
+    // VIOLATION: code-quality/deterministic/typeof-name-over-typeof-name
+    internal string Label => typeof(DiagnosticLabel).Name;
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/TelemetryPublisher.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/TelemetryPublisher.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+namespace UserServiceApp.Violations.CodeQuality;
+
+internal class TelemetryPublisher
+{
+    private const int FlushDelayMs = 5;
+
+    // VIOLATION: code-quality/deterministic/async-method-naming
+    internal async Task Publish()
+    {
+        await Task.Delay(FlushDelayMs);
+    }
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/ThresholdSelector.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/ThresholdSelector.cs
@@ -1,0 +1,19 @@
+namespace UserServiceApp.Violations.CodeQuality;
+
+internal class ThresholdSelector
+{
+    internal int Pick(bool isHigh, int high, int low)
+    {
+        int result;
+        // VIOLATION: code-quality/deterministic/if-else-instead-of-ternary
+        if (isHigh)
+        {
+            result = high;
+        }
+        else
+        {
+            result = low;
+        }
+        return result;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/CatalogPageController.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/CatalogPageController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Positive.Boundary.Architecture;
+
+/// <summary>
+/// A server-rendered MVC view controller: it derives from <c>Controller</c> and
+/// carries no <c>[ApiController]</c>, so its actions return rendered views and
+/// never appear in the generated API description. <c>[ProducesResponseType]</c>
+/// shapes only that API description, so requiring it here is a false positive —
+/// action-missing-producesresponsetype must not fire.
+/// </summary>
+[Route("catalog")]
+public sealed class CatalogPageController : Controller
+{
+    /// <summary>Renders the catalog landing page.</summary>
+    [HttpGet]
+    // SAFE: architecture/deterministic/action-missing-producesresponsetype
+    public IActionResult Index() => View();
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/IfElseTernaryChainSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/IfElseTernaryChainSafe.cs
@@ -1,0 +1,29 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// A three-arm if / else-if / else chain assigning one variable. It is not a
+/// binary if/else, so collapsing it into a two-arm ternary would drop an arm —
+/// if-else-instead-of-ternary must not fire on the else-if tail.
+/// </summary>
+public sealed class IfElseTernaryChainSafe
+{
+    /// <summary>Selects a tier label from two independent flags.</summary>
+    public string SelectTier(bool isPremium, bool isTrial)
+    {
+        string tier;
+        // SAFE: code-quality/deterministic/if-else-instead-of-ternary
+        if (isPremium)
+        {
+            tier = "premium";
+        }
+        else if (isTrial)
+        {
+            tier = "trial";
+        }
+        else
+        {
+            tier = "standard";
+        }
+        return tier;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/RequestTimingMiddleware.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/RequestTimingMiddleware.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// ASP.NET Core middleware convention: the pipeline invokes the component through
+/// a method named <c>Invoke</c> whose first parameter is the <c>HttpContext</c>.
+/// <c>UseMiddleware</c> binds it by that exact name, so the <c>Async</c> suffix
+/// must not be added — async-method-naming must not fire here.
+/// </summary>
+public sealed class RequestTimingMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    /// <summary>Captures the next component in the request pipeline.</summary>
+    public RequestTimingMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    /// <summary>Runs the middleware for the current request.</summary>
+    // SAFE: code-quality/deterministic/async-method-naming
+    public async Task Invoke(HttpContext context)
+    {
+        await _next(context);
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/TypeofNameGenericParamSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples3/TypeofNameGenericParamSafe.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// <c>typeof(T).Name</c> over a generic type parameter recovers the RUNTIME type
+/// argument's name. <c>nameof(T)</c> would yield the literal "T" instead, so the
+/// two are not equivalent and typeof-name-over-typeof-name must not fire.
+/// </summary>
+public sealed class TypeofNameGenericParamSafe
+{
+    /// <summary>Returns the runtime name of the supplied type argument.</summary>
+    public string RuntimeTypeName<TValue>()
+    {
+        // SAFE: code-quality/deterministic/typeof-name-over-typeof-name
+        return typeof(TValue).Name;
+    }
+}


### PR DESCRIPTION
Resolves 4 false positives found by the analyzer on `OrchardCMS/OrchardCore`
(`1d0ae14413f10e2b3c1a65927db463b30a6892fe`). All four are in-bounds C#
tree-sitter visitor fixes with paraphrased positive/negative fixtures.

Closes #764
Closes #768
Closes #771
Closes #772

## Fixes

| rule_key | issue | positive fixture | negative fixture |
|---|---|---|---|
| `architecture/deterministic/action-missing-producesresponsetype` | #764 | `sample-csharp-project-positive/services/ArchitectureSamples/CatalogPageController.cs` | `sample-csharp-project-negative/services/UserService/Violations/Architecture/CatalogApiController.cs` |
| `code-quality/deterministic/async-method-naming` | #768 | `sample-csharp-project-positive/services/CodeQualitySamples1/RequestTimingMiddleware.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/TelemetryPublisher.cs` |
| `code-quality/deterministic/typeof-name-over-typeof-name` | #771 | `sample-csharp-project-positive/services/CodeQualitySamples3/TypeofNameGenericParamSafe.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/DiagnosticLabel.cs` |
| `code-quality/deterministic/if-else-instead-of-ternary` | #772 | `sample-csharp-project-positive/services/CodeQualitySamples1/IfElseTernaryChainSafe.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/ThresholdSelector.cs` |

## architecture/deterministic/action-missing-producesresponsetype (#764)

OSS sources:
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Controllers/DashboardController.cs#L143``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore.Modules/OrchardCore.AdminMenu/Controllers/MenuController.cs#L135``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore.Modules/OrchardCore.AdminMenu/Controllers/NodeController.cs#L116``

The rule fired on every `*Controller` method carrying an HTTP-verb attribute,
including server-rendered MVC view controllers (all the sampled OrchardCore cases
derive from `Controller`, the view-supporting base). `[ProducesResponseType]` only
shapes the generated OpenAPI/API description, which covers the API surface. The
visitor now exempts an action whose controller derives from `Controller` (the MVC
view base) **and** is not marked `[ApiController]` — such controllers return
rendered views and never appear in the API description. Controllers on
`ControllerBase` (the API base) or marked `[ApiController]` are still checked, so
genuine API actions missing `[ProducesResponseType]` continue to fire. The existing
`RegistrationController` negative fixture — a plain MVC `Controller` — had its
`action-missing-producesresponsetype` marker removed to match the corrected
contract (its `missing-modelstate-validation` marker stays).

## code-quality/deterministic/async-method-naming (#768)

OSS sources:
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore/Modules/ModularTenantContainerMiddleware.cs#L27``

The rule flagged the ASP.NET Core middleware convention method
`Invoke(HttpContext …)`. `UseMiddleware<T>` binds this method by that exact name,
so the `Async` suffix cannot be added without breaking the convention. The visitor
now exempts a method named `Invoke`/`InvokeAsync` whose first parameter is the
`HttpContext`.

## code-quality/deterministic/typeof-name-over-typeof-name (#771)

OSS sources:
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentDefinitionManagerExtensions.cs#L56``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Abstractions/Json/Serialization/JsonDynamicJsonConverter.cs#L11``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.AdminMenu.Abstractions/Services/IAdminNodeProviderFactory.cs#L13``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentExtensions.cs#L57``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentItemExtensions.cs#L16``

The rule suggested rewriting `typeof(T).Name` as `nameof(T)` even when `T` is a
generic type parameter. For a generic parameter, `nameof(T)` yields the literal
string `"T"`, not the runtime type-argument's name that `typeof(T).Name` returns —
the two are not equivalent and the swap would break the code. The visitor now
exempts `typeof(...).Name` when the operand is a generic type parameter declared on
any enclosing method, local function, or type.

## code-quality/deterministic/if-else-instead-of-ternary (#772)

OSS sources:
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAIClientFactory.cs#L45``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAIClientFactory.cs#L78``

The rule fired on the tail `else if … else` of a three-arm `if / else-if / else`
chain, suggesting a two-arm ternary that silently drops the earlier arm. The
visitor now skips an `if_statement` that is itself the `alternative` (the `else if`)
of an enclosing `if`, so multi-arm chains are left alone; standalone binary
`if/else` assignments still fire.

## Skipped this batch

Attempted but not fixed — all deferred to a human-review session
(`cs-fp-human-review-needed` added, with an explanation on each issue):

- #763 `global-statement` — deferred-to-human-review (JS `var` heuristic is wrong at the root; correct fix needs data-flow or a rule-contract redesign).
- #765 `unsafe-any-usage` — deferred-to-human-review (OrchardCore's `dynamic` is deliberate API surface; narrowing is a design decision).
- #766 `extension-method-namespace` — deferred-to-human-review (implemented in the Roslyn host, out of the in-bounds scope).
- #767 `namespace-folder-mismatch` — deferred-to-human-review (Roslyn host rule).
- #769 `params-overload-ambiguity` — deferred-to-human-review (Roslyn host rule).
- #770 `no-undef` — deferred-to-human-review (rooted in data-flow known-globals, out of the in-bounds scope).

## FP-count delta (vs `1d0ae14413f10e2b3c1a65927db463b30a6892fe` on `OrchardCMS/OrchardCore`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `architecture/deterministic/action-missing-producesresponsetype` | 297 | 36 | -261 |
| `code-quality/deterministic/async-method-naming` | 274 | 268 | -6 |
| `code-quality/deterministic/typeof-name-over-typeof-name` | 94 | 0 | -94 |
| `code-quality/deterministic/if-else-instead-of-ternary` | 99 | 86 | -13 |
| **Total (these 4 rules)** | 764 | 390 | -374 |
| **All C# deterministic rules on target** | 15731 | 15357 | -374 |

Methodology note: a full `node dist/cli.mjs analyze` did not complete on this
target — the analyzer hangs in the deterministic phase parsing OrchardCore's
bundled multi-MB minified vendor JavaScript (`OrchardCore.Resources/wwwroot`
monaco `tsWorker.js` ~5.5 MB, `editor.main.js` ~3.6 MB, fontawesome bundles),
which is unrelated to these four C# rules. The numbers above were therefore
measured by running the deterministic C# tree-sitter tier over the target's
entire `.cs` corpus (5,125 files) with the pre-fix vs post-fix visitors. All four
fixed rules are deterministic C# visitors, so their deltas are exact; the
all-rules total is the C# deterministic tier only. The all-rules delta (-374)
equals the four-rule subtotal, confirming the change has no collateral effect on
any other rule.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgNh5vk6mHQeEK7TnuBiT1)_