### PR TITLE
feat(analyze): choose the model for LLM rules from the ones you actually have

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,10 +405,10 @@ your account, subscription, and org policy:
 
 ```
 ◆  Which model should LLM rules use?
-│  ● Opus 4.8 with 1M context · Best for everyday, complex tasks
-│  ○ Fable 5 · Most capable for your hardest and longest-running tasks
-│  ○ Sonnet 5 · Efficient for routine tasks
-│  ○ Haiku 4.5 · Fastest for quick answers
+│  ● Opus 4.8 with 1M context
+│  ○ Fable 5
+│  ○ Sonnet 5
+│  ○ Haiku 4.5
 └
 ```
 

--- a/README.md
+++ b/README.md
@@ -400,10 +400,22 @@ CLAUDE_CODE_MAX_CONCURRENCY=10        # max concurrent `claude` processes per ru
 ### Choosing the model for LLM rules
 
 When `truecourse analyze` runs LLM rules interactively it asks which model to
-use, listing the models your Claude Code install actually offers — the same set
-as its `/model` picker, scoped to your account, subscription, and org policy. An
-Opus model is pre-selected when you have one; Fable is never pre-selected, since
-it bills well above the Opus tier.
+use, listing the models your Claude Code install actually offers — scoped to
+your account, subscription, and org policy:
+
+```
+◆  Which model should LLM rules use?
+│  ● Opus 4.8 with 1M context · Best for everyday, complex tasks
+│  ○ Fable 5 · Most capable for your hardest and longest-running tasks
+│  ○ Sonnet 5 · Efficient for routine tasks
+│  ○ Haiku 4.5 · Fastest for quick answers
+└
+```
+
+An Opus model is pre-selected when you have one; Fable is never pre-selected,
+since it bills well above the Opus tier. Claude Code's own `default` entry is
+not offered — it names no model, so picking it would tell you nothing about
+what will run.
 
 The list is discovered by asking the `claude` CLI directly. It costs nothing —
 no prompt is sent to the API. Where TrueCourse can't ask (a non-interactive run,

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ your account, subscription, and org policy:
 
 ```
 ◆  Which model should LLM rules use?
-│  ● Opus 4.8 with 1M context
+│  ● Opus 4.8
 │  ○ Fable 5
 │  ○ Sonnet 5
 │  ○ Haiku 4.5

--- a/README.md
+++ b/README.md
@@ -391,11 +391,24 @@ For packaged installs (`npx truecourse` or `npm install -g truecourse`), the sim
 
 ```
 CLAUDE_CODE_BINARY=claude             # override the `claude` binary on PATH (CLAUDE_CODE_BIN also accepted)
