### PR TITLE
fix(fp): resolve 4 FPs from OrchardCMS/OrchardCore

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/csharp/uri-parameter-as-string.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/csharp/uri-parameter-as-string.ts
@@ -16,6 +16,20 @@ function enclosingPublicMethod(param: SyntaxNode): boolean {
   return hasCSharpModifier(method, 'public')
 }
 
+/**
+ * An extension method (its first parameter carries the `this` modifier) mirrors
+ * the API surface of the type it extends — a `this string url` receiver adapts
+ * the string itself, and later string parameters follow the extended type's own
+ * overloads (e.g. `LocalRedirect(this ControllerBase, string localUrl)` mirrors
+ * `ControllerBase.LocalRedirect(string)`). These follow framework convention,
+ * not the "accept System.Uri at your boundary" guidance, so they are exempt.
+ */
+function isExtensionMethod(param: SyntaxNode): boolean {
+  const paramList = param.parent
+  const firstParam = paramList?.namedChildren.find((c) => c?.type === 'parameter')
+  return firstParam ? hasCSharpModifier(firstParam, 'this') : false
+}
+
 export const csharpUriParameterAsStringVisitor: CodeRuleVisitor = {
   ruleKey: 'architecture/deterministic/uri-parameter-as-string',
   languages: ['csharp'],
@@ -25,6 +39,7 @@ export const csharpUriParameterAsStringVisitor: CodeRuleVisitor = {
     const name = node.childForFieldName('name')?.text
     if (!name || !nameLooksLikeUri(name)) return null
     if (!enclosingPublicMethod(node)) return null
+    if (isExtensionMethod(node)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/hardcoded-url.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/hardcoded-url.ts
@@ -5,7 +5,7 @@ import { isCSharpTestPath } from '../../../_shared/csharp-helpers.js'
 
 // XML/SOAP/schema namespace hosts — fixed identifiers, not service endpoints.
 // `tempuri.org` and `schemas.microsoft.com` are the .NET-specific additions.
-const NAMESPACE_URI_HOSTS = /w3\.org|schema\.org|xmlns|openxmlformats|xmlsoap|purl\.org|tempuri\.org|schemas\.microsoft\.com|tools\.ietf\.org|datatracker\.ietf\.org|rfc-editor\.org/
+const NAMESPACE_URI_HOSTS = /w3\.org|schema\.org|xmlns|openxmlformats|xmlsoap|purl\.org|tempuri\.org|schemas\.microsoft\.com|tools\.ietf\.org|datatracker\.ietf\.org|rfc-editor\.org|sitemaps\.org/
 
 // Stable third-party API/CDN domains with no environment-specific form.
 const STABLE_API_HOSTS = /googleapis\.com|maps\.google|api\.stripe\.com|api\.twilio\.com|api\.sendgrid\.com|api\.github\.com|cdn\.|fonts\.googleapis|cloudflare|unpkg\.com|cdnjs\.cloudflare|jsdelivr\.net|nuget\.org/

--- a/packages/analyzer/src/rules/reliability/visitors/csharp/unsafe-json-parse.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/csharp/unsafe-json-parse.ts
@@ -1,7 +1,7 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
-import { getCSharpArguments, getCSharpMethodName, getCSharpReceiver } from '../../../_shared/csharp-helpers.js'
+import { getCSharpArguments, getCSharpEnclosingFunction, getCSharpMethodName, getCSharpReceiver } from '../../../_shared/csharp-helpers.js'
 import { isInsideCSharpTryWithCatch, simpleTypeName } from './_helpers.js'
 
 /** receiver → methods that throw on malformed input. */
@@ -28,6 +28,45 @@ function bodyDeclaresMember(body: SyntaxNode, name: string): boolean {
         if (d?.type === 'variable_declarator' && d.childForFieldName('name')?.text === name) return true
       }
     }
+  }
+  return false
+}
+
+/**
+ * True when the enclosing method reads from a `Utf8JsonReader` — a custom
+ * `JsonConverter.Read(ref Utf8JsonReader reader, …)` override or a low-level
+ * reader helper (`Load(ref Utf8JsonReader reader, …)`). Inside these, throwing
+ * `JsonException` on malformed input is the (de)serialization contract that the
+ * caller's pipeline is expected to catch, so wrapping the parse in a try/catch
+ * would be wrong. Keyed on a `Utf8JsonReader` parameter, which is what both the
+ * converter `Read` signature and the reader helpers have in common.
+ */
+function isInsideJsonReaderContext(node: SyntaxNode): boolean {
+  const fn = getCSharpEnclosingFunction(node)
+  const params = fn?.childForFieldName('parameters')
+  if (!params) return false
+  for (const p of params.namedChildren) {
+    if (p?.type === 'parameter' && p.text.includes('Utf8JsonReader')) return true
+  }
+  return false
+}
+
+/**
+ * True when the parse sits inside a custom `JsonConverter` (a type deriving from
+ * System.Text.Json's `JsonConverter<T>` or Newtonsoft's `JsonConverter`). A
+ * converter's Read/Write body is (de)serialization contract code — including
+ * round-trip parses of just-serialized data (`JsonDocument.Parse(stream)` in a
+ * `Write` after `serializer.Serialize(stream)`) — where a `JsonException` is
+ * expected to propagate to the serializer pipeline, not be swallowed locally.
+ */
+function isInsideJsonConverter(node: SyntaxNode): boolean {
+  let current: SyntaxNode | null = node.parent
+  while (current) {
+    if (TYPE_DECLS.has(current.type)) {
+      const baseList = current.namedChildren.find((c) => c?.type === 'base_list')
+      if (baseList?.namedChildren.some((b) => b?.text.includes('JsonConverter'))) return true
+    }
+    current = current.parent
   }
   return false
 }
