### PR TITLE
fix(build): build guard-runner and guard-generator before core in build:dist

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -56,8 +56,9 @@ fs.mkdirSync(DIST, { recursive: true });
 // 1. Build packages in dependency order:
 //      shared → analyzer
 //      spec-consolidator → contract-verifier → contract-extractor → core
+//      guard-runner → guard-generator → core
 //
-// core's tsc imports the three contract/spec packages, so their .d.ts
+// core's tsc imports the contract/spec/guard packages, so their .d.ts
 // files MUST exist before core compiles. The intra-package graph:
 //
 //   shared             ←  no truecourse deps
@@ -66,10 +67,12 @@ fs.mkdirSync(DIST, { recursive: true });
 //   spec-consolidator  ←  shared + llm
 //   contract-verifier  ←  shared + analyzer
 //   contract-extractor ←  shared + contract-verifier + spec-consolidator + llm
+//   guard-runner       ←  shared
+//   guard-generator    ←  guard-runner (+ shared)
 //   core               ←  all of the above
 //
 // Sequential order below honors that graph. Prior to this, fresh-checkout
-// `pnpm build:dist` failed at core's tsc because the contract/spec
+// `pnpm build:dist` failed at core's tsc because the contract/spec/guard
 // packages weren't built yet — and later at spec-consolidator's tsc because
 // its @truecourse/llm dependency wasn't built yet.
 console.log('\n=== Building packages ===');
@@ -79,6 +82,8 @@ run('pnpm --filter @truecourse/analyzer build');
 run('pnpm --filter @truecourse/spec-consolidator build');
 run('pnpm --filter @truecourse/contract-verifier build');
 run('pnpm --filter @truecourse/contract-extractor build');
+run('pnpm --filter @truecourse/guard-runner build');
+run('pnpm --filter @truecourse/guard-generator build');
 run('pnpm --filter @truecourse/core build');
 
 // 2. Build dashboard client (static export)


### PR DESCRIPTION
Fixes #793.

## Summary

`pnpm build:dist` fails on a clean checkout of `main`. `scripts/build.ts` builds workspace packages in a hand-maintained order but omits `@truecourse/guard-runner` and `@truecourse/guard-generator`, even though `@truecourse/core` now imports from both. When the script reaches the `core` build, `tsc` can't resolve those modules (`TS2307`), cascading into implicit-any errors (`TS7006`), and the build dies at the `core` step.

This has been broken since the v0.7.0 guard pipeline landed (commit `69697e9`), which added the two packages and the core imports but never updated `scripts/build.ts` (last touched in `25080c7`, pre-dating the guard work).

## Why it slipped through

- `pnpm build` (= `turbo build`) resolves order from the workspace dependency graph, so it builds the guard packages first and succeeds. PR CI (`test.yml`) uses `pnpm build`, so PR checks stayed green.
- Only `pnpm build:dist` (the manual order in `scripts/build.ts`) is broken — the path that produces the bundled `dist/cli.mjs` and is used by `publish.yml` for releases.

## Change

Add the two missing builds immediately before the existing `core` build, honoring their dependency graph (`guard-runner` needs only `shared`; `guard-generator` needs `guard-runner`), and update the ordering comment to document the guard packages.

## Verification

- `pnpm build:dist` now completes end-to-end; `core` compiles cleanly and `dist/cli.mjs` is produced.
- `node dist/cli.mjs --version` → `0.7.2`.

The C# Roslyn host step is unaffected by this change (it's tolerant of a missing .NET SDK by design).

## Follow-up (not in this PR)

Per the issue, consider a guard so this can't regress silently — e.g. drive `build:dist` from the same dependency topology `turbo` uses, or add a CI job that runs `build:dist` (not just `pnpm build`) on PRs, since the release path depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019m4CAynW1JuHgCtrz7KQuo)_