-CLAUDE_CODE_MODEL=                    # Claude Code --model flag (empty = default)
+CLAUDE_CODE_MODEL=                    # Claude Code --model flag (empty = default; the analyze picker overrides it)
 CLAUDE_CODE_TIMEOUT_MS=120000         # per-call timeout (ms)
 CLAUDE_CODE_MAX_RETRIES=2             # retry attempts on parse/validation failure
 CLAUDE_CODE_MAX_CONCURRENCY=10        # max concurrent `claude` processes per run
 ```
+
+### Choosing the model for LLM rules
+
+When `truecourse analyze` runs LLM rules interactively it asks which model to
+use, listing the models your Claude Code install actually offers — the same set
+as its `/model` picker, scoped to your account, subscription, and org policy. An
+Opus model is pre-selected when you have one; Fable is never pre-selected, since
+it bills well above the Opus tier.
+
+The list is discovered by asking the `claude` CLI directly. It costs nothing —
+no prompt is sent to the API. Where TrueCourse can't ask (a non-interactive run,
+or a CLI too old to answer) it passes no `--model` and Claude Code picks, which
+is the behavior the variables above describe.
 
 Every command that uses Claude (`analyze` with LLM rules, `spec scan`, `guard generate`) runs a quick up-front preflight: it makes one tiny `claude` call to confirm the CLI is installed and logged in, and aborts with the CLI's own error message if not — so an expired login is caught immediately instead of failing every extraction subprocess at the end of a long run. `CLAUDE_CODE_BINARY` is the canonical way to point at a non-default binary; `CLAUDE_CODE_BIN` is honored as a legacy alias.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -220,6 +220,10 @@
       "types": "./dist/services/llm/model-prices.d.ts",
       "import": "./dist/services/llm/model-prices.js"
     },
+    "./services/llm/model-discovery": {
+      "types": "./dist/services/llm/model-discovery.d.ts",
+      "import": "./dist/services/llm/model-discovery.js"
+    },
     "./services/telemetry": {
       "types": "./dist/services/telemetry.service.d.ts",
       "import": "./dist/services/telemetry.service.js"

--- a/packages/core/src/commands/analyze-core.ts
+++ b/packages/core/src/commands/analyze-core.ts
@@ -130,6 +130,13 @@ export interface AnalyzeCoreOptions {
    * when an explicit `provider` is supplied (tests inject one that way).
    */
   transport?: LlmTransport;
+  /**
+   * Model for the auto-created provider, as chosen in the analyze model picker
+   * (e.g. `opus[1m]`). Omit to let Claude Code pick — the behavior that
+   * predates the picker, and the fallback when model discovery is unavailable.
+   * Ignored when an explicit `provider` is supplied.
+   */
+  selectedModel?: string;
   signal?: AbortSignal;
 }
 
@@ -361,7 +368,7 @@ export async function analyzeCore(
     const provider =
       options.provider ??
       (effectiveLlmRules
-        ? createLLMProvider(options.transport ?? getDefaultTransport())
+        ? createLLMProvider(options.transport ?? getDefaultTransport(), options.selectedModel)
         : undefined);
     if (provider) {
       provider.setAnalysisId(analysisId);

--- a/packages/core/src/commands/analyze-in-process.ts
+++ b/packages/core/src/commands/analyze-in-process.ts
@@ -50,6 +50,11 @@ export interface AnalyzeInProcessOptions {
   provider?: LLMProvider;
   /** LLM transport for the auto-created provider (cli default; agent for headless). */
   transport?: LlmTransport;
+  /**
+   * Model for the auto-created provider, as chosen in the analyze model picker.
+   * Omit to let Claude Code pick (the pre-picker behavior).
+   */
+  selectedModel?: string;
   signal?: AbortSignal;
   /**
    * Adapter that triggered this run. Auto-emitted in the telemetry payload so
@@ -66,7 +71,9 @@ export async function analyzeInProcess(
 ): Promise<AnalyzeInProcessResult> {
   const startedAt = Date.now();
   log.info(
-    `[LLM] Provider: claude-code, model: ${config.claudeCodeModel || 'default'}, maxConcurrency: ${config.claudeCodeMaxConcurrency}`,
+    `[LLM] Provider: claude-code, model: ${
+      options.selectedModel || config.claudeCodeModel || 'default (chosen by Claude Code)'
+    }, maxConcurrency: ${config.claudeCodeMaxConcurrency}`,
   );
   const core = await analyzeCore(project, { ...options, mode: 'full' });
   const result = await persistFullAnalysis(project, core, startedAt);

--- a/packages/core/src/services/llm/cli-provider.ts
+++ b/packages/core/src/services/llm/cli-provider.ts
@@ -867,6 +867,20 @@ export abstract class BaseCLIProvider implements LLMProvider {
 // ---------------------------------------------------------------------------
 
 export class ClaudeCodeProvider extends BaseCLIProvider {
+  /**
+   * The model this run was told to use, from the analyze model picker.
+   *
+   * Undefined means "no explicit choice", in which case we fall back to
+   * `CLAUDE_CODE_MODEL` and then to passing no `--model` at all — letting
+   * Claude Code pick, which is the behavior that predates the picker.
+   */
+  private readonly selectedModel?: string;
+
+  constructor(transport?: LlmTransport, selectedModel?: string) {
+    super(transport);
+    this.selectedModel = selectedModel;
+  }
+
   get binaryName(): string {
     return config.claudeCodeBinary ?? 'claude';
   }
@@ -881,7 +895,9 @@ export class ClaudeCodeProvider extends BaseCLIProvider {
   }
 
   get modelFlag(): string[] {
-    const model = config.claudeCodeModel;
+    // A picked model is a deliberate in-session choice, so it outranks the
+    // CLAUDE_CODE_MODEL background default.
+    const model = this.selectedModel || config.claudeCodeModel;
     return model ? ['--model', model] : [];
   }
 }

--- a/packages/core/src/services/llm/model-discovery.ts
+++ b/packages/core/src/services/llm/model-discovery.ts
@@ -154,13 +154,16 @@ export async function discoverClaudeModels(
   });
 }
 
+/** Model families we can recognize by name in an id or label. */
+const FAMILIES = ['opus', 'sonnet', 'haiku', 'fable'] as const;
+
 /** Fable bills well above the Opus tier — never auto-select it. */
 function isFable(model: ClaudeModelInfo): boolean {
   return /fable/i.test(`${model.value} ${model.displayName} ${model.resolvedModel ?? ''}`);
 }
 
 /**
- * Whether this entry *names* Opus — an explicit, stable choice.
+ * Whether this entry *names* Opus.
  *
  * Matches identity fields only. Descriptions are marketing prose that name
  * other tiers ("more capable than Opus 4.8"), so they are not evidence.
@@ -169,34 +172,49 @@ function isExplicitOpus(model: ClaudeModelInfo): boolean {
   return /opus/i.test(`${model.value} ${model.displayName}`);
 }
 
-/** Whether this entry currently *resolves* to Opus (e.g. the `default` alias). */
-function resolvesToOpus(model: ClaudeModelInfo): boolean {
-  return /opus/i.test(model.resolvedModel ?? '');
+/**
+ * Whether an entry tells you which model you'd actually get.
+ *
+ * `default` ("Default (recommended)" → `claude-opus-4-8[1m]`) does not: it is a
+ * moving alias for whatever Claude Code currently prefers. Offering it as a
+ * choice would be offering "surprise me", which is the behavior the picker
+ * exists to replace — and it is exactly how analysis silently ended up on a
+ * premium tier before it existed.
+ *
+ * The test is whether the entry names the family it resolves to. That covers
+ * `best` and `opusplan` too, without hardcoding a list of alias names. Entries
+ * with no `resolvedModel`, or one from a family we don't recognize, are kept —
+ * we only drop an entry when we have positive evidence it hides its model.
+ */
+function namesItsModel(model: ClaudeModelInfo): boolean {
+  const resolved = model.resolvedModel?.toLowerCase();
+  if (!resolved) return true;
+  const family = FAMILIES.find((f) => resolved.includes(f));
+  if (!family) return true;
+  return `${model.value} ${model.displayName}`.toLowerCase().includes(family);
 }
 
 /**
- * The model to pre-select when offering the picker. Returns `null` for an
- * empty list.
+ * The models worth offering: every entry whose label tells the user which model
+ * they are choosing. Order is preserved.
+ */
+export function selectableModels(models: ClaudeModelInfo[]): ClaudeModelInfo[] {
+  return models.filter(namesItsModel);
+}
+
+/**
+ * The model to pre-select when offering the picker. Expects an already
+ * `selectableModels`-filtered list. Returns `null` for an empty list.
  *
  * Opus is the deliberate default for analysis — the strongest tier we are
- * willing to spend on a user's behalf without being asked.
+ * willing to spend on a user's behalf without being asked. Failing that, the
+ * first model offered.
  *
- * Preference order:
- *   1. An entry that names Opus (`opus[1m]`) — explicit and stable.
- *   2. An entry that resolves to Opus today (`default` → `claude-opus-4-8`).
- *   3. The first non-Fable model.
- *
- * (1) outranks (2) deliberately: `default` is a moving alias that tracks
- * whatever Claude Code decides to prefer, so pinning analysis to it would
- * re-introduce the silent model drift this picker exists to prevent.
- *
- * Fable is never auto-selected at any tier — it bills well above Opus, and a
- * user should reach that tier by choosing it, not by accepting a default.
+ * Fable is never auto-selected — it bills well above Opus, and a user should
+ * reach that tier by choosing it, not by accepting a default.
  */
 export function pickDefaultModel(models: ClaudeModelInfo[]): ClaudeModelInfo | null {
   if (models.length === 0) return null;
   const candidates = models.filter((m) => !isFable(m));
-  return (
-    candidates.find(isExplicitOpus) ?? candidates.find(resolvesToOpus) ?? candidates[0] ?? null
-  );
+  return candidates.find(isExplicitOpus) ?? candidates[0] ?? null;
 }

--- a/packages/core/src/services/llm/model-discovery.ts
+++ b/packages/core/src/services/llm/model-discovery.ts
@@ -1,0 +1,202 @@
+/**
+ * Discovery of the Claude Code models available to the current user.
+ *
+ * Speaks the stdio control protocol the Claude Agent SDK uses, so we get the
+ * exact list the interactive `/model` picker shows — scoped to this account,
+ * subscription, org policy, and CLI version — without taking a dependency on
+ * `@anthropic-ai/claude-agent-sdk`.
+ *
+ * Costs nothing: the CLI answers `initialize` from local state. We never send
+ * a user message, so no prompt reaches the API.
+ *
+ * The protocol is an internal SDK surface, not a documented CLI contract, so it
+ * may change between Claude Code releases. Every failure here is therefore
+ * non-fatal: `discoverClaudeModels` returns `null` and callers fall back to
+ * letting Claude Code pick the model, exactly as before this module existed.
+ */
+
+import { spawn } from 'node:child_process';
+import os from 'node:os';
+import readline from 'node:readline';
+import { config } from '../../config/index.js';
+
+/** One entry of the CLI's `/model` picker. Mirrors the SDK's `ModelInfo`. */
+export interface ClaudeModelInfo {
+  /** The value to pass to `--model` (an alias like `opus[1m]`, or a full ID). */
+  value: string;
+  /**
+   * The concrete model an alias resolves to (e.g. `default` →
+   * `claude-opus-4-8[1m]`). Absent on entries that are already concrete.
+   * Undocumented in the SDK's typedef but present on the wire — treat as
+   * best-effort.
+   */
+  resolvedModel?: string;
+  displayName: string;
+  description?: string;
+  supportsEffort?: boolean;
+  supportedEffortLevels?: string[];
+  supportsAdaptiveThinking?: boolean;
+  supportsFastMode?: boolean;
+}
+
+export interface DiscoverClaudeModelsOptions {
+  /** Defaults to the binary every other Claude Code call site uses. */
+  binary?: string;
+  timeoutMs?: number;
+}
+
+/**
+ * A healthy CLI answers `initialize` from local state in ~1s. This is the
+ * budget for one that won't answer at all (too old to know the request,
+ * protocol drift): we wait a few multiples of the happy path, then fall back to
+ * letting Claude Code choose. Every second here is a second the user stares at
+ * a prompt that hasn't appeared yet, so it is deliberately not generous.
+ */
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * Ask the CLI which models this user can run.
+ *
+ * Returns `null` — never throws — when the binary is missing, the handshake
+ * fails, the protocol has drifted, or the CLI is too old to answer.
+ */
+export async function discoverClaudeModels(
+  options: DiscoverClaudeModelsOptions = {},
+): Promise<ClaudeModelInfo[] | null> {
+  const binary = options.binary ?? config.claudeCodeBinary ?? 'claude';
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(
+        binary,
+        ['--output-format', 'stream-json', '--verbose', '--input-format', 'stream-json'],
+        {
+          // Probe from an empty cwd: we want the account's model list, not one
+          // coloured by this repo's CLAUDE.md or .claude/settings.json.
+          cwd: os.tmpdir(),
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      );
+    } catch {
+      resolve(null);
+      return;
+    }
+
+    let settled = false;
+    const finish = (models: ClaudeModelInfo[] | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill('SIGTERM');
+      resolve(models);
+    };
+
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    timer.unref?.();
+
+    child.on('error', () => finish(null));
+    child.on('exit', () => finish(null));
+    // Drain stderr so a chatty CLI can't fill the pipe buffer and wedge.
+    child.stderr?.resume();
+
+    const requestId = `tc_${Math.random().toString(36).slice(2, 15)}`;
+
+    if (!child.stdout) {
+      finish(null);
+      return;
+    }
+
+    readline.createInterface({ input: child.stdout }).on('line', (line) => {
+      if (!line.trim()) return;
+
+      let msg: unknown;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        return; // Banner noise — not every stdout line is protocol traffic.
+      }
+
+      const envelope = msg as { type?: string; response?: Record<string, unknown> };
+      if (envelope.type !== 'control_response') return;
+
+      const res = envelope.response;
+      if (!res || res.request_id !== requestId) return;
+      if (res.subtype !== 'success') {
+        finish(null);
+        return;
+      }
+
+      const models = (res.response as { models?: unknown } | undefined)?.models;
+      if (!Array.isArray(models) || models.length === 0) {
+        finish(null);
+        return;
+      }
+
+      const parsed = models.filter(
+        (m): m is ClaudeModelInfo =>
+          !!m &&
+          typeof (m as ClaudeModelInfo).value === 'string' &&
+          typeof (m as ClaudeModelInfo).displayName === 'string',
+      );
+      finish(parsed.length > 0 ? parsed : null);
+    });
+
+    child.stdin?.on('error', () => finish(null));
+    child.stdin?.write(
+      `${JSON.stringify({
+        type: 'control_request',
+        request_id: requestId,
+        request: { subtype: 'initialize' },
+      })}\n`,
+    );
+  });
+}
+
+/** Fable bills well above the Opus tier — never auto-select it. */
+function isFable(model: ClaudeModelInfo): boolean {
+  return /fable/i.test(`${model.value} ${model.displayName} ${model.resolvedModel ?? ''}`);
+}
+
+/**
+ * Whether this entry *names* Opus — an explicit, stable choice.
+ *
+ * Matches identity fields only. Descriptions are marketing prose that name
+ * other tiers ("more capable than Opus 4.8"), so they are not evidence.
+ */
+function isExplicitOpus(model: ClaudeModelInfo): boolean {
+  return /opus/i.test(`${model.value} ${model.displayName}`);
+}
+
+/** Whether this entry currently *resolves* to Opus (e.g. the `default` alias). */
+function resolvesToOpus(model: ClaudeModelInfo): boolean {
+  return /opus/i.test(model.resolvedModel ?? '');
+}
+
+/**
+ * The model to pre-select when offering the picker. Returns `null` for an
+ * empty list.
+ *
+ * Opus is the deliberate default for analysis — the strongest tier we are
+ * willing to spend on a user's behalf without being asked.
+ *
+ * Preference order:
+ *   1. An entry that names Opus (`opus[1m]`) — explicit and stable.
+ *   2. An entry that resolves to Opus today (`default` → `claude-opus-4-8`).
+ *   3. The first non-Fable model.
+ *
+ * (1) outranks (2) deliberately: `default` is a moving alias that tracks
+ * whatever Claude Code decides to prefer, so pinning analysis to it would
+ * re-introduce the silent model drift this picker exists to prevent.
+ *
+ * Fable is never auto-selected at any tier — it bills well above Opus, and a
+ * user should reach that tier by choosing it, not by accepting a default.
+ */
+export function pickDefaultModel(models: ClaudeModelInfo[]): ClaudeModelInfo | null {
+  if (models.length === 0) return null;
+  const candidates = models.filter((m) => !isFable(m));
+  return (
+    candidates.find(isExplicitOpus) ?? candidates.find(resolvesToOpus) ?? candidates[0] ?? null
+  );
+}

--- a/packages/core/src/services/llm/provider.ts
+++ b/packages/core/src/services/llm/provider.ts
@@ -273,7 +273,10 @@ export interface LLMProvider {
  *    no-provider transport when none is set ⇒ EE never silently spawns the
  *    (absent) `claude` binary; LLM work errors clearly instead.
  * Pass an explicit `LlmTransport` to override (e.g. the agent file-mailbox).
+ *
+ * `selectedModel` is the model chosen in the analyze picker. Omit it to leave
+ * model selection to Claude Code, as callers did before the picker existed.
  */
-export function createLLMProvider(transport?: LlmTransport): LLMProvider {
-  return new ClaudeCodeProvider(transport ?? getDefaultTransport());
+export function createLLMProvider(transport?: LlmTransport, selectedModel?: string): LLMProvider {
+  return new ClaudeCodeProvider(transport ?? getDefaultTransport(), selectedModel);
 }

--- a/tests/cli/model-prompt.test.ts
+++ b/tests/cli/model-prompt.test.ts
@@ -49,18 +49,56 @@ afterEach(() => {
   process.stdin.isTTY = originalTTY;
 });
 
+/**
+ * What the picker actually receives: the `selectableModels`-filtered list, so
+ * without `default`. Mirrors the real flow in `promptModelChoice`.
+ */
+const SELECTABLE = MODELS.filter((m) => m.value !== 'default');
+
 describe('buildModelPickerOptions', () => {
-  it('labels every model with its identity, dropping the sales pitch after the dot', () => {
+  it('labels every model with just the model, dropping the pitch and context note', () => {
     // Not clack's `hint`: that renders only on the focused row, leaving the
     // rest as bare names.
-    const { options } = buildModelPickerOptions(MODELS);
-    expect(options.map((o) => o.label)).toEqual([
-      'Opus 4.8 with 1M context',
-      'Opus 4.8 with 1M context',
-      'Fable 5',
-      'Sonnet 5',
-      'Haiku 4.5',
+    const { options } = buildModelPickerOptions(SELECTABLE);
+    expect(options.map((o) => o.label)).toEqual(['Opus 4.8', 'Fable 5', 'Sonnet 5', 'Haiku 4.5']);
+  });
+
+  it('keeps the context note when it is the only thing telling two rows apart', () => {
+    // Some installs list a model twice, once per context window. Stripping the
+    // note there would leave two rows reading "Sonnet 4.6" and no way to choose.
+    const { options } = buildModelPickerOptions([
+      { value: 'sonnet', displayName: 'Sonnet', description: 'Sonnet 4.6 · Best for everyday' },
+      {
+        value: 'sonnet[1m]',
+        displayName: 'Sonnet (1M context)',
+        description: 'Sonnet 4.6 with 1M context · Billed as extra usage',
+      },
     ]);
+    expect(options.map((o) => o.label)).toEqual(['Sonnet 4.6', 'Sonnet 4.6 with 1M context']);
+  });
+
+  it('strips the context note from an unambiguous row even when a variant pair exists', () => {
+    const { options } = buildModelPickerOptions([
+      { value: 'opus[1m]', displayName: 'Opus', description: 'Opus 4.8 with 1M context · Best' },
+      { value: 'sonnet', displayName: 'Sonnet', description: 'Sonnet 4.6 · Everyday' },
+      {
+        value: 'sonnet[1m]',
+        displayName: 'Sonnet (1M)',
+        description: 'Sonnet 4.6 with 1M context · Extra',
+      },
+    ]);
+    expect(options.map((o) => o.label)).toEqual([
+      'Opus 4.8',
+      'Sonnet 4.6',
+      'Sonnet 4.6 with 1M context',
+    ]);
+  });
+
+  it('leaves a qualifier that is not a context note alone', () => {
+    const { options } = buildModelPickerOptions([
+      { value: 'x', displayName: 'X', description: 'Opus 4.8 with fast mode · Quick' },
+    ]);
+    expect(options[0].label).toBe('Opus 4.8 with fast mode');
   });
 
   it('keeps the whole description when there is no dot to cut at', () => {
@@ -78,7 +116,7 @@ describe('buildModelPickerOptions', () => {
   });
 
   it('never sets a hint, which clack would parenthesize and show on one row only', () => {
-    for (const option of buildModelPickerOptions(MODELS).options) {
+    for (const option of buildModelPickerOptions(SELECTABLE).options) {
       expect(option).not.toHaveProperty('hint');
     }
   });
@@ -89,9 +127,8 @@ describe('buildModelPickerOptions', () => {
   });
 
   it('preserves the order the CLI reported', () => {
-    const { options } = buildModelPickerOptions(MODELS);
+    const { options } = buildModelPickerOptions(SELECTABLE);
     expect(options.map((o) => o.value)).toEqual([
-      'default',
       'opus[1m]',
       'claude-fable-5[1m]',
       'sonnet',
@@ -100,7 +137,7 @@ describe('buildModelPickerOptions', () => {
   });
 
   it('pre-selects an Opus model', () => {
-    expect(buildModelPickerOptions(MODELS).initialValue).toBe('opus[1m]');
+    expect(buildModelPickerOptions(SELECTABLE).initialValue).toBe('opus[1m]');
   });
 
   it('does not pre-select Fable even when it is the only premium option', () => {

--- a/tests/cli/model-prompt.test.ts
+++ b/tests/cli/model-prompt.test.ts
@@ -50,17 +50,31 @@ afterEach(() => {
 });
 
 describe('buildModelPickerOptions', () => {
-  it('labels every model with its description, so each row names its model', () => {
+  it('labels every model with its identity, dropping the sales pitch after the dot', () => {
     // Not clack's `hint`: that renders only on the focused row, leaving the
     // rest as bare names.
     const { options } = buildModelPickerOptions(MODELS);
     expect(options.map((o) => o.label)).toEqual([
-      'Opus 4.8 with 1M context · Best for everyday, complex tasks',
-      'Opus 4.8 with 1M context · Best for everyday, complex tasks',
-      'Fable 5 · Most capable for your hardest and longest-running tasks',
-      'Sonnet 5 · Efficient for routine tasks',
-      'Haiku 4.5 · Fastest for quick answers',
+      'Opus 4.8 with 1M context',
+      'Opus 4.8 with 1M context',
+      'Fable 5',
+      'Sonnet 5',
+      'Haiku 4.5',
     ]);
+  });
+
+  it('keeps the whole description when there is no dot to cut at', () => {
+    const { options } = buildModelPickerOptions([
+      { value: 'sonnet', displayName: 'Sonnet', description: 'Sonnet 5' },
+    ]);
+    expect(options[0].label).toBe('Sonnet 5');
+  });
+
+  it('falls back to the display name when the description is only a pitch', () => {
+    const { options } = buildModelPickerOptions([
+      { value: 'sonnet', displayName: 'Sonnet', description: '· Efficient for routine tasks' },
+    ]);
+    expect(options[0].label).toBe('Sonnet');
   });
 
   it('never sets a hint, which clack would parenthesize and show on one row only', () => {

--- a/tests/cli/model-prompt.test.ts
+++ b/tests/cli/model-prompt.test.ts
@@ -5,11 +5,38 @@ import {
 } from '../../tools/cli/src/commands/model-prompt.js';
 import type { ClaudeModelInfo } from '@truecourse/core/services/llm/model-discovery';
 
+/** Mirrors what a real `claude` reports, `default` included. */
 const MODELS: ClaudeModelInfo[] = [
-  { value: 'default', displayName: 'Default (recommended)', resolvedModel: 'claude-opus-4-8[1m]' },
-  { value: 'opus[1m]', displayName: 'Opus', description: 'Opus 4.8' },
-  { value: 'claude-fable-5[1m]', displayName: 'Fable', description: 'Fable 5' },
-  { value: 'haiku', displayName: 'Haiku', description: 'Haiku 4.5' },
+  {
+    value: 'default',
+    displayName: 'Default (recommended)',
+    description: 'Opus 4.8 with 1M context · Best for everyday, complex tasks',
+    resolvedModel: 'claude-opus-4-8[1m]',
+  },
+  {
+    value: 'opus[1m]',
+    displayName: 'Opus',
+    description: 'Opus 4.8 with 1M context · Best for everyday, complex tasks',
+    resolvedModel: 'claude-opus-4-8[1m]',
+  },
+  {
+    value: 'claude-fable-5[1m]',
+    displayName: 'Fable',
+    description: 'Fable 5 · Most capable for your hardest and longest-running tasks',
+    resolvedModel: 'claude-fable-5',
+  },
+  {
+    value: 'sonnet',
+    displayName: 'Sonnet',
+    description: 'Sonnet 5 · Efficient for routine tasks',
+    resolvedModel: 'claude-sonnet-5',
+  },
+  {
+    value: 'haiku',
+    displayName: 'Haiku',
+    description: 'Haiku 4.5 · Fastest for quick answers',
+    resolvedModel: 'claude-haiku-4-5-20251001',
+  },
 ];
 
 const originalTTY = process.stdin.isTTY;
@@ -23,12 +50,37 @@ afterEach(() => {
 });
 
 describe('buildModelPickerOptions', () => {
-  it('offers every discovered model, in the order the CLI reported them', () => {
+  it('labels every model with its description, so each row names its model', () => {
+    // Not clack's `hint`: that renders only on the focused row, leaving the
+    // rest as bare names.
+    const { options } = buildModelPickerOptions(MODELS);
+    expect(options.map((o) => o.label)).toEqual([
+      'Opus 4.8 with 1M context · Best for everyday, complex tasks',
+      'Opus 4.8 with 1M context · Best for everyday, complex tasks',
+      'Fable 5 · Most capable for your hardest and longest-running tasks',
+      'Sonnet 5 · Efficient for routine tasks',
+      'Haiku 4.5 · Fastest for quick answers',
+    ]);
+  });
+
+  it('never sets a hint, which clack would parenthesize and show on one row only', () => {
+    for (const option of buildModelPickerOptions(MODELS).options) {
+      expect(option).not.toHaveProperty('hint');
+    }
+  });
+
+  it('falls back to the display name when a model has no description', () => {
+    const { options } = buildModelPickerOptions([{ value: 'sonnet', displayName: 'Sonnet' }]);
+    expect(options[0].label).toBe('Sonnet');
+  });
+
+  it('preserves the order the CLI reported', () => {
     const { options } = buildModelPickerOptions(MODELS);
     expect(options.map((o) => o.value)).toEqual([
       'default',
       'opus[1m]',
       'claude-fable-5[1m]',
+      'sonnet',
       'haiku',
     ]);
   });
@@ -43,16 +95,6 @@ describe('buildModelPickerOptions', () => {
       { value: 'haiku', displayName: 'Haiku' },
     ]);
     expect(initialValue).toBe('haiku');
-  });
-
-  it('carries the description through as the option hint', () => {
-    const opus = buildModelPickerOptions(MODELS).options.find((o) => o.value === 'opus[1m]');
-    expect(opus?.hint).toBe('Opus 4.8');
-  });
-
-  it('omits the hint when a model has no description', () => {
-    const dflt = buildModelPickerOptions(MODELS).options.find((o) => o.value === 'default');
-    expect(dflt).not.toHaveProperty('hint');
   });
 });
 
@@ -71,7 +113,31 @@ describe('promptModelChoice', () => {
     await promptModelChoice({ discover: async () => MODELS, select });
 
     expect(select.mock.calls[0][0].initialValue).toBe('opus[1m]');
-    expect(select.mock.calls[0][0].options).toHaveLength(4);
+  });
+
+  it('does not offer `default` — it names no model', async () => {
+    const select = vi.fn(async () => 'opus[1m]');
+
+    await promptModelChoice({ discover: async () => MODELS, select });
+
+    expect(select.mock.calls[0][0].options.map((o) => o.value)).toEqual([
+      'opus[1m]',
+      'claude-fable-5[1m]',
+      'sonnet',
+      'haiku',
+    ]);
+  });
+
+  it('falls back when the only model on offer is an opaque alias', async () => {
+    const select = vi.fn(async () => 'default');
+
+    const chosen = await promptModelChoice({
+      discover: async () => [MODELS[0]],
+      select,
+    });
+
+    expect(chosen).toBeUndefined();
+    expect(select).not.toHaveBeenCalled();
   });
 
   it('returns undefined when discovery fails, keeping the pre-picker default', async () => {

--- a/tests/cli/model-prompt.test.ts
+++ b/tests/cli/model-prompt.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  promptModelChoice,
+  buildModelPickerOptions,
+} from '../../tools/cli/src/commands/model-prompt.js';
+import type { ClaudeModelInfo } from '@truecourse/core/services/llm/model-discovery';
+
+const MODELS: ClaudeModelInfo[] = [
+  { value: 'default', displayName: 'Default (recommended)', resolvedModel: 'claude-opus-4-8[1m]' },
+  { value: 'opus[1m]', displayName: 'Opus', description: 'Opus 4.8' },
+  { value: 'claude-fable-5[1m]', displayName: 'Fable', description: 'Fable 5' },
+  { value: 'haiku', displayName: 'Haiku', description: 'Haiku 4.5' },
+];
+
+const originalTTY = process.stdin.isTTY;
+
+beforeEach(() => {
+  process.stdin.isTTY = true;
+});
+
+afterEach(() => {
+  process.stdin.isTTY = originalTTY;
+});
+
+describe('buildModelPickerOptions', () => {
+  it('offers every discovered model, in the order the CLI reported them', () => {
+    const { options } = buildModelPickerOptions(MODELS);
+    expect(options.map((o) => o.value)).toEqual([
+      'default',
+      'opus[1m]',
+      'claude-fable-5[1m]',
+      'haiku',
+    ]);
+  });
+
+  it('pre-selects an Opus model', () => {
+    expect(buildModelPickerOptions(MODELS).initialValue).toBe('opus[1m]');
+  });
+
+  it('does not pre-select Fable even when it is the only premium option', () => {
+    const { initialValue } = buildModelPickerOptions([
+      { value: 'claude-fable-5[1m]', displayName: 'Fable' },
+      { value: 'haiku', displayName: 'Haiku' },
+    ]);
+    expect(initialValue).toBe('haiku');
+  });
+
+  it('carries the description through as the option hint', () => {
+    const opus = buildModelPickerOptions(MODELS).options.find((o) => o.value === 'opus[1m]');
+    expect(opus?.hint).toBe('Opus 4.8');
+  });
+
+  it('omits the hint when a model has no description', () => {
+    const dflt = buildModelPickerOptions(MODELS).options.find((o) => o.value === 'default');
+    expect(dflt).not.toHaveProperty('hint');
+  });
+});
+
+describe('promptModelChoice', () => {
+  it('returns the model the user picked', async () => {
+    const chosen = await promptModelChoice({
+      discover: async () => MODELS,
+      select: async () => 'haiku',
+    });
+    expect(chosen).toBe('haiku');
+  });
+
+  it('offers the picker with Opus pre-selected', async () => {
+    const select = vi.fn(async () => 'opus[1m]');
+
+    await promptModelChoice({ discover: async () => MODELS, select });
+
+    expect(select.mock.calls[0][0].initialValue).toBe('opus[1m]');
+    expect(select.mock.calls[0][0].options).toHaveLength(4);
+  });
+
+  it('returns undefined when discovery fails, keeping the pre-picker default', async () => {
+    const select = vi.fn(async () => 'haiku');
+
+    const chosen = await promptModelChoice({ discover: async () => null, select });
+
+    expect(chosen).toBeUndefined();
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt or probe when non-interactive', async () => {
+    process.stdin.isTTY = false;
+    const discover = vi.fn(async () => MODELS);
+    const select = vi.fn(async () => 'haiku');
+
+    const chosen = await promptModelChoice({ discover, select });
+
+    expect(chosen).toBeUndefined();
+    expect(discover).not.toHaveBeenCalled();
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the user cancels, so the caller keeps its default', async () => {
+    const chosen = await promptModelChoice({
+      discover: async () => MODELS,
+      select: async () => Symbol.for('clack:cancel'),
+    });
+    expect(chosen).toBeUndefined();
+  });
+
+  it('returns undefined when discovery throws rather than failing the run', async () => {
+    const chosen = await promptModelChoice({
+      discover: async () => {
+        throw new Error('claude exploded');
+      },
+    });
+    expect(chosen).toBeUndefined();
+  });
+
+  it('skips the prompt when only one model is available and uses it', async () => {
+    const select = vi.fn(async () => 'unused');
+
+    const chosen = await promptModelChoice({
+      discover: async () => [{ value: 'sonnet', displayName: 'Sonnet' }],
+      select,
+    });
+
+    expect(chosen).toBe('sonnet');
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when discovery reports an empty list', async () => {
+    expect(await promptModelChoice({ discover: async () => [] })).toBeUndefined();
+  });
+});

--- a/tests/server/llm-provider-model.test.ts
+++ b/tests/server/llm-provider-model.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { ClaudeCodeProvider } from '../../packages/core/src/services/llm/cli-provider.js';
+import { createLLMProvider } from '../../packages/core/src/services/llm/provider.js';
+
+/**
+ * `config` snapshots CLAUDE_CODE_MODEL at import time, so these tests cover the
+ * explicit-override path (what the model picker sets). The env-var path is
+ * exercised by the existing config tests.
+ */
+describe('ClaudeCodeProvider model selection', () => {
+  afterEach(() => {
+    delete process.env.CLAUDE_CODE_MODEL;
+  });
+
+  it('passes --model when a model is explicitly selected', () => {
+    const provider = new ClaudeCodeProvider(undefined, 'opus[1m]');
+    expect(provider.modelFlag).toEqual(['--model', 'opus[1m]']);
+  });
+
+  it('omits --model when nothing is selected, preserving the pre-picker default', () => {
+    const provider = new ClaudeCodeProvider();
+    expect(provider.modelFlag).toEqual([]);
+  });
+
+  it('treats an empty selection as no selection', () => {
+    const provider = new ClaudeCodeProvider(undefined, '');
+    expect(provider.modelFlag).toEqual([]);
+  });
+
+  it('lets an explicit selection win over the CLAUDE_CODE_MODEL default', () => {
+    // The picker reflects a deliberate in-session choice; the env var is a
+    // background default, so the choice must take precedence.
+    const provider = new ClaudeCodeProvider(undefined, 'sonnet');
+    expect(provider.modelFlag).toEqual(['--model', 'sonnet']);
+  });
+
+  it('threads the selected model through createLLMProvider', () => {
+    const provider = createLLMProvider(undefined, 'haiku') as ClaudeCodeProvider;
+    expect(provider.modelFlag).toEqual(['--model', 'haiku']);
+  });
+
+  it('createLLMProvider without a model keeps current behavior', () => {
+    const provider = createLLMProvider() as ClaudeCodeProvider;
+    expect(provider.modelFlag).toEqual([]);
+  });
+});

--- a/tests/server/model-discovery.test.ts
+++ b/tests/server/model-discovery.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import {
   discoverClaudeModels,
   pickDefaultModel,
+  selectableModels,
   type ClaudeModelInfo,
 } from '../../packages/core/src/services/llm/model-discovery.js';
 
@@ -76,21 +77,7 @@ describe('pickDefaultModel', () => {
     expect(pickDefaultModel(models)?.value).toBe('sonnet');
   });
 
-  it('identifies Opus via resolvedModel when the alias does not say so', () => {
-    const models = [
-      model({ value: 'haiku', displayName: 'Haiku' }),
-      model({
-        value: 'default',
-        displayName: 'Default (recommended)',
-        resolvedModel: 'claude-opus-4-8[1m]',
-      }),
-    ];
-    expect(pickDefaultModel(models)?.value).toBe('default');
-  });
-
-  it('prefers an explicit Opus entry over the moving `default` alias', () => {
-    // `default` resolves to Opus today but tracks whatever Claude Code prefers
-    // tomorrow. Pinning to it would reintroduce silent model drift.
+  it('prefers an explicit Opus entry over an alias that merely resolves to Opus', () => {
     const models = [
       model({
         value: 'default',
@@ -121,6 +108,65 @@ describe('pickDefaultModel', () => {
 
   it('returns null for an empty list', () => {
     expect(pickDefaultModel([])).toBeNull();
+  });
+});
+
+describe('selectableModels', () => {
+  it('drops the `default` alias, which names no model', () => {
+    // Its label says "Default (recommended)" — picking it tells you nothing
+    // about what will run, which is the whole point of offering a choice.
+    const models = [
+      model({
+        value: 'default',
+        displayName: 'Default (recommended)',
+        resolvedModel: 'claude-opus-4-8[1m]',
+      }),
+      model({ value: 'opus[1m]', displayName: 'Opus', resolvedModel: 'claude-opus-4-8[1m]' }),
+    ];
+    expect(selectableModels(models).map((m) => m.value)).toEqual(['opus[1m]']);
+  });
+
+  it('drops any opaque alias, not just `default`', () => {
+    // `best` tracks whatever Claude Code judges best — same problem as `default`.
+    const models = [
+      model({ value: 'best', displayName: 'Best', resolvedModel: 'claude-opus-4-8' }),
+      model({ value: 'sonnet', displayName: 'Sonnet', resolvedModel: 'claude-sonnet-5' }),
+    ];
+    expect(selectableModels(models).map((m) => m.value)).toEqual(['sonnet']);
+  });
+
+  it('keeps every entry that names its own model family', () => {
+    const models = [
+      model({ value: 'opus[1m]', displayName: 'Opus', resolvedModel: 'claude-opus-4-8[1m]' }),
+      model({
+        value: 'claude-fable-5[1m]',
+        displayName: 'Fable',
+        resolvedModel: 'claude-fable-5',
+      }),
+      model({ value: 'sonnet', displayName: 'Sonnet', resolvedModel: 'claude-sonnet-5' }),
+      model({ value: 'haiku', displayName: 'Haiku', resolvedModel: 'claude-haiku-4-5-20251001' }),
+    ];
+    expect(selectableModels(models)).toHaveLength(4);
+  });
+
+  it('keeps entries with no resolvedModel — the entry is its own identity', () => {
+    const models = [model({ value: 'sonnet', displayName: 'Sonnet', resolvedModel: undefined })];
+    expect(selectableModels(models).map((m) => m.value)).toEqual(['sonnet']);
+  });
+
+  it('keeps an entry whose resolvedModel names no known family', () => {
+    // A future family we don't know about must not be silently hidden.
+    const models = [
+      model({ value: 'mythos', displayName: 'Mythos', resolvedModel: 'claude-mythos-9' }),
+    ];
+    expect(selectableModels(models).map((m) => m.value)).toEqual(['mythos']);
+  });
+
+  it('matches the family case-insensitively', () => {
+    const models = [
+      model({ value: 'OPUS[1m]', displayName: 'Opus', resolvedModel: 'claude-Opus-4-8' }),
+    ];
+    expect(selectableModels(models)).toHaveLength(1);
   });
 });
 

--- a/tests/server/model-discovery.test.ts
+++ b/tests/server/model-discovery.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  discoverClaudeModels,
+  pickDefaultModel,
+  type ClaudeModelInfo,
+} from '../../packages/core/src/services/llm/model-discovery.js';
+
+function model(over: Partial<ClaudeModelInfo> = {}): ClaudeModelInfo {
+  return {
+    value: 'sonnet',
+    displayName: 'Sonnet',
+    description: 'Sonnet 5 · Efficient for routine tasks',
+    ...over,
+  };
+}
+
+/**
+ * Write a fake `claude` that speaks the stdio control protocol: read one
+ * newline-delimited control_request, echo back the canned initialize response
+ * with a matching request_id. Lets us exercise the real spawn/parse path
+ * without a Claude login or network.
+ */
+function fakeClaude(dir: string, body: string): string {
+  const bin = path.join(dir, 'fake-claude.mjs');
+  fs.writeFileSync(
+    bin,
+    `#!/usr/bin/env node
+import readline from 'node:readline';
+readline.createInterface({ input: process.stdin }).on('line', (line) => {
+  const req = JSON.parse(line);
+  ${body}
+});
+`,
+    { mode: 0o755 },
+  );
+  return bin;
+}
+
+const RESPONDS_WITH_MODELS = `
+  process.stdout.write(JSON.stringify({
+    type: 'control_response',
+    response: {
+      subtype: 'success',
+      request_id: req.request_id,
+      response: {
+        account: { email: 'dev@example.com', subscriptionType: 'Claude Max' },
+        models: [
+          { value: 'default', resolvedModel: 'claude-opus-4-8[1m]', displayName: 'Default (recommended)', description: 'Opus 4.8' },
+          { value: 'opus[1m]', resolvedModel: 'claude-opus-4-8[1m]', displayName: 'Opus', description: 'Opus 4.8' },
+          { value: 'haiku', displayName: 'Haiku', description: 'Haiku 4.5' },
+        ],
+      },
+    },
+  }) + '\\n');
+`;
+
+describe('pickDefaultModel', () => {
+  it('prefers an Opus model over other tiers', () => {
+    const models = [
+      model({ value: 'haiku', displayName: 'Haiku' }),
+      model({ value: 'claude-fable-5[1m]', displayName: 'Fable' }),
+      model({ value: 'opus[1m]', displayName: 'Opus' }),
+      model({ value: 'sonnet', displayName: 'Sonnet' }),
+    ];
+    expect(pickDefaultModel(models)?.value).toBe('opus[1m]');
+  });
+
+  it('never picks Fable, which bills at a premium tier', () => {
+    const models = [
+      model({ value: 'claude-fable-5[1m]', displayName: 'Fable' }),
+      model({ value: 'sonnet', displayName: 'Sonnet' }),
+    ];
+    expect(pickDefaultModel(models)?.value).toBe('sonnet');
+  });
+
+  it('identifies Opus via resolvedModel when the alias does not say so', () => {
+    const models = [
+      model({ value: 'haiku', displayName: 'Haiku' }),
+      model({
+        value: 'default',
+        displayName: 'Default (recommended)',
+        resolvedModel: 'claude-opus-4-8[1m]',
+      }),
+    ];
+    expect(pickDefaultModel(models)?.value).toBe('default');
+  });
+
+  it('prefers an explicit Opus entry over the moving `default` alias', () => {
+    // `default` resolves to Opus today but tracks whatever Claude Code prefers
+    // tomorrow. Pinning to it would reintroduce silent model drift.
+    const models = [
+      model({
+        value: 'default',
+        displayName: 'Default (recommended)',
+        resolvedModel: 'claude-opus-4-8[1m]',
+      }),
+      model({ value: 'opus[1m]', displayName: 'Opus' }),
+    ];
+    expect(pickDefaultModel(models)?.value).toBe('opus[1m]');
+  });
+
+  it('does not mistake a Fable entry for Opus via its description', () => {
+    const models = [
+      model({
+        value: 'claude-fable-5[1m]',
+        displayName: 'Fable',
+        description: 'Most capable — more capable than Opus 4.8',
+      }),
+      model({ value: 'haiku', displayName: 'Haiku' }),
+    ];
+    expect(pickDefaultModel(models)?.value).toBe('haiku');
+  });
+
+  it('falls back to the first model when no Opus is available', () => {
+    const models = [model({ value: 'sonnet' }), model({ value: 'haiku' })];
+    expect(pickDefaultModel(models)?.value).toBe('sonnet');
+  });
+
+  it('returns null for an empty list', () => {
+    expect(pickDefaultModel([])).toBeNull();
+  });
+});
+
+describe('discoverClaudeModels', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-model-discovery-'));
+
+  it('returns the models reported by the control protocol', async () => {
+    const bin = fakeClaude(tmp, RESPONDS_WITH_MODELS);
+    const models = await discoverClaudeModels({ binary: bin });
+    expect(models?.map((m) => m.value)).toEqual(['default', 'opus[1m]', 'haiku']);
+    expect(models?.[0].resolvedModel).toBe('claude-opus-4-8[1m]');
+  });
+
+  it('ignores non-JSON banner noise on stdout', async () => {
+    const bin = fakeClaude(tmp, `process.stdout.write('starting up...\\n'); ${RESPONDS_WITH_MODELS}`);
+    const models = await discoverClaudeModels({ binary: bin });
+    expect(models?.map((m) => m.value)).toEqual(['default', 'opus[1m]', 'haiku']);
+  });
+
+  it('returns null when the binary does not exist', async () => {
+    const models = await discoverClaudeModels({ binary: '/nonexistent/claude-xyz' });
+    expect(models).toBeNull();
+  });
+
+  it('returns null when the CLI reports a control error', async () => {
+    const bin = fakeClaude(
+      tmp,
+      `process.stdout.write(JSON.stringify({
+        type: 'control_response',
+        response: { subtype: 'error', request_id: req.request_id, error: 'nope' },
+      }) + '\\n');`,
+    );
+    expect(await discoverClaudeModels({ binary: bin })).toBeNull();
+  });
+
+  it('returns null when the CLI exits without responding', async () => {
+    const bin = fakeClaude(tmp, `process.exit(1);`);
+    expect(await discoverClaudeModels({ binary: bin })).toBeNull();
+  });
+
+  it('returns null when the CLI hangs past the timeout', async () => {
+    const bin = fakeClaude(tmp, `/* never respond */`);
+    expect(await discoverClaudeModels({ binary: bin, timeoutMs: 300 })).toBeNull();
+  });
+
+  it('returns null when the response carries no models', async () => {
+    const bin = fakeClaude(
+      tmp,
+      `process.stdout.write(JSON.stringify({
+        type: 'control_response',
+        response: { subtype: 'success', request_id: req.request_id, response: { account: {} } },
+      }) + '\\n');`,
+    );
+    expect(await discoverClaudeModels({ binary: bin })).toBeNull();
+  });
+
+  it('ignores a control_response for a different request', async () => {
+    const bin = fakeClaude(
+      tmp,
+      `process.stdout.write(JSON.stringify({
+        type: 'control_response',
+        response: { subtype: 'success', request_id: 'someone-else', response: { models: [{ value: 'x', displayName: 'X', description: '' }] } },
+      }) + '\\n');`,
+    );
+    expect(await discoverClaudeModels({ binary: bin, timeoutMs: 500 })).toBeNull();
+  });
+});

--- a/tools/cli/src/commands/analyze.ts
+++ b/tools/cli/src/commands/analyze.ts
@@ -12,6 +12,7 @@ import { closeLogger, configureLogger } from "@truecourse/core/lib/logger";
 import { preflightClaudeOrExit } from "../lib/claude-preflight.js";
 import { exitMissingNonInteractiveFlag, isInteractive, promptInstallSkills, renderViolationsSummary } from "./helpers.js";
 import { promptLlmEstimate } from "./llm-prompt.js";
+import { promptModelChoice } from "./model-prompt.js";
 import { showFirstRunNotice } from "../telemetry.js";
 import { recordAnalyzeAndMaybePrompt } from "../community-prompts.js";
 
@@ -281,6 +282,13 @@ export async function runAnalyze(options: AnalyzeOptions = {}): Promise<void> {
   // `--no-llm` analysis (tree-sitter only) needs no Claude login.
   if (enableLlmRules) await preflightClaudeOrExit();
 
+  // LLM rules are on and `claude` is reachable, so let the user say which model
+  // runs them. `undefined` means "no explicit choice": no `--model` flag, and
+  // Claude Code picks — what analyze did before this prompt existed. That's the
+  // path for non-interactive runs and for installs whose CLI can't answer the
+  // discovery probe.
+  const selectedModel = enableLlmRules ? await promptModelChoice() : undefined;
+
   // Resolve stash decision before any analyzer work — keeps the prompt out
   // of the shared core service (which the dashboard server also calls).
   const stashDecision = await resolveStashDecision(options, project.path);
@@ -331,6 +339,7 @@ export async function runAnalyze(options: AnalyzeOptions = {}): Promise<void> {
       skipStash: stashDecision.skipStash,
       enabledCategoriesOverride: enabledCategories,
       enableLlmRulesOverride: enableLlmRules,
+      selectedModel,
       source: "cli",
       onLlmEstimate: async (estimate) => {
         stopSpinner();

--- a/tools/cli/src/commands/model-prompt.ts
+++ b/tools/cli/src/commands/model-prompt.ts
@@ -13,20 +13,43 @@ export interface ModelPickerOption {
 }
 
 /**
- * The label for one row: which model this is, and nothing else.
+ * The model half of a description: everything before the pitch.
  *
- * Claude Code's descriptions are `"<identity> · <pitch>"` — "Opus 4.8 with 1M
- * context · Best for everyday, complex tasks". Only the identity earns its
- * place here: anyone choosing a model already has Claude Code and knows what
- * Opus is, so the pitch is noise on every row. The identity half is kept whole
- * because the context window ("with 1M context") distinguishes real choices.
+ * Claude Code's descriptions are `"<model> · <pitch>"` — "Opus 4.8 with 1M
+ * context · Best for everyday, complex tasks". Only the model half earns a
+ * place in the list: anyone choosing a model already has Claude Code and knows
+ * what Opus is, so the pitch is noise repeated on every row.
  *
  * Falls back to `displayName` when there's no description, or when cutting the
- * pitch leaves nothing.
+ * pitch leaves nothing behind.
  */
-function labelFor(model: ClaudeModelInfo): string {
-  const identity = model.description?.split('·')[0]?.trim();
-  return identity || model.displayName;
+function modelHalf(model: ClaudeModelInfo): string {
+  return model.description?.split('·')[0]?.trim() || model.displayName;
+}
+
+/**
+ * Drop a trailing context-window note: "Opus 4.8 with 1M context" → "Opus 4.8".
+ *
+ * 1M is not a distinguishing fact — Opus 4.8, Fable 5, and Sonnet 5 all offer
+ * it — so noting it on one row and not the others says nothing about the
+ * choice. Matched narrowly (`with … context`) so unrelated qualifiers survive.
+ */
+function withoutContextNote(label: string): string {
+  return label.replace(/\s+with\s+\S+\s+context$/i, '');
+}
+
+/**
+ * Label every row with its model, shortest form that stays unambiguous.
+ *
+ * The context note is dropped — except where it is the only thing telling two
+ * rows apart. Some installs list a model once per context window (`sonnet` and
+ * `sonnet[1m]`, whose descriptions differ only by "with 1M context"); stripping
+ * it there would render two identical rows and no way to pick between them.
+ */
+function labelsFor(models: ClaudeModelInfo[]): string[] {
+  const short = models.map((m) => withoutContextNote(modelHalf(m)));
+  const collisions = new Set(short.filter((l, i) => short.indexOf(l) !== i));
+  return models.map((m, i) => (collisions.has(short[i]) ? modelHalf(m) : short[i]));
 }
 
 /**
@@ -44,8 +67,9 @@ export function buildModelPickerOptions(models: ClaudeModelInfo[]): {
   options: ModelPickerOption[];
   initialValue: string | undefined;
 } {
+  const labels = labelsFor(models);
   return {
-    options: models.map((m) => ({ value: m.value, label: labelFor(m) })),
+    options: models.map((m, i) => ({ value: m.value, label: labels[i] })),
     initialValue: pickDefaultModel(models)?.value,
   };
 }

--- a/tools/cli/src/commands/model-prompt.ts
+++ b/tools/cli/src/commands/model-prompt.ts
@@ -13,27 +13,39 @@ export interface ModelPickerOption {
 }
 
 /**
+ * The label for one row: which model this is, and nothing else.
+ *
+ * Claude Code's descriptions are `"<identity> · <pitch>"` — "Opus 4.8 with 1M
+ * context · Best for everyday, complex tasks". Only the identity earns its
+ * place here: anyone choosing a model already has Claude Code and knows what
+ * Opus is, so the pitch is noise on every row. The identity half is kept whole
+ * because the context window ("with 1M context") distinguishes real choices.
+ *
+ * Falls back to `displayName` when there's no description, or when cutting the
+ * pitch leaves nothing.
+ */
+function labelFor(model: ClaudeModelInfo): string {
+  const identity = model.description?.split('·')[0]?.trim();
+  return identity || model.displayName;
+}
+
+/**
  * Shape the discovered models into picker options.
  *
- * The description becomes the label rather than clack's `hint`, because clack
- * renders a hint only for the row the cursor is on — so exactly one model would
- * describe itself and the rest would show a bare name. Every row should say
+ * The label carries the model's identity rather than clack's `hint`, because
+ * clack renders a hint only for the row the cursor is on — so exactly one model
+ * would name itself and the rest would show a bare alias. Every row should say
  * which model it is. (clack also hardcodes parentheses around hints.)
  *
- * Claude Code's descriptions already lead with the model ("Opus 4.8 with 1M
- * context · …"), so they stand alone; `displayName` is the fallback for an
- * entry that has none. Order is preserved as the CLI reported it, so the list
- * reads like Claude Code's own `/model` picker.
+ * Order is preserved as the CLI reported it, so the list reads like Claude
+ * Code's own `/model` picker.
  */
 export function buildModelPickerOptions(models: ClaudeModelInfo[]): {
   options: ModelPickerOption[];
   initialValue: string | undefined;
 } {
   return {
-    options: models.map((m) => ({
-      value: m.value,
-      label: m.description || m.displayName,
-    })),
+    options: models.map((m) => ({ value: m.value, label: labelFor(m) })),
     initialValue: pickDefaultModel(models)?.value,
   };
 }

--- a/tools/cli/src/commands/model-prompt.ts
+++ b/tools/cli/src/commands/model-prompt.ts
@@ -1,0 +1,102 @@
+import * as p from "@clack/prompts";
+import {
+  discoverClaudeModels,
+  pickDefaultModel,
+  type ClaudeModelInfo,
+} from "@truecourse/core/services/llm/model-discovery";
+import { isInteractive } from "./helpers.js";
+
+export interface ModelPickerOption {
+  value: string;
+  label: string;
+  hint?: string;
+}
+
+/**
+ * Shape the discovered models into picker options.
+ *
+ * Order is preserved as the CLI reported it, so the list reads the same as
+ * Claude Code's own `/model` picker.
+ */
+export function buildModelPickerOptions(models: ClaudeModelInfo[]): {
+  options: ModelPickerOption[];
+  initialValue: string | undefined;
+} {
+  return {
+    options: models.map((m) => ({
+      value: m.value,
+      label: m.displayName,
+      ...(m.description ? { hint: m.description } : {}),
+    })),
+    initialValue: pickDefaultModel(models)?.value,
+  };
+}
+
+/** Seams so the prompt is testable without a TTY or a Claude login. */
+export interface PromptModelChoiceOptions {
+  discover?: () => Promise<ClaudeModelInfo[] | null>;
+  select?: (args: {
+    message: string;
+    initialValue: string | undefined;
+    options: ModelPickerOption[];
+  }) => Promise<string | symbol>;
+}
+
+const defaultSelect: NonNullable<PromptModelChoiceOptions["select"]> = (args) =>
+  p.select(args) as Promise<string | symbol>;
+
+/**
+ * Ask which Claude model the LLM rules should run on.
+ *
+ * Returns the chosen `--model` value, or `undefined` meaning "no explicit
+ * choice" — which callers must treat as: pass no `--model` and let Claude Code
+ * pick, exactly as analyze behaved before this prompt existed.
+ *
+ * `undefined` comes back whenever we cannot or should not ask:
+ *   - non-interactive (scripts and agents must never block on stdin)
+ *   - discovery unavailable (old CLI, protocol drift, not logged in)
+ *   - the user cancelled
+ *
+ * Discovery is skipped entirely when non-interactive, so we never spawn a probe
+ * whose answer nobody could act on.
+ */
+export async function promptModelChoice({
+  discover = discoverClaudeModels,
+  select = defaultSelect,
+}: PromptModelChoiceOptions = {}): Promise<string | undefined> {
+  if (!isInteractive()) return undefined;
+
+  // Discovery spawns the CLI, so it is not instant. Say so — without this the
+  // terminal just sits there, and on an install that can't answer the probe the
+  // silence lasts until the timeout.
+  const s = p.spinner();
+  s.start("Checking which models you can use");
+
+  let models: ClaudeModelInfo[] | null;
+  try {
+    models = await discover();
+  } catch {
+    // Discovery is a convenience, never a gate: a broken probe must not stop an
+    // analysis that would otherwise run fine on Claude Code's default model.
+    models = null;
+  }
+
+  if (!models || models.length === 0) {
+    s.stop("Using the model Claude Code picks");
+    return undefined;
+  }
+  s.stop(`${models.length} models available`);
+
+  // Nothing to choose between — take it rather than spend a prompt on the user.
+  if (models.length === 1) return models[0].value;
+
+  const { options, initialValue } = buildModelPickerOptions(models);
+  const choice = await select({
+    message: "Which model should LLM rules use?",
+    initialValue,
+    options,
+  });
+
+  if (p.isCancel(choice)) return undefined;
+  return typeof choice === "string" ? choice : undefined;
+}

--- a/tools/cli/src/commands/model-prompt.ts
+++ b/tools/cli/src/commands/model-prompt.ts
@@ -2,6 +2,7 @@ import * as p from "@clack/prompts";
 import {
   discoverClaudeModels,
   pickDefaultModel,
+  selectableModels,
   type ClaudeModelInfo,
 } from "@truecourse/core/services/llm/model-discovery";
 import { isInteractive } from "./helpers.js";
@@ -9,14 +10,20 @@ import { isInteractive } from "./helpers.js";
 export interface ModelPickerOption {
   value: string;
   label: string;
-  hint?: string;
 }
 
 /**
  * Shape the discovered models into picker options.
  *
- * Order is preserved as the CLI reported it, so the list reads the same as
- * Claude Code's own `/model` picker.
+ * The description becomes the label rather than clack's `hint`, because clack
+ * renders a hint only for the row the cursor is on — so exactly one model would
+ * describe itself and the rest would show a bare name. Every row should say
+ * which model it is. (clack also hardcodes parentheses around hints.)
+ *
+ * Claude Code's descriptions already lead with the model ("Opus 4.8 with 1M
+ * context · …"), so they stand alone; `displayName` is the fallback for an
+ * entry that has none. Order is preserved as the CLI reported it, so the list
+ * reads like Claude Code's own `/model` picker.
  */
 export function buildModelPickerOptions(models: ClaudeModelInfo[]): {
   options: ModelPickerOption[];
@@ -25,8 +32,7 @@ export function buildModelPickerOptions(models: ClaudeModelInfo[]): {
   return {
     options: models.map((m) => ({
       value: m.value,
-      label: m.displayName,
-      ...(m.description ? { hint: m.description } : {}),
+      label: m.description || m.displayName,
     })),
     initialValue: pickDefaultModel(models)?.value,
   };
@@ -72,16 +78,18 @@ export async function promptModelChoice({
   const s = p.spinner();
   s.start("Checking which models you can use");
 
-  let models: ClaudeModelInfo[] | null;
+  let discovered: ClaudeModelInfo[] | null;
   try {
-    models = await discover();
+    discovered = await discover();
   } catch {
     // Discovery is a convenience, never a gate: a broken probe must not stop an
     // analysis that would otherwise run fine on Claude Code's default model.
-    models = null;
+    discovered = null;
   }
 
-  if (!models || models.length === 0) {
+  const models = discovered ? selectableModels(discovered) : [];
+
+  if (models.length === 0) {
     s.stop("Using the model Claude Code picks");
     return undefined;
   }


### PR DESCRIPTION
## The problem

`analyze` passed `--model` only when `CLAUDE_CODE_MODEL` was set. With it unset — the common case — the spawned `claude -p` inherited whatever model the user's **interactive Claude Code** was configured with.

So a user whose editor default is Fable 5 was silently billing every analysis at the premium tier (\$10/\$50 per MTok, 2× Opus 4.8) without ever choosing it, and nothing in the run told them which model was used. That's how this was found.

## What changes

When LLM rules run interactively, analyze asks which model to use and lists the models **that user's Claude Code actually offers** — scoped to their account, subscription, org policy, and CLI version:

```
◇  `claude` CLI ready
│
◇  4 models available
│
◆  Which model should LLM rules use?
│  ● Opus 4.8
│  ○ Fable 5
│  ○ Sonnet 5
│  ○ Haiku 4.5
└
```

The choice flows through to every `claude` call for that run.

Every row names its model and nothing else. Claude Code's descriptions are `"<model> · <pitch>"` ("Opus 4.8 with 1M context · Best for everyday, complex tasks"); only the model half is kept, since anyone picking a model here already knows what Opus is.

The context-window note goes too — it implied 1M was something Opus had and the others didn't, when Opus 4.8, Fable 5, and Sonnet 5 all offer it and only Haiku 4.5 is smaller. It survives in one case: where it is the only thing telling two rows apart. Some installs list a model once per window (`sonnet` and `sonnet[1m]`, whose descriptions differ by exactly that phrase), and stripping it there would render two identical rows. The rule is the shortest label that stays unambiguous, decided per list.

That identity is the row *label* rather than clack's `hint` — a hint renders only on the focused row, so exactly one model would name itself and the rest would show a bare alias (and clack hardcodes parentheses around it).

## What isn't offered: `default`

Claude Code's own `default` entry is filtered out. Its label ("Default (recommended)") names no model, so picking it tells you nothing about what will run — it's "surprise me", which is the behavior this picker exists to replace, and exactly how analysis silently ended up on a premium tier.

The rule is generic: **drop an entry that doesn't name the family it resolves to**. That covers `best` and `opusplan` without hardcoding alias names. Entries with no `resolvedModel`, or from a family we don't recognize, are kept — we only drop on positive evidence that an entry hides its model, so a future family can't be silently swallowed.

## How discovery works (and why there's no new dependency)

The Claude Agent SDK can list available models, but depending on it for this is heavy — it bundles its own CLI. Instead we speak the same stdio control protocol directly:

```
→ {"type":"control_request","request_id":"…","request":{"subtype":"initialize"}}
← {"type":"control_response","response":{"subtype":"success","request_id":"…",
   "response":{"models":[…],"account":{…}}}}