@@ -83,6 +122,11 @@ export const csharpUnsafeJsonParseVisitor: CodeRuleVisitor = {
     }
 
     if (isInsideCSharpTryWithCatch(node)) return null
+
+    // A parse inside a Utf8JsonReader-based reader method, or anywhere inside a
+    // custom JsonConverter, is expected to throw JsonException as its
+    // (de)serialization contract, not swallow it.
+    if (isInsideJsonReaderContext(node) || isInsideJsonConverter(node)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'medium',

--- a/packages/analyzer/src/rules/security/exclusions.ts
+++ b/packages/analyzer/src/rules/security/exclusions.ts
@@ -45,6 +45,12 @@ export const GLOBAL_ALLOWLIST: RegExp[] = [
   // are deliberately NOT allowlisted here.
   /^phc_[A-Za-z0-9]{30,}$/,
 
+  // Subresource Integrity (SRI) hashes (`sha256-`/`sha384-`/`sha512-` + base64)
+  // — public asset digests published in page markup so the browser can verify a
+  // fetched script/stylesheet. Their base64 body collides with the generic
+  // Cohere-token shape, but an SRI hash is public by design, not a credential.
+  /^sha(?:256|384|512)-[A-Za-z0-9+/]+={0,2}$/,
+
   // Common config patterns that aren't secrets
   /^\*+$/, // All asterisks (masked values)
   /^x+$/i, // All x's (placeholder)

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -1855,6 +1855,12 @@
       "layer": "service"
     },
     {
+      "name": "CallbackRegistrar",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "CartItem",
       "service": "UserService",
       "kind": "class",
@@ -1913,6 +1919,12 @@
       "service": "UserService",
       "kind": "class",
       "layer": "service"
+    },
+    {
+      "name": "Current",
+      "service": "UserService",
+      "kind": "standalone",
+      "layer": "external"
     },
     {
       "name": "CustomerAddress",
@@ -2305,6 +2317,12 @@
       "layer": "service"
     },
     {
+      "name": "PartnerApiClient",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "external"
+    },
+    {
       "name": "PassthroughFormatter",
       "service": "UserService",
       "kind": "class",
@@ -2332,6 +2350,12 @@
       "name": "PatternValidators",
       "service": "UserService",
       "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "PayloadReader",
+      "service": "UserService",
+      "kind": "class",
       "layer": "service"
     },
     {

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/CallbackRegistrar.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/CallbackRegistrar.cs
@@ -1,0 +1,18 @@
+namespace UserServiceApp.Violations.Architecture;
+
+/// <summary>
+/// Registers outbound webhook targets. Its public API accepts a callback URL as a
+/// raw string at a genuine boundary (not an extension method), losing the
+/// validation a System.Uri parameter would provide.
+/// </summary>
+internal sealed class CallbackRegistrar
+{
+    /// <summary>Registers a webhook target by its callback URL.</summary>
+    // VIOLATION: architecture/deterministic/uri-parameter-as-string
+    public void Register(string callbackUrl)
+    {
+        _targets.Add(callbackUrl);
+    }
+
+    private readonly System.Collections.Generic.List<string> _targets = new();
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/PartnerApiClient.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/PartnerApiClient.cs
@@ -1,0 +1,11 @@
+namespace UserServiceApp.Violations.CodeQuality;
+
+/// <summary>Calls a partner API at a hardcoded base URL that belongs in configuration.</summary>
+internal sealed class PartnerApiClient
+{
+    // VIOLATION: code-quality/deterministic/hardcoded-url
+    private const string BaseUrl = "https://api.acme-partner.io/v2";
+
+    /// <summary>Returns the partner service base address.</summary>
+    public string Read() => BaseUrl;
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Reliability/PayloadReader.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Reliability/PayloadReader.cs
@@ -1,0 +1,11 @@
+using System.Text.Json;
+
+namespace UserServiceApp.Violations.Reliability;
+
+/// <summary>Parses an untrusted request body without guarding against malformed JSON.</summary>
+internal sealed class PayloadReader
+{
+    /// <summary>Parses the raw request body into a JSON document.</summary>
+    // VIOLATION: reliability/deterministic/unsafe-json-parse
+    public JsonDocument ReadBody(string body) => JsonDocument.Parse(body);
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Security/VendorApiClient.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Security/VendorApiClient.cs
@@ -1,0 +1,11 @@
+namespace UserServiceApp.Violations.Security;
+
+/// <summary>Holds a hardcoded third-party API key — a real leaked credential in source.</summary>
+internal static class VendorApiClient
+{
+    // VIOLATION: security/deterministic/hardcoded-secret
+    private const string ApiKey = "h6JsqmOJRUeLjSA6K7ydR2nvJPy37RvYPdnmOY1l";
+
+    /// <summary>Returns the configured vendor key.</summary>
+    public static string Current() => ApiKey;
+}

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/AssetIntegrity.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/AssetIntegrity.cs
@@ -1,0 +1,26 @@
+namespace Demo.Assets;
+
+/// <summary>Builds asset registrations with an optional integrity digest.</summary>
+public interface IAssetBuilder
+{
+    /// <summary>Sets the Subresource Integrity digest for the current asset.</summary>
+    IAssetBuilder SetIntegrity(string integrity);
+}
+
+/// <summary>
+/// Registers third-party CDN assets with their public Subresource Integrity (SRI)
+/// hashes. An SRI hash is a base64-encoded digest published in page markup so the
+/// browser can verify a fetched asset; it is public by design, not a credential.
+/// </summary>
+public sealed class AssetIntegrity
+{
+    /// <summary>Registers the bundled script and stylesheet with their integrity digests.</summary>
+    public void Register(IAssetBuilder builder)
+    {
+        System.ArgumentNullException.ThrowIfNull(builder);
+        // SAFE: security/deterministic/hardcoded-secret
+        builder.SetIntegrity("sha384-7WpWrH0ntmtZcMh7I0Ki2S7POsj9zpTEWbnZtVOAEucnVPmZPtngEHCWDSyuugZb");
+        // SAFE: security/deterministic/hardcoded-secret
+        builder.SetIntegrity("sha256-ilpsfmubxoqeiwFOsTcI6qgPOIC6332so0jrZZhcBDY=");
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/SitemapWriter.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/SitemapWriter.cs
@@ -1,0 +1,15 @@
+namespace Demo.Sitemaps;
+
+/// <summary>
+/// Writes sitemap XML. The sitemaps.org schema URL is a fixed XML namespace
+/// identifier (like a w3.org or schema.org namespace), not a configurable
+/// network endpoint, so it must not be flagged as a hardcoded URL.
+/// </summary>
+public sealed class SitemapWriter
+{
+    // SAFE: code-quality/deterministic/hardcoded-url
+    private const string SchemaNamespace = "https://www.sitemaps.org/schemas/sitemap/0.9";
+
+    /// <summary>Reports whether the given namespace is the sitemap schema namespace.</summary>
+    public bool Matches(string ns) => ns == SchemaNamespace;
+}

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/UrlExtensions.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/UrlExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Text;
+
+namespace Demo.Web;
+
+/// <summary>
+/// URL-shaped string helpers exposed as extension methods. An extension method's
+/// string parameters mirror the conventions of the type it extends (here a
+/// framework StringBuilder), so a URL-named string parameter follows that shape
+/// rather than the "accept System.Uri at your boundary" guidance and must not be
+/// flagged as a URI typed as string.
+/// </summary>
+public static class UrlExtensions
+{
+    /// <summary>Appends a local URL to the builder, mirroring a string-based API.</summary>
+    public static StringBuilder AppendLocalUrl(this StringBuilder builder, string localUrl)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(localUrl);
+        return builder.Append(localUrl);
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/WidgetConverter.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/WidgetConverter.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Demo.Serialization;
+
+/// <summary>A value carried through a custom JSON converter.</summary>
+public sealed class Widget
+{
+    /// <summary>The widget name.</summary>
+    public string Name { get; init; }
+}
+
+/// <summary>
+/// A custom System.Text.Json converter. Its Read method reads from a
+/// Utf8JsonReader, where throwing JsonException on malformed input is the
+/// converter contract — wrapping the parse in a try/catch would be wrong, so
+/// the parse must not be flagged as an unguarded JSON parse.
+/// </summary>
+public sealed class WidgetConverter : JsonConverter<Widget>
+{
+    /// <summary>Reads a widget from the reader.</summary>
+    public override Widget Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var document = JsonDocument.ParseValue(ref reader);
+        var raw = document.RootElement.GetRawText();
+        // SAFE: reliability/deterministic/unsafe-json-parse
+        return JsonSerializer.Deserialize<Widget>(raw, options);
+    }
+
+    /// <summary>Writes a widget.</summary>
+    public override void Write(Utf8JsonWriter writer, Widget value, JsonSerializerOptions options)
+        => JsonSerializer.Serialize(writer, value, options);
+}


### PR DESCRIPTION
Resolves 4 false-positive analyzer bugs found on `OrchardCMS/OrchardCore` (ref `1d0ae14`). Each fix is an in-bounds rule/visitor change plus a paraphrased positive (FP) regression case and a true-bug negative case.

Closes #773
Closes #774
Closes #778
Closes #779

## Fixes

| rule_key | issue | positive fixture | negative fixture |
|---|---|---|---|
| `architecture/deterministic/uri-parameter-as-string` | #773 | `sample-csharp-project-positive/src/FpRegression/UrlExtensions.cs` | `sample-csharp-project-negative/services/UserService/Violations/Architecture/CallbackRegistrar.cs` |
| `security/deterministic/hardcoded-secret` | #774 | `sample-csharp-project-positive/src/FpRegression/AssetIntegrity.cs` | `sample-csharp-project-negative/services/UserService/Violations/Security/VendorApiClient.cs` |
| `code-quality/deterministic/hardcoded-url` | #778 | `sample-csharp-project-positive/src/FpRegression/SitemapWriter.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/PartnerApiClient.cs` |
| `reliability/deterministic/unsafe-json-parse` | #779 | `sample-csharp-project-positive/src/FpRegression/WidgetConverter.cs` | `sample-csharp-project-negative/services/UserService/Violations/Reliability/PayloadReader.cs` |

## architecture/deterministic/uri-parameter-as-string (#773)

OSS sources:
- https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Abstractions/StringUriExtensions.cs#L5
- https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Abstractions/StringUriExtensions.cs#L22
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Mvc.Core/Extensions/ControllerBaseExtensions.cs#L44``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Mvc.Core/Extensions/ControllerBaseExtensions.cs#L61``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/Extensions/HttpRequestExtensions.cs#L36``

Extension-method parameters are now exempt from the rule. An extension method (its first parameter carries the `this` modifier) mirrors the API surface of the type it extends: a `this string url` receiver adapts the string itself, and later string parameters follow the extended type's own overloads — e.g. `LocalRedirect(this ControllerBase, string localUrl)` mirrors the framework's `ControllerBase.LocalRedirect(string)`. These follow framework convention, not the "accept `System.Uri` at your boundary" guidance, so they are no longer flagged. Added an `isExtensionMethod()` guard to the visitor. A genuine non-extension public API method taking a URI-named `string` (the negative case) still fires.

## security/deterministic/hardcoded-secret (#774)

OSS sources:
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs#L52``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs#L68``

Added Subresource Integrity (SRI) hashes (`sha256-`/`sha384-`/`sha512-` followed by base64) to the secret-scanner global allowlist. An SRI hash is a public asset digest published in page markup so the browser can verify a fetched script/stylesheet; its base64 body collides with the generic Cohere-token pattern, but it is not a credential (same rationale as the existing PostHog `phc_` public-key carve-out). This is the highest-impact fix in the batch — the Resources config alone carried 71 such FPs. A genuine hardcoded API token (the negative case) still fires.

## code-quality/deterministic/hardcoded-url (#778)

OSS sources:
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceBuilder.cs#L15``

Added `sitemaps.org` to the visitor's `NAMESPACE_URI_HOSTS` list, alongside the existing schema-namespace hosts (`w3.org`, `schema.org`, `xmlns`, `openxmlformats`, …). `http://www.sitemaps.org/schemas/sitemap/0.9` is a fixed XML schema-namespace identifier, not a configurable network endpoint. A genuine hardcoded partner-API base URL (the negative case) still fires.

## reliability/deterministic/unsafe-json-parse (#779)

OSS sources:
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Elasticsearch.Core/Json/ElasticsearchIndexMetadataConverter.cs#L42``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Elasticsearch.Core/Json/ElasticsearchIndexMapConverter.cs#L64``
- https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Abstractions/Json/Nodes/JNode.cs#L29

A parse inside custom JSON (de)serialization code is expected to throw `JsonException`, which the serializer pipeline catches — wrapping it in a local try/catch would be wrong. Two signals now exempt these, together covering all three samples: (a) the enclosing method takes a `Utf8JsonReader` — a `JsonConverter.Read(ref Utf8JsonReader, …)` override or a low-level reader helper such as `JNode.Load(ref Utf8JsonReader)`; and (b) the parse sits anywhere inside a type deriving from `JsonConverter`, which also covers a `Write`-method round-trip parse of just-serialized data (`JsonDocument.Parse(stream)` after `serializer.Serialize(stream)` in `ElasticsearchIndexMapConverter`). An unguarded parse of an untrusted request body in a plain method (the negative case) still fires.

## Skipped this batch

Six issues were attempted but deferred to the human-review queue (labeled `cs-fp-human-review-needed`) because a correct fix would cross the in-bounds boundary (rule visitor + fixtures only). Each has a detailed comment on the issue:

- deferred-to-human-review: #775 (`event-listener-no-remove`) — needs plain-script-vs-SPA-component context analysis.
- deferred-to-human-review: #776 (`implicit-global-declaration`) — the 3-line var-branch fix is ready, but a module-scoped `var` also (legitimately) trips `js-style-preference`/`no-var-declaration`, so a zero-violation positive fixture is impossible in-bounds.
- deferred-to-human-review: #777 (`uri-property-as-string`) — needs base-type/usage analysis to tell relative/app-relative URLs and DB columns from absolute URIs.
- deferred-to-human-review: #780 (`generic-parameter-not-inferable`) — the rule's only firing condition (return-type-only generics) is idiomatic in C#; a rule-design decision.
- deferred-to-human-review: #781 (`no-extraneous-class`) and #782 (`static-holder-type-not-sealed`) — coupled: both fire on the same protected-static inheritance base, and #782 runs in the Roslyn host (out of bounds). Must be fixed together in a human-review session.

## FP-count delta (vs `1d0ae14413f10e2b3c1a65927db463b30a6892fe` on `OrchardCMS/OrchardCore`)

| Rule | Before | After | Delta |
|---|---:|---:|---:|
| `architecture/deterministic/uri-parameter-as-string` | 100 | 83 | -17 |
| `security/deterministic/hardcoded-secret` | 115 | 41 | -74 |
| `code-quality/deterministic/hardcoded-url` | 62 | 57 | -5 |
| `reliability/deterministic/unsafe-json-parse` | 81 | 76 | -5 |
| **Total (these 4 rules)** | 358 | 257 | **-101** |
| **All-rules total on target** | 31547 | 31446 | **-101** |

> Measurement note: the whole-repo `node dist/cli.mjs analyze` did not complete on this OrchardCore checkout in the session's environment (it ran ~4h and peaked at ~16.5 GB RAM on a 15 GB box before being stopped — a resource/perf wall in the analyze pipeline on this very large repo, unrelated to these rule changes). Because all four fixed rules are tree-sitter rules, the before/after counts above were measured by running the analyzer's tree-sitter deterministic rule pass over every `.cs`/`.js`/`.ts` file in the target at the same ref (5,553 files, identical method for before and after). The all-rules total is therefore the tree-sitter-rule total (it excludes Roslyn host/workspace rules), and the −101 delta is entirely attributable to the four rules changed here.

## Test status

`pnpm test`: **7332 passed, 5 failed, 3 skipped.** All 5 failures are the *same* environmental issue — the project-aware Roslyn **workspace / MSBuild** tier is unavailable here (`could not locate a .NET SDK to open the project via MSBuild: No instances of MSBuild could be detected`) — in `roslyn-workspace.test.ts` (2), `csharp-negative-project.test.ts` (1), and the three CLI e2e C# analyze tests. None are assertion/violation-count mismatches, and these changes touch only tree-sitter and Roslyn-**host** rules (nothing in the workspace/project-loading path), so they fail identically on a clean checkout in this environment. Every test that exercises the changed rules passed: `csharp-positive`, `csharp-negative`, `csharp-positive-coverage`, the C# rule suites, the security/secret-scanner tests, and the JS suites.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_016uaCDWuTyoQrMdp28G7WYN)_