### PR TITLE
fix(analyzer): reconcile EF Core schemas across files

### DIFF
--- a/packages/analyzer/src/database-detector.ts
+++ b/packages/analyzer/src/database-detector.ts
@@ -3,7 +3,8 @@ import { join, resolve } from 'path'
 import type { FileAnalysis, DatabaseType, DatabaseInfo, DatabaseConnectionInfo, DatabaseDetectionResult, TableInfo, RelationInfo } from '@truecourse/shared'
 import { DATABASE_IMPORT_MAP, DOCKER_IMAGE_MAP } from './patterns/database-patterns.js'
 import { parsePrismaSchema } from './schema-parsers/prisma.js'
-import { SCHEMA_PARSERS } from './schema-parsers/registry.js'
+import { parseEfCoreProject, type EfCoreProjectFile } from './schema-parsers/efcore.js'
+import { EF_CORE_SCHEMA_PARSER, SCHEMA_PARSERS } from './schema-parsers/registry.js'
 import { readAllDependencies } from './service-detectors/registry.js'
 import type { Service } from './service-detector.js'
 
@@ -123,9 +124,69 @@ export function detectDatabases(
     schemaResults.set(dbType, existing)
   }
 
+  // EF Core is a model-scoped ORM: DbContext declarations, entity classes,
+  // navigation properties, and fluent mappings normally live in separate
+  // files. Parse all matching files together per service so those facts can be
+  // reconciled before emitting tables and relations.
+  const efParser = EF_CORE_SCHEMA_PARSER
+  if (efParser.scope === 'service') {
+    const efFiles: EfCoreProjectFile[] = []
+    const serviceByFile = new Map<string, Service>()
+    for (const service of services) {
+      for (const filePath of service.files) serviceByFile.set(filePath, service)
+    }
+    const efServiceNames = new Set(
+      detections
+        .filter((detection) => detection.driver.startsWith('efcore-'))
+        .map((detection) => detection.serviceName),
+    )
+    for (const analysis of analyses) {
+      if (!efParser.matchesImport(analysis)) continue
+      const service = serviceByFile.get(analysis.filePath)
+      if (service) efServiceNames.add(service.name)
+    }
+
+    for (const analysis of analyses) {
+      if (analysis.language !== 'csharp') continue
+
+      const service = serviceByFile.get(analysis.filePath)
+      const serviceName = service?.name ?? '__root__'
+      const hasEfEvidence = efParser.matchesImport(analysis)
+      if (!hasEfEvidence && !efServiceNames.has(serviceName)) continue
+
+      try {
+        const content = readFileSync(resolve(analysis.filePath), 'utf-8')
+
+        const providerTypes = detections
+          .filter((detection) =>
+            detection.serviceName === serviceName && detection.driver.startsWith('efcore-')
+          )
+          .map((detection) => detection.type)
+
+        efFiles.push({
+          filePath: analysis.filePath,
+          content,
+          serviceName,
+          providerTypes,
+        })
+      } catch {
+        // Skip files that can't be read
+      }
+    }
+
+    for (const result of parseEfCoreProject(efFiles)) {
+      if (result.dbType === null) continue
+      const existing = schemaResults.get(result.dbType) || { tables: [], relations: [] }
+      existing.tables.push(...result.tables)
+      existing.relations.push(...result.relations)
+      schemaResults.set(result.dbType, existing)
+    }
+  }
+
   // Import-based schema parsers (Drizzle, SQLAlchemy, etc.)
   for (const analysis of analyses) {
     for (const parser of SCHEMA_PARSERS) {
+      if (parser.scope === 'service') continue // handled repository-wide above
       if (!parser.matchesImport(analysis)) continue
 
       try {

--- a/packages/analyzer/src/schema-parsers/efcore.ts
+++ b/packages/analyzer/src/schema-parsers/efcore.ts
@@ -1,137 +1,1201 @@
-import type { TableInfo, ColumnInfo, RelationInfo } from '@truecourse/shared'
+import type {
+  ColumnInfo,
+  DatabaseType,
+  RelationInfo,
+  TableInfo,
+} from '@truecourse/shared'
+
+export interface EfCoreProjectFile {
+  filePath: string
+  content: string
+  serviceName: string
+  /** EF provider types detected for the containing service. */
+  providerTypes?: DatabaseType[]
+}
+
+export interface EfCoreProjectSchema {
+  dbType: DatabaseType | null
+  serviceName: string
+  contextName: string | null
+  tables: TableInfo[]
+  relations: RelationInfo[]
+}
+
+interface ParsedFile {
+  input: EfCoreProjectFile
+  masked: string
+  namespace: string
+  usings: string[]
+  entities: EntityCandidate[]
+  contexts: ContextCandidate[]
+  configurations: ConfigurationCandidate[]
+  providerHints: ProviderHint[]
+}
+
+interface EntityCandidate {
+  name: string
+  fullName: string
+  namespace: string
+  tableAttribute?: string
+  annotated: boolean
+  isAbstract: boolean
+  baseTypes: string[]
+  dbSets: DbSetCandidate[]
+  toTables: ToTableCandidate[]
+  appliedConfigurations: string[]
+  applyAllConfigurations: boolean
+  inlineProviderTypes: DatabaseType[]
+  properties: PropertyCandidate[]
+  file: ParsedFile
+}
+
+interface PropertyCandidate {
+  name: string
+  rawType: string
+  attributes: string
+  columnName?: string
+  navigationType?: string
+  collectionNavigationType?: string
+  foreignKeyNavigation?: string
+  isKey: boolean
+  isNullable: boolean
+  file: ParsedFile
+}
+
+interface ContextCandidate {
+  name: string
+  fullName: string
+  isAbstract: boolean
+  dbSets: DbSetCandidate[]
+  toTables: ToTableCandidate[]
+  baseTypes: string[]
+  appliedConfigurations: string[]
+  applyAllConfigurations: boolean
+  inlineProviderTypes: DatabaseType[]
+  file: ParsedFile
+}
+
+interface DbSetCandidate {
+  entityType: string
+  propertyName: string
+}
+
+interface ToTableCandidate {
+  entityType: string
+  tableName: string
+  file: ParsedFile
+}
+
+interface ConfigurationCandidate {
+  name: string
+  fullName: string
+  entityType: string
+  toTables: ToTableCandidate[]
+  file: ParsedFile
+}
+
+interface ProviderHint {
+  contextType: string
+  dbType: DatabaseType
+  file: ParsedFile
+}
+
+interface EntityBinding {
+  entity: EntityCandidate
+  dbSetName?: string
+  toTableName?: string
+}
+
+interface EntityIndex {
+  byFullName: Map<string, EntityCandidate>
+  bySimpleName: Map<string, EntityCandidate[]>
+}
 
 /**
- * Parse an Entity Framework Core file and extract tables and relations.
+ * Parse all EF Core source files belonging to one or more services.
  *
- * Handles two file shapes:
- * - DbContext files: `public DbSet<Order> Orders { get; set; }` — yields the
- *   table names the context exposes (entity properties live in other files).
- * - Entity files: classes with `[Table("…")]` / `[Key]` annotations — yields
- *   tables with full column info ([Column] mappings, nullable `?` types,
- *   foreign keys by `<Nav>Id` convention).
- *
- * Convention-only entities (no annotations at all) are intentionally not
- * guessed at from bare POCOs — that would turn every DTO into a table.
+ * EF's model is repository-scoped evidence: the DbContext, entity classes, and
+ * fluent configuration normally live in different files. Keeping those facts
+ * separate until this reconciliation pass prevents empty DbSet stubs, duplicate
+ * class-name tables, and relation endpoints that do not name emitted tables.
  */
+export function parseEfCoreProject(files: EfCoreProjectFile[]): EfCoreProjectSchema[] {
+  const parsedFiles = files.map(parseProjectFile)
+  const filesByService = new Map<string, ParsedFile[]>()
+
+  for (const file of parsedFiles) {
+    const serviceFiles = filesByService.get(file.input.serviceName) ?? []
+    serviceFiles.push(file)
+    filesByService.set(file.input.serviceName, serviceFiles)
+  }
+
+  const schemas: EfCoreProjectSchema[] = []
+
+  for (const [serviceName, serviceFiles] of filesByService) {
+    const { entities, contexts } = reconcileClassDeclarations(serviceFiles)
+    const configurations = serviceFiles.flatMap((file) => file.configurations)
+    const providerHints = serviceFiles.flatMap((file) => file.providerHints)
+    const index = buildEntityIndex(entities)
+    const providerTypes = dedupe(
+      serviceFiles.flatMap((file) => file.input.providerTypes ?? []),
+    )
+    const concreteContexts = contexts.filter((context) => !context.isAbstract)
+    if (concreteContexts.length > 0) {
+      for (const context of concreteContexts) {
+        const schema = buildContextSchema(
+          serviceName,
+          context,
+          concreteContexts.length,
+          entities,
+          index,
+          providerTypes,
+          contexts,
+          configurations,
+          providerHints,
+        )
+        if (schema.tables.length > 0) schemas.push(schema)
+      }
+    }
+
+    // Preserve annotated entity-only schemas when a project has no context in
+    // the scanned surface. When there is exactly one context, annotated types
+    // are already included in that model. With several contexts, unclaimed
+    // annotated types are deliberately left unassigned instead of guessing.
+    if (concreteContexts.length === 0) {
+      const annotated = entities.filter((entity) => entity.annotated)
+      if (annotated.length > 0) {
+        const explicitTypes = dedupe(
+          serviceFiles
+            .map((file) => detectProviderFromContent(file.input.content))
+            .filter((type): type is DatabaseType => type !== undefined),
+        )
+        const dbType = chooseProvider(explicitTypes, providerTypes)
+        const schema = buildStandaloneSchema(serviceName, dbType, annotated, index)
+        if (schema.tables.length > 0) schemas.push(schema)
+      }
+    }
+  }
+
+  return schemas
+}
+
+/** Parse one EF Core source file. Kept as the registry's single-file seam. */
 export function parseEfCoreSchema(content: string): {
   tables: TableInfo[]
   relations: RelationInfo[]
 } {
-  const tables: TableInfo[] = []
-  const relations: RelationInfo[] = []
+  const schemas = parseEfCoreProject([
+    {
+      filePath: '<memory>',
+      content,
+      serviceName: '<memory>',
+      providerTypes: [detectProviderFromContent(content)]
+        .filter((type): type is DatabaseType => type !== undefined),
+    },
+  ])
 
-  // ---- DbContext shape: DbSet<Entity> PropertyName ----
-  // EF's default table name IS the DbSet property name. When the entity class
-  // is declared in the same file, its columns merge into this table below;
-  // otherwise the name-only table still records the schema surface.
-  const dbSets = [...content.matchAll(/DbSet<(\w+)>\s+(\w+)\s*(?:\{|=>|;)/g)]
-  const dbSetByEntity = new Map<string, string>()
-  for (const m of dbSets) {
-    dbSetByEntity.set(m[1], m[2])
+  return {
+    tables: schemas.flatMap((schema) => schema.tables),
+    relations: schemas.flatMap((schema) => schema.relations),
   }
+}
 
-  // ---- Entity shape: annotated classes ----
-  // Split on top-level class/record declarations and inspect each body.
-  const classRegex = /(?:\[[^\]]*\]\s*)*(?:public|internal)?\s*(?:sealed\s+|partial\s+)*(?:class|record)\s+(\w+)[^{]*\{/g
+function parseProjectFile(input: EfCoreProjectFile): ParsedFile {
+  const masked = maskCSharpTrivia(input.content)
+  const file = {
+    input,
+    masked,
+    namespace: extractNamespace(masked),
+    usings: extractUsings(masked),
+    entities: [],
+    contexts: [],
+    configurations: [],
+    providerHints: [],
+  } as ParsedFile
+
+  file.providerHints = extractProviderHints(file)
+
+  const classRegex = /\b(?:(?:public|internal|protected|private)\s+)?(?:(?:abstract|sealed|static|partial)\s+)*(?:class|record(?:\s+class)?)\s+([A-Za-z_]\w*)([^;{}]*)\{/g
   let match: RegExpExecArray | null
-  while ((match = classRegex.exec(content)) !== null) {
-    const className = match[1]
-    // Attributes immediately preceding the declaration
-    const preceding = content.slice(Math.max(0, match.index - 300), match.index)
-    const tableAttr = preceding.match(/\[Table\(\s*"([^"]+)"/)
 
-    const body = extractBracedBlock(content, match.index + match[0].length - 1)
-    if (body === null) continue
+  while ((match = classRegex.exec(masked)) !== null) {
+    const name = match[1]
+    if (name === 'class' || name === 'struct') continue
 
-    const hasKey = /\[Key\]/.test(body)
-    if (!tableAttr && !hasKey) continue // not provably an entity
+    const openBrace = match.index + match[0].lastIndexOf('{')
+    const closeBrace = findMatchingBrace(masked, openBrace)
+    if (closeBrace === -1) continue
 
-    const columns: ColumnInfo[] = []
-    let primaryKey: string | undefined
+    const classNamespace = extractNamespace(masked.slice(0, match.index)) || file.namespace
+    const fullName = classNamespace ? `${classNamespace}.${name}` : name
+    const originalBody = input.content.slice(openBrace + 1, closeBrace)
+    const maskedBody = masked.slice(openBrace + 1, closeBrace)
+    const headerTail = match[2]
+    const isAbstract = /\babstract\b/.test(match[0].slice(0, match[0].indexOf(name)))
+    const baseTypes = extractBaseTypes(headerTail)
+    const dbSets = extractDbSets(maskedBody)
+    const toTables = extractToTables(originalBody, maskedBody, file)
+    const appliedConfigurations = extractAppliedConfigurations(maskedBody)
+    const applyAllConfigurations = /\bApplyConfigurationsFromAssembly\s*\(/.test(maskedBody)
+    const inlineProvider = detectProviderFromMasked(maskedBody)
+    const inlineProviderTypes = inlineProvider ? [inlineProvider] : []
+    const configurationEntityType = extractConfigurationEntityType(baseTypes)
+    const isDbContext = baseTypes.some((baseType) => {
+      const simpleName = simpleTypeName(baseType)
+      return simpleName === 'DbContext' || simpleName === 'IdentityDbContext'
+    })
 
-    // Property declarations with optional preceding attributes
-    const propRegex = /((?:\[[^\]]*\]\s*)*)public\s+(?:virtual\s+)?([\w?<>.]+)\s+(\w+)\s*\{\s*get;/g
-    let prop: RegExpExecArray | null
-    const navProps: { name: string; type: string }[] = []
-    while ((prop = propRegex.exec(body)) !== null) {
-      const attrs = prop[1]
-      const rawType = prop[2]
-      const propName = prop[3]
-
-      if (/\[NotMapped\]/.test(attrs)) continue
-
-      // Collection / reference navigation properties → relations, not columns
-      const collection = rawType.match(/^(?:ICollection|List|IEnumerable|HashSet)<(\w+)>$/)
-      if (collection) {
-        navProps.push({ name: propName, type: collection[1] })
-        continue
-      }
-      if (/^[A-Z]/.test(rawType) && !KNOWN_VALUE_TYPES.has(rawType.replace(/\?$/, ''))) {
-        // PascalCase non-BCL type — likely a reference navigation
-        navProps.push({ name: propName, type: rawType.replace(/\?$/, '') })
-        continue
-      }
-
-      const columnAttr = attrs.match(/\[Column\(\s*"([^"]+)"/)
-      const columnName = columnAttr ? columnAttr[1] : snakeCase(propName)
-      const isKey = /\[Key\]/.test(attrs) || propName === 'Id' || propName === `${className}Id`
-      const foreignKey = propName.endsWith('Id') && propName !== 'Id' && propName !== `${className}Id`
-
-      const column: ColumnInfo = {
-        name: columnName,
-        type: rawType.replace(/\?$/, ''),
-        ...(rawType.endsWith('?') ? { isNullable: true } : {}),
-        ...(isKey && !primaryKey ? { isPrimaryKey: true } : {}),
-        ...(foreignKey ? { isForeignKey: true, referencesTable: snakeCase(propName.slice(0, -2)) } : {}),
-      }
-      if (isKey && !primaryKey) primaryKey = columnName
-      columns.push(column)
-
-      if (foreignKey) {
-        relations.push({
-          sourceTable: tableAttr ? tableAttr[1] : snakeCase(className),
-          targetTable: snakeCase(propName.slice(0, -2)),
-          relationType: 'one-to-many',
-          foreignKeyColumn: columnName,
-        })
-      }
+    if (configurationEntityType) {
+      file.configurations.push({
+        name,
+        fullName,
+        entityType: configurationEntityType,
+        toTables: extractConfigurationToTables(originalBody, maskedBody, configurationEntityType, file),
+        file,
+      })
+      classRegex.lastIndex = closeBrace + 1
+      continue
     }
 
-    // Naming precedence: explicit [Table("…")] > same-file DbSet property
-    // name (EF's convention default) > snake_cased class name.
-    const tableName = tableAttr ? tableAttr[1] : dbSetByEntity.get(className) ?? snakeCase(className)
-    tables.push({
-      name: tableName,
-      columns,
-      ...(primaryKey ? { primaryKey } : {}),
-      aliases: dedupe([className, snakeCase(className), snakeCase(tableName)]).filter((a) => a !== tableName),
-    })
+    if (isDbContext) {
+      file.contexts.push({
+        name,
+        fullName,
+        isAbstract,
+        dbSets,
+        toTables,
+        baseTypes,
+        appliedConfigurations,
+        applyAllConfigurations,
+        inlineProviderTypes,
+        file,
+      })
+    } else {
+      const attributes = attributesBefore(input.content, masked, match.index)
+      const tableAttribute = extractStringAttribute(attributes, 'Table')
+      const properties = extractProperties(originalBody, maskedBody, name, file)
+      file.entities.push({
+        name,
+        fullName,
+        namespace: classNamespace,
+        tableAttribute,
+        annotated: tableAttribute !== undefined
+          || properties.some((property) => /\[\s*Key\s*\]/.test(property.attributes)),
+        isAbstract,
+        baseTypes,
+        dbSets,
+        toTables,
+        appliedConfigurations,
+        applyAllConfigurations,
+        inlineProviderTypes,
+        properties,
+        file,
+      })
+    }
 
-    // Collection navigations imply the reverse FK relation lives on the
-    // other entity; FK-column relations are already recorded above, so
-    // navProps only contribute when no matching Id column exists.
-    void navProps
+    classRegex.lastIndex = closeBrace + 1
   }
 
-  // Name-only tables for DbSets whose entity class lives in another file
-  const emittedNames = new Set(tables.map((t) => t.name))
-  const emittedAliases = new Set(tables.flatMap((t) => t.aliases ?? []))
-  for (const [entityName, setName] of dbSetByEntity) {
-    if (emittedNames.has(setName) || emittedAliases.has(entityName)) continue
+  return file
+}
+
+function reconcileClassDeclarations(
+  files: ParsedFile[],
+): { entities: EntityCandidate[]; contexts: ContextCandidate[] } {
+  const entities = mergeEntityDeclarations(files.flatMap((file) => file.entities))
+  const contexts = mergeContextDeclarations(files.flatMap((file) => file.contexts))
+
+  // A partial declaration may omit the base list. Once any part proves the
+  // type is a context, absorb DbSet/configuration facts from every other part.
+  for (const context of contexts) {
+    const partialIndex = entities.findIndex((entity) => entity.fullName === context.fullName)
+    if (partialIndex === -1) continue
+    mergeContextFacts(context, entities[partialIndex])
+    entities.splice(partialIndex, 1)
+  }
+
+  // Resolve indirect context inheritance using the declarations available in
+  // the service (AppContext : BaseContext : DbContext).
+  let changed = true
+  while (changed) {
+    changed = false
+    const declarations = [...contexts, ...entities]
+    for (let i = entities.length - 1; i >= 0; i--) {
+      const entity = entities[i]
+      const derivesFromContext = entity.baseTypes.some((baseType) => {
+        const base = resolveNamedCandidate(baseType, entity.file, declarations)
+        return base !== undefined && contexts.some((context) => context.fullName === base.fullName)
+      })
+      if (!derivesFromContext) continue
+
+      contexts.push({
+        name: entity.name,
+        fullName: entity.fullName,
+        isAbstract: entity.isAbstract,
+        dbSets: entity.dbSets,
+        toTables: entity.toTables,
+        baseTypes: entity.baseTypes,
+        appliedConfigurations: entity.appliedConfigurations,
+        applyAllConfigurations: entity.applyAllConfigurations,
+        inlineProviderTypes: entity.inlineProviderTypes,
+        file: entity.file,
+      })
+      entities.splice(i, 1)
+      changed = true
+    }
+  }
+
+  inheritContextFacts(contexts)
+  return { entities, contexts }
+}
+
+function mergeEntityDeclarations(parts: EntityCandidate[]): EntityCandidate[] {
+  const grouped = groupBy(parts, (part) => part.fullName)
+  return [...grouped.values()].map((declarations) => {
+    const first = declarations[0]
+    return {
+      ...first,
+      tableAttribute: declarations.find((part) => part.tableAttribute)?.tableAttribute,
+      annotated: declarations.some((part) => part.annotated),
+      isAbstract: declarations.some((part) => part.isAbstract),
+      baseTypes: dedupe(declarations.flatMap((part) => part.baseTypes)),
+      dbSets: dedupeBy(
+        declarations.flatMap((part) => part.dbSets),
+        (dbSet) => `${dbSet.entityType}:${dbSet.propertyName}`,
+      ),
+      toTables: declarations.flatMap((part) => part.toTables),
+      appliedConfigurations: dedupe(
+        declarations.flatMap((part) => part.appliedConfigurations),
+      ),
+      applyAllConfigurations: declarations.some((part) => part.applyAllConfigurations),
+      inlineProviderTypes: dedupe(
+        declarations.flatMap((part) => part.inlineProviderTypes),
+      ),
+      properties: dedupeBy(
+        declarations.flatMap((part) => part.properties),
+        (property) => property.name,
+      ),
+    }
+  })
+}
+
+function mergeContextDeclarations(parts: ContextCandidate[]): ContextCandidate[] {
+  const grouped = groupBy(parts, (part) => part.fullName)
+  return [...grouped.values()].map((declarations) => {
+    const first = declarations[0]
+    return {
+      ...first,
+      isAbstract: declarations.some((part) => part.isAbstract),
+      dbSets: dedupeBy(
+        declarations.flatMap((part) => part.dbSets),
+        (dbSet) => `${dbSet.entityType}:${dbSet.propertyName}`,
+      ),
+      toTables: declarations.flatMap((part) => part.toTables),
+      baseTypes: dedupe(declarations.flatMap((part) => part.baseTypes)),
+      appliedConfigurations: dedupe(
+        declarations.flatMap((part) => part.appliedConfigurations),
+      ),
+      applyAllConfigurations: declarations.some((part) => part.applyAllConfigurations),
+      inlineProviderTypes: dedupe(
+        declarations.flatMap((part) => part.inlineProviderTypes),
+      ),
+    }
+  })
+}
+
+function mergeContextFacts(context: ContextCandidate, partial: EntityCandidate): void {
+  context.dbSets = dedupeBy(
+    [...context.dbSets, ...partial.dbSets],
+    (dbSet) => `${dbSet.entityType}:${dbSet.propertyName}`,
+  )
+  context.toTables.push(...partial.toTables)
+  context.baseTypes = dedupe([...context.baseTypes, ...partial.baseTypes])
+  context.appliedConfigurations = dedupe([
+    ...context.appliedConfigurations,
+    ...partial.appliedConfigurations,
+  ])
+  context.applyAllConfigurations ||= partial.applyAllConfigurations
+  context.inlineProviderTypes = dedupe([
+    ...context.inlineProviderTypes,
+    ...partial.inlineProviderTypes,
+  ])
+}
+
+function inheritContextFacts(contexts: ContextCandidate[]): void {
+  const applied = new Set<string>()
+  const visiting = new Set<string>()
+
+  const apply = (context: ContextCandidate): void => {
+    if (applied.has(context.fullName) || visiting.has(context.fullName)) return
+    visiting.add(context.fullName)
+
+    for (const baseType of context.baseTypes) {
+      const baseContext = resolveNamedCandidate(baseType, context.file, contexts)
+      if (!baseContext || baseContext.fullName === context.fullName) continue
+      apply(baseContext)
+
+      const dbSets = new Map<string, DbSetCandidate>()
+      for (const dbSet of [...baseContext.dbSets, ...context.dbSets]) {
+        dbSets.set(normalizeTypeReference(dbSet.entityType), dbSet)
+      }
+      context.dbSets = [...dbSets.values()]
+      context.toTables = [...baseContext.toTables, ...context.toTables]
+      context.appliedConfigurations = dedupe([
+        ...baseContext.appliedConfigurations,
+        ...context.appliedConfigurations,
+      ])
+      context.applyAllConfigurations ||= baseContext.applyAllConfigurations
+      context.inlineProviderTypes = dedupe([
+        ...baseContext.inlineProviderTypes,
+        ...context.inlineProviderTypes,
+      ])
+    }
+
+    visiting.delete(context.fullName)
+    applied.add(context.fullName)
+  }
+
+  for (const context of contexts) apply(context)
+}
+
+function buildContextSchema(
+  serviceName: string,
+  context: ContextCandidate,
+  contextCount: number,
+  serviceEntities: EntityCandidate[],
+  index: EntityIndex,
+  serviceProviderTypes: DatabaseType[],
+  serviceContexts: ContextCandidate[],
+  configurations: ConfigurationCandidate[],
+  providerHints: ProviderHint[],
+): EfCoreProjectSchema {
+  const bindings = new Map<string, EntityBinding>()
+  const unresolvedDbSets: DbSetCandidate[] = []
+
+  for (const dbSet of context.dbSets) {
+    const entity = resolveEntityReference(dbSet.entityType, context.file, index)
+    if (!entity) {
+      unresolvedDbSets.push(dbSet)
+      continue
+    }
+    const binding = bindings.get(entity.fullName) ?? { entity }
+    binding.dbSetName ??= dbSet.propertyName
+    bindings.set(entity.fullName, binding)
+  }
+
+  const activeConfigurations = context.applyAllConfigurations
+    ? configurations
+    : context.appliedConfigurations
+      .map((reference) => resolveNamedCandidate(reference, context.file, configurations))
+      .filter((candidate): candidate is ConfigurationCandidate => candidate !== undefined)
+  const tableMappings = [
+    ...context.toTables,
+    ...activeConfigurations.flatMap((configuration) => configuration.toTables),
+  ]
+
+  for (const mapping of tableMappings) {
+    const entity = resolveEntityReference(mapping.entityType, mapping.file, index)
+    if (!entity) continue
+    const binding = bindings.get(entity.fullName) ?? { entity }
+    binding.toTableName = mapping.tableName
+    bindings.set(entity.fullName, binding)
+  }
+
+  // A single context owns the service's provable annotated entities. With
+  // multiple contexts we require DbSet/ToTable/navigation evidence so simple
+  // class-name collisions are never merged across model scopes.
+  if (contextCount === 1) {
+    for (const entity of serviceEntities) {
+      if (!entity.annotated) continue
+      bindings.set(entity.fullName, bindings.get(entity.fullName) ?? { entity })
+    }
+  }
+
+  addNavigationClosure(bindings, index)
+  const { tables, relations } = emitBindings(bindings, index)
+
+  for (const dbSet of unresolvedDbSets) {
     tables.push({
-      name: setName,
+      name: dbSet.propertyName,
       columns: [],
-      aliases: dedupe([entityName, snakeCase(setName), snakeCase(entityName)]).filter((a) => a !== setName),
+      aliases: dedupe([
+        normalizeTypeReference(dbSet.entityType),
+        snakeCase(dbSet.entityType.split('.').pop() ?? dbSet.entityType),
+        snakeCase(dbSet.propertyName),
+      ]).filter((alias) => alias && alias !== dbSet.propertyName),
     })
+  }
+
+  const configuredProviders = providerHints
+    .filter((hint) =>
+      resolveNamedCandidate(hint.contextType, hint.file, serviceContexts)?.fullName
+        === context.fullName
+    )
+    .map((hint) => hint.dbType)
+  const explicitProviders = dedupe([
+    ...context.inlineProviderTypes,
+    ...configuredProviders,
+  ])
+  const dbType = chooseProvider(explicitProviders, serviceProviderTypes)
+
+  return {
+    dbType,
+    serviceName,
+    contextName: context.fullName,
+    tables,
+    relations,
+  }
+}
+
+function buildStandaloneSchema(
+  serviceName: string,
+  dbType: DatabaseType | null,
+  entities: EntityCandidate[],
+  index: EntityIndex,
+): EfCoreProjectSchema {
+  const bindings = new Map<string, EntityBinding>(
+    entities.map((entity) => [entity.fullName, { entity }]),
+  )
+  addNavigationClosure(bindings, index)
+  const { tables, relations } = emitBindings(bindings, index)
+
+  return { dbType, serviceName, contextName: null, tables, relations }
+}
+
+function emitBindings(
+  bindings: Map<string, EntityBinding>,
+  index: EntityIndex,
+): { tables: TableInfo[]; relations: RelationInfo[] } {
+  const canonicalNames = new Map<string, string>()
+  for (const [identity, binding] of bindings) {
+    canonicalNames.set(identity, canonicalTableName(binding))
+  }
+
+  const tables: TableInfo[] = []
+  const relations: RelationInfo[] = []
+  for (const binding of bindings.values()) {
+    const built = buildEntityTable(
+      binding,
+      canonicalNames.get(binding.entity.fullName)!,
+      canonicalNames,
+      index,
+    )
+    tables.push(built.table)
+    relations.push(...built.relations)
   }
 
   return { tables, relations }
 }
 
+function addNavigationClosure(
+  bindings: Map<string, EntityBinding>,
+  index: EntityIndex,
+): void {
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const binding of [...bindings.values()]) {
+      for (const property of binding.entity.properties) {
+        const targetType = property.navigationType ?? property.collectionNavigationType
+        if (!targetType) continue
+        const target = resolveEntityReference(targetType, property.file, index)
+        if (!target || bindings.has(target.fullName)) continue
+        bindings.set(target.fullName, { entity: target })
+        changed = true
+      }
+    }
+  }
+}
+
+function buildEntityTable(
+  binding: EntityBinding,
+  tableName: string,
+  canonicalNames: Map<string, string>,
+  index: EntityIndex,
+): { table: TableInfo; relations: RelationInfo[] } {
+  const { entity } = binding
+  const columns: ColumnInfo[] = []
+  const relations: RelationInfo[] = []
+  const navigations = new Map(
+    entity.properties
+      .filter((property) => property.navigationType)
+      .map((property) => [property.name, property]),
+  )
+  let primaryKey: string | undefined
+
+  for (const property of entity.properties) {
+    if (property.navigationType || property.collectionNavigationType) continue
+
+    const columnName = property.columnName ?? snakeCase(property.name)
+    const isKey = property.isKey || property.name === 'Id' || property.name === `${entity.name}Id`
+    const conventionNavigation =
+      property.name.endsWith('Id') && property.name !== 'Id' && property.name !== `${entity.name}Id`
+        ? property.name.slice(0, -2)
+        : undefined
+    const navigationName = property.foreignKeyNavigation ?? conventionNavigation
+    const navigation = navigationName
+      ? navigations.get(navigationName)
+      : entity.properties.find((candidate) =>
+        candidate.navigationType && candidate.foreignKeyNavigation === property.name
+      )
+    const targetEntity = navigation?.navigationType
+      ? resolveEntityReference(navigation.navigationType, navigation.file, index)
+      : undefined
+    const targetTable = targetEntity ? canonicalNames.get(targetEntity.fullName) : undefined
+    const isForeignKey = targetTable !== undefined || property.foreignKeyNavigation !== undefined
+
+    columns.push({
+      name: columnName,
+      type: normalizePropertyType(property.rawType),
+      ...(property.isNullable ? { isNullable: true } : {}),
+      ...(isKey && !primaryKey ? { isPrimaryKey: true } : {}),
+      ...(isForeignKey ? { isForeignKey: true } : {}),
+      ...(targetTable ? { referencesTable: targetTable } : {}),
+    })
+
+    if (isKey && !primaryKey) primaryKey = columnName
+    if (targetTable) {
+      relations.push({
+        sourceTable: tableName,
+        targetTable,
+        relationType: 'one-to-many',
+        foreignKeyColumn: columnName,
+      })
+    }
+  }
+
+  const aliases = dedupe([
+    entity.name,
+    entity.fullName,
+    snakeCase(entity.name),
+    binding.dbSetName,
+    binding.dbSetName ? snakeCase(binding.dbSetName) : undefined,
+    entity.tableAttribute,
+  ].filter((value): value is string => value !== undefined && value.length > 0))
+    .filter((alias) => alias !== tableName)
+
+  return {
+    table: {
+      name: tableName,
+      columns,
+      ...(primaryKey ? { primaryKey } : {}),
+      ...(aliases.length > 0 ? { aliases } : {}),
+    },
+    relations,
+  }
+}
+
+function canonicalTableName(binding: EntityBinding): string {
+  return binding.toTableName
+    ?? binding.entity.tableAttribute
+    ?? binding.dbSetName
+    ?? snakeCase(binding.entity.name)
+}
+
+function buildEntityIndex(entities: EntityCandidate[]): EntityIndex {
+  const byFullName = new Map<string, EntityCandidate>()
+  const bySimpleName = new Map<string, EntityCandidate[]>()
+
+  for (const entity of entities) {
+    byFullName.set(entity.fullName, entity)
+    const sameName = bySimpleName.get(entity.name) ?? []
+    sameName.push(entity)
+    bySimpleName.set(entity.name, sameName)
+  }
+
+  return { byFullName, bySimpleName }
+}
+
+function resolveNamedCandidate<T extends { name: string; fullName: string; file: ParsedFile }>(
+  rawType: string,
+  sourceFile: ParsedFile,
+  candidates: T[],
+): T | undefined {
+  const typeName = normalizeNamedTypeReference(rawType)
+  const simpleName = typeName.split('.').pop() ?? typeName
+  const byFullName = new Map(candidates.map((candidate) => [candidate.fullName, candidate]))
+
+  const exact = byFullName.get(typeName)
+  if (exact) return exact
+
+  if (typeName.includes('.') && sourceFile.namespace) {
+    const relative = byFullName.get(`${sourceFile.namespace}.${typeName}`)
+    if (relative) return relative
+  }
+
+  if (sourceFile.namespace) {
+    const sameNamespace = byFullName.get(`${sourceFile.namespace}.${simpleName}`)
+    if (sameNamespace) return sameNamespace
+  }
+
+  const imported = sourceFile.usings
+    .map((namespace) => byFullName.get(`${namespace}.${simpleName}`))
+    .filter((candidate): candidate is T => candidate !== undefined)
+  if (imported.length === 1) return imported[0]
+
+  const sameName = candidates.filter((candidate) => candidate.name === simpleName)
+  return sameName.length === 1 ? sameName[0] : undefined
+}
+
+function resolveEntityReference(
+  rawType: string,
+  sourceFile: ParsedFile,
+  index: EntityIndex,
+): EntityCandidate | undefined {
+  const typeName = normalizeTypeReference(rawType)
+  const simpleName = typeName.split('.').pop() ?? typeName
+
+  const exact = index.byFullName.get(typeName)
+  if (exact) return exact
+
+  if (typeName.includes('.') && sourceFile.namespace) {
+    const relative = index.byFullName.get(`${sourceFile.namespace}.${typeName}`)
+    if (relative) return relative
+  }
+
+  if (sourceFile.namespace) {
+    const sameNamespace = index.byFullName.get(`${sourceFile.namespace}.${simpleName}`)
+    if (sameNamespace) return sameNamespace
+  }
+
+  const imported = sourceFile.usings
+    .map((namespace) => index.byFullName.get(`${namespace}.${simpleName}`))
+    .filter((candidate): candidate is EntityCandidate => candidate !== undefined)
+  if (imported.length === 1) return imported[0]
+
+  const candidates = index.bySimpleName.get(simpleName) ?? []
+  return candidates.length === 1 ? candidates[0] : undefined
+}
+
+function extractDbSets(maskedBody: string): DbSetCandidate[] {
+  const dbSets: DbSetCandidate[] = []
+  const regex = /\bpublic\s+(?:(?:virtual|required|new)\s+)*(?:Microsoft\.EntityFrameworkCore\.)?DbSet\s*<\s*([^>]+?)\s*>\s*\??\s+([A-Za-z_]\w*)\s*(?=\{|=>)/g
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(maskedBody)) !== null) {
+    dbSets.push({ entityType: match[1].trim(), propertyName: match[2] })
+  }
+  return dbSets
+}
+
+function extractToTables(
+  originalBody: string,
+  maskedBody: string,
+  file: ParsedFile,
+): ToTableCandidate[] {
+  const mappings: ToTableCandidate[] = []
+  const entityRegex = /\bEntity\s*<\s*([^>]+?)\s*>\s*\(/g
+  const entityMatches = [...maskedBody.matchAll(entityRegex)]
+
+  for (let i = 0; i < entityMatches.length; i++) {
+    const match = entityMatches[i]
+    const segmentStart = match.index! + match[0].length
+    const segmentEnd = entityMatches[i + 1]?.index ?? maskedBody.length
+    const segment = maskedBody.slice(segmentStart, segmentEnd)
+    const toTable = /\bToTable\s*\(/.exec(segment)
+    if (!toTable) continue
+
+    const callStart = segmentStart + toTable.index
+    const openParen = maskedBody.indexOf('(', callStart)
+    const closeParen = findMatchingDelimiter(maskedBody, openParen, '(', ')')
+    if (closeParen === -1 || closeParen >= segmentEnd) continue
+
+    const originalCall = originalBody.slice(callStart, closeParen + 1)
+    const tableMatch = /\bToTable\s*\(\s*"((?:\\.|[^"\\])*)"/.exec(originalCall)
+    if (!tableMatch) continue
+    mappings.push({
+      entityType: match[1].trim(),
+      tableName: tableMatch[1].replace(/\\"/g, '"'),
+      file,
+    })
+  }
+
+  return mappings
+}
+
+function extractConfigurationToTables(
+  originalBody: string,
+  maskedBody: string,
+  entityType: string,
+  file: ParsedFile,
+): ToTableCandidate[] {
+  const mappings: ToTableCandidate[] = []
+  const regex = /\bToTable\s*\(/g
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(maskedBody)) !== null) {
+    const openParen = maskedBody.indexOf('(', match.index)
+    const closeParen = findMatchingDelimiter(maskedBody, openParen, '(', ')')
+    if (closeParen === -1) continue
+    const originalCall = originalBody.slice(match.index, closeParen + 1)
+    const tableMatch = /\bToTable\s*\(\s*"((?:\\.|[^"\\])*)"/.exec(originalCall)
+    if (!tableMatch) continue
+    mappings.push({
+      entityType,
+      tableName: tableMatch[1].replace(/\\"/g, '"'),
+      file,
+    })
+    regex.lastIndex = closeParen + 1
+  }
+
+  return mappings
+}
+
+function extractAppliedConfigurations(maskedBody: string): string[] {
+  return [
+    ...maskedBody.matchAll(
+      /\bApplyConfiguration\s*\(\s*new\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)/g,
+    ),
+  ].map((match) => match[1])
+}
+
+function extractProviderHints(file: ParsedFile): ProviderHint[] {
+  const hints: ProviderHint[] = []
+  const regex = /\bAddDbContext(?:Pool|Factory)?\s*<\s*([^>]+?)\s*>\s*\(/g
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(file.masked)) !== null) {
+    const openParen = file.masked.indexOf('(', match.index)
+    const closeParen = findMatchingDelimiter(file.masked, openParen, '(', ')')
+    if (closeParen === -1) continue
+    const dbType = detectProviderFromMasked(file.masked.slice(openParen, closeParen + 1))
+    if (dbType) hints.push({ contextType: match[1].trim(), dbType, file })
+    regex.lastIndex = closeParen + 1
+  }
+
+  return hints
+}
+
+function extractBaseTypes(headerTail: string): string[] {
+  const colon = headerTail.indexOf(':')
+  if (colon === -1) return []
+  const clause = headerTail.slice(colon + 1).split(/\bwhere\b/, 1)[0]
+  return splitTopLevel(clause, ',').map((part) => part.trim()).filter(Boolean)
+}
+
+function extractConfigurationEntityType(baseTypes: string[]): string | undefined {
+  for (const baseType of baseTypes) {
+    const match = /(?:^|\.)IEntityTypeConfiguration\s*<\s*(.+)\s*>$/.exec(baseType)
+    if (match) return match[1].trim()
+  }
+  return undefined
+}
+
+function extractProperties(
+  originalBody: string,
+  maskedBody: string,
+  className: string,
+  file: ParsedFile,
+): PropertyCandidate[] {
+  const properties: PropertyCandidate[] = []
+  const regex = /((?:\[[^\]]*\]\s*)*)\bpublic\s+(?:(?:virtual|required|new|override)\s+)*([\w.?:<>,\[\]]+)\s+([A-Za-z_]\w*)\s*\{\s*(?:get|init)\s*;/g
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(maskedBody)) !== null) {
+    const rawType = match[2]
+    const name = match[3]
+    const attributeLength = match[1].length
+    const attributes = originalBody.slice(match.index, match.index + attributeLength)
+    if (/\[\s*NotMapped\b/.test(attributes)) continue
+
+    const collectionNavigationType = extractCollectionElement(rawType)
+    const normalizedType = normalizePropertyType(rawType)
+    const navigationType = !collectionNavigationType && !isKnownValueType(normalizedType)
+      ? normalizedType
+      : undefined
+    const columnName = extractStringAttribute(attributes, 'Column')
+    const foreignKeyNavigation = extractForeignKeyNavigation(attributes)
+    const isKey = /\[\s*Key\s*\]/.test(attributes)
+      || name === 'Id'
+      || name === `${className}Id`
+
+    properties.push({
+      name,
+      rawType,
+      attributes,
+      columnName,
+      navigationType,
+      collectionNavigationType,
+      foreignKeyNavigation,
+      isKey,
+      isNullable: rawType.trim().endsWith('?'),
+      file,
+    })
+  }
+
+  return properties
+}
+
+function attributesBefore(
+  content: string,
+  maskedContent: string,
+  declarationStart: number,
+): string {
+  let cursor = skipWhitespaceBackward(maskedContent, declarationStart)
+  let attributeStart = declarationStart
+  let foundAttribute = false
+
+  while (cursor > 0 && maskedContent[cursor - 1] === ']') {
+    const openBracket = findMatchingOpeningDelimiter(maskedContent, cursor - 1, '[', ']')
+    if (openBracket === -1) break
+    attributeStart = openBracket
+    foundAttribute = true
+    cursor = skipWhitespaceBackward(maskedContent, openBracket)
+  }
+
+  return foundAttribute ? content.slice(attributeStart, declarationStart) : ''
+}
+
+function extractStringAttribute(attributes: string, attributeName: string): string | undefined {
+  const regex = new RegExp(`\\[\\s*(?:[\\w.]+\\.)?${attributeName}(?:Attribute)?\\s*\\(\\s*"([^"]+)"`)
+  return regex.exec(attributes)?.[1]
+}
+
+function extractForeignKeyNavigation(attributes: string): string | undefined {
+  const stringForm = /\[\s*(?:[\w.]+\.)?ForeignKey(?:Attribute)?\s*\(\s*"([^"]+)"/.exec(attributes)
+  if (stringForm) return stringForm[1]
+  return /\[\s*(?:[\w.]+\.)?ForeignKey(?:Attribute)?\s*\(\s*nameof\s*\(\s*([A-Za-z_]\w*)\s*\)/.exec(attributes)?.[1]
+}
+
+function extractCollectionElement(rawType: string): string | undefined {
+  const normalized = rawType.replace(/\?$/, '').trim()
+  return /^(?:(?:System\.Collections\.Generic\.)?(?:ICollection|IEnumerable|IReadOnlyCollection|List|HashSet|Collection))\s*<\s*([^>]+)\s*>$/.exec(normalized)?.[1]?.trim()
+}
+
+function extractNamespace(maskedContent: string): string {
+  const matches = [...maskedContent.matchAll(/\bnamespace\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*[;{]/g)]
+  return matches.at(-1)?.[1] ?? ''
+}
+
+function extractUsings(maskedContent: string): string[] {
+  return [...maskedContent.matchAll(/(?:^|\n)\s*(?:global\s+)?using\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*;/g)]
+    .map((match) => match[1])
+}
+
+function detectProviderFromContent(content: string): DatabaseType | undefined {
+  return detectProviderFromMasked(maskCSharpTrivia(content))
+}
+
+function detectProviderFromMasked(masked: string): DatabaseType | undefined {
+  if (/\bUseSqlServer\s*\(/.test(masked)) return 'sqlserver'
+  if (/\bUseSqlite\s*\(/.test(masked)) return 'sqlite'
+  if (/\bUseMySql\s*\(/.test(masked)) return 'mysql'
+  if (/\bUseNpgsql\s*\(/.test(masked)) return 'postgres'
+  return undefined
+}
+
+function chooseProvider(
+  explicitTypes: DatabaseType[],
+  serviceTypes: DatabaseType[],
+): DatabaseType | null {
+  if (explicitTypes.length === 1) return explicitTypes[0]
+  if (explicitTypes.length > 1) return null
+  if (serviceTypes.length === 1) return serviceTypes[0]
+  return null
+}
+
+function simpleTypeName(rawType: string): string {
+  const normalized = normalizeNamedTypeReference(rawType)
+  return normalized.split('.').pop() ?? normalized
+}
+
+function normalizeNamedTypeReference(rawType: string): string {
+  const normalized = normalizeTypeReference(rawType)
+  let result = ''
+  let genericDepth = 0
+  for (const char of normalized) {
+    if (char === '<') {
+      genericDepth++
+      continue
+    }
+    if (char === '>') {
+      genericDepth--
+      continue
+    }
+    if (genericDepth === 0) result += char
+  }
+  return result
+}
+
+function splitTopLevel(content: string, separator: string): string[] {
+  const parts: string[] = []
+  let start = 0
+  let genericDepth = 0
+  let parenDepth = 0
+  for (let i = 0; i < content.length; i++) {
+    if (content[i] === '<') genericDepth++
+    else if (content[i] === '>') genericDepth--
+    else if (content[i] === '(') parenDepth++
+    else if (content[i] === ')') parenDepth--
+    else if (content[i] === separator && genericDepth === 0 && parenDepth === 0) {
+      parts.push(content.slice(start, i))
+      start = i + 1
+    }
+  }
+  parts.push(content.slice(start))
+  return parts
+}
+
+function normalizeTypeReference(rawType: string): string {
+  return rawType
+    .replace(/^global::/, '')
+    .replace(/\?$/, '')
+    .replace(/\s+/g, '')
+}
+
+function normalizePropertyType(rawType: string): string {
+  const normalized = normalizeTypeReference(rawType)
+  const nullable = /^Nullable<(.+)>$/.exec(normalized)
+  return nullable?.[1] ?? normalized
+}
+
+function isKnownValueType(typeName: string): boolean {
+  if (typeName.endsWith('[]')) return true
+  const simpleName = typeName.split('.').pop() ?? typeName
+  return KNOWN_VALUE_TYPES.has(simpleName)
+}
+
 const KNOWN_VALUE_TYPES = new Set([
+  'bool', 'byte', 'sbyte', 'char', 'decimal', 'double', 'float',
+  'int', 'uint', 'nint', 'nuint', 'long', 'ulong', 'short', 'ushort',
+  'object', 'string',
   'Guid', 'DateTime', 'DateTimeOffset', 'DateOnly', 'TimeOnly', 'TimeSpan',
-  'String', 'Boolean', 'Byte', 'Int16', 'Int32', 'Int64', 'Decimal', 'Double', 'Single',
+  'String', 'Boolean', 'Byte', 'SByte', 'Char', 'Int16', 'Int32', 'Int64',
+  'UInt16', 'UInt32', 'UInt64', 'Decimal', 'Double', 'Single',
 ])
+
+/**
+ * Replace comments, strings, and character literals with spaces while keeping
+ * newlines and string length stable. Regex-based declaration extraction can
+ * then operate on code tokens without treating prose as a class/record.
+ */
+function maskCSharpTrivia(content: string): string {
+  const chars = content.split('')
+  const blank = (index: number) => {
+    if (chars[index] !== '\n' && chars[index] !== '\r') chars[index] = ' '
+  }
+  const hasQuoteRun = (index: number, length: number) => {
+    for (let offset = 0; offset < length; offset++) {
+      if (chars[index + offset] !== '"') return false
+    }
+    return true
+  }
+
+  let i = 0
+  while (i < chars.length) {
+    if (chars[i] === '/' && chars[i + 1] === '/') {
+      blank(i++)
+      blank(i++)
+      while (i < chars.length && chars[i] !== '\n') blank(i++)
+      continue
+    }
+    if (chars[i] === '/' && chars[i + 1] === '*') {
+      blank(i++)
+      blank(i++)
+      while (i < chars.length) {
+        if (chars[i] === '*' && chars[i + 1] === '/') {
+          blank(i++)
+          blank(i++)
+          break
+        }
+        blank(i++)
+      }
+      continue
+    }
+    if (chars[i] === '"') {
+      let quoteRun = 1
+      while (chars[i + quoteRun] === '"') quoteRun++
+      const rawQuoteCount = quoteRun >= 3 ? quoteRun : 1
+      const verbatim = (i > 0 && chars[i - 1] === '@')
+        || (i > 1 && chars[i - 1] === '$' && chars[i - 2] === '@')
+      for (let n = 0; n < rawQuoteCount; n++) blank(i++)
+      while (i < chars.length) {
+        if (rawQuoteCount >= 3 && hasQuoteRun(i, rawQuoteCount)) {
+          for (let n = 0; n < rawQuoteCount; n++) blank(i++)
+          break
+        }
+        if (rawQuoteCount === 1 && chars[i] === '"') {
+          if (verbatim && chars[i + 1] === '"') {
+            blank(i++)
+            blank(i++)
+            continue
+          }
+          blank(i++)
+          break
+        }
+        if (!verbatim && rawQuoteCount === 1 && chars[i] === '\\') {
+          blank(i++)
+          if (i < chars.length) blank(i++)
+          continue
+        }
+        blank(i++)
+      }
+      continue
+    }
+    if (chars[i] === "'") {
+      blank(i++)
+      while (i < chars.length) {
+        if (chars[i] === '\\') {
+          blank(i++)
+          if (i < chars.length) blank(i++)
+          continue
+        }
+        const done = chars[i] === "'"
+        blank(i++)
+        if (done) break
+      }
+      continue
+    }
+    i++
+  }
+
+  return chars.join('')
+}
+
+function findMatchingBrace(content: string, openBrace: number): number {
+  return findMatchingDelimiter(content, openBrace, '{', '}')
+}
+
+function findMatchingDelimiter(
+  content: string,
+  openIndex: number,
+  open: string,
+  close: string,
+): number {
+  if (openIndex < 0 || content[openIndex] !== open) return -1
+  let depth = 0
+  for (let i = openIndex; i < content.length; i++) {
+    if (content[i] === open) depth++
+    else if (content[i] === close) {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+function findMatchingOpeningDelimiter(
+  content: string,
+  closeIndex: number,
+  open: string,
+  close: string,
+): number {
+  if (closeIndex < 0 || content[closeIndex] !== close) return -1
+  let depth = 0
+  for (let i = closeIndex; i >= 0; i--) {
+    if (content[i] === close) depth++
+    else if (content[i] === open) {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+function skipWhitespaceBackward(content: string, end: number): number {
+  let cursor = end
+  while (cursor > 0 && /\s/.test(content[cursor - 1])) cursor--
+  return cursor
+}
 
 function snakeCase(name: string): string {
   return name
@@ -140,20 +1204,27 @@ function snakeCase(name: string): string {
     .toLowerCase()
 }
 
-function dedupe(values: string[]): string[] {
+function dedupe<T>(values: T[]): T[] {
   return [...new Set(values)]
 }
 
-/** The contents of a {…} block starting at the given `{` index. */
-function extractBracedBlock(content: string, openBraceIndex: number): string | null {
-  if (content[openBraceIndex] !== '{') return null
-  let depth = 0
-  for (let i = openBraceIndex; i < content.length; i++) {
-    if (content[i] === '{') depth++
-    else if (content[i] === '}') {
-      depth--
-      if (depth === 0) return content.slice(openBraceIndex + 1, i)
-    }
+function dedupeBy<T>(values: T[], key: (value: T) => string): T[] {
+  const seen = new Set<string>()
+  return values.filter((value) => {
+    const identity = key(value)
+    if (seen.has(identity)) return false
+    seen.add(identity)
+    return true
+  })
+}
+
+function groupBy<T>(values: T[], key: (value: T) => string): Map<string, T[]> {
+  const groups = new Map<string, T[]>()
+  for (const value of values) {
+    const identity = key(value)
+    const group = groups.get(identity) ?? []
+    group.push(value)
+    groups.set(identity, group)
   }
-  return null
+  return groups
 }

--- a/packages/analyzer/src/schema-parsers/registry.ts
+++ b/packages/analyzer/src/schema-parsers/registry.ts
@@ -12,7 +12,7 @@ import { parseDrizzleSchema } from './drizzle.js'
 import { parseSqlAlchemySchema } from './sqlalchemy.js'
 import { parseEfCoreSchema } from './efcore.js'
 
-interface SchemaParserEntry {
+interface SchemaParserBase {
   /** Name for logging */
   name: string
   /** Check if a file's imports indicate this ORM */
@@ -21,13 +21,40 @@ interface SchemaParserEntry {
   validateContent?(content: string): boolean
   /** Parse the file content and return tables + relations */
   parse(content: string): { tables: TableInfo[]; relations: RelationInfo[] }
+}
+
+interface FileSchemaParser extends SchemaParserBase {
+  scope: 'file'
   /** Determine the database type from the file content */
   detectDbType(content: string): DatabaseType
+}
+
+interface ServiceSchemaParser extends SchemaParserBase {
+  scope: 'service'
+}
+
+type SchemaParserEntry = FileSchemaParser | ServiceSchemaParser
+
+export const EF_CORE_SCHEMA_PARSER: ServiceSchemaParser = {
+  name: 'EFCore',
+  scope: 'service',
+  // Entity POCOs often import only DataAnnotations, not EF itself
+  matchesImport: (fa) =>
+    fa.language === 'csharp' &&
+    fa.imports.some(
+      (imp) =>
+        imp.source.startsWith('Microsoft.EntityFrameworkCore') ||
+        imp.source.startsWith('System.ComponentModel.DataAnnotations'),
+    ),
+  validateContent: (content) =>
+    /DbSet</.test(content) || /\[Table\(/.test(content) || /\[Key\]/.test(content),
+  parse: parseEfCoreSchema,
 }
 
 export const SCHEMA_PARSERS: SchemaParserEntry[] = [
   {
     name: 'Drizzle',
+    scope: 'file',
     matchesImport: (fa) => fa.imports.some((imp) => imp.source.startsWith('drizzle-orm')),
     validateContent: (content) => /(?:pgTable|mysqlTable|sqliteTable)\s*\(/.test(content),
     parse: parseDrizzleSchema,
@@ -39,6 +66,7 @@ export const SCHEMA_PARSERS: SchemaParserEntry[] = [
   },
   {
     name: 'SQLAlchemy',
+    scope: 'file',
     matchesImport: (fa) => fa.imports.some(
       (imp) => imp.source === 'sqlalchemy' || imp.source.startsWith('sqlalchemy.')
     ),
@@ -46,25 +74,6 @@ export const SCHEMA_PARSERS: SchemaParserEntry[] = [
     parse: parseSqlAlchemySchema,
     detectDbType: () => 'postgres', // SQLAlchemy default; could parse engine URL for others
   },
-  {
-    name: 'EFCore',
-    // Entity POCOs often import only DataAnnotations, not EF itself
-    matchesImport: (fa) =>
-      fa.language === 'csharp' &&
-      fa.imports.some(
-        (imp) =>
-          imp.source.startsWith('Microsoft.EntityFrameworkCore') ||
-          imp.source.startsWith('System.ComponentModel.DataAnnotations'),
-      ),
-    validateContent: (content) =>
-      /DbSet</.test(content) || /\[Table\(/.test(content) || /\[Key\]/.test(content),
-    parse: parseEfCoreSchema,
-    detectDbType: (content) => {
-      if (content.includes('UseSqlServer')) return 'sqlserver'
-      if (content.includes('UseSqlite')) return 'sqlite'
-      if (content.includes('UseMySql')) return 'mysql'
-      return 'postgres' // UseNpgsql and the most common default
-    },
-  },
+  EF_CORE_SCHEMA_PARSER,
   // Prisma is handled separately (file-based, not import-based) — see database-detector.ts
 ]

--- a/tests/analyzer/efcore-parser.test.ts
+++ b/tests/analyzer/efcore-parser.test.ts
@@ -1,0 +1,729 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type { FileAnalysis } from '@truecourse/shared'
+import { detectDatabases } from '../../packages/analyzer/src/database-detector'
+import type { Service } from '../../packages/analyzer/src/service-detector'
+import {
+  parseEfCoreProject,
+  parseEfCoreSchema,
+  type EfCoreProjectFile,
+} from '../../packages/analyzer/src/schema-parsers/efcore'
+
+function projectFile(
+  filePath: string,
+  content: string,
+  options: Partial<EfCoreProjectFile> = {},
+): EfCoreProjectFile {
+  return {
+    filePath,
+    content,
+    serviceName: 'Publishing',
+    providerTypes: ['postgres'],
+    ...options,
+  }
+}
+
+describe('EF Core schema parser', () => {
+  it('uses one canonical table and navigation-based relations for a same-file model', () => {
+    const result = parseEfCoreSchema(`
+      using Microsoft.EntityFrameworkCore;
+      using System.ComponentModel.DataAnnotations;
+
+      public class AppDbContext : DbContext
+      {
+        public DbSet<Article> Articles { get; set; }
+        public DbSet<Account> Accounts => Set<Account>();
+      }
+
+      public class Account
+      {
+        [Key]
+        public Guid Id { get; set; }
+      }
+
+      public class Article
+      {
+        [Key]
+        public Guid Id { get; set; }
+        public Guid OwnerId { get; set; }
+        public Account Owner { get; set; }
+        public Guid? ParentId { get; set; }
+        public Article Parent { get; set; }
+        public Guid PrincipalId { get; set; }
+      }
+    `)
+
+    expect(result.tables.map((table) => table.name).sort()).toEqual(['Accounts', 'Articles'])
+    const articleColumns = result.tables.find((table) => table.name === 'Articles')?.columns
+    expect(articleColumns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'owner_id', isForeignKey: true, referencesTable: 'Accounts' }),
+        expect.objectContaining({ name: 'parent_id', isForeignKey: true, referencesTable: 'Articles' }),
+      ]),
+    )
+    const principalId = articleColumns?.find((column) => column.name === 'principal_id')
+    expect(principalId).not.toHaveProperty('isForeignKey')
+    expect(principalId).not.toHaveProperty('referencesTable')
+    expect(result.relations).toEqual([
+      {
+        sourceTable: 'Articles',
+        targetTable: 'Accounts',
+        relationType: 'one-to-many',
+        foreignKeyColumn: 'owner_id',
+      },
+      {
+        sourceTable: 'Articles',
+        targetTable: 'Articles',
+        relationType: 'one-to-many',
+        foreignKeyColumn: 'parent_id',
+      },
+    ])
+  })
+
+  it('honors explicit table names and ignores declaration-like text in comments and strings', () => {
+    const result = parseEfCoreSchema(`
+      using System.ComponentModel.DataAnnotations;
+      using System.ComponentModel.DataAnnotations.Schema;
+
+      // Stores a record of publishing actions and the class of actor involved.
+      [Table("PublishedArticles")]
+      public class Article
+      {
+        [Key]
+        public Guid Id { get; set; }
+        public string Description { get; set; } = "a record of class of examples";
+      }
+    `)
+
+    expect(result.tables).toHaveLength(1)
+    expect(result.tables[0]).toMatchObject({ name: 'PublishedArticles', primaryKey: 'id' })
+  })
+
+  it('ignores declaration-like text in raw strings with extended delimiters', () => {
+    const result = parseEfCoreSchema(`
+      using System.ComponentModel.DataAnnotations;
+      using System.ComponentModel.DataAnnotations.Schema;
+
+      public static class Copy
+      {
+        public const string Description = """" class of fake records """";
+      }
+
+      [Table("PublishedArticles")]
+      public class Article
+      {
+        [Key]
+        public Guid Id { get; set; }
+      }
+    `)
+
+    expect(result.tables).toHaveLength(1)
+    expect(result.tables[0].name).toBe('PublishedArticles')
+  })
+
+  it('supports attributes separated by comments and ForeignKey on a navigation property', () => {
+    const result = parseEfCoreSchema(`
+      using Microsoft.EntityFrameworkCore;
+      using System.ComponentModel.DataAnnotations;
+      using System.ComponentModel.DataAnnotations.Schema;
+
+      public class AppDbContext : DbContext
+      {
+        public DbSet<Article> Articles { get; set; }
+        public DbSet<Account> Accounts { get; set; }
+      }
+
+      public class Account { [Key] public Guid Id { get; set; } }
+
+      [Table("PublishedArticles")]
+      // The comment between the attribute and declaration is valid C#.
+      public class Article
+      {
+        [Key]
+        public Guid Id { get; set; }
+        public Guid OwnerKey { get; set; }
+
+        [ForeignKey(nameof(OwnerKey))]
+        public Account Owner { get; set; }
+      }
+    `)
+
+    expect(result.tables.find((table) => table.name === 'PublishedArticles')?.columns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'owner_key', referencesTable: 'Accounts' }),
+      ]),
+    )
+    expect(result.relations).toContainEqual(
+      expect.objectContaining({
+        sourceTable: 'PublishedArticles',
+        targetTable: 'Accounts',
+        foreignKeyColumn: 'owner_key',
+      }),
+    )
+  })
+
+  it('ignores private DbSet fields outside a DbContext', () => {
+    const result = parseEfCoreSchema(`
+      public class AccountRepository
+      {
+        private readonly DbSet<Account> _dbSet;
+      }
+    `)
+
+    expect(result).toEqual({ tables: [], relations: [] })
+  })
+})
+
+describe('EF Core project reconciliation', () => {
+  it('emits equivalent schemas for same-file and split-file models', () => {
+    const context = `
+      using Microsoft.EntityFrameworkCore;
+      using Publishing.Domain;
+      namespace Publishing.Data;
+
+      public class AppDbContext : DbContext
+      {
+        public DbSet<Article> Articles { get; set; }
+        public DbSet<Account> Accounts { get; set; }
+      }
+    `
+    const entities = `
+      namespace Publishing.Domain;
+
+      public class Account
+      {
+        public Guid Id { get; set; }
+      }
+
+      public class Article
+      {
+        public Guid Id { get; set; }
+        public Guid OwnerId { get; set; }
+        public Account Owner { get; set; }
+      }
+    `
+
+    const sameFile = parseEfCoreProject([
+      projectFile('/repo/Model.cs', `${context}\n${entities}`),
+    ])
+    const splitFiles = parseEfCoreProject([
+      projectFile('/repo/AppDbContext.cs', context),
+      projectFile('/repo/Entities.cs', entities),
+    ])
+
+    expect(sameFile).toHaveLength(1)
+    expect(splitFiles).toHaveLength(1)
+    expect(splitFiles[0].tables).toEqual(sameFile[0].tables)
+    expect(splitFiles[0].relations).toEqual(sameFile[0].relations)
+  })
+
+  it('reconciles split convention-only entities with their DbSet properties', () => {
+    const results = parseEfCoreProject([
+      projectFile('/repo/Data/AppDbContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        using Publishing.Domain;
+        namespace Publishing.Data;
+
+        public class AppDbContext : DbContext
+        {
+          public DbSet<Article> Articles { get; set; }
+          public DbSet<Account> Accounts { get; set; }
+        }
+      `),
+      projectFile('/repo/Domain/Article.cs', `
+        namespace Publishing.Domain;
+        public class Article
+        {
+          public Guid Id { get; set; }
+          public Guid OwnerId { get; set; }
+          public Account Owner { get; set; }
+        }
+      `),
+      projectFile('/repo/Domain/Account.cs', `
+        namespace Publishing.Domain;
+        public class Account
+        {
+          public Guid Id { get; set; }
+        }
+
+        public class ArticleDto
+        {
+          public Guid Id { get; set; }
+        }
+      `),
+    ])
+
+    expect(results).toHaveLength(1)
+    expect(results[0].dbType).toBe('postgres')
+    expect(results[0].tables.map((table) => table.name).sort()).toEqual(['Accounts', 'Articles'])
+    expect(results[0].tables.find((table) => table.name === 'Articles')?.columns.length).toBeGreaterThan(1)
+    expect(results[0].relations).toEqual([
+      {
+        sourceTable: 'Articles',
+        targetTable: 'Accounts',
+        relationType: 'one-to-many',
+        foreignKeyColumn: 'owner_id',
+      },
+    ])
+  })
+
+  it('applies active ToTable configuration before attribute and DbSet names', () => {
+    const results = parseEfCoreProject([
+      projectFile('/repo/AppDbContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        using Publishing.Domain;
+        namespace Publishing.Data;
+
+        public class AppDbContext : DbContext
+        {
+          public DbSet<Article> Articles { get; set; }
+
+          protected override void OnModelCreating(ModelBuilder modelBuilder)
+          {
+            modelBuilder.Entity<Article>().ToTable("CurrentArticles");
+          }
+        }
+      `),
+      projectFile('/repo/Article.cs', `
+        using System.ComponentModel.DataAnnotations;
+        using System.ComponentModel.DataAnnotations.Schema;
+        namespace Publishing.Domain;
+
+        [Table("PublishedArticles")]
+        public class Article
+        {
+          [Key]
+          public Guid Id { get; set; }
+        }
+      `),
+    ])
+
+    expect(results[0].tables).toHaveLength(1)
+    expect(results[0].tables[0].name).toBe('CurrentArticles')
+  })
+
+  it('parses active mappings without fixed source-length limits', () => {
+    const spacing = ' '.repeat(1_200)
+    const results = parseEfCoreProject([
+      projectFile('/repo/AppDbContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing;
+        public class AppDbContext : DbContext
+        {
+          public DbSet<Article> Articles { get; set; }
+          protected override void OnModelCreating(ModelBuilder modelBuilder)
+          {
+            modelBuilder.Entity<Article>().ToTable(${spacing}"LongFormArticles");
+          }
+        }
+      `),
+      projectFile('/repo/Article.cs', `
+        using System.ComponentModel.DataAnnotations.Schema;
+        namespace Publishing;
+        [Table("PublishedArticles")]
+        ${spacing}
+        public class Article { public Guid Id { get; set; } }
+      `),
+    ])
+
+    expect(results[0].tables).toHaveLength(1)
+    expect(results[0].tables[0].name).toBe('LongFormArticles')
+  })
+
+  it('merges partial entity declarations before emitting columns', () => {
+    const results = parseEfCoreProject([
+      projectFile('/repo/AppDbContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing;
+        public class AppDbContext : DbContext
+        {
+          public DbSet<Article> Articles { get; set; }
+        }
+      `),
+      projectFile('/repo/Article.Key.cs', `
+        namespace Publishing;
+        public partial class Article { public Guid Id { get; set; } }
+      `),
+      projectFile('/repo/Article.Fields.cs', `
+        namespace Publishing;
+        public partial class Article { public string Title { get; set; } }
+      `),
+    ])
+
+    expect(results).toHaveLength(1)
+    expect(results[0].tables).toHaveLength(1)
+    expect(results[0].tables[0].columns.map((column) => column.name).sort()).toEqual([
+      'id',
+      'title',
+    ])
+  })
+
+  it('merges partial DbContext declarations before applying table mappings', () => {
+    const results = parseEfCoreProject([
+      projectFile('/repo/AppDbContext.Sets.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing;
+        public partial class AppDbContext : DbContext
+        {
+          public DbSet<Article> Articles { get; set; }
+        }
+      `),
+      projectFile('/repo/AppDbContext.Mapping.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing;
+        public partial class AppDbContext
+        {
+          protected override void OnModelCreating(ModelBuilder modelBuilder)
+          {
+            modelBuilder.Entity<Article>().ToTable("CurrentArticles");
+          }
+        }
+      `),
+      projectFile('/repo/Article.cs', `
+        namespace Publishing;
+        public class Article { public Guid Id { get; set; } }
+      `),
+    ])
+
+    expect(results).toHaveLength(1)
+    expect(results[0].contextName).toBe('Publishing.AppDbContext')
+    expect(results[0].tables).toHaveLength(1)
+    expect(results[0].tables[0].name).toBe('CurrentArticles')
+  })
+
+  it('recognizes DbContext inheritance through a service-local base class', () => {
+    const results = parseEfCoreProject([
+      projectFile('/repo/BaseContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing;
+        public abstract class BaseContext : DbContext
+        {
+          public DbSet<Account> Accounts { get; set; }
+        }
+      `),
+      projectFile('/repo/AppDbContext.cs', `
+        namespace Publishing;
+        public class AppDbContext : BaseContext
+        {
+          public DbSet<Article> Articles { get; set; }
+        }
+      `),
+      projectFile('/repo/Article.cs', `
+        namespace Publishing;
+        public class Account { public Guid Id { get; set; } }
+        public class Article
+        {
+          public Guid Id { get; set; }
+          public Guid OwnerId { get; set; }
+          public Account Owner { get; set; }
+        }
+      `),
+    ])
+
+    expect(results).toHaveLength(1)
+    expect(results[0].contextName).toBe('Publishing.AppDbContext')
+    expect(results[0].tables.map((table) => table.name).sort()).toEqual(['Accounts', 'Articles'])
+    expect(results[0].relations).toContainEqual({
+      sourceTable: 'Articles',
+      targetTable: 'Accounts',
+      relationType: 'one-to-many',
+      foreignKeyColumn: 'owner_id',
+    })
+  })
+
+  it('uses an explicitly applied IEntityTypeConfiguration mapping', () => {
+    const results = parseEfCoreProject([
+      projectFile('/repo/AppDbContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing;
+        public class AppDbContext : DbContext
+        {
+          public DbSet<Article> Articles { get; set; }
+          protected override void OnModelCreating(ModelBuilder modelBuilder)
+          {
+            modelBuilder.ApplyConfiguration(new ArticleConfiguration());
+          }
+        }
+      `),
+      projectFile('/repo/ArticleConfiguration.cs', `
+        using Microsoft.EntityFrameworkCore;
+        using Microsoft.EntityFrameworkCore.Metadata.Builders;
+        namespace Publishing;
+        public class ArticleConfiguration : IEntityTypeConfiguration<Article>
+        {
+          public void Configure(EntityTypeBuilder<Article> builder)
+          {
+            builder.ToTable("ConfiguredArticles");
+          }
+        }
+      `),
+      projectFile('/repo/Article.cs', `
+        namespace Publishing;
+        public class Article { public Guid Id { get; set; } }
+      `),
+    ])
+
+    expect(results).toHaveLength(1)
+    expect(results[0].tables).toHaveLength(1)
+    expect(results[0].tables[0].name).toBe('ConfiguredArticles')
+  })
+
+  it('applies Table attributes before DbSet and convention names', () => {
+    const results = parseEfCoreProject([
+      projectFile('/repo/AppDbContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing;
+        public class AppDbContext : DbContext
+        {
+          public DbSet<Article> Articles { get; set; }
+        }
+      `),
+      projectFile('/repo/Article.cs', `
+        using System.ComponentModel.DataAnnotations.Schema;
+        namespace Publishing;
+        [Table("PublishedArticles")]
+        public class Article { public Guid Id { get; set; } }
+      `),
+    ])
+
+    expect(results[0].tables).toHaveLength(1)
+    expect(results[0].tables[0].name).toBe('PublishedArticles')
+  })
+
+  it.each([
+    ['postgres', 'postgres'],
+    ['sqlserver', 'sqlserver'],
+    ['mysql', 'mysql'],
+    ['sqlite', 'sqlite'],
+  ] as const)('keeps split entity schema with its %s provider', (_name, provider) => {
+    const results = parseEfCoreProject([
+      projectFile('/repo/AppDbContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing.Data;
+        public class AppDbContext : DbContext
+        {
+          public DbSet<Article> Articles { get; set; }
+        }
+      `, { providerTypes: [provider] }),
+      projectFile('/repo/Article.cs', `
+        using System.ComponentModel.DataAnnotations;
+        namespace Publishing.Data;
+        public class Article
+        {
+          [Key]
+          public Guid Id { get; set; }
+        }
+      `, { providerTypes: [provider] }),
+    ])
+
+    expect(results).toHaveLength(1)
+    expect(results[0].dbType).toBe(provider)
+    expect(results[0].tables[0]).toMatchObject({ name: 'Articles', primaryKey: 'id' })
+  })
+
+  it('associates AddDbContext provider setup with the referenced model', () => {
+    const providerTypes = ['postgres', 'sqlserver'] as const
+    const options = { providerTypes: [...providerTypes] }
+    const results = parseEfCoreProject([
+      projectFile('/repo/Program.cs', `
+        services.AddDbContext<SalesContext>(options => options.UseNpgsql(connectionString));
+        services.AddDbContext<SupportContext>(options => options.UseSqlServer(connectionString));
+      `, options),
+      projectFile('/repo/SalesContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing;
+        public class SalesContext : DbContext
+        {
+          public DbSet<Sale> Sales { get; set; }
+        }
+        public class Sale { public Guid Id { get; set; } }
+      `, options),
+      projectFile('/repo/SupportContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing;
+        public class SupportContext : DbContext
+        {
+          public DbSet<Ticket> Tickets { get; set; }
+        }
+        public class Ticket { public Guid Id { get; set; } }
+      `, options),
+    ])
+
+    expect(results).toHaveLength(2)
+    expect(results.find((result) => result.contextName?.endsWith('SalesContext'))?.dbType)
+      .toBe('postgres')
+    expect(results.find((result) => result.contextName?.endsWith('SupportContext'))?.dbType)
+      .toBe('sqlserver')
+  })
+
+  it('leaves an ambiguous provider unresolved instead of guessing PostgreSQL', () => {
+    const results = parseEfCoreProject([
+      projectFile('/repo/AppDbContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing;
+        public class AppDbContext : DbContext
+        {
+          public DbSet<Article> Articles { get; set; }
+        }
+        public class Article { public Guid Id { get; set; } }
+      `, { providerTypes: ['postgres', 'sqlserver'] }),
+    ])
+
+    expect(results).toHaveLength(1)
+    expect(results[0].dbType).toBeNull()
+  })
+
+  it('does not merge same-named entities from different model scopes', () => {
+    const results = parseEfCoreProject([
+      projectFile('/repo/SalesContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Sales;
+        public class SalesContext : DbContext
+        {
+          public DbSet<Sales.Customer> SalesCustomers { get; set; }
+        }
+        public class Customer { public Guid Id { get; set; } }
+      `),
+      projectFile('/repo/SupportContext.cs', `
+        using Microsoft.EntityFrameworkCore;
+        namespace Support;
+        public class SupportContext : DbContext
+        {
+          public DbSet<Support.Customer> SupportCustomers { get; set; }
+        }
+        public class Customer { public Guid Id { get; set; } }
+      `),
+    ])
+
+    expect(results).toHaveLength(2)
+    expect(results.flatMap((result) => result.tables.map((table) => table.name)).sort()).toEqual([
+      'SalesCustomers',
+      'SupportCustomers',
+    ])
+  })
+
+  it('collects convention-only entity files from a detected EF service', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'truecourse-efcore-project-'))
+    try {
+      const contextPath = path.join(root, 'AppDbContext.cs')
+      const entityPath = path.join(root, 'Article.cs')
+      fs.writeFileSync(path.join(root, 'Publishing.csproj'), `
+        <Project Sdk="Microsoft.NET.Sdk">
+          <ItemGroup>
+            <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
+          </ItemGroup>
+        </Project>
+      `)
+      fs.writeFileSync(contextPath, `
+        using Microsoft.EntityFrameworkCore;
+        namespace Publishing;
+        public class AppDbContext : DbContext
+        {
+          public DbSet<Article> Articles { get; set; }
+        }
+      `)
+      fs.writeFileSync(entityPath, `
+        namespace Publishing;
+        public class Article
+        {
+          public Guid Id { get; set; }
+          public string Title { get; set; }
+        }
+      `)
+
+      const analyses = [
+        {
+          filePath: contextPath,
+          language: 'csharp',
+          imports: [{ source: 'Microsoft.EntityFrameworkCore' }],
+        },
+        {
+          filePath: entityPath,
+          language: 'csharp',
+          imports: [],
+        },
+      ] as unknown as FileAnalysis[]
+      const services = [{
+        name: 'Publishing',
+        rootPath: root,
+        files: [contextPath, entityPath],
+      }] as unknown as Service[]
+
+      const detected = detectDatabases(root, analyses, services)
+      const postgres = detected.databases.find((database) => database.type === 'postgres')
+
+      expect(postgres?.tables).toHaveLength(1)
+      expect(postgres?.tables[0]).toMatchObject({
+        name: 'Articles',
+        columns: expect.arrayContaining([
+          expect.objectContaining({ name: 'title', type: 'string' }),
+        ]),
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('collects top-level provider setup and keeps detector schemas model-scoped', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'truecourse-efcore-providers-'))
+    try {
+      const files = new Map([
+        [path.join(root, 'Program.cs'), `
+          using Microsoft.EntityFrameworkCore;
+          services.AddDbContext<SalesContext>(options => options.UseNpgsql(pgConnection));
+          services.AddDbContext<SupportContext>(options => options.UseSqlServer(sqlConnection));
+        `],
+        [path.join(root, 'SalesContext.cs'), `
+          using Microsoft.EntityFrameworkCore;
+          namespace Publishing;
+          public class SalesContext : DbContext
+          {
+            public DbSet<Sale> Sales { get; set; }
+          }
+          public class Sale { public Guid Id { get; set; } }
+        `],
+        [path.join(root, 'SupportContext.cs'), `
+          using Microsoft.EntityFrameworkCore;
+          namespace Publishing;
+          public class SupportContext : DbContext
+          {
+            public DbSet<Ticket> Tickets { get; set; }
+          }
+          public class Ticket { public Guid Id { get; set; } }
+        `],
+      ])
+      fs.writeFileSync(path.join(root, 'Publishing.csproj'), `
+        <Project Sdk="Microsoft.NET.Sdk">
+          <ItemGroup>
+            <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
+            <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+          </ItemGroup>
+        </Project>
+      `)
+      for (const [filePath, content] of files) fs.writeFileSync(filePath, content)
+
+      const analyses = [...files.keys()].map((filePath) => ({
+        filePath,
+        language: 'csharp',
+        imports: filePath.endsWith('Program.cs') || filePath.endsWith('Context.cs')
+          ? [{ source: 'Microsoft.EntityFrameworkCore' }]
+          : [],
+      })) as unknown as FileAnalysis[]
+      const services = [{
+        name: 'Publishing',
+        rootPath: root,
+        files: [...files.keys()],
+      }] as unknown as Service[]
+
+      const detected = detectDatabases(root, analyses, services)
+      expect(detected.databases.find((database) => database.type === 'postgres')?.tables)
+        .toEqual([expect.objectContaining({ name: 'Sales' })])
+      expect(detected.databases.find((database) => database.type === 'sqlserver')?.tables)
+        .toEqual([expect.objectContaining({ name: 'Tickets' })])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- reconcile EF Core `DbContext`, entity, navigation, and fluent-configuration evidence across service files
- emit one canonical table per entity using `ToTable` > `[Table]` > `DbSet` > convention precedence
- resolve foreign keys through navigation types and canonical table identities instead of guessing from `*Id` names
- preserve model/provider scope across PostgreSQL, SQL Server, MySQL, and SQLite

## Root cause

The EF Core schema parser processed files independently. `DbContext` files emitted empty `DbSet` tables while entity files emitted separate detailed tables under class-derived names. Because foreign-key targets were guessed from scalar property names, many relation endpoints did not correspond to an emitted table.

## What changed

- added a service-scoped parser capability to the schema-parser registry
- introduced model reconciliation for split and partial entities/contexts, indirect `DbContext` inheritance, and explicitly applied `IEntityTypeConfiguration<T>` mappings
- retained canonical entity identity until tables, column references, and relation endpoints are emitted
- ignored private repository `DbSet` fields and unrelated convention-only POCOs
- associated `AddDbContext<T>(...UseX...)` provider evidence with the referenced context; ambiguous providers remain unresolved rather than defaulting
- masked comments, ordinary/verbatim/raw strings, and character literals before declaration extraction
- added focused parser and detector regression coverage for the reported failure modes

## Impact

Standard EF Core projects now produce detailed canonical tables and drawable relationships instead of duplicate entity/`DbSet` nodes and dangling guessed edges.

## Validation

- `vitest run tests/analyzer/efcore-parser.test.ts tests/analyzer/csharp-graph-snapshot.test.ts` — 29 passed
- `tsc -p packages/analyzer/tsconfig.json --noEmit`
- `tsc -p packages/analyzer/tsconfig.json`
- `dotnet build -c Release tools/csharp-roslyn-host` — 0 warnings, 0 errors
- `git diff --check`

The existing C# CLI e2e fixture has a separate restore/setup failure tracked in #795; this PR intentionally does not mix that test-infrastructure fix into the EF schema change.

Closes #790
