### PR TITLE
fix(fp): resolve 3 FPs from OrchardCMS/OrchardCore

### DIFF
--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/empty-comment.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/empty-comment.ts
@@ -1,3 +1,4 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 
@@ -19,6 +20,27 @@ function commentBody(text: string): string {
 // char (e.g. `------`, `======`, `######`).
 const DIVIDER = /^[-=*#~_]{2,}$/
 
+// A `//` line comment, excluding `///` XML doc comments.
+const isLineComment = (t: string): boolean => t.startsWith('//') && !t.startsWith('///')
+
+/**
+ * An empty `//` line that sits between two non-empty `//` lines is a deliberate
+ * paragraph separator inside a multi-line line-comment block (the blank `//`
+ * keeps the block visually contiguous), not stray noise. It is a separator only
+ * when *both* the row above and the row below are non-empty `//` (not `///`)
+ * line comments; a trailing/leading blank `//` next to code still fires.
+ */
+function isParagraphSeparator(node: SyntaxNode): boolean {
+  const row = node.startPosition.row
+  const contentSibling = (n: SyntaxNode | null, atRow: number): boolean =>
+    n != null &&
+    n.type === 'comment' &&
+    isLineComment(n.text) &&
+    n.startPosition.row === atRow &&
+    commentBody(n.text).trim().length > 0
+  return contentSibling(node.previousSibling, row - 1) && contentSibling(node.nextSibling, row + 1)
+}
+
 export const csharpEmptyCommentVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/empty-comment',
   languages: ['csharp'],
@@ -27,6 +49,9 @@ export const csharpEmptyCommentVisitor: CodeRuleVisitor = {
     const body = commentBody(node.text).trim()
     if (body.length > 0 && !DIVIDER.test(body)) return null
     if (DIVIDER.test(body)) return null
+
+    // A blank `//` between two content `//` lines is a paragraph break, not noise.
+    if (isLineComment(node.text) && isParagraphSeparator(node)) return null
 
     return makeViolation(
       this.ruleKey, node, filePath, 'low',

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/parameter-duplicates-method-name.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/parameter-duplicates-method-name.ts
@@ -1,11 +1,45 @@
+import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+
+const TYPE_DECL_KINDS = ['class_declaration', 'struct_declaration', 'record_declaration', 'interface_declaration']
+
+/** Name of the type (class/struct/record/interface) that encloses this node. */
+function enclosingTypeName(node: SyntaxNode): string | null {
+  let anc: SyntaxNode | null = node.parent
+  while (anc && !TYPE_DECL_KINDS.includes(anc.type)) anc = anc.parent
+  return anc?.childForFieldName('name')?.text ?? null
+}
+
+/**
+ * A fluent builder/setter method returns a chainable type: its own containing
+ * type (an instance builder like `OrchardCoreBuilder Configure(...)`) or, for
+ * an extension method, the extended `this` receiver's type (`Builder
+ * Attachable(this Builder builder, bool attachable = true)`). A parameter named
+ * after such a method is the idiomatic "value the setter carries", not a
+ * copy-paste artifact, so the match must not be flagged.
+ */
+function isFluentBuilder(method: SyntaxNode): boolean {
+  const returns = method.childForFieldName('returns')?.text
+  if (!returns || returns === 'void') return false
+
+  if (returns === enclosingTypeName(method)) return true
+
+  const params = method.childForFieldName('parameters')
+  const first = params?.namedChildren.find((c) => c?.type === 'parameter')
+  if (first) {
+    const isExtensionReceiver = first.namedChildren.some((c) => c?.type === 'modifier' && c.text === 'this')
+    if (isExtensionReceiver && first.childForFieldName('type')?.text === returns) return true
+  }
+  return false
+}
 
 /**
  * A parameter whose name matches its enclosing method's name (case-insensitively)
  * is almost always a copy-paste artifact and reads confusingly at the call site.
  * The check fires on a `method_declaration` with a `parameter` whose identifier
- * equals the method name.
+ * equals the method name — except on fluent builder/setter methods, where a
+ * value parameter mirroring the method name is the intended idiom.
  */
 export const csharpParameterDuplicatesMethodNameVisitor: CodeRuleVisitor = {
   ruleKey: 'code-quality/deterministic/parameter-duplicates-method-name',
@@ -17,6 +51,10 @@ export const csharpParameterDuplicatesMethodNameVisitor: CodeRuleVisitor = {
 
     const params = node.childForFieldName('parameters')
     if (!params) return null
+
+    // Fluent builder/setter parameters idiomatically mirror the method name.
+    if (isFluentBuilder(node)) return null
+
     for (const param of params.namedChildren) {
       if (param?.type !== 'parameter') continue
       const pName = param.childForFieldName('name')?.text

--- a/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/MemberShapes.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/ApiGateway/Violations/CodeQuality/MemberShapes.cs
@@ -96,6 +96,15 @@ internal sealed class MemberShapes
     {
         _last = id;
     }
+
+    // A non-fluent value-returning method: the return type is not this class and
+    // it is not an extension receiver, so a parameter named after it is still a
+    // copy-paste artifact and must fire.
+    // VIOLATION: code-quality/deterministic/parameter-duplicates-method-name
+    internal int Compute(int compute)
+    {
+        return compute;
+    }
 }
 
 internal sealed class EventRaiser

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/CommentHygiene.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/CommentHygiene.cs
@@ -28,6 +28,14 @@ internal class CommentHygiene
         Track(1);
     }
 
+    internal void Compact()
+    {
+        Track(0);
+        // VIOLATION: code-quality/deterministic/empty-comment
+        /*  */
+        Track(1);
+    }
+
     private void Track(int value)
     {
         _values.Add(value);

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/FeatureToggles.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/FeatureToggles.cs
@@ -12,13 +12,19 @@ public sealed class FeatureToggles
     // VIOLATION: code-quality/deterministic/static-field-initialize-inline
     private static readonly string ConfigRoot;
 
+    // VIOLATION: code-quality/deterministic/static-field-initialize-inline
+    private static readonly string ConfigVersion;
+
     // VIOLATION: code-quality/deterministic/mutable-private-member
     // VIOLATION: code-quality/deterministic/field-can-be-readonly
     private string _environment;
 
+    // Both static fields are assigned by simple statements that are the whole cctor
+    // body, so inlining them drops the constructor and gains beforefieldinit.
     static FeatureToggles()
     {
         ConfigRoot = "/etc/userservice";
+        ConfigVersion = "v1";
     }
 
     public FeatureToggles(string environment)
@@ -35,5 +41,5 @@ public sealed class FeatureToggles
     // VIOLATION: code-quality/deterministic/obsolete-without-message
     // VIOLATION: code-quality/deterministic/obsolete-without-explanation
     [Obsolete]
-    public string ConfigPath() => ConfigRoot;
+    public string ConfigPath() => ConfigRoot + ConfigVersion;
 }

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/CommentBlocks.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/CommentBlocks.cs
@@ -1,0 +1,26 @@
+namespace Demo.Http;
+
+/// <summary>
+/// Multi-line `//` notes that use a blank `//` line as a paragraph separator
+/// inside a single comment block. The blank `//` keeps the block visually
+/// contiguous between paragraphs — deliberate formatting, not empty-comment
+/// noise, so it must not be flagged.
+/// </summary>
+internal sealed class CommentBlocks
+{
+    // Default sweep interval of ten seconds is a reasonable balance.
+    // Rough sizing, in words:
+    // about ten tracked keys, each living at least a second, means a sweep
+    // queue of roughly a hundred items.
+    //
+    // Frequent enough in practice, and we also lean on the collector to
+    // reclaim entries in the background.
+    public int SweepSeconds { get; } = 10;
+
+    // A fresh timer is used for each sweep cycle, guarded by a lock. Nothing
+    // here needs disposing because the timer is started and stopped on demand.
+    //
+    // The type itself need not be disposable; once nothing references it, the
+    // runtime reclaims it like any other object.
+    public bool Reclaimable { get; } = true;
+}

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/FluentBuilder.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/FluentBuilder.cs
@@ -1,0 +1,30 @@
+namespace Demo.Building;
+
+/// <summary>
+/// A fluent builder whose setter methods take a single value parameter named
+/// after the method and return the builder for chaining. The parameter mirrors
+/// the method name by idiom, not by copy-paste, so it must not be flagged as a
+/// parameter duplicating its method name.
+/// </summary>
+public sealed class FluentBuilder
+{
+    /// <summary>Whether the built item is visible.</summary>
+    public bool VisibleFlag { get; private set; }
+
+    /// <summary>The built item's weight.</summary>
+    public int WeightValue { get; private set; }
+
+    /// <summary>Sets visibility; returns the builder for chaining.</summary>
+    public FluentBuilder Visible(bool visible)
+    {
+        VisibleFlag = visible;
+        return this;
+    }
+
+    /// <summary>Sets the weight; returns the builder for chaining.</summary>
+    public FluentBuilder Weight(int weight)
+    {
+        WeightValue = weight;
+        return this;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/FluentBuilderExtensions.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/FluentBuilderExtensions.cs
@@ -1,0 +1,18 @@
+using Demo.Building;
+
+namespace Demo.Fluent;
+
+/// <summary>
+/// Fluent extension setters over <see cref="FluentBuilder"/>. Each returns the
+/// extended `this` receiver type, so a value parameter named after the method is
+/// the idiomatic builder shape and must not be flagged as duplicating the method
+/// name.
+/// </summary>
+public static class FluentBuilderExtensions
+{
+    /// <summary>Marks the item pinned; returns the receiver for chaining.</summary>
+    public static FluentBuilder Pinned(this FluentBuilder builder, bool pinned)
+    {
+        return builder.Visible(pinned);
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/src/FpRegression/SettingsRegistry.cs
+++ b/tests/fixtures/sample-csharp-project-positive/src/FpRegression/SettingsRegistry.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace Demo.Serialization;
+
+/// <summary>
+/// Assembles default lookups in a static constructor that also runs a loop, so
+/// the constructor cannot be removed. Inlining any single field here yields no
+/// beforefieldinit benefit (the loop keeps the cctor alive), so none of these
+/// static fields must be flagged as "initialize inline".
+/// </summary>
+internal static class SettingsRegistry
+{
+    private static readonly string[] KnownKeys = { "alpha", "beta", "gamma" };
+
+    private static readonly Dictionary<string, int> Ranks;
+
+    static SettingsRegistry()
+    {
+        Ranks = new Dictionary<string, int>();
+
+        var order = 0;
+        foreach (var key in KnownKeys)
+        {
+            Ranks[key] = order;
+            order++;
+        }
+    }
+
+    /// <summary>Returns the assembled rank for <paramref name="key"/>, or -1 when unknown.</summary>
+    public static int RankOf(string key) => Ranks.TryGetValue(key, out var rank) ? rank : -1;
+}

--- a/tools/csharp-roslyn-host/Rules/CodeQuality/StaticFieldInitializeInline.cs
+++ b/tools/csharp-roslyn-host/Rules/CodeQuality/StaticFieldInitializeInline.cs
@@ -25,6 +25,15 @@ internal sealed class StaticFieldInitializeInline : ISemanticRule
                 .FirstOrDefault(c => c.Modifiers.Any(SyntaxKind.StaticKeyword));
             if (cctor?.Body is not { } body) continue;
 
+            // The beforefieldinit win only materializes if inlining removes the ENTIRE
+            // static constructor. That requires every statement in it to be a simple
+            // assignment to a distinct static field of this type. If the cctor does
+            // anything else — a loop, a method call, a local, a multi-statement build,
+            // or member mutation of an already-assigned field — it stays regardless, so
+            // inlining any single field yields no beforefieldinit benefit and is a false
+            // positive. Skip the whole type in that case.
+            if (!StaticCtorFullyLiftable(type, body, model)) continue;
+
             // Inspect every static field declared on this type with no initializer.
             foreach (var fieldDecl in type.Members.OfType<FieldDeclarationSyntax>())
             {
@@ -46,6 +55,39 @@ internal sealed class StaticFieldInitializeInline : ISemanticRule
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// True iff the static constructor could be dropped entirely by inlining: every
+    /// statement is a simple assignment to a *distinct* static field of this type
+    /// (each such field assigned exactly once), and there is at least one. Any other
+    /// statement — a loop, a call, a local, member mutation, or a re-assignment —
+    /// means the cctor survives and no beforefieldinit is gained.
+    /// </summary>
+    private static bool StaticCtorFullyLiftable(TypeDeclarationSyntax type, BlockSyntax body, SemanticModel model)
+    {
+        if (model.GetDeclaredSymbol(type) is not INamedTypeSymbol typeSymbol) return false;
+
+        var assigned = new HashSet<IFieldSymbol>(SymbolEqualityComparer.Default);
+        foreach (var stmt in body.Statements)
+        {
+            if (stmt is not ExpressionStatementSyntax { Expression: AssignmentExpressionSyntax assign }) return false;
+            if (!assign.IsKind(SyntaxKind.SimpleAssignmentExpression)) return false;
+
+            var target = assign.Left switch
+            {
+                MemberAccessExpressionSyntax ma => ma.Name,
+                IdentifierNameSyntax id => (SimpleNameSyntax)id,
+                _ => null,
+            };
+            if (target is null) return false;
+            if (model.GetSymbolInfo(target).Symbol is not IFieldSymbol f) return false;
+            if (!f.IsStatic) return false;
+            if (!SymbolEqualityComparer.Default.Equals(f.ContainingType, typeSymbol)) return false;
+            if (!assigned.Add(f)) return false; // assigned more than once → not a single inline initializer
+        }
+
+        return body.Statements.Count > 0;
     }
 
     /// True iff exactly one statement in the cctor body is a simple assignment whose


### PR DESCRIPTION
Resolves three false positives found in `OrchardCMS/OrchardCore` (C# campaign, `cs-` scope). Each fix is an in-bounds change to the rule's own detection logic plus a paraphrased positive (FP-regression) fixture and a true-bug negative case.

Closes #787
Closes #786
Closes #784

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| `code-quality/deterministic/empty-comment` | #787 | `sample-csharp-project-positive/src/FpRegression/CommentBlocks.cs` | `sample-csharp-project-negative/.../CodeQuality/CommentHygiene.cs` |
| `code-quality/deterministic/static-field-initialize-inline` | #786 | `sample-csharp-project-positive/src/FpRegression/SettingsRegistry.cs` | `sample-csharp-project-negative/.../CodeQuality/FeatureToggles.cs` |
| `code-quality/deterministic/parameter-duplicates-method-name` | #784 | `sample-csharp-project-positive/src/FpRegression/FluentBuilder.cs` (+ `FluentBuilderExtensions.cs`) | `sample-csharp-project-negative/.../CodeQuality/MemberShapes.cs` |

## code-quality/deterministic/empty-comment (#787)

Upstream FPs (paraphrased, not copied):
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore/Modules/Overrides/HttpClient/TenantHttpClientFactory.cs#L33``
- …#L39, #L47, #L176, #L228

A blank `//` line placed between two content `//` lines is a deliberate paragraph separator inside a multi-line line-comment block (the blank `//` keeps the block visually contiguous), not stray noise. The `csharpEmptyCommentVisitor` now exempts an empty `//` only when **both** the row above and the row below are non-empty `//` (not `///`) line comments; a trailing/leading blank `//` next to code still fires. Verified on the cited file: 12 fires → 1 (the remaining one is a genuine trailing empty comment, never claimed as an FP).

## code-quality/deterministic/static-field-initialize-inline (#786)

Upstream FPs (paraphrased):
- https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Abstractions/Json/JOptions.cs#L34
- …#L35, #L40; `OrchardCore.ContentManagement.GraphQL/Queries/IndexPropertyProvider.cs#L9`

The `beforefieldinit` win the rule recommends only materializes if inlining removes the **entire** static constructor. The Roslyn rule now requires every statement in the cctor to be a simple assignment to a *distinct* static field of the type; if the cctor does anything else (a loop, a call, a local, a multi-statement build, or member mutation of an already-assigned field), it survives regardless, so inlining any single field gains nothing — a false positive. Those types are skipped. Verified on the cited files: 8 fires → 0. The negative fixture keeps firing (a cctor that is purely field assignments) and now also exercises the multi-field droppable-cctor path.

## code-quality/deterministic/parameter-duplicates-method-name (#784)

Upstream FPs (paraphrased):
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Abstractions/Modules/Builder/OrchardCoreBuilder.cs#L63``
- `OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentPartSettingsExtensions.cs#L9`, #L19
- `.../Metadata/Settings/ContentTypeSettingsExtensions.cs#L7`, #L12

A fluent builder/setter returns a chainable type — its own containing type (an instance builder like `OrchardCoreBuilder Configure(...)`) or, for an extension method, the extended `this` receiver type (`Builder Attachable(this Builder builder, bool attachable)`). A value parameter named after such a method is the intended idiom, not a copy-paste artifact, so the `csharpParameterDuplicatesMethodNameVisitor` exempts it. A non-fluent method (returns `void` or a foreign type) with a matching parameter still fires. Verified on the cited files: 11 fires → 0.

## FP-count delta (vs `1d0ae14413f10e2b3c1a65927db463b30a6892fe` on `OrchardCMS/OrchardCore`)

unavailable (whole-repo): a full `analyze` of OrchardCore (~5,551 analyzable C# files, tens of thousands of violations) needs ~2.3 CPU-hours, and this session's container recycles roughly every 2 hours — the before/after passes were killed twice mid-run by container restarts, so a whole-repo before/after count could not be produced this session.

Scoped measurement instead — each fixed rule run directly on the exact files cited in its issue, at `1d0ae144…`, before vs after this batch:

| Rule | Cited-file FPs before | After | Delta |
|---|---:|---:|---:|
| `code-quality/deterministic/empty-comment` | 12 | 1 | -11 |
| `code-quality/deterministic/static-field-initialize-inline` | 8 | 0 | -8 |
| `code-quality/deterministic/parameter-duplicates-method-name` | 11 | 0 | -11 |

(The one remaining `empty-comment` fire is a genuine trailing empty comment, not one of the reported FPs.) The full C# fixture suite — `csharp-positive` (zero-FP, both tree-sitter and Roslyn-host engines), `csharp-negative` (marker coverage), and `csharp-graph-snapshot` — is green. Pre-existing suite failures in this environment (the absent `@truecourse/ee-db` enterprise packages; the MSBuild-workspace e2e) are unrelated to these C#-only rule changes.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgFMWucsbAbLkpF1ZfN9Uh)_