```

**It costs nothing** — the CLI answers `initialize` from local state; no prompt reaches the API. It runs **once per analyze**, not once per call (verified: 1 probe across 44 spawns).

## Why Opus is pre-selected

Opus is the strongest tier we're willing to spend on a user's behalf unasked. **Fable is never pre-selected** — it bills well above Opus, and reaching that tier should be a choice, not a default you accept by pressing Enter.

## Fallback: unchanged behavior, guaranteed

The protocol is an internal SDK surface, not a documented CLI contract, so it can change between Claude Code releases. Every failure is non-fatal and lands on the **pre-existing** behavior — no `--model`, Claude Code picks:

| Situation | Result |
|---|---|
| Non-interactive (`--llm`, CI, agents) | No prompt, **no probe spawned**, no `--model` |
| CLI too old / protocol drift / timeout | No prompt, no `--model` |
| Binary missing, control error, empty list | No prompt, no `--model` |
| Nothing selectable (only opaque aliases) | No prompt, no `--model` |
| User cancels | No `--model` |

Verified end-to-end, not just asserted: with a CLI that can't answer the probe, no picker appears and analyze proceeds exactly as before; non-interactive runs spawn **zero** probes and pass **zero** `--model` flags.

## Verification

Driven through the real CLI on a 367-file fixture (not just unit tests):

- **41/41** `claude` spawns carried `--model haiku` after selecting Haiku — the flag reaches the real invocation:
  `--print --output-format json --dangerously-skip-permissions --no-session-persistence --model haiku --json-schema {…}`
- Picker renders with Opus pre-selected; arrow-key navigation and confirmation work.
- Probe-failure and non-interactive fallbacks confirmed at the surface.

**One issue found and fixed during verification:** an install that can't answer the probe stalled for a silent **15s** with no feedback. The real probe answers in ~1.2s, so the timeout is now 5s and a spinner reports progress (`Checking which models you can use` → `Using the model Claude Code picks`). Measured 15,034ms → 5,053ms.

## Tests

41 new tests, TDD. `pnpm test` (cli + server): **265 passed**.

Notable coverage: `default`/`best` filtering and the keep-on-no-evidence cases; Opus preference over Fable; not mistaking Fable for Opus via its description ("more capable than Opus 4.8"); every row labelled with its model and never a hint; context note kept only to break a tie; protocol parsing against a fake CLI (banner noise, control errors, early exit, hang, wrong request_id, empty list); provider flag precedence.

## Decision worth a look

**Non-interactive runs keep the old behavior** rather than defaulting to Opus. `--llm` in CI can't prompt, so forcing a model there would silently change what scripted callers have been getting. That means a CI job on a Fable-defaulted machine still uses Fable — say the word if you'd rather it default to Opus everywhere.

Out of scope: the dashboard still uses Claude Code's default (no picker); the staged spec/guard pipelines are unaffected — they already pass explicit per-stage models via `STAGE_DEFAULTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

