### PR TITLE
fix(ee-knowledge): sweep delta measures synced-vs-processed; spec UI fixes

### DIFF
--- a/apps/dashboard/client/src/components/spec/SpecCorpusView.tsx
+++ b/apps/dashboard/client/src/components/spec/SpecCorpusView.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Loader2, Play, FileText, ChevronRight, ChevronDown, AlertCircle, GitMerge, EyeOff, Search, X, Unlink, ExternalLink } from 'lucide-react';
+import { Loader2, Play, FileText, ChevronRight, ChevronDown, AlertCircle, GitMerge, EyeOff, Search, X, Unlink } from 'lucide-react';
 import { toast } from 'sonner';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -536,7 +536,6 @@ export function SpecCorpusView({
                     key={doc.ref}
                     docRef={doc.ref}
                     title={doc.title}
-                    url={doc.url}
                     reason={doc.reason}
                     active={activeKey === doc.ref}
                     actionLabel="include"
@@ -779,28 +778,6 @@ function Section({
 }
 
 /**
- * A deep link to a doc's source (Confluence / Jira / …), shown when the workspace
- * ledger has a URL for the ref. An anchor that stops propagation so it opens the
- * source without triggering the row's preview/pin. Hover help via HoverPopover.
- */
-function DocLink({ url }: { url: string }) {
-  return (
-    <HoverPopover content="Open source" side="top" align="end">
-      <a
-        href={url}
-        target="_blank"
-        rel="noreferrer"
-        onClick={(e) => e.stopPropagation()}
-        aria-label="Open source"
-        className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-foreground"
-      >
-        <ExternalLink className="h-3 w-3" />
-      </a>
-    </HoverPopover>
-  );
-}
-
-/**
  * A kept-doc row (the "Documents" section). Previewable like every list row —
  * single-click previews, double-click pins. Carries an inline "skip" action
  * (force-exclude) revealed on hover; the action button stops propagation so it
@@ -857,7 +834,6 @@ function DocRow({
           </span>
         )}
       </span>
-      {doc.url && <DocLink url={doc.url} />}
       <HoverPopover content={disabledReason ?? null} side="top" align="end">
         <button
           type="button"
@@ -887,7 +863,6 @@ function DocRow({
 function IncludeRow({
   docRef,
   title,
-  url,
   reason,
   active,
   actionLabel,
@@ -900,8 +875,6 @@ function IncludeRow({
   docRef: string;
   /** Workspace only: the ledger's human title for this ref. Falls back to the ref. */
   title?: string;
-  /** Workspace only: deep link to the source doc, when the ledger has one. */
-  url?: string | null;
   reason?: string;
   active: boolean;
   actionLabel: string;
@@ -934,7 +907,6 @@ function IncludeRow({
         )}
         {pending && <span className="text-[10px] italic text-muted-foreground/60">pending rescan</span>}
       </span>
-      {url && <DocLink url={url} />}
       <HoverPopover content={disabledReason ?? null} side="top" align="end">
         <button
           type="button"
@@ -1060,7 +1032,6 @@ function SkippedSection({
               key={doc.ref}
               docRef={doc.ref}
               title={doc.title}
-              url={doc.url}
               reason={doc.reason}
               active={activeKey === doc.ref}
               actionLabel="include"

--- a/apps/dashboard/client/src/components/spec/SpecDocViewer.tsx
+++ b/apps/dashboard/client/src/components/spec/SpecDocViewer.tsx
@@ -100,7 +100,10 @@ export function SpecDocViewer({
           )}
           <span className="truncate text-xs font-medium text-foreground">{title ?? docRef}</span>
           {url && (
-            <HoverPopover content="Open source" side="top">
+            // The header sits at the top-right of the pane, inside an
+            // `overflow-hidden` column — anchor the tooltip below-and-left so it
+            // isn't clipped by the pane top or the viewport right edge.
+            <HoverPopover content="Open source" side="bottom" align="end">
               <a
                 href={url}
                 target="_blank"

--- a/apps/dashboard/client/src/components/spec/WorkspaceBadge.tsx
+++ b/apps/dashboard/client/src/components/spec/WorkspaceBadge.tsx
@@ -4,26 +4,15 @@
  * to a kept-doc row / conflict side so an inherited doc reads distinctly from a
  * repo-local one. Absent in OSS and on repo-local docs (no `layer`). Same geometry
  * as the guard status chips (GuardHeldBadge / GuardFindingBadge) so it sits inline
- * with them; a HoverPopover explains the inheritance.
+ * with them.
  */
-
-import { Building2 } from 'lucide-react';
-import { HoverPopover } from '@/components/ui/hover-popover';
 
 export function WorkspaceBadge({ className = '' }: { className?: string }) {
   return (
-    <HoverPopover
-      content="Inherited from the workspace Knowledge corpus — shared by every repo in this organization."
-      width="narrow"
-      side="top"
-      align="end"
+    <span
+      className={`inline-flex shrink-0 items-center rounded border border-border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground ${className}`}
     >
-      <span
-        className={`inline-flex shrink-0 items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground ${className}`}
-      >
-        <Building2 className="h-2.5 w-2.5" />
-        workspace
-      </span>
-    </HoverPopover>
+      workspace
+    </span>
   );
 }

--- a/apps/dashboard/server/src/routes/spec.ts
+++ b/apps/dashboard/server/src/routes/spec.ts
@@ -29,7 +29,10 @@ import { readRepoDoc } from '@truecourse/core/lib/repo-doc-reader';
 import { getBackgroundTaskRunner } from '@truecourse/core/lib/background-tasks';
 import { getGuardGenerateEnqueue } from '@truecourse/core/lib/guard-generate-enqueue';
 import { getSpecConflictsResolvedHook } from '@truecourse/core/lib/spec-conflicts-resolved-hook';
-import { getKnowledgeLedgerReader } from '@truecourse/core/lib/knowledge-ledger-reader';
+import {
+  getKnowledgeLedgerReader,
+  getKnowledgeDocBodyReader,
+} from '@truecourse/core/lib/knowledge-ledger-reader';
 import { readGuardResultForView } from '@truecourse/core/commands/guard-read';
 import { isGitRepo, NOT_A_GIT_REPO_MESSAGE } from '@truecourse/core/lib/git';
 import {
@@ -122,6 +125,25 @@ export async function enrichWorkspaceLayer(
     return { ...d, layer: 'workspace' as const, ...(m ? { title: m.title, url: m.url } : {}) };
   });
   return { ...corpus, docs };
+}
+
+/**
+ * Resolve an inherited workspace doc's body for the repo Spec-tab doc route (hosted).
+ * A connected repo folds its workspace Knowledge into its own spec, so a ref under the
+ * `knowledge/` prefix (the inherited layer `enrichWorkspaceLayer` tags) names a doc
+ * whose body lives in the workspace document store, never the repo tree. Hosted + such
+ * a ref is served through the body-reader seam (EE installs it; unset ⇒ missing).
+ * Any other case — OSS in-place, or a repo-local ref — returns `{ inherited: false }`
+ * so the route reads the repo tree as before. `content: null` (row/body absent) is the
+ * route's 404 trigger.
+ */
+export async function readInheritedDoc(
+  repoKey: string,
+  ref: string,
+): Promise<{ inherited: false } | { inherited: true; content: string | null }> {
+  if (specsMaterializeInPlace() || !ref.startsWith('knowledge/')) return { inherited: false };
+  const reader = getKnowledgeDocBodyReader();
+  return { inherited: true, content: reader ? await reader(repoKey, ref) : null };
 }
 
 async function corpusPayload(repoPath: string, ref?: string, pr?: number): Promise<SpecCorpusPayload> {
@@ -235,6 +257,18 @@ router.get(
       // holds in EE too, where repo.path is a repoKey, not a filesystem path.
       if (path.isAbsolute(ref) || ref.split(/[\\/]/).includes('..')) {
         res.status(400).json({ error: 'ref escapes the repository.' });
+        return;
+      }
+      // A `knowledge/` ref (hosted) is an inherited workspace doc: its body lives in
+      // the workspace document store, not the repo tree — serve it through the seam.
+      // `commit` doesn't apply (the current workspace snapshot); a missing row/body 404s.
+      const inherited = await readInheritedDoc(repo.path, ref);
+      if (inherited.inherited) {
+        if (inherited.content == null) {
+          res.status(404).json({ error: `Doc not found: ${ref}` });
+          return;
+        }
+        res.json({ ref, content: inherited.content });
         return;
       }
       // Read through the seam: local working tree in OSS, GitHub (App) in EE.

--- a/ee/packages/client/src/KnowledgePage.tsx
+++ b/ee/packages/client/src/KnowledgePage.tsx
@@ -14,19 +14,23 @@
  * workspace-level Scenarios tab.
  *
  * Tabs:
- *   - Spec (default): areas → kept docs + conflicts; right pane = doc markdown /
- *     conflict resolution. Force-include / exclude + pick-a-side verdicts all hit
- *     the workspace decision endpoints.
+ *   - Spec (default): areas → kept docs + conflicts; the right pane opens each in
+ *     the house preview/pin tab strip (single-click preview, double-click pin,
+ *     `?spec=`-synced) — a doc opens the markdown viewer, a conflict the resolution
+ *     detail. Force-include / exclude + pick-a-side verdicts all hit the workspace
+ *     decision endpoints.
  *   - Sources: the provenance ledger (server-paginated, searchable, kind-filtered).
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { BookOpen, Database, FileText, Loader2, Search } from 'lucide-react';
+import { BookOpen, Database, FileText, GitMerge, Loader2, Search } from 'lucide-react';
 import { EmptyState } from '@/components/ui/empty-state';
 import { SpecCorpusView, useSpecCorpus, parseSpecKey } from '@/components/spec/SpecCorpusView';
 import { SpecOverlapDetail } from '@/components/spec/SpecOverlapDetail';
 import { SpecDocViewer } from '@/components/spec/SpecDocViewer';
 import { SpecSourceProvider } from '@/components/spec/spec-source';
+import { GuardTabStrip, type GuardTabStripItem } from '@/components/guard/GuardTabStrip';
+import { useGuardTabs } from '@/hooks/useGuardTabs';
 import { getJson } from './api';
 import { createWorkspaceSpecSource } from './knowledge-spec-source';
 
@@ -88,50 +92,77 @@ export default function KnowledgePage() {
 // ---------------------------------------------------------------------------
 
 function KnowledgeSpecTab() {
-  const [activeKey, setActiveKey] = useState<string | null>(null);
   const corpus = useSpecCorpus('ws', true);
-  const open = useCallback((key: string) => setActiveKey(key), []);
-  const sel = useMemo(() => (activeKey ? parseSpecKey(activeKey) : null), [activeKey]);
+  // The shared preview/pin tab model (single-click preview, double-click pin),
+  // `?spec=`-synced — the same reducer + strip the repo Spec views use.
+  const { activeId, openTabs, open, close, selectOverview } = useGuardTabs('spec', 'ws');
+  const sel = useMemo(() => (activeId ? parseSpecKey(activeId) : null), [activeId]);
   // The kept docs' ledger title + deep link, so a doc preview reads its human title.
   const docMeta = useMemo(
     () => new Map((corpus.data?.corpus.docs ?? []).map((d) => [d.ref, d] as const)),
     [corpus.data],
   );
+  const labelOf = useCallback((ref: string): string => docMeta.get(ref)?.title ?? ref, [docMeta]);
+
+  // Each open tab as a strip item: a doc labels by its ledger title (ref fallback),
+  // a conflict by "a ↔ b" (both titles) — truncated in the strip, full on hover.
+  const tabItems = useMemo<GuardTabStripItem[]>(
+    () =>
+      openTabs.map((t) => {
+        const k = parseSpecKey(t.id);
+        if (k.kind === 'overlap') {
+          const label = `${labelOf(k.a)} ↔ ${labelOf(k.b)}`;
+          return { ...t, label, title: label, icon: GitMerge };
+        }
+        const label = labelOf(k.ref);
+        return { ...t, label, title: label, icon: FileText };
+      }),
+    [openTabs, labelOf],
+  );
 
   return (
     <div className="flex h-full">
       <div className="w-[380px] shrink-0 overflow-auto border-r border-border">
-        <SpecCorpusView repoId="ws" corpus={corpus} activeKey={activeKey} onOpen={open} />
+        <SpecCorpusView repoId="ws" corpus={corpus} activeKey={activeId} onOpen={open} />
       </div>
-      <div className="min-w-0 flex-1 overflow-auto">
-        {sel?.kind === 'overlap' && corpus.data ? (
-          <SpecOverlapDetail
-            repoId="ws"
-            area={sel.area}
-            docA={sel.a}
-            docB={sel.b}
-            data={corpus.data}
-            onResolved={(res) => {
-              if (res) corpus.apply(res);
-              else void corpus.refetch();
-            }}
-            onConflictChange={(list) => corpus.applyConflictResolutions(list)}
-            onClose={() => setActiveKey(null)}
-          />
-        ) : sel?.kind === 'doc' ? (
-          <SpecDocViewer
-            repoId="ws"
-            docRef={sel.ref}
-            title={docMeta.get(sel.ref)?.title}
-            url={docMeta.get(sel.ref)?.url}
-          />
-        ) : (
-          <EmptyState
-            icon={FileText}
-            title="Select a document or conflict"
-            body="Choose a document to read it, or a conflict to resolve it."
-          />
-        )}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <GuardTabStrip
+          tabs={tabItems}
+          activeId={activeId}
+          onSelect={(t) => open(t.id, t.pinned)}
+          onSelectOverview={selectOverview}
+          onClose={close}
+        />
+        <div className="min-h-0 flex-1 overflow-auto">
+          {sel?.kind === 'overlap' && corpus.data ? (
+            <SpecOverlapDetail
+              repoId="ws"
+              area={sel.area}
+              docA={sel.a}
+              docB={sel.b}
+              data={corpus.data}
+              onResolved={(res) => {
+                if (res) corpus.apply(res);
+                else void corpus.refetch();
+              }}
+              onConflictChange={(list) => corpus.applyConflictResolutions(list)}
+              onClose={() => activeId && close(activeId)}
+            />
+          ) : sel?.kind === 'doc' ? (
+            <SpecDocViewer
+              repoId="ws"
+              docRef={sel.ref}
+              title={docMeta.get(sel.ref)?.title}
+              url={docMeta.get(sel.ref)?.url}
+            />
+          ) : (
+            <EmptyState
+              icon={FileText}
+              title="Select a document or conflict"
+              body="Choose a document to read it, or a conflict to resolve it."
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/ee/packages/data-store/src/knowledge-store.ts
+++ b/ee/packages/data-store/src/knowledge-store.ts
@@ -24,6 +24,8 @@ export interface KnowledgeDocRow {
   url: string | null;
   version: string | null;
   contentHash: string;
+  /** sha256 of the body the last process consolidated; null until first processed. */
+  processedHash: string | null;
   lastSyncedAt: string;
 }
 
@@ -64,9 +66,12 @@ export class PgKnowledgeStore {
     return this.content.gc(contentScope.knowledge(workspaceOrgId), liveHashes);
   }
 
-  /** Insert or update one source-doc provenance row (keyed by org+sourceKind+externalId). */
+  /** Insert or update one source-doc provenance row (keyed by org+sourceKind+externalId).
+   *  `processedHash` is deliberately NOT set here — sync leaves the processed marker
+   *  untouched (a new row defaults to null; an existing row keeps its marker), so the
+   *  sweep delta measures synced-vs-processed. Only {@link markProcessed} stamps it. */
   async upsertDocument(
-    row: Omit<KnowledgeDocRow, 'lastSyncedAt'> & { lastSyncedAt?: string },
+    row: Omit<KnowledgeDocRow, 'lastSyncedAt' | 'processedHash'> & { lastSyncedAt?: string },
   ): Promise<void> {
     const now = row.lastSyncedAt ?? new Date().toISOString();
     await this.db
@@ -100,6 +105,32 @@ export class PgKnowledgeStore {
       });
   }
 
+  /**
+   * Stamp the processed marker for the docs a process just consolidated, in ONE
+   * statement. `processedHash` is the sha of the body that consolidation actually
+   * saw (passed explicitly, not read back from `content_hash`, so a concurrent sync
+   * that re-hashed the row can't misattribute the marker). Keyed by the doc's unique
+   * `docPath`. After this, a re-sweep reads those docs as up to date until their
+   * content changes again.
+   */
+  async markProcessed(
+    workspaceOrgId: string,
+    entries: Array<{ docPath: string; processedHash: string }>,
+  ): Promise<void> {
+    if (entries.length === 0) return;
+    const values = sql.join(
+      entries.map((e) => sql`(${e.docPath}::text, ${e.processedHash}::text)`),
+      sql`, `,
+    );
+    await this.db.execute(sql`
+      update ${knowledgeDocuments} as k
+         set processed_hash = v.processed_hash
+        from (values ${values}) as v(doc_path, processed_hash)
+       where k.workspace_org_id = ${workspaceOrgId}
+         and k.doc_path = v.doc_path
+    `);
+  }
+
   /** Every source doc for a workspace, newest-synced first. */
   async listDocuments(workspaceOrgId: string): Promise<KnowledgeDocRow[]> {
     const rows = await this.db
@@ -116,6 +147,7 @@ export class PgKnowledgeStore {
         url: r.url,
         version: r.version,
         contentHash: r.contentHash,
+        processedHash: r.processedHash,
         lastSyncedAt: r.lastSyncedAt,
       }))
       .sort((a, b) => (a.lastSyncedAt < b.lastSyncedAt ? 1 : a.lastSyncedAt > b.lastSyncedAt ? -1 : 0));
@@ -164,6 +196,7 @@ export class PgKnowledgeStore {
         url: r.url,
         version: r.version,
         contentHash: r.contentHash,
+        processedHash: r.processedHash,
         lastSyncedAt: r.lastSyncedAt,
       })),
       total: countRow?.total ?? 0,
@@ -193,6 +226,7 @@ export class PgKnowledgeStore {
       url: r.url,
       version: r.version,
       contentHash: r.contentHash,
+      processedHash: r.processedHash,
       lastSyncedAt: r.lastSyncedAt,
     };
   }

--- a/ee/packages/db/drizzle/0009_stale_mister_fear.sql
+++ b/ee/packages/db/drizzle/0009_stale_mister_fear.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "knowledge_documents" ADD COLUMN "processed_hash" text;

--- a/ee/packages/db/drizzle/meta/0009_snapshot.json
+++ b/ee/packages/db/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,2116 @@
+{
+  "id": "3cd4f65c-b1dc-4f91-850b-299f1e21c491",
+  "prevId": "aa1d3797-4ac7-462c-a616-d583af00d597",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.gh_baselines": {
+      "name": "gh_baselines",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_inferred_actions": {
+      "name": "gh_inferred_actions",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gh_inferred_actions_repo_full_name_kind_identity_pk": {
+          "name": "gh_inferred_actions_repo_full_name_kind_identity_pk",
+          "columns": [
+            "repo_full_name",
+            "kind",
+            "identity"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_installations": {
+      "name": "gh_installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_prs": {
+      "name": "gh_prs",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gh_prs_repo_full_name_pr_number_pk": {
+          "name": "gh_prs_repo_full_name_pr_number_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_repos": {
+      "name": "gh_repos",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocking": {
+          "name": "blocking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "code_quality_blocking": {
+          "name": "code_quality_blocking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "code_quality_min_severity": {
+          "name": "code_quality_min_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'high'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_emails": {
+          "name": "notify_emails",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_runs": {
+      "name": "gh_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_count": {
+          "name": "added_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_count": {
+          "name": "resolved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_runs_repo_created_idx": {
+          "name": "gh_runs_repo_created_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_provider_config": {
+      "name": "llm_provider_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_model": {
+          "name": "fallback_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_enc": {
+          "name": "api_key_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_key_id": {
+          "name": "access_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content": {
+      "name": "content",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_scope_sha_pk": {
+          "name": "content_scope_sha_pk",
+          "columns": [
+            "scope",
+            "sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analyses": {
+      "name": "analyses",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "analyses_repo_analysis_idx": {
+          "name": "analyses_repo_analysis_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "analysis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "analyses_repo_key_filename_pk": {
+          "name": "analyses_repo_key_filename_pk",
+          "columns": [
+            "repo_key",
+            "filename"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_current": {
+      "name": "analysis_current",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "analysis_current_repo_key_kind_pk": {
+          "name": "analysis_current_repo_key_kind_pk",
+          "columns": [
+            "repo_key",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_history": {
+      "name": "analysis_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry": {
+          "name": "entry",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "analysis_history_repo_idx": {
+          "name": "analysis_history_repo_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decisions": {
+      "name": "decisions",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registry": {
+      "name": "registry",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_opened": {
+          "name": "last_opened",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_analyzed": {
+          "name": "last_analyzed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registry_path_unique": {
+          "name": "registry_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_config": {
+      "name": "repo_config",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_ui_state": {
+      "name": "repo_ui_state",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spec_sets": {
+      "name": "spec_sets",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha": {
+          "name": "content_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "spec_sets_repo_artifact_created_idx": {
+          "name": "spec_sets_repo_artifact_created_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "spec_sets_repo_key_commit_sha_artifact_pk": {
+          "name": "spec_sets_repo_key_commit_sha_artifact_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha",
+            "artifact"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extraction_cache": {
+      "name": "extraction_cache",
+      "schema": "",
+      "columns": {
+        "cache_name": {
+          "name": "cache_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "extraction_cache_cache_name_cache_key_pk": {
+          "name": "extraction_cache_cache_name_cache_key_pk",
+          "columns": [
+            "cache_name",
+            "cache_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_documents": {
+      "name": "knowledge_documents",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_path": {
+          "name": "doc_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_hash": {
+          "name": "processed_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "knowledge_documents_org_idx": {
+          "name": "knowledge_documents_org_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "knowledge_documents_workspace_org_id_source_kind_external_id_pk": {
+          "name": "knowledge_documents_workspace_org_id_source_kind_external_id_pk",
+          "columns": [
+            "workspace_org_id",
+            "source_kind",
+            "external_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_spec_sets": {
+      "name": "workspace_spec_sets",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha": {
+          "name": "content_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workspace_spec_sets_workspace_org_id_artifact_pk": {
+          "name": "workspace_spec_sets_workspace_org_id_artifact_pk",
+          "columns": [
+            "workspace_org_id",
+            "artifact"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_enc": {
+          "name": "token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending": {
+          "name": "pending",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "integration_connections_org_idx": {
+          "name": "integration_connections_org_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "integration_connections_workspace_org_id_provider_pk": {
+          "name": "integration_connections_workspace_org_id_provider_pk",
+          "columns": [
+            "workspace_org_id",
+            "provider"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_backfill_markers": {
+      "name": "guard_backfill_markers",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress_current": {
+          "name": "progress_current",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_total": {
+          "name": "progress_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_message": {
+          "name": "progress_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "jobs_org_idx": {
+          "name": "jobs_org_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_active_key_uniq": {
+          "name": "jobs_active_key_uniq",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status in ('queued','running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notifications_org_created_idx": {
+          "name": "notifications_org_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_baselines": {
+      "name": "pending_baselines",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiet": {
+          "name": "quiet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_guard_baselines": {
+      "name": "pending_guard_baselines",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_traces": {
+      "name": "llm_traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slice_id": {
+          "name": "slice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_sha": {
+          "name": "prompt_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_sha": {
+          "name": "output_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_sha": {
+          "name": "reasoning_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "llm_traces_org_created_idx": {
+          "name": "llm_traces_org_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_traces_trace_idx": {
+          "name": "llm_traces_trace_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_traces_org_stage_idx": {
+          "name": "llm_traces_org_stage_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_traces_org_prompt_idx": {
+          "name": "llm_traces_org_prompt_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_settings": {
+      "name": "workspace_settings",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_analysis_llm": {
+          "name": "code_analysis_llm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_results": {
+      "name": "guard_results",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guard_results_repo_key_commit_sha_pk": {
+          "name": "guard_results_repo_key_commit_sha_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_runs": {
+      "name": "guard_runs",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_baseline": {
+          "name": "is_baseline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guard_runs_repo_ran_idx": {
+          "name": "guard_runs_repo_ran_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guard_runs_baseline_idx": {
+          "name": "guard_runs_baseline_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_baseline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guard_runs_repo_run_idx": {
+          "name": "guard_runs_repo_run_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guard_runs_repo_key_commit_sha_pk": {
+          "name": "guard_runs_repo_key_commit_sha_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_scenario_sets": {
+      "name": "guard_scenario_sets",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guard_scenario_sets_repo_key_commit_sha_pk": {
+          "name": "guard_scenario_sets_repo_key_commit_sha_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/ee/packages/db/drizzle/meta/_journal.json
+++ b/ee/packages/db/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1784078678264,
       "tag": "0008_wakeful_natasha_romanoff",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1784239769917,
+      "tag": "0009_stale_mister_fear",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/db/src/schema/integrations.ts
+++ b/ee/packages/db/src/schema/integrations.ts
@@ -47,7 +47,8 @@ export interface IntegrationPendingEstimate {
  * @truecourse/shared.
  */
 export interface IntegrationPending {
-  /** Doc delta vs the provenance ledger, counted by content hash. */
+  /** Doc delta vs what Process has consolidated (the `processed_hash` marker),
+   *  counted by content hash — new/changed/removed unprocessed work. */
   delta: { new: number; changed: number; removed: number; total: number };
   /** The full estimate captured at sweep time — the Process confirm dialog. */
   estimate: IntegrationPendingEstimate;

--- a/ee/packages/db/src/schema/knowledge.ts
+++ b/ee/packages/db/src/schema/knowledge.ts
@@ -56,6 +56,14 @@ export const knowledgeDocuments = pgTable(
     version: text('version'),
     /** sha256 of the body at last sync — the incremental-sync diff key. */
     contentHash: text('content_hash').notNull(),
+    /**
+     * sha256 of the body the LAST process (consolidation) actually saw; null until
+     * the doc is first processed. The sweep delta compares this against the fetched
+     * `contentHash` — a doc synced but never processed (null), or whose content has
+     * changed since it was consolidated, is pending work. Sync never touches this;
+     * only the processing job stamps it (`markProcessed`).
+     */
+    processedHash: text('processed_hash'),
     lastSyncedAt: ts('last_synced_at').notNull(),
     createdAt: ts('created_at').notNull(),
   },

--- a/ee/packages/server/src/index.ts
+++ b/ee/packages/server/src/index.ts
@@ -21,8 +21,8 @@ import { setGuardGenerateEnqueue } from '@truecourse/core/lib/guard-generate-enq
 import { setGuardPrRegenEnqueue } from '@truecourse/core/lib/guard-pr-regen-enqueue';
 import { setSpecConflictsResolvedHook } from '@truecourse/core/lib/spec-conflicts-resolved-hook';
 import { setSpecInheritanceHook } from '@truecourse/core/lib/spec-inheritance-hook';
-import { setKnowledgeLedgerReader } from '@truecourse/core/lib/knowledge-ledger-reader';
-import { createSpecInheritanceHook, createKnowledgeLedgerReader } from './knowledge/inheritance.js';
+import { setKnowledgeLedgerReader, setKnowledgeDocBodyReader } from '@truecourse/core/lib/knowledge-ledger-reader';
+import { createSpecInheritanceHook, createKnowledgeLedgerReader, createKnowledgeDocBodyReader } from './knowledge/inheritance.js';
 import { guardGateJobKey } from './jobs/constants.js';
 import { loadWorkosConfig } from './config.js';
 import { createAuthRouter, createSessionVerifier } from './auth.js';
@@ -196,11 +196,14 @@ const plugin: EePlugin = {
     // corpus into its own spec. The spec pipeline materializes the workspace doc
     // bodies + merges the workspace decisions (repo wins) into the checkout before
     // curate/generate through this seam; the repo corpus GET enriches the inherited
-    // docs' title/url through the ledger reader seam. Both resolve the repo's
-    // workspace org from the gate store; a repo with no workspace inherits nothing.
+    // docs' title/url through the ledger reader seam, and the repo Spec-tab doc route
+    // serves an inherited (`knowledge/`) doc's body through the body reader seam
+    // (those bodies live in the workspace store, not the repo tree). All resolve the
+    // repo's workspace org from the gate store; a repo with no workspace inherits nothing.
     const knowledgeStore = new PgKnowledgeStore(eeDb);
     setSpecInheritanceHook(createSpecInheritanceHook({ store: gateStore, knowledge: knowledgeStore }));
     setKnowledgeLedgerReader(createKnowledgeLedgerReader({ store: gateStore, knowledge: knowledgeStore }));
+    setKnowledgeDocBodyReader(createKnowledgeDocBodyReader({ store: gateStore, knowledge: knowledgeStore }));
 
     // The Spec tab reads source docs (README, ADRs) by repo path. OSS reads the
     // working tree; EE has no checkout, so fetch them from GitHub via the App

--- a/ee/packages/server/src/knowledge/inheritance.ts
+++ b/ee/packages/server/src/knowledge/inheritance.ts
@@ -22,7 +22,10 @@ import type {
   SpecInheritanceHook,
   WorkspaceInheritanceDoc,
 } from '@truecourse/core/lib/spec-inheritance-hook';
-import type { KnowledgeLedgerReader } from '@truecourse/core/lib/knowledge-ledger-reader';
+import type {
+  KnowledgeLedgerReader,
+  KnowledgeDocBodyReader,
+} from '@truecourse/core/lib/knowledge-ledger-reader';
 
 export interface InheritanceDeps {
   /** Resolves a connected repo's workspace org from the stored gate records. */
@@ -69,5 +72,24 @@ export function createKnowledgeLedgerReader(deps: InheritanceDeps): KnowledgeLed
     const link = await deps.store.getRepo(repoKey);
     if (!link?.workspaceOrgId) return new Map();
     return deps.knowledge.titlesByDocPath(link.workspaceOrgId, docPaths);
+  };
+}
+
+/**
+ * Build the `(repoKey, docPath) → stored body` reader installed via
+ * `setKnowledgeDocBodyReader`. Resolves the repo's workspace org from the gate
+ * records, then reads the inherited doc's STORED body from its ledger row's content
+ * hash (no connector I/O — Sync already persisted it). Null when the repo has no
+ * workspace, no ledger row for the path, or the body is absent; the repo Spec-tab
+ * doc route renders any of those as a 404.
+ */
+export function createKnowledgeDocBodyReader(deps: InheritanceDeps): KnowledgeDocBodyReader {
+  return async (repoKey, docPath) => {
+    const link = await deps.store.getRepo(repoKey);
+    if (!link?.workspaceOrgId) return null;
+    const org = link.workspaceOrgId;
+    const row = await deps.knowledge.findByDocPath(org, docPath);
+    if (!row) return null;
+    return deps.knowledge.getDocBody(org, row.contentHash);
   };
 }

--- a/ee/packages/server/src/knowledge/sync.ts
+++ b/ee/packages/server/src/knowledge/sync.ts
@@ -7,8 +7,10 @@
  *     content-addressed into the shared `content` table (sha = its `contentHash`,
  *     so identical bodies dedup), and the provenance ledger is reconciled for this
  *     source (upsert present docs, prune removed ones). Sources therefore fills the
- *     moment a sync completes. The pending record's `delta` is counted against the
- *     ledger BEFORE the upsert. See {@link syncSource}.
+ *     moment a sync completes. The pending record's `delta` is counted against what
+ *     Process has consolidated (the `processed_hash` marker), NOT the ledger — so a
+ *     re-sync of an unchanged-but-unprocessed source still reports the pending work.
+ *     See {@link syncSource}.
  *   - **Process (workspace union)** — NO connector I/O. Load every ledger row + its
  *     stored body, re-consolidate the FULL union via `syncWorkspaceCorpusInProcess`
  *     (the corpus path: materialize the docs into a transient scratch tree, curate
@@ -29,9 +31,11 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   syncWorkspaceCorpusInProcess,
+  type CuratedCorpus,
   type DecisionsFile,
   type WorkspaceDocInput,
 } from '@truecourse/core/commands/spec-in-process';
+import { loadWorkspaceSpec } from '@truecourse/core/lib/spec-store';
 import { estimateScanTokens } from '@truecourse/core/services/llm/spec-estimate';
 import { getModelPrices } from '@truecourse/core/services/llm/model-prices';
 import type { LlmEstimate } from '@truecourse/core/commands/analyze-core';
@@ -216,6 +220,9 @@ export async function processWorkspaceKnowledge(
   // union on one gap). Doc path + newest-wins timestamp ride from the ledger row.
   const docs: WorkspaceDocInput[] = [];
   const bySource: Record<string, number> = {};
+  // The processed marker to stamp per consolidated doc: its docPath + the exact
+  // body sha this run saw (`contentHash`), so a later sweep diffs synced-vs-processed.
+  const consolidated: Array<{ docPath: string; processedHash: string }> = [];
   let loaded = 0;
   for (const row of rows) {
     const markdown = await knowledge.getDocBody(org, row.contentHash);
@@ -223,6 +230,7 @@ export async function processWorkspaceKnowledge(
     await progress?.(loaded, total, SYNC_MSG_FETCH);
     if (markdown == null) continue;
     docs.push({ docPath: row.docPath, markdown, lastTouched: row.lastSyncedAt });
+    consolidated.push({ docPath: row.docPath, processedHash: row.contentHash });
     bySource[row.sourceKind] = (bySource[row.sourceKind] ?? 0) + 1;
   }
   await progress?.(total, total, SYNC_MSG_CONSOLIDATE);
@@ -236,24 +244,35 @@ export async function processWorkspaceKnowledge(
     tracker: opts.tracker,
   });
 
+  // Stamp the processed marker for every doc this run consolidated, AFTER the
+  // corpus persists — so the next sweep reads them as up to date (delta measures
+  // synced-vs-processed, not synced-vs-ledger). A crash before this leaves the
+  // markers stale-low, which only over-reports pending — safe (idempotent re-run).
+  await knowledge.markProcessed(org, consolidated);
+
   return { synced: docs.length, bySource };
 }
 
 // --- Sync ("Sync now"): fetch + persist + price (no LLM) -------------
 
 /**
- * Ledger delta for a sync, counted by CONTENT HASH (not the source's version /
- * `updatedAt`): a doc whose upstream timestamp bumped but whose body is unchanged
- * is a cache hit, not a change. `total` is the current doc count.
+ * Sweep delta, counted by CONTENT HASH against what has actually been PROCESSED —
+ * NOT against the ledger. Since the storage pivot, a sync reconciles the ledger the
+ * moment it runs, so a fetched-vs-ledger diff reads empty on the second sweep of an
+ * unchanged source and would strand synced-but-unprocessed docs. The processed
+ * marker (`knowledge_documents.processed_hash`, stamped only by Process) is the
+ * baseline instead: work is pending until Process has consolidated the current body.
+ * `total` is the current upstream doc count.
  */
 export interface SyncDelta {
-  /** Docs not yet in the provenance ledger. */
+  /** Docs present upstream that Process has never consolidated (no processed marker). */
   new: number;
-  /** Docs in the ledger whose content hash differs. */
+  /** Docs processed before whose fetched body now differs from the processed one. */
   changed: number;
-  /** Ledger docs no longer present upstream (pruned on the sync). */
+  /** Docs the persisted corpus still holds that are gone upstream — pruned at sync,
+   *  not yet processed out of the corpus. */
   removed: number;
-  /** Current doc count (new + unchanged + changed). */
+  /** Current upstream doc count (new + unchanged + changed). */
   total: number;
 }
 
@@ -267,27 +286,52 @@ export interface WorkspaceSyncEstimate extends LlmEstimate {
   delta: SyncDelta;
 }
 
-/** Count new / changed / removed docs for this source against the provenance ledger (content-hash exact). */
-async function deltaAgainstLedger(
+/**
+ * Count new / changed / removed docs for this source against what Process has
+ * consolidated — the fix for the synced-≠-processed conflation. For each fetched
+ * (present-upstream) doc we read its ledger row's `processedHash`:
+ *   - new     = no processed marker yet (a brand-new row, or one synced on an
+ *               earlier sweep but never processed) — the fetched content is unseen.
+ *   - changed = a marker exists but differs from the fetched body's hash — the doc
+ *               was processed at an older content (fetched-vs-processed, content
+ *               exact so a bumped `updatedAt` alone is not a change).
+ *   - removed = a doc the persisted workspace corpus still holds that is no longer
+ *               present upstream — it was (or will be) pruned from the ledger at
+ *               this sync but stays in the corpus until the next Process drops it.
+ * Corpus refs are the connector-namespaced docPaths, so filtering by this source's
+ * `knowledge/<kind>/` prefix keeps the count per-source. The corpus load returns
+ * null before the first Process (no EE spec store / no corpus) ⇒ removed = 0.
+ */
+async function deltaAgainstProcessed(
   org: string,
   knowledge: PgKnowledgeStore,
   sourceKind: string,
   docs: SyncDoc[],
 ): Promise<SyncDelta> {
-  const priorHash = new Map<string, string>();
+  const priorProcessed = new Map<string, string | null>();
   for (const row of await knowledge.listDocuments(org)) {
-    if (row.sourceKind === sourceKind) priorHash.set(row.externalId, row.contentHash);
+    if (row.sourceKind === sourceKind) priorProcessed.set(row.externalId, row.processedHash);
   }
-  const present = new Set(docs.map((d) => d.externalId));
   let added = 0;
   let changed = 0;
   for (const d of docs) {
-    const prev = priorHash.get(d.externalId);
-    if (prev === undefined) added++;
-    else if (prev !== d.contentHash) changed++;
+    const processed = priorProcessed.get(d.externalId);
+    // No row, or a row synced but never processed → the fetched content is unseen.
+    if (processed === undefined || processed === null) added++;
+    // Processed before, but at a different body → re-processing produces new work.
+    else if (processed !== d.contentHash) changed++;
   }
+  // Removed: corpus docs of this source no longer present upstream (the post-sync
+  // ledger will not hold them). Diff the corpus refs against the fetched set.
+  const present = new Set(docs.map((d) => d.doc.docPath));
+  const corpus = await loadWorkspaceSpec<CuratedCorpus>({ workspaceOrgId: org }, 'corpus');
+  const prefix = `knowledge/${sourceKind}/`;
   let removed = 0;
-  for (const id of priorHash.keys()) if (!present.has(id)) removed++;
+  if (corpus) {
+    for (const cd of corpus.docs) {
+      if (cd.ref.startsWith(prefix) && !present.has(cd.ref)) removed++;
+    }
+  }
   return { new: added, changed, removed, total: docs.length };
 }
 
@@ -326,16 +370,17 @@ export interface EstimateOptions {
 
 /**
  * "Sync now" — the ONLY stage that talks to a source. Sweep it (list + fetch,
- * preferring `fetchMany`), count the ledger `delta` BEFORE any write, then PERSIST:
+ * preferring `fetchMany`), count the synced-vs-PROCESSED `delta`, then PERSIST:
  * every body content-addressed into the store + the ledger reconciled for this
  * source (upsert present, prune removed, GC orphaned bodies) — so Sources fills
  * immediately and Process needs no connector. Finally price the classify +
  * consolidate stage BEFORE it runs by running the cache-aware estimators against a
  * transient scratch tree of the fetched docs — the same `LlmEstimate` the OSS scan
- * modal renders, plus the `delta`. Unchanged docs are cache hits (zero cost); the
- * content-hash delta is exact, so a doc whose `updatedAt` bumped without a body
- * change doesn't inflate it. The delta is counted before the upsert, so a re-sync
- * of unchanged docs still reports "unchanged".
+ * modal renders, plus the `delta`. Docs already processed (and cached) are zero
+ * cost; the content-hash delta is exact, so a doc whose `updatedAt` bumped without a
+ * body change doesn't inflate it. The delta is against the `processed_hash` marker
+ * (untouched by sync), so a re-sync of synced-but-unprocessed docs still reports the
+ * pending work — Process, not sync, is what clears it.
  */
 export async function syncSource<Cfg extends ConnectorConfig>(
   org: string,
@@ -346,9 +391,11 @@ export async function syncSource<Cfg extends ConnectorConfig>(
 ): Promise<WorkspaceSyncEstimate> {
   const refs = await connector.list(cfg);
   const docs = await fetchSyncDocs(connector, cfg, refs, opts.onFetchProgress);
-  const delta = await deltaAgainstLedger(org, knowledge, connector.kind, docs);
-  // Persist bodies + reconcile the ledger AFTER the delta read (delta is vs the
-  // pre-upsert ledger). Sources reflects this sync the moment it returns.
+  // Delta is synced-vs-PROCESSED: the processed marker is untouched by sync, so it
+  // reads the same before or after the reconcile below; we compute it first anyway.
+  const delta = await deltaAgainstProcessed(org, knowledge, connector.kind, docs);
+  // Persist bodies + reconcile the ledger. Sources reflects this sync the moment it
+  // returns; the processed markers stay put until the next Process consolidates them.
   await persistSyncedSource(org, knowledge, connector.kind, docs);
 
   const prices = await getModelPrices();

--- a/packages/core/src/lib/knowledge-ledger-reader.ts
+++ b/packages/core/src/lib/knowledge-ledger-reader.ts
@@ -41,3 +41,29 @@ export function setKnowledgeLedgerReader(fn: KnowledgeLedgerReader | null): void
 export function getKnowledgeLedgerReader(): KnowledgeLedgerReader | null {
   return reader;
 }
+
+/**
+ * The STORED body of a repo's inherited doc, by its `knowledge/`-prefixed path — the
+ * inherited layer folds workspace docs into the repo corpus at scan time, but their
+ * bodies live in the workspace document store, not the repo tree. The repo Spec-tab
+ * doc route reads them through this seam so a `knowledge/` ref serves the same content
+ * that scan folded in. Null when the repo has no workspace, no ledger row for the path,
+ * or the body is absent (the route renders that as its 404). Same seam idiom as the
+ * title reader above; EE installs it, unset in OSS/tests. Reads only.
+ */
+export type KnowledgeDocBodyReader = (
+  repoKey: string,
+  docPath: string,
+) => Promise<string | null>;
+
+let bodyReader: KnowledgeDocBodyReader | null = null;
+
+/** Install the EE body reader (or clear it with null). Called once at boot. */
+export function setKnowledgeDocBodyReader(fn: KnowledgeDocBodyReader | null): void {
+  bodyReader = fn;
+}
+
+/** The active body reader, or null when none is registered (OSS/tests). */
+export function getKnowledgeDocBodyReader(): KnowledgeDocBodyReader | null {
+  return bodyReader;
+}

--- a/packages/shared/src/types/ee.ts
+++ b/packages/shared/src/types/ee.ts
@@ -250,7 +250,8 @@ export interface IntegrationPendingEstimate {
  * estimate: source bodies are never stored (Process re-fetches internally).
  */
 export interface IntegrationPendingView {
-  /** Doc delta vs the provenance ledger, counted by content hash. */
+  /** Doc delta vs what Process has consolidated (the processed marker), counted by
+   *  content hash — new/changed/removed unprocessed work. */
   delta: { new: number; changed: number; removed: number; total: number }
   /** The full estimate captured at sweep time — the Process confirm dialog. */
   estimate: IntegrationPendingEstimate

--- a/tests/dashboard-client/knowledge-page.test.tsx
+++ b/tests/dashboard-client/knowledge-page.test.tsx
@@ -12,8 +12,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 
 import KnowledgePage from '../../ee/packages/client/src/KnowledgePage';
+
+// The Spec tab opens docs/conflicts through the house preview/pin tab strip, which
+// is `?spec=`-synced — so the page mounts under a router.
+const renderPage = () => render(<KnowledgePage />, { wrapper: MemoryRouter });
 
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
@@ -95,7 +100,7 @@ describe('KnowledgePage — Spec tab (workspace corpus)', () => {
   afterEach(() => vi.unstubAllGlobals());
 
   it('renders kept docs by their ledger title (ref fallback) + the cross-source conflict', async () => {
-    render(<KnowledgePage />);
+    renderPage();
     // The corpus GET hits the workspace spec route (not a repo route).
     await waitFor(() => expect(screen.getByText('Documents')).toBeInTheDocument());
     expect(calls.some((u) => u.includes('/api/ee/knowledge/spec/corpus'))).toBe(true);
@@ -108,23 +113,61 @@ describe('KnowledgePage — Spec tab (workspace corpus)', () => {
     expect(
       screen.getByText('ADR 0002 — Error response envelope ↔ knowledge/jira/2.md'),
     ).toBeInTheDocument();
-    // The titled doc carries the ledger's deep link (the Open-source affordance).
-    const link = screen.getByRole('link', { name: 'Open source' });
-    expect(link).toHaveAttribute('href', 'https://acme.atlassian.net/wiki/1');
+    // The Open-source deep link is NOT on the list rows — it lives in the detail
+    // header only (exercised below).
+    expect(screen.queryByRole('link', { name: 'Open source' })).not.toBeInTheDocument();
   });
 
   it('opens a doc in the right pane via the workspace doc endpoint', async () => {
     const user = userEvent.setup();
-    render(<KnowledgePage />);
+    renderPage();
     await screen.findByText('knowledge/jira/2.md');
     await user.click(screen.getByText('knowledge/jira/2.md'));
     expect(await screen.findByText('48h.')).toBeInTheDocument();
     expect(calls.some((u) => u.includes('/api/ee/knowledge/spec/doc?ref='))).toBe(true);
   });
 
+  it('surfaces the doc source deep link in the detail header, not the list rows', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('ADR 0002 — Error response envelope');
+    // No Open-source affordance in the left nav…
+    expect(screen.queryByRole('link', { name: 'Open source' })).not.toBeInTheDocument();
+    // …until the titled doc is opened, when its detail header carries the ledger link.
+    await user.click(screen.getByText('ADR 0002 — Error response envelope'));
+    const link = await screen.findByRole('link', { name: 'Open source' });
+    expect(link).toHaveAttribute('href', 'https://acme.atlassian.net/wiki/1');
+  });
+
+  it('opens docs through the preview/pin tab strip (single-click previews + replaces, double-click pins)', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const adr = await screen.findByText('ADR 0002 — Error response envelope');
+    const jira = screen.getByText('knowledge/jira/2.md');
+
+    // Single-click opens a transient preview tab.
+    await user.click(adr);
+    expect(await screen.findByRole('button', { name: 'Close knowledge/confluence/1.md' })).toBeInTheDocument();
+
+    // A second single-click REPLACES the preview — one tab, now the Jira doc.
+    await user.click(jira);
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Close knowledge/confluence/1.md' })).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole('button', { name: 'Close knowledge/jira/2.md' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /^Close / })).toHaveLength(1);
+
+    // Double-click PINS — the pinned tab survives the next single-click preview.
+    await user.dblClick(adr);
+    await user.click(jira);
+    expect(screen.getByRole('button', { name: 'Close knowledge/confluence/1.md' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close knowledge/jira/2.md' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /^Close / })).toHaveLength(2);
+  });
+
   it('the "Not included" expander pages + searches via the paged skipped endpoint', async () => {
     const user = userEvent.setup();
-    render(<KnowledgePage />);
+    renderPage();
     // Header shows the SUMMARY count, with no rows shipped in the corpus payload.
     const header = await screen.findByText('Not included');
     expect(within(header.closest('button')!).getByText('120')).toBeInTheDocument();
@@ -169,7 +212,7 @@ describe('KnowledgePage — Spec tab (workspace corpus)', () => {
         return json({});
       }),
     );
-    render(<KnowledgePage />);
+    renderPage();
     await user.click(await screen.findByText('Not included'));
     await screen.findByText('JIRA-0: flaky ticket 0');
     // Include the first row → it leaves the skipped list and appears under Force-included.
@@ -203,7 +246,7 @@ describe('KnowledgePage — Sources tab (paginated ledger)', () => {
       }),
     );
     const user = userEvent.setup();
-    render(<KnowledgePage />);
+    renderPage();
     await user.click(await screen.findByRole('button', { name: /Sources/ }));
     expect(await screen.findByText('No sources yet')).toBeInTheDocument();
     // Sources fills after Sync (not Process) now.
@@ -225,7 +268,7 @@ describe('KnowledgePage — Sources tab (paginated ledger)', () => {
       }),
     );
     const user = userEvent.setup();
-    render(<KnowledgePage />);
+    renderPage();
     await user.click(await screen.findByRole('button', { name: /Sources/ }));
 
     // First page (50 of 120) + a "Load more" affordance.
@@ -260,7 +303,7 @@ describe('KnowledgePage — tab strip (Scenarios retired)', () => {
         return json({});
       }),
     );
-    render(<KnowledgePage />);
+    renderPage();
     // The tab strip carries Spec + Sources and nothing else.
     expect(await screen.findByRole('button', { name: /Spec/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sources/ })).toBeInTheDocument();

--- a/tests/dashboard-client/spec-workspace-badge.test.tsx
+++ b/tests/dashboard-client/spec-workspace-badge.test.tsx
@@ -94,6 +94,8 @@ describe('SpecCorpusView — workspace badge', () => {
     // The inherited doc's kept row carries the badge…
     const wsRow = screen.getByText('Workspace ADR').closest('[role="button"]')!;
     expect(within(wsRow as HTMLElement).getByText('workspace')).toBeInTheDocument();
+    // …as a plain chip — no hover tooltip.
+    expect(within(wsRow as HTMLElement).queryByRole('tooltip')).not.toBeInTheDocument();
     // …the repo-local doc's row does not.
     const localRow = screen.getByText('docs/local.md').closest('[role="button"]')!;
     expect(within(localRow as HTMLElement).queryByText('workspace')).not.toBeInTheDocument();

--- a/tests/ee-server/knowledge-sync-estimate.test.ts
+++ b/tests/ee-server/knowledge-sync-estimate.test.ts
@@ -22,7 +22,13 @@ vi.mock('@truecourse/core/services/llm/model-prices', () => ({
 
 import { estimateScanTokens } from '@truecourse/core/services/llm/spec-estimate';
 import { syncWorkspaceCorpusInProcess } from '@truecourse/core/commands/spec-in-process';
-import { PgKnowledgeStore } from '../../ee/packages/data-store/src/index';
+import {
+  setSpecStore,
+  resetSpecStore,
+  saveWorkspaceSpec,
+} from '@truecourse/core/lib/spec-store';
+import { PgKnowledgeStore, PgSpecStore } from '../../ee/packages/data-store/src/index';
+import { pendingFromEstimate } from '../../ee/packages/server/src/jobs/worker';
 import {
   syncSource,
   processWorkspaceKnowledge,
@@ -114,7 +120,9 @@ function plainConnector(opts: {
   };
 }
 
-/** Pre-seed the provenance ledger with content-hashed rows (the prior sync's state). */
+/** Pre-seed the ledger with rows that have been synced AND processed at their
+ *  current content (the realistic prior-run baseline the sweep delta measures
+ *  against — stamps `processedHash = contentHash`). */
 async function seedLedger(
   store: PgKnowledgeStore,
   kind: string,
@@ -133,6 +141,10 @@ async function seedLedger(
       lastSyncedAt: '2026-01-01T00:00:00Z',
     });
   }
+  await store.markProcessed(
+    ORG,
+    rows.map((r) => ({ docPath: connectorDocPath(kind, r.externalId), processedHash: hash(r.markdown) })),
+  );
 }
 
 /** Seed the store the way Sync leaves it: the body content-addressed + the ledger row. */
@@ -159,6 +171,19 @@ async function seedStored(
 
 const ids = async (store: PgKnowledgeStore): Promise<string[]> =>
   (await store.listDocuments(ORG)).map((d) => d.externalId).sort();
+
+/** Persist a minimal workspace corpus whose kept docs are the given refs — the
+ *  `removed` half of the delta diffs these against the fetched set. Requires the
+ *  Postgres spec store to be installed (see the Stage-1 describe's beforeEach). */
+async function seedCorpus(refs: string[]): Promise<void> {
+  await saveWorkspaceSpec({ workspaceOrgId: ORG }, 'corpus', {
+    version: 3,
+    generatedAt: '2026-01-01T00:00:00Z',
+    docs: refs.map((ref) => ({ ref, kind: 'spec', lastTouched: '2026-01-01T00:00:00Z', areaTags: [] })),
+    areas: [],
+    skippedDocs: [],
+  });
+}
 
 describe('syncSource — fetch + persist bodies + reconcile the ledger', () => {
   let client: PGlite;
@@ -314,10 +339,15 @@ describe('syncSource — Stage-1 cost estimate', () => {
 
   beforeEach(async () => {
     client = new PGlite();
-    knowledge = new PgKnowledgeStore(await makeDb(client));
+    const db = await makeDb(client);
+    knowledge = new PgKnowledgeStore(db);
+    // The delta's `removed` diffs the persisted workspace corpus against the fetched
+    // set — install the Postgres spec store so `loadWorkspaceSpec` can read it.
+    setSpecStore(new PgSpecStore(db));
     vi.mocked(estimateScanTokens).mockReset().mockResolvedValue(EMPTY);
   });
   afterEach(async () => {
+    resetSpecStore();
     await client.close();
   });
 
@@ -358,7 +388,9 @@ describe('syncSource — Stage-1 cost estimate', () => {
       { externalId: '1', markdown: md1 },
       { externalId: '2', markdown: bodyOf('2') },
     ]);
-    // Issue 2 deleted upstream; issue 1 unchanged.
+    // Both were processed into the corpus; issue 2 is now deleted upstream. `removed`
+    // is the corpus doc no longer present upstream (pending removal at next Process).
+    await seedCorpus([connectorDocPath('jira', '1'), connectorDocPath('jira', '2')]);
     const conn = batchConnector({ refs: [ref('1')], bodies: { '1': md1 } });
 
     const est = await syncSource(ORG, knowledge, conn, {});
@@ -366,17 +398,17 @@ describe('syncSource — Stage-1 cost estimate', () => {
     expect(est.stages).toEqual([]); // zero LLM cost → the client skips the modal, still runs Process
   });
 
-  it('persists the fetched bodies + reconciles the ledger (delta is vs the PRE-upsert state)', async () => {
+  it('persists the fetched bodies + reconciles the ledger (delta is vs the processed marker)', async () => {
     await seedLedger(knowledge, 'jira', [{ externalId: '1', markdown: bodyOf('1'), version: 'v-orig' }]);
 
-    // Issue 1 edited, issue 2 brand new.
+    // Issue 1 edited (processed before at bodyOf('1')), issue 2 brand new.
     const conn = batchConnector({
       refs: [ref('1', 'bumped'), ref('2', 'new')],
       bodies: { '1': bodyOf('1', 9), '2': bodyOf('2') },
     });
     const est = await syncSource(ORG, knowledge, conn, {});
 
-    // The delta is counted against the ledger BEFORE the upsert.
+    // Issue 1's body differs from what was processed → changed; issue 2 → new.
     expect(est.delta).toEqual({ new: 1, changed: 1, removed: 0, total: 2 });
     // …and the ledger + bodies now reflect the sweep.
     expect(await ids(knowledge)).toEqual(['1', '2']);
@@ -435,5 +467,97 @@ describe('syncSource — Stage-1 cost estimate', () => {
     // A new doc → scenario generation follows unpriced → the cost is a partial total.
     expect(est.costPartial).toBe(true);
     expect(est.subjectLabel).toBe('1 new of 1 doc');
+  });
+});
+
+describe('syncSource — delta measures synced-vs-PROCESSED (storage-pivot regression)', () => {
+  let client: PGlite;
+  let knowledge: PgKnowledgeStore;
+
+  beforeEach(async () => {
+    client = new PGlite();
+    const db = await makeDb(client);
+    knowledge = new PgKnowledgeStore(db);
+    setSpecStore(new PgSpecStore(db));
+    vi.mocked(estimateScanTokens).mockReset().mockResolvedValue(EMPTY);
+    vi.mocked(syncWorkspaceCorpusInProcess).mockClear();
+  });
+  afterEach(async () => {
+    resetSpecStore();
+    await client.close();
+  });
+
+  const nineRefs = Array.from({ length: 9 }, (_, i) => ref(String(i + 1)));
+  const nineBodies = Object.fromEntries(nineRefs.map((r) => [r.id, bodyOf(r.id)]));
+  const sweep = () => syncSource(ORG, knowledge, batchConnector({ refs: nineRefs, bodies: nineBodies }), {});
+
+  it('a second sweep of an unchanged-but-UNPROCESSED source keeps the Process work (the bug)', async () => {
+    // Sweep #1: 9 tickets land in the ledger; none processed yet → all pending.
+    const est1 = await sweep();
+    expect(est1.delta).toEqual({ new: 9, changed: 0, removed: 0, total: 9 });
+    expect(pendingFromEstimate(est1, 'Jira', 't1').pending).not.toBeNull();
+
+    // Sweep #2: source unchanged and STILL nothing processed. Pre-fix the ledger
+    // matched the fetch → empty delta → pending cleared → 9 docs stranded. Now the
+    // delta is synced-vs-processed, so the 9 stay pending and Process is intact.
+    const est2 = await sweep();
+    expect(est2.delta).toEqual({ new: 9, changed: 0, removed: 0, total: 9 });
+    expect(pendingFromEstimate(est2, 'Jira', 't2').pending).not.toBeNull();
+  });
+
+  it('Process stamps the processed marker on every consolidated doc', async () => {
+    await sweep();
+    // Pre-process: no doc carries a processed marker.
+    expect((await knowledge.listDocuments(ORG)).every((r) => r.processedHash === null)).toBe(true);
+
+    await processWorkspaceKnowledge(ORG, knowledge);
+
+    // Post-process: every ledger row is stamped with the body it was consolidated at.
+    for (const row of await knowledge.listDocuments(ORG)) {
+      expect(row.processedHash).toBe(row.contentHash);
+    }
+  });
+
+  it('process → re-sweep unchanged → up to date, clearing pending', async () => {
+    await sweep();
+    await processWorkspaceKnowledge(ORG, knowledge);
+
+    const est = await sweep();
+    expect(est.delta).toEqual({ new: 0, changed: 0, removed: 0, total: 9 });
+    // Empty delta → the sweep clears the pending record ("up to date").
+    expect(pendingFromEstimate(est, 'Jira', 't').pending).toBeNull();
+  });
+
+  it('detects a doc edited AFTER it was processed as changed (not new)', async () => {
+    await syncSource(ORG, knowledge, batchConnector({ refs: [ref('1')], bodies: { '1': bodyOf('1', 1) } }), {});
+    await processWorkspaceKnowledge(ORG, knowledge);
+
+    // Ticket 1 edited upstream after processing → changed, not new, not up to date.
+    const est = await syncSource(
+      ORG,
+      knowledge,
+      batchConnector({ refs: [ref('1', 'bumped')], bodies: { '1': bodyOf('1', 2) } }),
+      {},
+    );
+    expect(est.delta).toEqual({ new: 0, changed: 1, removed: 0, total: 1 });
+  });
+
+  it('keeps the estimate honest on a repeat sweep — unprocessed cold docs still price stages', async () => {
+    // The estimator gates its stages on the relevance caches; unprocessed docs stay
+    // cold, so a repeat sweep must still surface non-empty stages — the delta being
+    // "9 new" and the priced work must agree. Simulate a cold cache with one stage.
+    vi.mocked(estimateScanTokens).mockResolvedValue({
+      totalEstimatedTokens: 100,
+      tiers: [],
+      stages: [
+        { stage: 'relevance', label: 'Filtering docs', model: 'haiku', calls: 9, estimatedTokens: 100, estimatedCostUsd: 0.01 },
+      ],
+      estimatedCostUsd: 0.01,
+      costSource: 'bundled',
+    });
+    await sweep();
+    const est2 = await sweep();
+    expect(est2.delta.new).toBe(9);
+    expect(est2.stages?.length).toBeGreaterThan(0); // honest: still priced, not zeroed
   });
 });

--- a/tests/server/spec-corpus-inheritance.test.ts
+++ b/tests/server/spec-corpus-inheritance.test.ts
@@ -6,7 +6,7 @@
  * untouched; OSS (in-place store, no seam) is fully inert.
  */
 import { afterEach, describe, expect, it } from 'vitest';
-import { enrichWorkspaceLayer } from '../../apps/dashboard/server/src/routes/spec';
+import { enrichWorkspaceLayer, readInheritedDoc } from '../../apps/dashboard/server/src/routes/spec';
 import {
   setSpecStore,
   resetSpecStore,
@@ -14,6 +14,7 @@ import {
 } from '@truecourse/core/lib/spec-store';
 import {
   setKnowledgeLedgerReader,
+  setKnowledgeDocBodyReader,
   type KnowledgeDocMeta,
 } from '@truecourse/core/lib/knowledge-ledger-reader';
 import type { CuratedCorpus } from '@truecourse/spec-consolidator';
@@ -45,6 +46,7 @@ function corpusFixture(): CuratedCorpus {
 afterEach(() => {
   resetSpecStore();
   setKnowledgeLedgerReader(null);
+  setKnowledgeDocBodyReader(null);
 });
 
 type EnrichedDoc = CuratedCorpus['docs'][number] & {
@@ -111,5 +113,57 @@ describe('enrichWorkspaceLayer', () => {
   it('a null corpus passes through', async () => {
     setSpecStore(hostedStore);
     expect(await enrichWorkspaceLayer('acme/api', null)).toBeNull();
+  });
+});
+
+// The repo Spec-tab doc route (GET /:id/spec/doc) resolves an inherited `knowledge/`
+// doc's body through the body-reader seam instead of the repo tree — the bug where a
+// hosted repo 404'd on an inherited doc because knowledge/* never exists on GitHub.
+describe('readInheritedDoc', () => {
+  it('OSS (in-place store) is inert — even a knowledge/ ref reads the repo tree', async () => {
+    // Default FileSpecStore materializes in place → OSS. No body seam installed.
+    expect(await readInheritedDoc('acme/api', 'knowledge/jira/10000.md')).toEqual({ inherited: false });
+    expect(await readInheritedDoc('acme/api', 'docs/adr-001.md')).toEqual({ inherited: false });
+  });
+
+  it('hosted: a knowledge/ ref serves the stored body via the seam', async () => {
+    setSpecStore(hostedStore);
+    const seen: string[][] = [];
+    setKnowledgeDocBodyReader(async (repoKey, docPath) => {
+      seen.push([repoKey, docPath]);
+      return '# Jira 10000\n\nInherited body.';
+    });
+
+    const out = await readInheritedDoc('acme/api', 'knowledge/jira/10000.md');
+    expect(out).toEqual({ inherited: true, content: '# Jira 10000\n\nInherited body.' });
+    // The seam was queried with the repoKey + the exact ref.
+    expect(seen).toEqual([['acme/api', 'knowledge/jira/10000.md']]);
+  });
+
+  it('hosted: a knowledge/ ref with no ledger row/body → inherited but null (the route 404s)', async () => {
+    setSpecStore(hostedStore);
+    setKnowledgeDocBodyReader(async () => null); // ledger row or body missing
+
+    expect(await readInheritedDoc('acme/api', 'knowledge/jira/10000.md')).toEqual({
+      inherited: true,
+      content: null,
+    });
+  });
+
+  it('hosted with no seam installed: a knowledge/ ref is inherited but null (the route 404s)', async () => {
+    setSpecStore(hostedStore);
+    setKnowledgeDocBodyReader(null);
+
+    expect(await readInheritedDoc('acme/api', 'knowledge/jira/10000.md')).toEqual({
+      inherited: true,
+      content: null,
+    });
+  });
+
+  it('hosted: a repo-local ref falls through to the repo tree (not inherited)', async () => {
+    setSpecStore(hostedStore);
+    setKnowledgeDocBodyReader(async () => '# should not be read');
+
+    expect(await readInheritedDoc('acme/api', 'docs/adr-001.md')).toEqual({ inherited: false });
   });
 });


### PR DESCRIPTION
## The Sync bug

The sweep's pending delta conflated **synced** with **processed**. Since the storage pivot reconciles the provenance ledger at sync time, a repeat Sync of an unchanged source read `fetched == ledger` as *up to date*, cleared the pending record, and stranded unprocessed documents with no Process affordance (and a zero-cost estimate that was false).

Fix: processing stamps `processed_hash` per consolidated doc (migration `0009`, one nullable column); the delta now counts:
- **new** — never processed (including synced-but-unprocessed rows, the bug case)
- **changed** — processed at older content (content-exact; `updatedAt` bumps don't count)
- **removed** — still in the corpus but gone upstream

Re-sweeping unprocessed docs keeps the pending intact; *up to date* now means processed, not fetched. The user's reproduction sequence is the pinning test.

## Spec UI fixes

- The workspace Knowledge Spec tab adopts the house preview/pin tab machinery (`useGuardTabs` + `GuardTabStrip`, `?spec=`-synced) instead of a static right pane — same behavior as the repo page by construction.
- "Open source" deep links render only in detail headers (removed from list rows); the header tooltip now stays inside the viewport (popover side/align collision API).
- `WorkspaceBadge` is a plain smallest-house-chip span — tooltip removed, size matched to `GuardHeldBadge`.

## Notes

- Docs processed before this change carry no stamp, so the first sweep after deploy reports them once as "to process" — one cache-hit Process clears it; exact semantics thereafter.
- Verified: full build green; ee-server 268, client 430, server+core 382 (pre-rebase) — all passing on this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)