### PR TITLE
fix(csharp): open .slnx solutions by upgrading the Roslyn host to Roslyn 5.0

### DIFF
--- a/tests/cli/analyze-csharp-roslyn-host.test.ts
+++ b/tests/cli/analyze-csharp-roslyn-host.test.ts
@@ -61,10 +61,14 @@ describe.skipIf(!hostBuilt)('CLI analyze e2e — Roslyn host violations reach th
     execSync('git init -q -b main', { cwd: workDir, env })
     execSync('git add -A', { cwd: workDir, env })
     execSync('git -c commit.gpgsign=false commit -q -m init', { cwd: workDir, env })
+    // The Roslyn host (MSBuildWorkspace BuildHost) requires a restored project —
+    // an unrestored one silently loads with an empty reference set and the host
+    // fails hard on it. Framework-only, so this restore needs no network.
+    execSync('dotnet restore Demo.csproj', { cwd: workDir, stdio: 'ignore' })
     project = await registerProject(workDir)
     await updateProjectConfig(workDir, { enableLlmRules: false })
     clearLatestCache()
-  }, 30_000)
+  }, 120_000)
 
   afterAll(async () => {
     if (project) await unregisterProject(project.slug)

--- a/tools/csharp-roslyn-host/CSharpRoslynHost.csproj
+++ b/tools/csharp-roslyn-host/CSharpRoslynHost.csproj
@@ -21,22 +21,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <!-- MSBuildWorkspace project loading (the `analyze-project` op): opens a real
          .csproj/.sln with its actual references for full-fidelity semantics.
          Microsoft.Build.Locator must register an installed SDK before any MSBuild
          type is touched — see Program.AnalyzeProjectGuarded (lazy + guarded so the
          runtime-only `analyze` op never needs an SDK). -->
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
     <!-- The C# language-specific workspace service; without it MSBuildWorkspace
          reports "language 'C#' is not supported". -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
     <!-- Referenced so the loose-text `analyze` mode resolves common framework
          types in analyzed code (ILogger, Newtonsoft.Json) for the rules that
          need them. In `analyze-project` mode the project's own references cover
          these. Cross-platform only. -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/tools/csharp-roslyn-host/Program.cs
+++ b/tools/csharp-roslyn-host/Program.cs
@@ -149,10 +149,10 @@ internal static class Program
 
         using var workspace = MSBuildWorkspace.Create();
         var failures = new List<string>();
-        workspace.WorkspaceFailed += (_, e) =>
+        using var failedRegistration = workspace.RegisterWorkspaceFailedHandler(e =>
         {
             if (e.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure) failures.Add(e.Diagnostic.Message);
-        };
+        });
 
         var projects = new List<Project>();
         // `.slnx` (newer XML solution format) opens as a solution too — and note

--- a/tools/csharp-roslyn-host/Rules/Style/PartialReturnTypeEscape.cs
+++ b/tools/csharp-roslyn-host/Rules/Style/PartialReturnTypeEscape.cs
@@ -12,6 +12,14 @@ namespace TrueCourse.RoslynHost;
 /// return-type position and confirm via the semantic model that it binds to a real
 /// named type (not the modifier), so legitimate partial-member declarations are
 /// never touched.
+///
+/// Under the C# 14 grammar (partial constructors) the method form no longer even
+/// parses as a return type: <c>partial M()</c> inside <c>class C</c> becomes a
+/// *constructor* named M with a <c>partial</c> modifier — silently, with no parse
+/// diagnostics. That shape is caught by the constructor branch: a partial
+/// "constructor" whose name differs from its containing type, while a type named
+/// <c>partial</c> is in scope, can only be the pre-C#14 method form. Property and
+/// indexer positions still parse the old way and stay on the return-type branch.
 /// </summary>
 internal sealed class PartialReturnTypeEscape : ISemanticRule
 {
@@ -21,6 +29,26 @@ internal sealed class PartialReturnTypeEscape : ISemanticRule
     {
         foreach (var node in tree.GetRoot().DescendantNodes())
         {
+            // C# 14 misparse shape: `partial M()` inside `class C` parses as a
+            // partial constructor named M. A genuine partial constructor is named
+            // after its type, so a name mismatch plus a type named `partial` in
+            // scope means this was a method returning that type.
+            if (node is ConstructorDeclarationSyntax ctor)
+            {
+                var partialToken = ctor.Modifiers.FirstOrDefault(t => t.IsKind(SyntaxKind.PartialKeyword));
+                if (partialToken == default) continue;
+                var typeName = (ctor.Parent as BaseTypeDeclarationSyntax)?.Identifier.ValueText;
+                if (typeName is null || typeName == ctor.Identifier.ValueText) continue;
+                if (!model.LookupNamespacesAndTypes(partialToken.SpanStart, name: "partial")
+                        .OfType<INamedTypeSymbol>().Any()) continue;
+
+                var ctorPos = partialToken.GetLocation().GetLineSpan().StartLinePosition;
+                yield return new Violation(
+                    RuleKey, tree.FilePath, ctorPos.Line + 1, ctorPos.Character + 1,
+                    "Return type named 'partial' must be escaped as '@partial' to remain valid under newer C# rules.");
+                continue;
+            }
+
             var returnType = node switch
             {
                 MethodDeclarationSyntax m => m.ReturnType,


### PR DESCRIPTION
## Problem

Analyzing [NimblePros/eShopOnWeb](https://github.com/NimblePros/eShopOnWeb) — a repo whose only solution file is the new XML-based `eShopOnWeb.slnx` — failed:

```
Project-aware C# analysis failed for eShopOnWeb.slnx: Roslyn host error: No file format header found.
```

The host already routes `.slnx` to `OpenSolutionAsync` (`Program.cs`), but the pinned `Microsoft.CodeAnalysis.Workspaces.MSBuild` **4.8.0** only parses the classic text `.sln` format — it looks for the `Microsoft Visual Studio Solution File` header and chokes on XML. Native `.slnx` support landed in **Roslyn 5.0** via [dotnet/roslyn#77326](https://github.com/dotnet/roslyn/pull/77326) (see [dotnet/roslyn#73004](https://github.com/dotnet/roslyn/issues/73004)). Since `.slnx` is becoming the default for new .NET repos, the host keeps hitting this without the upgrade.

## Changes

- **`CSharpRoslynHost.csproj`** — `Microsoft.CodeAnalysis.*` 4.8.0 → 5.0.0; `Microsoft.Extensions.Logging.Abstractions` 8.0.0 → 9.0.0 (required transitively).
- **`Program.cs`** — migrate the obsoleted `Workspace.WorkspaceFailed` event to `RegisterWorkspaceFailedHandler` (verified empirically it loses no diagnostics — an unrestored project emits zero workspace diagnostics either way).
- **`Rules/Style/PartialReturnTypeEscape.cs`** — the one rule regression from the upgrade: under the C# 14 grammar `partial M()` parses as a partial *constructor* named `M` (silently, no parse diagnostics — C# 14 added partial constructors) instead of a method with return type `partial`, so the old return-type detection never saw it. Added a constructor branch: a partial "constructor" whose name differs from its containing type, with a type named `partial` in scope, can only be the pre-C#14 method form. Property/indexer positions still parse the old way and stay on the existing branch.
- **`tests/cli/analyze-csharp-roslyn-host.test.ts`** — Roslyn 5.0 loads projects via an out-of-proc BuildHost that strictly requires a restored project (unrestored ones silently load with an empty reference set and trip the host's fail-hard check; 4.8's in-proc build happened to tolerate dependency-less fixtures). The test now `dotnet restore`s its temp fixture. (#798, merged meanwhile, did the same for `analyze-csharp.test.ts` and `analyze.test.ts` — this PR is rebased on top of it.)

## Verification

- Direct host call on `eShopOnWeb.slnx` returns real violations (previously the parse error).
- Full `truecourse analyze --no-llm` on eShopOnWeb completes: 3 services, 332 files, 1230 violations incl. 196 from the semantic host.
- All 62 `tests/analyzer` files + both C# CLI e2e files pass (5,043 tests, 0 failures); re-ran the affected files after the rebase onto #798.

Note: "restore before analyze" is now a hard requirement for C# project-aware analysis in every case — the existing fail-hard error message already instructs exactly that, so no doc changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)