### PR TITLE
fix(spec): fail loud on an empty corpus at every surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ Stages run in order, each producing committable artifacts the next consumes:
 
 **1. Spec consolidation** — Walks every `.md` file in the repo (PRDs, ADRs, RFCs, READMEs, design notes; `.truecourse/`, `node_modules/`, `.git/` etc. are skipped). An LLM relevance filter drops obvious non-spec material (task lists, research logs, AI agent prompts). For the docs that remain, an LLM tags each into **areas** (`product/concern`) and flags within-area **overlaps** where two docs may disagree. Output: `.truecourse/specs/corpus.json` (the curated corpus every downstream stage consumes — kept docs + area tags, docs grouped by area, overlap flags, and the relevance-dropped docs; committable) and `.truecourse/specs/decisions.json` (the user's resolutions: `manualAreas`, `manualIncludes`, `manualExcludes`, and conflict verdicts — committable).
 
+An **empty corpus fails loud**: when discovery finds no docs at all (e.g. an rst-only repo — only markdown is scanned; ignored doc-like files are counted by extension in the corpus's scan stats), or the relevance filter drops every doc, `spec scan` warns (exit 0), `spec status` explains why, and `guard generate` refuses with the same explanation (exit 1) — never a false "nothing changed".
+
 Only genuine within-area **disagreements** flag as overlaps — docs that agree never surface. You resolve them in the dashboard's Guard → Coverage tab or via `spec conflicts` (pick a side or dismiss).
 
 **2. Guard generation** (`truecourse guard generate`) — Splits each kept doc into sections and, per section: **classifies** whether the section makes a claim a driver can assert (today's driver runs your project's CLI; a non-testable verdict carries a one-sentence reason and surfaces as a visible coverage gap), **authors** one or more declarative YAML scenarios from the section's claim plus the code, and **birth-validates** each one by running it immediately — a scenario that fails at birth is reported as a finding (the spec and the code already disagree) instead of being silently committed. Output, all committable: `.truecourse/scenarios/<area>/*.yaml` (the scenarios), `scenarios/recipe.json` (how to build/prepare the repo for a run), and `scenarios/manifest.json` (section ↔ scenario bindings + section fingerprints, so re-generates only touch changed sections).
@@ -232,7 +234,7 @@ The spec, the scenarios, and a guard baseline are committable so they travel wit
 ```
 .truecourse/
 ├── specs/                  ← curated corpus (committable)
-│   ├── corpus.json          ← kept docs + area tags, docs-by-area, overlap flags, dropped docs
+│   ├── corpus.json          ← kept docs + area tags, docs-by-area, overlap flags, dropped docs, scan stats
 │   └── decisions.json       ← user resolutions: conflict verdicts + manual areas + manual includes/excludes
 ├── scenarios/               ← the guard scenario corpus (committable)
 │   ├── recipe.json           ← how to build/prepare the repo for a run

--- a/apps/dashboard/client/src/components/spec/SpecCorpusView.tsx
+++ b/apps/dashboard/client/src/components/spec/SpecCorpusView.tsx
@@ -16,7 +16,7 @@ import { toast } from 'sonner';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { EmptyState } from '@/components/ui/empty-state';
 import { HoverPopover } from '@/components/ui/hover-popover';
-import { buildCorpusConflicts, orphanedConflictResolutions, type ConflictResolutionLike } from '@truecourse/shared';
+import { buildCorpusConflicts, deriveEmptyCorpus, formatEmptyCorpus, orphanedConflictResolutions, type ConflictResolutionLike } from '@truecourse/shared';
 import type { SpecCorpusResponse, SpecCorpusDoc, SpecConflictResolution, SpecDecisionAck, SpecSkippedDoc } from '@/lib/api';
 import { createRepoSpecSource, useSpecSource, type SkippedPage, type SpecSource } from './spec-source';
 import { WorkspaceBadge } from './WorkspaceBadge';
@@ -161,6 +161,21 @@ export function useSpecCorpus(
       // confirm — leave existing data untouched.
       if (!res || 'cancelled' in res) return;
       setData(res);
+      // An empty corpus (a fresh scan kept no docs) is a loud WARNING, never the
+      // silent "nothing changed" success (issue #807): the driver forces noChanges
+      // false and reports the flavor, so we explain it here with the shared wording
+      // (identical to the CLI's) rather than pretend the corpus is up to date.
+      if (res.emptyCorpus) {
+        const stats = res.corpus?.stats;
+        toast.warning('No spec corpus', {
+          description: formatEmptyCorpus({
+            flavor: res.emptyCorpus,
+            docsScanned: stats?.docsScanned ?? 0,
+            ignoredNonMarkdown: stats?.ignoredNonMarkdown,
+          }),
+        });
+        return;
+      }
       // Every doc was unchanged (no LLM calls) — toast it, mirroring generate.
       if (res.noChanges) {
         toast.success('Nothing changed', {
@@ -353,6 +368,31 @@ export function SpecCorpusView({
   }
 
   const { corpus: c } = data;
+  // Empty-corpus flavor (issue #807): a corpus present but holding no kept docs is
+  // surfaced explicitly, never as a barren "0 documents" tree that reads as success.
+  //  - no-docs-found: nothing was discoverable → a full EmptyState (below), with the
+  //    ignored-extension breakdown + config remedy (there is nothing to force-include).
+  //  - all-docs-dropped: docs were scanned but the relevance filter kept none → the
+  //    normal tree still renders so its "Not included" list is the force-include remedy,
+  //    with an explanation banner on top. Derived from the persisted scan stats, with a
+  //    legacy fallback (older corpora lack stats) of docsScanned = kept + skipped.
+  const emptyFlavor = deriveEmptyCorpus({
+    docsScanned: c.stats?.docsScanned ?? c.docs.length + (c.skippedDocs?.length ?? 0),
+    docsKept: c.docs.length,
+  });
+  if (emptyFlavor === 'no-docs-found') {
+    return (
+      <EmptyState
+        icon={FileText}
+        title="No spec documents found"
+        body={formatEmptyCorpus({
+          flavor: 'no-docs-found',
+          docsScanned: c.stats?.docsScanned ?? 0,
+          ignoredNonMarkdown: c.stats?.ignoredNonMarkdown,
+        })}
+      />
+    );
+  }
   const manualIncludes = data.manualIncludes ?? [];
   const manualExcludes = data.manualExcludes ?? [];
   // The section rows derive from the decision lists over the unchanged corpus, so
@@ -451,6 +491,11 @@ export function SpecCorpusView({
       {baselineFallback && (
         <div className="border-b border-border bg-card/40 px-4 py-1.5 text-[11px] text-muted-foreground">
           Showing the base spec — this PR changed no docs.
+        </div>
+      )}
+      {emptyFlavor === 'all-docs-dropped' && (
+        <div className="border-b border-border bg-amber-500/10 px-4 py-2 text-[11px] text-amber-700 dark:text-amber-300">
+          {formatEmptyCorpus({ flavor: 'all-docs-dropped', docsScanned: c.stats?.docsScanned ?? 0 })}
         </div>
       )}
       {allTags.length > 1 && (

--- a/apps/dashboard/client/src/components/spec/SpecCorpusView.tsx
+++ b/apps/dashboard/client/src/components/spec/SpecCorpusView.tsx
@@ -16,7 +16,7 @@ import { toast } from 'sonner';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { EmptyState } from '@/components/ui/empty-state';
 import { HoverPopover } from '@/components/ui/hover-popover';
-import { buildCorpusConflicts, deriveEmptyCorpus, formatEmptyCorpus, orphanedConflictResolutions, type ConflictResolutionLike } from '@truecourse/shared';
+import { buildCorpusConflicts, corpusScanCounts, deriveEmptyCorpus, formatEmptyCorpus, orphanedConflictResolutions, type ConflictResolutionLike } from '@truecourse/shared';
 import type { SpecCorpusResponse, SpecCorpusDoc, SpecConflictResolution, SpecDecisionAck, SpecSkippedDoc } from '@/lib/api';
 import { createRepoSpecSource, useSpecSource, type SkippedPage, type SpecSource } from './spec-source';
 import { WorkspaceBadge } from './WorkspaceBadge';
@@ -166,13 +166,8 @@ export function useSpecCorpus(
       // false and reports the flavor, so we explain it here with the shared wording
       // (identical to the CLI's) rather than pretend the corpus is up to date.
       if (res.emptyCorpus) {
-        const stats = res.corpus?.stats;
         toast.warning('No spec corpus', {
-          description: formatEmptyCorpus({
-            flavor: res.emptyCorpus,
-            docsScanned: stats?.docsScanned ?? 0,
-            ignoredNonMarkdown: stats?.ignoredNonMarkdown,
-          }),
+          description: formatEmptyCorpus({ flavor: res.emptyCorpus, ...corpusScanCounts(res.corpus) }),
         });
         return;
       }
@@ -376,20 +371,14 @@ export function SpecCorpusView({
   //    normal tree still renders so its "Not included" list is the force-include remedy,
   //    with an explanation banner on top. Derived from the persisted scan stats, with a
   //    legacy fallback (older corpora lack stats) of docsScanned = kept + skipped.
-  const emptyFlavor = deriveEmptyCorpus({
-    docsScanned: c.stats?.docsScanned ?? c.docs.length + (c.skippedDocs?.length ?? 0),
-    docsKept: c.docs.length,
-  });
+  const scanCounts = corpusScanCounts(c);
+  const emptyFlavor = deriveEmptyCorpus(scanCounts);
   if (emptyFlavor === 'no-docs-found') {
     return (
       <EmptyState
         icon={FileText}
         title="No spec documents found"
-        body={formatEmptyCorpus({
-          flavor: 'no-docs-found',
-          docsScanned: c.stats?.docsScanned ?? 0,
-          ignoredNonMarkdown: c.stats?.ignoredNonMarkdown,
-        })}
+        body={formatEmptyCorpus({ flavor: 'no-docs-found', ...scanCounts })}
       />
     );
   }
@@ -495,7 +484,7 @@ export function SpecCorpusView({
       )}
       {emptyFlavor === 'all-docs-dropped' && (
         <div className="border-b border-border bg-amber-500/10 px-4 py-2 text-[11px] text-amber-700 dark:text-amber-300">
-          {formatEmptyCorpus({ flavor: 'all-docs-dropped', docsScanned: c.stats?.docsScanned ?? 0 })}
+          {formatEmptyCorpus({ flavor: 'all-docs-dropped', ...scanCounts })}
         </div>
       )}
       {allTags.length > 1 && (

--- a/apps/dashboard/client/src/hooks/useGuardGenerate.ts
+++ b/apps/dashboard/client/src/hooks/useGuardGenerate.ts
@@ -41,7 +41,14 @@ export function useGuardGenerate(repoId: string | undefined): GuardGenerateState
       try {
         const res = await api.triggerGuardGenerate(repoId, confirmed);
         if (res.cancelled) return;
-        if (res.noChanges) {
+        // A `no-docs` generate returns 200 with a status + reason (the empty-corpus
+        // explanation when the last scan found no spec docs, #807) — surface it as an
+        // error toast, never the misleading "wrote 0 scenarios" success.
+        if (res.status === 'no-docs') {
+          toast.error('No spec documents to guard', {
+            description: res.reason ?? 'The last scan found no spec documents.',
+          });
+        } else if (res.noChanges) {
           toast.success('Nothing changed', {
             description: 'Every section is already guarded since the last generate.',
           });

--- a/apps/dashboard/client/src/lib/api.ts
+++ b/apps/dashboard/client/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
   BrowseDirResponse,
   CapabilitiesResponse,
+  EmptyCorpusFlavor,
   GuardClaimIdentity,
   GuardDecisions,
   GuardDocCoverage,
@@ -803,6 +804,18 @@ export interface SpecCorpus {
   areas: SpecCorpusArea[];
   /** Docs the relevance filter dropped (path + reason). */
   skippedDocs?: SpecSkippedDoc[];
+  /**
+   * Scan counts persisted with the corpus: docs discovered in scope
+   * (`docsScanned`), docs kept after the relevance filter (`docsKept`), and the
+   * per-extension count of ignored doc-like non-markdown files (`.rst` → count).
+   * Absent on legacy corpora scanned before the field existed; drives the
+   * empty-corpus EmptyState (issue #807).
+   */
+  stats?: {
+    docsScanned: number;
+    docsKept: number;
+    ignoredNonMarkdown: Record<string, number>;
+  };
 }
 
 export interface SpecCorpusResponse {
@@ -821,6 +834,13 @@ export interface SpecCorpusResponse {
   skipped?: SpecSkippedSummary;
   /** Set by the scan endpoint: true when the rescan found no doc changes (0 LLM calls). */
   noChanges?: boolean;
+  /**
+   * Set by the scan endpoint when the fresh corpus is empty (issue #807):
+   * `'no-docs-found'` (nothing discoverable) or `'all-docs-dropped'` (docs scanned,
+   * relevance filter kept none). Forces the scan to warn rather than report the
+   * false "nothing changed" success. Absent on a non-empty scan.
+   */
+  emptyCorpus?: EmptyCorpusFlavor;
   /**
    * EE PR view: the commit whose corpus was actually returned. When it differs
    * from the requested `ref`, the server fell back to the baseline corpus (e.g.
@@ -1088,6 +1108,9 @@ export interface GuardGenerateTriggerResult {
   noChanges?: boolean;
   written?: number;
   birthFindings?: number;
+  /** For a non-ok status (`no-docs` / `recipe-failed`): the user-facing reason —
+   *  e.g. the empty-corpus explanation when the last scan found no spec docs (#807). */
+  reason?: string;
   /** True when the user declined the estimate — a clean no-op, not an error. */
   cancelled?: boolean;
 }

--- a/apps/dashboard/server/src/routes/guard-actions.ts
+++ b/apps/dashboard/server/src/routes/guard-actions.ts
@@ -186,6 +186,10 @@ router.post('/:id/guard/generate', async (req: Request, res: Response, next: Nex
       noChanges: guard.noChanges,
       written: guard.written.length,
       birthFindings: guard.birthFindings.length,
+      // A non-ok status (`no-docs` / `recipe-failed`) carries a user-facing reason —
+      // the empty-corpus explanation when the last scan found no spec docs (#807).
+      // The client surfaces it as an error toast instead of a false "wrote 0".
+      ...(guard.reason ? { reason: guard.reason } : {}),
     });
   } catch (e) {
     // User declined the cost estimate — a clean cancel, not an error (mirrors the

--- a/apps/dashboard/server/src/routes/spec.ts
+++ b/apps/dashboard/server/src/routes/spec.ts
@@ -225,7 +225,15 @@ router.get(
         onLlmEstimate: createSocketSpecEstimateHandler(repoIdForCleanup),
       });
       emitSpecComplete(repoIdForCleanup, 'scan');
-      res.json({ ...(await corpusPayload(repo.path)), noChanges: result.noChanges });
+      // `emptyCorpus` (issue #807): when the fresh corpus holds no kept docs the
+      // driver forces `noChanges` false and reports the flavor, so the client warns
+      // instead of showing the false "nothing changed" success. Undefined on a
+      // non-empty scan (dropped by JSON serialization).
+      res.json({
+        ...(await corpusPayload(repo.path)),
+        noChanges: result.noChanges,
+        emptyCorpus: result.emptyCorpus,
+      });
     } catch (e) {
       // User declined the cost estimate — a clean cancel, not an error. Return
       // 200 with a `cancelled` flag so the client treats it as a no-op (no toast,

--- a/docs/SPEC_GUARD_PLAN.md
+++ b/docs/SPEC_GUARD_PLAN.md
@@ -911,6 +911,20 @@ root fix + the scoped no-tools guardrail; 503 tests green). Awaiting the paid va
 
 
 
+## Empty corpus fails loud (#807 — BUILT 2026-07-17)
+
+An empty corpus (rst-only repos, or every doc relevance-dropped) never reads as success.
+Two flavors, distinguished at every surface: `no-docs-found` (0 docs discovered — discovery
+now counts ignored doc-like non-markdown files by extension, persisted in `corpus.json`'s
+optional `stats` block) and `all-docs-dropped` (scanned > 0, kept 0). The shared derivation +
+wording live in `@truecourse/shared` (`corpusScanCounts` / `deriveEmptyCorpus` /
+`formatEmptyCorpus` — one copy for CLI and dashboard; legacy corpora without `stats` fall back
+to kept + skipped). Surfaces: `spec scan` warns loudly (exit 0, `noChanges` forced false);
+`spec status` explains instead of pointing at generate; `guard generate` exits 1 via `no-docs`
+with the flavor reason; `guard run`/`guard status` cite the empty corpus. EE gate untouched —
+`no-docs`/`no-scenarios` stay neutral, never blocking. Messages carry no issue links (rst
+support itself is #806) and never point at `guard generate`.
+
 ## guard generate (the LLM pipeline)
 
 Call-timeout note (measured 2026-07-07): authoring calls on borderline claims have a heavy

--- a/packages/core/src/commands/spec-in-process.ts
+++ b/packages/core/src/commands/spec-in-process.ts
@@ -48,7 +48,7 @@ import {
   type ValidationIssue,
 } from '@truecourse/contract-extractor';
 import { resolveFallbackModel, resolveModel, type StageId } from '../config/llm-models.js';
-import { openConflicts } from '@truecourse/shared';
+import { openConflicts, deriveEmptyCorpus, type EmptyCorpusFlavor } from '@truecourse/shared';
 
 export type {
   DecisionsFile,
@@ -450,6 +450,15 @@ export interface SpecCurateInProcessResult {
   curate: CurateResult;
   /** True when the scan made zero LLM calls — every doc was unchanged (cached). */
   noChanges: boolean;
+  /**
+   * Set when the resulting corpus holds no kept docs, distinguishing "nothing
+   * discoverable" ('no-docs-found', docsScanned 0) from "every doc dropped by
+   * relevance" ('all-docs-dropped', docsKept 0). Undefined for a non-empty
+   * corpus. When set, {@link noChanges} is FORCED false — an empty corpus is
+   * never a silent "nothing changed" success. Surfaces render the shared
+   * `formatEmptyCorpus` explanation.
+   */
+  emptyCorpus?: EmptyCorpusFlavor;
 }
 
 export interface CurateInProcessOptions {
@@ -615,7 +624,13 @@ export async function curateInProcess(
     // cache hit — cache hits don't reach the transport, so they don't record
     // usage). Lets the dashboard tell the user a rescan found no doc changes.
     const llmCalls = [...getStageUsage().values()].reduce((n, u) => n + u.calls, 0);
-    return { curate: result, noChanges: llmCalls === 0 };
+    // An empty corpus (no kept docs) is NEVER a silent "nothing changed": force
+    // noChanges false so the surfaces raise the empty-corpus warning instead.
+    const emptyCorpus = deriveEmptyCorpus({
+      docsScanned: result.stats.docsScanned,
+      docsKept: result.stats.docsKept,
+    });
+    return { curate: result, noChanges: emptyCorpus ? false : llmCalls === 0, emptyCorpus };
   } finally {
     if (llmLog) {
       setLlmCallSink(undefined);

--- a/packages/core/src/commands/spec-in-process.ts
+++ b/packages/core/src/commands/spec-in-process.ts
@@ -493,10 +493,14 @@ export interface CurateInProcessOptions {
   // --- test seams (mirror curate(); production passes none) -----------------
   relevanceRunner?: CurateOptions['relevanceRunner'];
   areaTagRunner?: CurateOptions['areaTagRunner'];
+  // Vocab reconciliation is the one stage with no per-doc cache, so an
+  // un-stubbed test run spawns a real `claude` — the seam keeps tests hermetic.
+  vocabRunner?: CurateOptions['vocabRunner'];
   overlapRunner?: CurateOptions['overlapRunner'];
   verifyOverlapRunner?: CurateOptions['verifyOverlapRunner'];
   disableRelevanceFilter?: boolean;
   disableAreaTagging?: boolean;
+  disableVocabNormalization?: boolean;
   disableOverlapDetection?: boolean;
 }
 
@@ -575,10 +579,12 @@ export async function curateInProcess(
         decisions: options.decisions,
         relevanceRunner: options.relevanceRunner,
         areaTagRunner: options.areaTagRunner,
+        vocabRunner: options.vocabRunner,
         overlapRunner: options.overlapRunner,
         verifyOverlapRunner: options.verifyOverlapRunner,
         disableRelevanceFilter: options.disableRelevanceFilter,
         disableAreaTagging: options.disableAreaTagging,
+        disableVocabNormalization: options.disableVocabNormalization,
         disableOverlapDetection: options.disableOverlapDetection,
         onRelevanceProgress: (done, total) => {
           if (total > 0) tracker?.detail('discover', withUsage('discover', `${done}/${total} docs`)!);

--- a/packages/guard-generator/src/generate.ts
+++ b/packages/guard-generator/src/generate.ts
@@ -317,15 +317,9 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
   // and never loops the user back to `spec scan` — there is nothing left to scan.
   const counts = readCorpusScanCounts(repoRoot)
   if (counts) {
-    const flavor = deriveEmptyCorpus({ docsScanned: counts.docsScanned, docsKept: counts.docsKept })
+    const flavor = deriveEmptyCorpus(counts)
     if (flavor) {
-      return emptyResult('no-docs', {
-        reason: formatEmptyCorpus({
-          flavor,
-          docsScanned: counts.docsScanned,
-          ignoredNonMarkdown: counts.ignoredNonMarkdown,
-        }),
-      })
+      return emptyResult('no-docs', { reason: formatEmptyCorpus({ flavor, ...counts }) })
     }
   }
 

--- a/packages/guard-generator/src/generate.ts
+++ b/packages/guard-generator/src/generate.ts
@@ -45,7 +45,9 @@ import {
 import {
   GUARD_FORMAT_VERSION,
   composeBlockedOnReason,
+  deriveEmptyCorpus,
   dismissedClaimKey,
+  formatEmptyCorpus,
   isRunnableDriver,
   type GuardBirthFinding,
   type OutputExcerpts,
@@ -61,6 +63,7 @@ import {
   planGuardWork,
   collectWorkDocs,
   hasGuardUniverse,
+  readCorpusScanCounts,
   generationInputsHash,
   type GuardDoc,
   type SectionInput,
@@ -306,6 +309,24 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
     return emptyResult('no-docs', {
       reason: 'No corpus found. Run `truecourse spec scan` to curate the spec docs first.',
     })
+  }
+
+  // A corpus that EXISTS but curated zero kept docs is not "nothing changed" — it is
+  // an empty corpus (#807). Report it as no-docs with a DISTINCT reason (the shared
+  // empty-corpus wording, incl. ignored-extension counts) so the surface explains WHY
+  // and never loops the user back to `spec scan` — there is nothing left to scan.
+  const counts = readCorpusScanCounts(repoRoot)
+  if (counts) {
+    const flavor = deriveEmptyCorpus({ docsScanned: counts.docsScanned, docsKept: counts.docsKept })
+    if (flavor) {
+      return emptyResult('no-docs', {
+        reason: formatEmptyCorpus({
+          flavor,
+          docsScanned: counts.docsScanned,
+          ignoredNonMarkdown: counts.ignoredNonMarkdown,
+        }),
+      })
+    }
   }
 
   // 1. Recipe — the shared entrypoint every scenario runs against.

--- a/packages/guard-generator/src/section-plan.ts
+++ b/packages/guard-generator/src/section-plan.ts
@@ -23,7 +23,7 @@ import {
   recipePath,
   readManifest,
 } from '@truecourse/guard-runner'
-import { GUARD_FORMAT_VERSION, type GuardManifestSection } from '@truecourse/shared'
+import { GUARD_FORMAT_VERSION, corpusScanCounts, type CorpusScanCounts, type GuardManifestSection } from '@truecourse/shared'
 import { EXTRACT_PROMPT_FINGERPRINT, GENERATE_PROMPT_FINGERPRINT, FIDELITY_PROMPT_FINGERPRINT } from './prompts.js'
 import { readSuppressionIndex, suppressedQuotesIn, suppressionKey } from './suppression.js'
 
@@ -150,21 +150,11 @@ const CorpusCountsShape = z
   })
   .passthrough()
 
-/** The scan counts an empty-corpus classification needs (#807). */
-export interface CorpusScanCounts {
-  /** Docs discovered in scope before the relevance filter (the "Scanned N" number). */
-  docsScanned: number
-  /** Kept docs (the corpus's `docs` length). */
-  docsKept: number
-  /** Ignored doc-like non-markdown files by extension (`.rst` → count), keys carry the dot. */
-  ignoredNonMarkdown: Record<string, number>
-}
-
 /**
  * Read corpus.json's scan counts tolerantly — `null` when the corpus is absent or
- * unreadable (a corrupt corpus is a separate problem, not an "empty" one). `docsKept`
- * is the kept-doc count; `docsScanned` reads the persisted stats, falling back to
- * kept + skipped for a legacy corpus written before the stats block existed.
+ * unreadable (a corrupt corpus is a separate problem, not an "empty" one). The
+ * counts themselves (incl. the legacy kept + skipped fallback for corpora written
+ * before the stats block existed) come from the shared `corpusScanCounts`.
  */
 export function readCorpusScanCounts(repoRoot: string): CorpusScanCounts | null {
   const file = path.join(repoRoot, '.truecourse', 'specs', 'corpus.json')
@@ -172,10 +162,7 @@ export function readCorpusScanCounts(repoRoot: string): CorpusScanCounts | null 
   try {
     const parsed = CorpusCountsShape.safeParse(JSON.parse(fs.readFileSync(file, 'utf-8')))
     if (!parsed.success) return null
-    const docsKept = parsed.data.docs?.length ?? 0
-    const skipped = parsed.data.skippedDocs?.length ?? 0
-    const docsScanned = parsed.data.stats?.docsScanned ?? docsKept + skipped
-    return { docsScanned, docsKept, ignoredNonMarkdown: parsed.data.stats?.ignoredNonMarkdown ?? {} }
+    return corpusScanCounts({ ...parsed.data, docs: parsed.data.docs ?? [] })
   } catch {
     return null
   }

--- a/packages/guard-generator/src/section-plan.ts
+++ b/packages/guard-generator/src/section-plan.ts
@@ -134,6 +134,53 @@ export function hasGuardUniverse(repoRoot: string): boolean {
   return fs.existsSync(path.join(repoRoot, '.truecourse', 'specs', 'corpus.json'))
 }
 
+// A tolerant view of the corpus's scan counts — the kept-doc count plus the
+// (optional, back-compat) persisted stats. Unknown shapes / extra keys pass through.
+const CorpusCountsShape = z
+  .object({
+    docs: z.array(z.unknown()).optional(),
+    skippedDocs: z.array(z.unknown()).optional(),
+    stats: z
+      .object({
+        docsScanned: z.number().optional(),
+        ignoredNonMarkdown: z.record(z.string(), z.number()).optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough()
+
+/** The scan counts an empty-corpus classification needs (#807). */
+export interface CorpusScanCounts {
+  /** Docs discovered in scope before the relevance filter (the "Scanned N" number). */
+  docsScanned: number
+  /** Kept docs (the corpus's `docs` length). */
+  docsKept: number
+  /** Ignored doc-like non-markdown files by extension (`.rst` → count), keys carry the dot. */
+  ignoredNonMarkdown: Record<string, number>
+}
+
+/**
+ * Read corpus.json's scan counts tolerantly — `null` when the corpus is absent or
+ * unreadable (a corrupt corpus is a separate problem, not an "empty" one). `docsKept`
+ * is the kept-doc count; `docsScanned` reads the persisted stats, falling back to
+ * kept + skipped for a legacy corpus written before the stats block existed.
+ */
+export function readCorpusScanCounts(repoRoot: string): CorpusScanCounts | null {
+  const file = path.join(repoRoot, '.truecourse', 'specs', 'corpus.json')
+  if (!fs.existsSync(file)) return null
+  try {
+    const parsed = CorpusCountsShape.safeParse(JSON.parse(fs.readFileSync(file, 'utf-8')))
+    if (!parsed.success) return null
+    const docsKept = parsed.data.docs?.length ?? 0
+    const skipped = parsed.data.skippedDocs?.length ?? 0
+    const docsScanned = parsed.data.stats?.docsScanned ?? docsKept + skipped
+    return { docsScanned, docsKept, ignoredNonMarkdown: parsed.data.stats?.ignoredNonMarkdown ?? {} }
+  } catch {
+    return null
+  }
+}
+
 /**
  * Plan the deterministic work for a generate run. `recipeFingerprint` defaults to
  * the current recipe-input fingerprint; the driver passes the fingerprint of a

--- a/packages/shared/src/spec/empty-corpus.ts
+++ b/packages/shared/src/spec/empty-corpus.ts
@@ -1,0 +1,79 @@
+/**
+ * The SINGLE empty-corpus derivation + user-facing explanation — ONE copy in
+ * @truecourse/shared, imported by the spec-scan CLI, the guard CLI, and the
+ * dashboard client so every surface explains an empty corpus identically.
+ *
+ * "Empty corpus" has two distinct flavors, and silence-as-success (reporting an
+ * empty corpus as "nothing changed") is the bug this closes:
+ *   - 'no-docs-found'   — nothing was discoverable (docsScanned === 0). The repo
+ *                         may hold non-markdown docs (.rst/.adoc/…), out-of-scope
+ *                         markdown, or ignored paths — only markdown is scanned.
+ *   - 'all-docs-dropped' — docs were scanned but the relevance filter kept none
+ *                         (docsScanned > 0, docsKept === 0). Drop reasons live in
+ *                         the corpus's skippedDocs; force-include via decisions.
+ *
+ * The messages carry generic remedy pointers and NEVER point at `guard generate`
+ * (an empty corpus has nothing to guard) — see the surface layers that render them.
+ */
+
+export type EmptyCorpusFlavor = 'no-docs-found' | 'all-docs-dropped';
+
+/** The two scan counts that decide empty-corpus flavor (from CurateStats or persisted corpus.json stats). */
+export interface CorpusScanCounts {
+  docsScanned: number;
+  docsKept: number;
+}
+
+/**
+ * Classify a corpus's empty-ness, or `undefined` when it holds at least one kept
+ * doc. `no-docs-found` wins whenever nothing was discoverable (docsScanned === 0),
+ * regardless of docsKept.
+ */
+export function deriveEmptyCorpus(counts: CorpusScanCounts): EmptyCorpusFlavor | undefined {
+  if (counts.docsScanned === 0) return 'no-docs-found';
+  if (counts.docsKept === 0) return 'all-docs-dropped';
+  return undefined;
+}
+
+export interface EmptyCorpusMessageInput {
+  flavor: EmptyCorpusFlavor;
+  /** Docs discovered (in scope) before the relevance filter — the N in "Scanned N docs". */
+  docsScanned: number;
+  /**
+   * Per-extension counts of ignored doc-like non-markdown files (`.rst` → count),
+   * surfaced only for the 'no-docs-found' flavor to explain why nothing was found.
+   * rst support itself is a separate feature (#806); this is just the count.
+   */
+  ignoredNonMarkdown?: Record<string, number>;
+}
+
+/** "23 .rst, 2 .adoc" — counts descending, extension ascending on ties. Empty ⇒ "". */
+function formatIgnoredBreakdown(ignored: Record<string, number>): string {
+  return Object.entries(ignored)
+    .filter(([, n]) => n > 0)
+    .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+    .map(([ext, n]) => `${n} ${ext}`)
+    .join(', ');
+}
+
+/**
+ * The one user-facing explanation of an empty corpus, as a single string (one or
+ * more sentences). Callers render it via a WARNING channel (CLI `p.log.warn`, a
+ * warning-styled toast, or an EmptyState body) — the wording itself is neutral.
+ */
+export function formatEmptyCorpus(input: EmptyCorpusMessageInput): string {
+  if (input.flavor === 'no-docs-found') {
+    const parts = ['No spec documents found — only markdown (.md) documents are scanned.'];
+    const breakdown = formatIgnoredBreakdown(input.ignoredNonMarkdown ?? {});
+    if (breakdown) parts.push(`Ignored ${breakdown} files.`);
+    parts.push(
+      'Check your .truecourseignore and the spec.include scope in .truecourse/config.json.',
+    );
+    return parts.join(' ');
+  }
+  // all-docs-dropped
+  return (
+    `Scanned ${input.docsScanned} docs but kept none — every doc was dropped as not spec-relevant. ` +
+    'Review the drop reasons and force-include any real specs via spec decisions (manualIncludes).'
+  );
+}

--- a/packages/shared/src/spec/empty-corpus.ts
+++ b/packages/shared/src/spec/empty-corpus.ts
@@ -18,10 +18,42 @@
 
 export type EmptyCorpusFlavor = 'no-docs-found' | 'all-docs-dropped';
 
-/** The two scan counts that decide empty-corpus flavor (from CurateStats or persisted corpus.json stats). */
+/** The scan counts an empty-corpus classification and message need. */
 export interface CorpusScanCounts {
+  /** Docs discovered in scope before the relevance filter (the "Scanned N" number). */
   docsScanned: number;
+  /** Kept docs (the corpus's `docs` length). */
   docsKept: number;
+  /** Ignored doc-like non-markdown files by extension (`.rst` → count), keys carry the dot. */
+  ignoredNonMarkdown: Record<string, number>;
+}
+
+/**
+ * The minimal persisted-corpus shape `corpusScanCounts` reads — structural, so the
+ * server-side CuratedCorpus, the tolerant guard-generator parse, and the client's
+ * corpus payload all satisfy it without depending on each other's full types.
+ * (Named for its role — `CorpusLike` is taken by the overlap derivation's shape.)
+ */
+export interface CorpusCountsSource {
+  docs: readonly unknown[];
+  skippedDocs?: readonly unknown[];
+  stats?: { docsScanned?: number; ignoredNonMarkdown?: Record<string, number> };
+}
+
+/**
+ * The ONE corpus → scan-counts derivation, including the legacy fallback: a corpus
+ * written before the stats block existed reconstructs `docsScanned` as kept +
+ * skipped (exact — every discovered doc lands in one of the two lists). Accepts
+ * a missing corpus for caller convenience (all-zero counts).
+ */
+export function corpusScanCounts(corpus: CorpusCountsSource | null | undefined): CorpusScanCounts {
+  if (!corpus) return { docsScanned: 0, docsKept: 0, ignoredNonMarkdown: {} };
+  const docsKept = corpus.docs.length;
+  return {
+    docsScanned: corpus.stats?.docsScanned ?? docsKept + (corpus.skippedDocs?.length ?? 0),
+    docsKept,
+    ignoredNonMarkdown: corpus.stats?.ignoredNonMarkdown ?? {},
+  };
 }
 
 /**
@@ -29,7 +61,9 @@ export interface CorpusScanCounts {
  * doc. `no-docs-found` wins whenever nothing was discoverable (docsScanned === 0),
  * regardless of docsKept.
  */
-export function deriveEmptyCorpus(counts: CorpusScanCounts): EmptyCorpusFlavor | undefined {
+export function deriveEmptyCorpus(
+  counts: Pick<CorpusScanCounts, 'docsScanned' | 'docsKept'>,
+): EmptyCorpusFlavor | undefined {
   if (counts.docsScanned === 0) return 'no-docs-found';
   if (counts.docsKept === 0) return 'all-docs-dropped';
   return undefined;

--- a/packages/shared/src/spec/index.ts
+++ b/packages/shared/src/spec/index.ts
@@ -1,1 +1,2 @@
 export * from './overlap-resolution.js'
+export * from './empty-corpus.js'

--- a/packages/spec-consolidator/src/corpus-store.ts
+++ b/packages/spec-consolidator/src/corpus-store.ts
@@ -15,7 +15,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { CuratedCorpusSchema, type Area, type CorpusDoc, type CuratedCorpus, type SkippedDoc } from './corpus-types.js';
+import { CuratedCorpusSchema, type Area, type CorpusDoc, type CorpusStats, type CuratedCorpus, type SkippedDoc } from './corpus-types.js';
 
 const CORPUS_FILE = 'corpus.json';
 
@@ -44,6 +44,7 @@ export function writeCorpus(
     docs: CorpusDoc[];
     areas: Area[];
     skippedDocs?: SkippedDoc[];
+    stats?: CorpusStats;
     generatedAt?: string;
   },
 ): void {
@@ -57,6 +58,7 @@ export function writeCorpus(
     docs: input.docs,
     areas: input.areas,
     skippedDocs: input.skippedDocs ?? [],
+    ...(input.stats ? { stats: input.stats } : {}),
   };
   fs.writeFileSync(file, JSON.stringify(payload, null, 2) + '\n');
 }

--- a/packages/spec-consolidator/src/corpus-types.ts
+++ b/packages/spec-consolidator/src/corpus-types.ts
@@ -311,6 +311,20 @@ export const SkippedDocSchema = z.object({
 });
 export type SkippedDoc = z.infer<typeof SkippedDocSchema>;
 
+/**
+ * Scan-count summary persisted alongside the corpus so `spec status`, the guard
+ * CLI, and the dashboard can explain an empty corpus (0 docs) without re-running
+ * the scan — distinguishing "nothing discoverable" (docsScanned 0) from "every
+ * doc dropped by relevance" (docsKept 0). `ignoredNonMarkdown` (ext → count, ext
+ * with leading dot) records doc-like non-markdown files discovery passed over.
+ */
+export const CorpusStatsSchema = z.object({
+  docsScanned: z.number().int().nonnegative(),
+  docsKept: z.number().int().nonnegative(),
+  ignoredNonMarkdown: z.record(z.string(), z.number()).default({}),
+});
+export type CorpusStats = z.infer<typeof CorpusStatsSchema>;
+
 export const CuratedCorpusSchema = z.object({
   version: z.literal(3),
   generatedAt: z.string(),
@@ -318,5 +332,11 @@ export const CuratedCorpusSchema = z.object({
   areas: z.array(AreaSchema),
   /** Docs the relevance filter dropped (path + reason); empty for older corpora. */
   skippedDocs: z.array(SkippedDocSchema).default([]),
+  /**
+   * Scan-count summary. OPTIONAL for back-compat: corpora written before this
+   * field still parse (older files simply have no stats). Written on every scan
+   * from here on.
+   */
+  stats: CorpusStatsSchema.optional(),
 });
 export type CuratedCorpus = z.infer<typeof CuratedCorpusSchema>;

--- a/packages/spec-consolidator/src/curate.ts
+++ b/packages/spec-consolidator/src/curate.ts
@@ -14,7 +14,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { LlmTransport } from '@truecourse/shared/llm';
 import { loadSpecScope } from '@truecourse/shared';
-import { discoverDocs, type DocCandidate } from './discovery.js';
+import { discoverDocsWithStats, type DocCandidate } from './discovery.js';
 import { filterByRelevance, type RelevanceRunner } from './relevance-filter.js';
 import { tagDocs, type AreaTagRunner } from './area-tagger.js';
 import { normalizeVocabulary, type VocabRunner } from './vocab-normalizer.js';
@@ -71,6 +71,12 @@ export interface CurateOptions {
 export interface CurateStats {
   docsScanned: number;
   docsKept: number;
+  /**
+   * Doc-like non-markdown files discovery passed over (ext → count, ext with
+   * leading dot). Explains an empty corpus (0 docs scanned) — e.g. an rst-only
+   * repo. Empty for injected doc sources (no filesystem walk).
+   */
+  ignoredNonMarkdown: Record<string, number>;
   areaCount: number;
   overlapFlags: number;
   /** Flagged overlaps the verify pass pruned as detector false positives (never reach the corpus). */
@@ -115,11 +121,16 @@ export async function curate(repoRoot: string, opts: CurateOptions = {}): Promis
   let allDocs: DocCandidate[];
   let scopeGlobs: string[] = [];
   let outOfScopeManualIncludes: string[] = [];
+  // Doc-like non-markdown counts from the walk — empty for injected doc sources
+  // (EE has no live tree to walk). Explains an empty corpus downstream.
+  let ignoredNonMarkdown: Record<string, number> = {};
   if (opts.docSource) {
     allDocs = await opts.docSource();
   } else {
     const scope = loadSpecScope(repoRoot);
-    allDocs = discoverDocs(repoRoot, { skipGit: opts.skipGit, scope });
+    const discovered = discoverDocsWithStats(repoRoot, { skipGit: opts.skipGit, scope });
+    allDocs = discovered.docs;
+    ignoredNonMarkdown = discovered.ignoredNonMarkdown;
     scopeGlobs = scope.globs;
     if (scope.active) {
       outOfScopeManualIncludes = (decisions.manualIncludes ?? []).filter((p) => !scope.includes(p));
@@ -203,6 +214,13 @@ export async function curate(repoRoot: string, opts: CurateOptions = {}): Promis
     // Persist the dropped docs so the dashboard can surface them (force-include)
     // without re-running the scan. Map the candidate path to a DocRef.
     skippedDocs: skippedDocs.map((s) => ({ ref: s.path, reason: s.reason })),
+    // Scan counts travel with the corpus so an empty-corpus surface (status /
+    // guard CLI / dashboard) can explain it without re-running the scan.
+    stats: {
+      docsScanned: allDocs.length,
+      docsKept: docs.length,
+      ignoredNonMarkdown,
+    },
   };
   if (!opts.skipCorpusWrite) {
     // Pass the corpus's own generatedAt so the persisted file equals the returned object.
@@ -210,6 +228,7 @@ export async function curate(repoRoot: string, opts: CurateOptions = {}): Promis
       docs: corpus.docs,
       areas: corpus.areas,
       skippedDocs: corpus.skippedDocs,
+      stats: corpus.stats,
       generatedAt: corpus.generatedAt,
     });
   }
@@ -220,6 +239,7 @@ export async function curate(repoRoot: string, opts: CurateOptions = {}): Promis
   const stats: CurateStats = {
     docsScanned: allDocs.length,
     docsKept: docs.length,
+    ignoredNonMarkdown,
     areaCount: areas.length,
     overlapFlags: openOverlaps.length,
     overlapRefuted: verified.refuted,

--- a/packages/spec-consolidator/src/discovery.ts
+++ b/packages/spec-consolidator/src/discovery.ts
@@ -74,6 +74,15 @@ const SKIP_DIR_PROBE = '__tc_skipdir_probe__.md';
 
 const PREVIEW_LINE_LIMIT = 200;
 
+/**
+ * Non-markdown extensions we recognize as "doc-like": a repo full of these but no
+ * `.md` (e.g. rst-only yamllint) discovers zero docs, and we count them so the
+ * empty corpus can explain WHY instead of reading as success. Counting only —
+ * these files are never scanned (only `.md` is; rst support is #806). Keys in the
+ * returned record carry the leading dot (`.rst`), matching `path.extname`.
+ */
+const DOC_LIKE_EXTENSIONS = new Set(['.rst', '.adoc', '.asciidoc', '.txt', '.org']);
+
 export interface DiscoveryOptions {
   /**
    * Override the preview line cap. Tests use this to keep previews
@@ -93,6 +102,17 @@ export interface DiscoveryOptions {
   scope?: SpecScope;
 }
 
+/** Discovery output: the markdown candidates plus free bookkeeping from the same walk. */
+export interface DiscoveryResult {
+  docs: DocCandidate[];
+  /**
+   * Doc-like non-markdown files (ext → count, ext with leading dot) that survived
+   * the SAME `.truecourseignore` / SKIP_DIRS / include-scope filters a `.md` would.
+   * Lets an empty corpus explain why nothing was scanned. Empty when none / EE.
+   */
+  ignoredNonMarkdown: Record<string, number>;
+}
+
 /**
  * Walk `rootDir` recursively and return one `DocCandidate` per
  * markdown file found. Order is filesystem-walk-deterministic
@@ -100,8 +120,19 @@ export interface DiscoveryOptions {
  * cache stability.
  */
 export function discoverDocs(rootDir: string, opts: DiscoveryOptions = {}): DocCandidate[] {
+  return discoverDocsWithStats(rootDir, opts).docs;
+}
+
+/**
+ * Same walk as {@link discoverDocs}, additionally counting the doc-like
+ * non-markdown files it passes over — so a caller (curate) can persist the
+ * counts and surface an explanation for an otherwise-silent empty corpus. Single
+ * walk: the count is free bookkeeping alongside the markdown collection.
+ */
+export function discoverDocsWithStats(rootDir: string, opts: DiscoveryOptions = {}): DiscoveryResult {
   const previewLines = opts.previewLines ?? PREVIEW_LINE_LIMIT;
   const out: DocCandidate[] = [];
+  const ignoredNonMarkdown: Record<string, number> = {};
   // Repo-root `.truecourseignore` — same exclusions as code analysis.
   const tcIgnore = loadTcIgnore(rootDir);
   // Opt-in include-scope (`spec.include`). Inactive ⇒ everything, and the guard
@@ -145,14 +176,24 @@ export function discoverDocs(rootDir: string, opts: DiscoveryOptions = {}): DocC
         continue;
       }
       if (!entry.isFile()) continue;
-      if (path.extname(entry.name).toLowerCase() !== '.md') continue;
-      // Include-scope: when configured, only markdown matching a scope glob
-      // enters the universe. `.truecourseignore` already subtracted above, so a
-      // scope glob can never resurrect an ignored path. Out-of-scope files are
-      // never candidates — they don't appear in skippedDocs either.
+      const ext = path.extname(entry.name).toLowerCase();
+      const isMarkdown = ext === '.md';
+      // Only markdown is scanned; doc-like non-markdown is merely counted. Files
+      // that are neither are ignored entirely (no count, no candidate).
+      if (!isMarkdown && !DOC_LIKE_EXTENSIONS.has(ext)) continue;
+      // Include-scope: when configured, only files matching a scope glob enter
+      // the universe. `.truecourseignore` already subtracted above, so a scope
+      // glob can never resurrect an ignored path. Out-of-scope files are never
+      // candidates (nor counted) — they don't appear in skippedDocs either. The
+      // same gate applies to the doc-like count so it mirrors what a `.md` sees.
       if (scope.active) {
         const rel = path.relative(rootDir, full).split(path.sep).join('/');
         if (!scope.includes(rel)) continue;
+      }
+
+      if (!isMarkdown) {
+        ignoredNonMarkdown[ext] = (ignoredNonMarkdown[ext] ?? 0) + 1;
+        continue;
       }
 
       const candidate = makeCandidate(full, rootDir, previewLines, opts);
@@ -160,7 +201,7 @@ export function discoverDocs(rootDir: string, opts: DiscoveryOptions = {}): DocC
     }
   };
   visit(rootDir);
-  return out;
+  return { docs: out, ignoredNonMarkdown };
 }
 
 function makeCandidate(

--- a/packages/spec-consolidator/src/index.ts
+++ b/packages/spec-consolidator/src/index.ts
@@ -31,6 +31,7 @@ export {
   OverlapSchema,
   OverlapSectionSchema,
   AreaSchema,
+  CorpusStatsSchema,
   CuratedCorpusSchema,
   normalizeArea,
   canonicalizeConcern,
@@ -48,6 +49,7 @@ export type {
   Overlap,
   OverlapSection,
   Area,
+  CorpusStats,
   CuratedCorpus,
   VocabMap,
 } from './corpus-types.js';
@@ -105,8 +107,8 @@ export type {
 export { curate, readCorpusDecisions } from './curate.js';
 export type { CurateModels, CurateOptions, CurateResult, CurateStats } from './curate.js';
 
-export { discoverDocs, classifyDoc } from './discovery.js';
-export type { DocCandidate, DiscoveryOptions } from './discovery.js';
+export { discoverDocs, discoverDocsWithStats, classifyDoc } from './discovery.js';
+export type { DocCandidate, DiscoveryOptions, DiscoveryResult } from './discovery.js';
 export { prefilterDocs } from './relevance-filter.js';
 
 export { defaultConcurrency } from './runner.js';

--- a/tests/cli/guard-empty-corpus.test.ts
+++ b/tests/cli/guard-empty-corpus.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Empty-corpus surfaces on the `guard` CLI (issue #807):
+ *   - `guard generate` (item 8) — a present-but-empty corpus is a no-docs FAILURE
+ *      with a DISTINCT reason (the shared empty-corpus wording, never "run spec
+ *      scan first" — that loops); a MISSING corpus keeps the spec-scan pointer.
+ *   - `guard run` (item 9) — a no-scenarios run over an empty corpus adds ONE info
+ *      line explaining WHY before "Nothing ran." (runFailureMessage stays pure).
+ *   - `guard status` (item 10) — with no coverage manifest and an empty corpus, the
+ *      "coverage (none) — run guard generate" hint is replaced by the empty-corpus
+ *      line; a missing corpus keeps the hint.
+ * All read the persisted corpus.json through the shared derivation.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { runGuardGenerate, runGuardRun, runGuardStatus } from '../../tools/cli/src/commands/guard';
+import { makeTempRepo, rmrf } from '../guard-generator/helpers.js';
+import { writeRecipe as writeRunRecipe } from '../guard-runner/helpers.js';
+
+const repos: string[] = [];
+const homes: string[] = [];
+function repo(): string {
+  const r = makeTempRepo();
+  repos.push(r);
+  execSync('git init -q -b main', { cwd: r });
+  return r;
+}
+afterEach(() => {
+  while (repos.length) rmrf(repos.pop()!);
+  while (homes.length) rmrf(homes.pop()!);
+  delete process.env.TRUECOURSE_HOME;
+});
+
+/** Seed a committable corpus.json with 0 kept docs and the given scan stats. */
+function writeEmptyCorpus(
+  r: string,
+  over: {
+    skippedDocs?: { ref: string; reason: string }[];
+    stats?: { docsScanned: number; docsKept: number; ignoredNonMarkdown?: Record<string, number> };
+  } = {},
+): void {
+  const dir = path.join(r, '.truecourse', 'specs');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'corpus.json'),
+    JSON.stringify({
+      version: 3,
+      generatedAt: '2026-01-01T00:00:00Z',
+      docs: [],
+      areas: [],
+      skippedDocs: over.skippedDocs ?? [],
+      ...(over.stats ? { stats: over.stats } : {}),
+    }),
+  );
+}
+
+/** Run a guard command capturing stdout (clack) + stderr (renderer) + exit code. */
+async function captureGuard(fn: () => Promise<void>): Promise<{ out: string; err: string; exit: number | null }> {
+  let exit: number | null = null;
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    exit = code ?? 0;
+    throw new Error(`process.exit(${code})`);
+  }) as never);
+  const cap = (chunks: string[]) =>
+    ((chunk: unknown, ...rest: unknown[]) => {
+      chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+      const cb = rest.find((a) => typeof a === 'function') as (() => void) | undefined;
+      cb?.();
+      return true;
+    }) as never;
+  const outChunks: string[] = [];
+  const errChunks: string[] = [];
+  const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(cap(outChunks));
+  const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(cap(errChunks));
+  try {
+    await fn();
+  } catch (e) {
+    if (!(e instanceof Error) || !e.message.startsWith('process.exit(')) throw e;
+  } finally {
+    outSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+  const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+  return { out: strip(outChunks.join('')), err: strip(errChunks.join('')), exit };
+}
+
+function withHome(): void {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-guard-empty-home-'));
+  homes.push(home);
+  process.env.TRUECOURSE_HOME = home;
+}
+
+// ---------------------------------------------------------------------------
+// item 8 — guard generate
+// ---------------------------------------------------------------------------
+
+describe('runGuardGenerate — empty corpus (item 8)', () => {
+  it('a present-but-empty corpus fails with the empty-corpus reason and NEVER loops back to `spec scan`', async () => {
+    const r = repo();
+    withHome();
+    writeEmptyCorpus(r, { stats: { docsScanned: 0, docsKept: 0, ignoredNonMarkdown: { '.rst': 4 } } });
+
+    const io = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-guard-io-'));
+    const { out, exit } = await captureGuard(() => runGuardGenerate({ cwd: r, llmTransport: 'agent', io, yes: true }));
+    rmrf(io);
+
+    expect(out).toContain('No spec documents found');
+    expect(out).toContain('Ignored 4 .rst files.');
+    // The distinct empty-corpus path must not send the user back to `spec scan`.
+    expect(out).not.toMatch(/spec scan/);
+    expect(exit).toBe(1);
+  });
+
+  it('a MISSING corpus keeps the current "Run `truecourse spec scan` first" pointer', async () => {
+    const r = repo();
+    withHome();
+    // No corpus.json at all.
+    const io = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-guard-io-'));
+    const { out, exit } = await captureGuard(() => runGuardGenerate({ cwd: r, llmTransport: 'agent', io, yes: true }));
+    rmrf(io);
+
+    expect(out).toContain('spec scan');
+    expect(out).not.toContain('No spec documents found');
+    expect(exit).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// item 9 — guard run (no scenarios)
+// ---------------------------------------------------------------------------
+
+describe('runGuardRun — no scenarios over an empty corpus (item 9)', () => {
+  it('adds an info line explaining the empty corpus before "Nothing ran.", exit 0', async () => {
+    const r = repo();
+    writeRunRecipe(r); // a recipe but no scenario files → no-scenarios
+    writeEmptyCorpus(r, { stats: { docsScanned: 0, docsKept: 0, ignoredNonMarkdown: { '.rst': 9 } } });
+
+    const { out, exit } = await captureGuard(() => runGuardRun({ cwd: r }));
+
+    expect(out).toContain('No scenarios found');
+    expect(out).toContain('No spec documents found');
+    expect(out).toContain('Ignored 9 .rst files.');
+    expect(out).toContain('Nothing ran.');
+    expect(exit).toBe(0);
+  });
+
+  it('a MISSING corpus adds no empty-corpus line (just the plain no-scenarios message)', async () => {
+    const r = repo();
+    writeRunRecipe(r);
+    const { out, exit } = await captureGuard(() => runGuardRun({ cwd: r }));
+    expect(out).toContain('No scenarios found');
+    expect(out).not.toContain('No spec documents found');
+    expect(exit).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// item 10 — guard status (no coverage manifest)
+// ---------------------------------------------------------------------------
+
+describe('runGuardStatus — empty corpus, no coverage (item 10)', () => {
+  it('replaces the coverage hint with the empty-corpus line', async () => {
+    const r = repo();
+    writeEmptyCorpus(r, { stats: { docsScanned: 0, docsKept: 0, ignoredNonMarkdown: { '.adoc': 2 } } });
+
+    const { out } = await captureGuard(() => runGuardStatus({ cwd: r }));
+
+    expect(out).toContain('No spec documents found');
+    expect(out).toContain('Ignored 2 .adoc files.');
+    // The old "coverage (none) — run guard generate" hint is gone for an empty corpus.
+    expect(out).not.toContain('coverage    (none) — run `truecourse guard generate`');
+  });
+
+  it('a MISSING corpus keeps the "coverage (none) — run `truecourse guard generate`" hint', async () => {
+    const r = repo();
+    const { out } = await captureGuard(() => runGuardStatus({ cwd: r }));
+    expect(out).toContain('coverage    (none) — run `truecourse guard generate`');
+    expect(out).not.toContain('No spec documents found');
+  });
+});

--- a/tests/cli/spec-empty-corpus.test.ts
+++ b/tests/cli/spec-empty-corpus.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Empty-corpus surfaces on the `spec` CLI (issue #807):
+ *   - `spec scan`  (item 6) — an empty corpus is a LOUD warning + exit 0, never the
+ *                  false "Nothing changed" success and never the "run guard generate"
+ *                  outro. curateInProcess is mocked to the two empty-corpus flavors.
+ *   - `spec status` (item 7) — a persisted corpus with 0 docs prints the
+ *                  flavor-appropriate warning and an outro that never says
+ *                  "guard generate".
+ * Both render the ONE shared formatter (`@truecourse/shared`), so the wording is
+ * asserted here only for the pieces the surface is responsible for.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+vi.mock('@truecourse/core/commands/spec-in-process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@truecourse/core/commands/spec-in-process')>();
+  return { ...actual, curateInProcess: vi.fn() };
+});
+
+import { runSpecScan, runSpecStatus } from '../../tools/cli/src/commands/spec.js';
+import { curateInProcess } from '@truecourse/core/commands/spec-in-process';
+
+let repo: string;
+let home: string;
+const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+async function capture(fn: () => Promise<void>): Promise<{ out: string; exit: number | null }> {
+  const chunks: string[] = [];
+  let exit: number | null = null;
+  const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation((c: any) => {
+    chunks.push(typeof c === 'string' ? c : c.toString());
+    return true;
+  });
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    exit = code ?? 0;
+    throw new Error(`process.exit(${code})`);
+  }) as never);
+  try {
+    await fn();
+  } catch (e) {
+    if (!(e instanceof Error) || !e.message.startsWith('process.exit(')) throw e;
+  } finally {
+    outSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+  return { out: stripAnsi(chunks.join('')), exit };
+}
+
+/** A minimal committable corpus.json with 0 kept docs and the given scan stats. */
+function writeEmptyCorpus(over: {
+  skippedDocs?: { ref: string; reason: string }[];
+  stats?: { docsScanned: number; docsKept: number; ignoredNonMarkdown?: Record<string, number> };
+}): void {
+  const corpus = {
+    version: 3,
+    generatedAt: '2026-01-01T00:00:00Z',
+    docs: [],
+    areas: [],
+    skippedDocs: over.skippedDocs ?? [],
+    ...(over.stats ? { stats: over.stats } : {}),
+  };
+  fs.writeFileSync(path.join(repo, '.truecourse', 'specs', 'corpus.json'), JSON.stringify(corpus));
+}
+
+beforeEach(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-spec-empty-'));
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-spec-empty-home-'));
+  process.env.TRUECOURSE_HOME = home;
+  fs.mkdirSync(path.join(repo, '.truecourse', 'specs'), { recursive: true });
+  execSync('git init -q -b main', { cwd: repo });
+  vi.mocked(curateInProcess).mockReset();
+});
+afterEach(() => {
+  delete process.env.TRUECOURSE_HOME;
+  fs.rmSync(repo, { recursive: true, force: true });
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// item 6 — spec scan
+// ---------------------------------------------------------------------------
+
+describe('runSpecScan — empty corpus (item 6)', () => {
+  it("'no-docs-found' warns with the ignored-extension breakdown, exits 0, never says 'Nothing changed' or 'guard generate'", async () => {
+    vi.mocked(curateInProcess).mockResolvedValue({
+      curate: { stats: { docsScanned: 0, docsKept: 0, ignoredNonMarkdown: { '.rst': 23, '.adoc': 2 } } },
+      noChanges: false,
+      emptyCorpus: 'no-docs-found',
+    } as never);
+
+    const { out, exit } = await capture(() => runSpecScan({ cwd: repo, llm: 'agent', io: repo, yes: true }));
+
+    expect(out).toContain('No spec documents found');
+    expect(out).toContain('Ignored 23 .rst, 2 .adoc files.');
+    expect(out).not.toContain('Nothing changed');
+    expect(out).not.toContain('guard generate');
+    expect(out).not.toContain('Corpus written');
+    // exit 0: the command returned; process.exit was not invoked with a failure.
+    expect(exit).toBeNull();
+  });
+
+  it("'all-docs-dropped' warns that every scanned doc was dropped, never points at 'guard generate'", async () => {
+    vi.mocked(curateInProcess).mockResolvedValue({
+      curate: { stats: { docsScanned: 7, docsKept: 0, ignoredNonMarkdown: {} } },
+      noChanges: false,
+      emptyCorpus: 'all-docs-dropped',
+    } as never);
+
+    const { out } = await capture(() => runSpecScan({ cwd: repo, llm: 'agent', io: repo, yes: true }));
+
+    expect(out).toContain('Scanned 7 docs but kept none');
+    expect(out).not.toContain('Nothing changed');
+    expect(out).not.toContain('guard generate');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// item 7 — spec status
+// ---------------------------------------------------------------------------
+
+describe('runSpecStatus — empty corpus (item 7)', () => {
+  it("'no-docs-found' (persisted stats) warns and the outro never says 'guard generate'", async () => {
+    writeEmptyCorpus({ stats: { docsScanned: 0, docsKept: 0, ignoredNonMarkdown: { '.rst': 5 } } });
+    const { out } = await capture(() => runSpecStatus({ cwd: repo }));
+    expect(out).toContain('No spec documents found');
+    expect(out).toContain('Ignored 5 .rst files.');
+    expect(out).not.toContain('guard generate');
+  });
+
+  it("'all-docs-dropped' (0 kept, N skipped) warns about the relevance drop, no 'guard generate'", async () => {
+    writeEmptyCorpus({
+      stats: { docsScanned: 3, docsKept: 0, ignoredNonMarkdown: {} },
+      skippedDocs: [
+        { ref: 'docs/a.md', reason: 'not spec-relevant' },
+        { ref: 'docs/b.md', reason: 'not spec-relevant' },
+        { ref: 'docs/c.md', reason: 'not spec-relevant' },
+      ],
+    });
+    const { out } = await capture(() => runSpecStatus({ cwd: repo }));
+    expect(out).toContain('Scanned 3 docs but kept none');
+    expect(out).not.toContain('guard generate');
+  });
+
+  it('a legacy empty corpus without stats still derives all-docs-dropped from skippedDocs', async () => {
+    // No `stats` block (older corpus) — docsScanned falls back to kept + skipped.
+    writeEmptyCorpus({ skippedDocs: [{ ref: 'docs/a.md', reason: 'dropped' }] });
+    const { out } = await capture(() => runSpecStatus({ cwd: repo }));
+    expect(out).toContain('Scanned 1 docs but kept none');
+    expect(out).not.toContain('guard generate');
+  });
+});

--- a/tests/core/corpus-in-process.test.ts
+++ b/tests/core/corpus-in-process.test.ts
@@ -79,6 +79,67 @@ describe('curateInProcess', () => {
   });
 });
 
+describe('curateInProcess — empty-corpus signal', () => {
+  it('no-docs-found: a repo with only non-markdown docs forces noChanges false', async () => {
+    // yamllint-shaped repo: rst only, no markdown → nothing discoverable.
+    fs.rmSync(path.join(repo, 'docs'), { recursive: true, force: true });
+    const docs = path.join(repo, 'docs');
+    fs.mkdirSync(docs, { recursive: true });
+    fs.writeFileSync(path.join(docs, 'guide.rst'), 'restructured text');
+    fs.writeFileSync(path.join(docs, 'api.rst'), 'more rst');
+
+    const result = await curateInProcess(repo, {
+      relevanceRunner: includeAll,
+      areaTagRunner: tagByPath,
+      disableOverlapDetection: true,
+      skipGit: true,
+    });
+    expect(result.emptyCorpus).toBe('no-docs-found');
+    // Silence-as-success is the bug: an empty corpus is never "nothing changed".
+    expect(result.noChanges).toBe(false);
+    expect(result.curate.stats.docsScanned).toBe(0);
+    expect(result.curate.stats.ignoredNonMarkdown).toEqual({ '.rst': 2 });
+  });
+
+  it('all-docs-dropped: docs scanned but relevance kept none forces noChanges false', async () => {
+    const result = await curateInProcess(repo, {
+      // Drop every doc.
+      relevanceRunner: async ({ doc }: { doc: { path: string } }) => ({
+        path: doc.path,
+        include: false,
+        reason: 'not a spec',
+      }),
+      areaTagRunner: tagByPath,
+      disableOverlapDetection: true,
+      skipGit: true,
+    });
+    expect(result.emptyCorpus).toBe('all-docs-dropped');
+    expect(result.noChanges).toBe(false);
+    expect(result.curate.stats.docsScanned).toBe(2);
+    expect(result.curate.stats.docsKept).toBe(0);
+  });
+
+  it('a non-empty corpus keeps the genuine cache-hit noChanges path (emptyCorpus undefined)', async () => {
+    const opts = {
+      relevanceRunner: includeAll,
+      areaTagRunner: tagByPath,
+      disableOverlapDetection: true,
+      skipGit: true,
+    };
+    // First run populates the per-doc caches (real calls → noChanges false).
+    const first = await curateInProcess(repo, opts);
+    expect(first.emptyCorpus).toBeUndefined();
+    expect(first.noChanges).toBe(false);
+
+    // Re-scan of unchanged docs: every stage is a cache hit (no transport calls),
+    // so the genuine "nothing changed" signal must still fire for a non-empty corpus.
+    const second = await curateInProcess(repo, opts);
+    expect(second.emptyCorpus).toBeUndefined();
+    expect(second.noChanges).toBe(true);
+    expect(second.curate.stats.docsKept).toBeGreaterThan(0);
+  });
+});
+
 describe('generateFromCorpusInProcess', () => {
   it('skips when no corpus.json exists', async () => {
     const { corpus } = await generateFromCorpusInProcess(repo, { disableRepair: true });

--- a/tests/core/corpus-in-process.test.ts
+++ b/tests/core/corpus-in-process.test.ts
@@ -50,6 +50,7 @@ describe('curateInProcess', () => {
     const { curate } = await curateInProcess(repo, {
       relevanceRunner: includeAll,
       areaTagRunner: tagByPath,
+      disableVocabNormalization: true,
       disableOverlapDetection: true,
       skipGit: true,
     });
@@ -69,6 +70,7 @@ describe('curateInProcess', () => {
         reason: doc.path.includes('auth') ? 'not a spec' : 'ok',
       }),
       areaTagRunner: tagByPath,
+      disableVocabNormalization: true,
       disableOverlapDetection: true,
       skipGit: true,
     });
@@ -91,6 +93,7 @@ describe('curateInProcess — empty-corpus signal', () => {
     const result = await curateInProcess(repo, {
       relevanceRunner: includeAll,
       areaTagRunner: tagByPath,
+      disableVocabNormalization: true,
       disableOverlapDetection: true,
       skipGit: true,
     });
@@ -110,6 +113,7 @@ describe('curateInProcess — empty-corpus signal', () => {
         reason: 'not a spec',
       }),
       areaTagRunner: tagByPath,
+      disableVocabNormalization: true,
       disableOverlapDetection: true,
       skipGit: true,
     });
@@ -119,24 +123,41 @@ describe('curateInProcess — empty-corpus signal', () => {
     expect(result.curate.stats.docsKept).toBe(0);
   });
 
-  it('a non-empty corpus keeps the genuine cache-hit noChanges path (emptyCorpus undefined)', async () => {
+  it('a non-empty corpus is never force-flagged, and its per-doc stages cache on re-scan', async () => {
+    // `noChanges` counts REAL transport calls, which stubbed stages never make —
+    // so this asserts what a hermetic run can actually prove: a non-empty corpus
+    // is left to the genuine llmCalls derivation (never forced false like an
+    // empty one), and the per-doc caches really do absorb the second scan.
+    let relevanceCalls = 0;
+    let tagCalls = 0;
     const opts = {
-      relevanceRunner: includeAll,
-      areaTagRunner: tagByPath,
+      relevanceRunner: async (input: { doc: { path: string } }) => {
+        relevanceCalls += 1;
+        return includeAll(input);
+      },
+      areaTagRunner: async (input: { doc: { path: string } }) => {
+        tagCalls += 1;
+        return tagByPath(input);
+      },
+      disableVocabNormalization: true,
       disableOverlapDetection: true,
       skipGit: true,
     };
-    // First run populates the per-doc caches (real calls → noChanges false).
     const first = await curateInProcess(repo, opts);
     expect(first.emptyCorpus).toBeUndefined();
-    expect(first.noChanges).toBe(false);
+    expect(first.curate.stats.docsKept).toBe(2);
+    expect(relevanceCalls).toBe(2);
+    expect(tagCalls).toBe(2);
 
-    // Re-scan of unchanged docs: every stage is a cache hit (no transport calls),
-    // so the genuine "nothing changed" signal must still fire for a non-empty corpus.
+    // Re-scan of unchanged docs: every per-doc stage is a content-keyed cache hit,
+    // so neither runner is consulted again and the "nothing changed" signal stands
+    // for a non-empty corpus (only an EMPTY corpus is forced to false).
     const second = await curateInProcess(repo, opts);
     expect(second.emptyCorpus).toBeUndefined();
     expect(second.noChanges).toBe(true);
-    expect(second.curate.stats.docsKept).toBeGreaterThan(0);
+    expect(second.curate.stats.docsKept).toBe(2);
+    expect(relevanceCalls).toBe(2);
+    expect(tagCalls).toBe(2);
   });
 });
 
@@ -150,6 +171,7 @@ describe('generateFromCorpusInProcess', () => {
     await curateInProcess(repo, {
       relevanceRunner: includeAll,
       areaTagRunner: tagByPath,
+      disableVocabNormalization: true,
       disableOverlapDetection: true,
       skipGit: true,
     });
@@ -179,6 +201,7 @@ describe('generateFromCorpusInProcess', () => {
     await curateInProcess(repo, {
       relevanceRunner: includeAll,
       areaTagRunner: tagByPath,
+      disableVocabNormalization: true,
       disableOverlapDetection: true,
       skipGit: true,
     });
@@ -203,6 +226,7 @@ describe('generateFromCorpusInProcess', () => {
     await curateInProcess(repo, {
       relevanceRunner: includeAll,
       areaTagRunner: tagByPath,
+      disableVocabNormalization: true,
       disableOverlapDetection: true,
       skipGit: true,
     });

--- a/tests/core/curate-in-process-decisions.test.ts
+++ b/tests/core/curate-in-process-decisions.test.ts
@@ -51,6 +51,7 @@ function run(decisions: DecisionsFile) {
     decisions,
     relevanceRunner: relevance,
     areaTagRunner: areaTagger,
+    disableVocabNormalization: true,
     overlapRunner: flagAll,
     verifyOverlapRunner: confirmAll,
   });

--- a/tests/core/spec-progress-model-display.test.ts
+++ b/tests/core/spec-progress-model-display.test.ts
@@ -56,6 +56,7 @@ async function runCapturingDetails(): Promise<string[]> {
     skipCorpusWrite: true,
     relevanceRunner: relevance,
     areaTagRunner: areaTagger,
+    disableVocabNormalization: true,
     overlapRunner: flagAll,
     verifyOverlapRunner: confirmAll,
   });

--- a/tests/dashboard-client/guard-actions.test.tsx
+++ b/tests/dashboard-client/guard-actions.test.tsx
@@ -13,6 +13,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
 import type { GuardScenarioInventory } from '@truecourse/shared';
 import { useGuardGenerate } from '@/hooks/useGuardGenerate';
 import { useGuardRun } from '@/hooks/useGuardRun';
@@ -123,6 +124,39 @@ describe('Guard Generate — estimate gate', () => {
     expect(screen.queryByRole('button', { name: 'Proceed' })).not.toBeInTheDocument();
     const post = calls.find((c) => c.url.includes('/guard/generate'));
     expect(JSON.parse(post!.body ?? '{}')).toEqual({ confirmed: true });
+  });
+
+  it('surfaces a no-docs generate as an error toast with the reason (issue #807), not a false success', async () => {
+    // The estimate has no stages (an empty corpus changed nothing to estimate), so
+    // begin() triggers directly; the generate returns status no-docs + the empty-corpus
+    // reason. The client must error-toast the reason, never "Wrote 0 scenarios".
+    const err = vi.spyOn(toast, 'error').mockReturnValue('id' as never);
+    const ok = vi.spyOn(toast, 'success').mockReturnValue('id' as never);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string | URL) => {
+        const u = String(url);
+        if (u.includes('/guard/estimate')) return json({ estimate: EMPTY });
+        if (u.includes('/guard/generate')) {
+          return json({
+            status: 'no-docs',
+            noChanges: false,
+            written: 0,
+            birthFindings: 0,
+            reason: 'The corpus is empty — the last scan found no spec documents.',
+          });
+        }
+        return json({});
+      }),
+    );
+    render(<Harness />);
+    await userEvent.click(genButton());
+    await waitFor(() => expect(err).toHaveBeenCalledTimes(1));
+    const [, opts] = err.mock.calls[0] as [string, { description?: string }];
+    expect(opts.description).toMatch(/last scan found no spec documents/);
+    expect(ok).not.toHaveBeenCalled();
+    err.mockRestore();
+    ok.mockRestore();
   });
 
   it('disables both guard buttons while a generate is in flight', async () => {

--- a/tests/dashboard-client/spec-corpus-view.test.tsx
+++ b/tests/dashboard-client/spec-corpus-view.test.tsx
@@ -12,6 +12,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useState, type ComponentProps } from 'react';
 import { render, screen, waitFor, renderHook, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
 import { SpecCorpusView, useSpecCorpus, overlapKey, type SpecCorpusState } from '../../apps/dashboard/client/src/components/spec/SpecCorpusView';
 import { SpecScanButton } from '../../apps/dashboard/client/src/components/spec/SpecScanButton';
 import { SpecDocViewer } from '../../apps/dashboard/client/src/components/spec/SpecDocViewer';
@@ -149,6 +150,59 @@ describe('SpecCorpusView (left nav)', () => {
   it('shows the empty state when there is no corpus', () => {
     render(<SpecCorpusView corpus={state({ data: null })} activeKey={null} onOpen={vi.fn()} />);
     expect(screen.getByText('No corpus yet')).toBeInTheDocument();
+  });
+
+  // Issue #807 — a corpus present but holding no kept docs must be surfaced
+  // explicitly (never a barren "0 documents" tree that reads as success). Two
+  // flavors, distinguished from the persisted scan stats.
+  it('no-docs-found: renders a distinct EmptyState (NOT "No corpus yet") with the ignored-extension breakdown', () => {
+    const empty: SpecCorpusResponse = {
+      corpus: {
+        version: 3,
+        generatedAt: '2026-01-01T00:00:00Z',
+        docs: [],
+        areas: [],
+        skippedDocs: [],
+        stats: { docsScanned: 0, docsKept: 0, ignoredNonMarkdown: { '.rst': 23, '.adoc': 2 } },
+      },
+    };
+    render(<SpecCorpusView repoId="r1" corpus={state({ data: empty })} activeKey={null} onOpen={vi.fn()} />);
+    expect(screen.getByText('No spec documents found')).toBeInTheDocument();
+    // The shared formatter's wording — only markdown is scanned + the counts.
+    expect(screen.getByText(/only markdown \(\.md\) documents are scanned/)).toBeInTheDocument();
+    expect(screen.getByText(/Ignored 23 \.rst, 2 \.adoc files\./)).toBeInTheDocument();
+    // Distinct from the no-corpus-yet state, and never points at guard generate.
+    expect(screen.queryByText('No corpus yet')).not.toBeInTheDocument();
+    expect(screen.queryByText(/guard generate/i)).not.toBeInTheDocument();
+  });
+
+  it('all-docs-dropped: renders the normal tree with a banner + the "Not included" force-include remedy', async () => {
+    const dropped: SpecCorpusResponse = {
+      corpus: {
+        version: 3,
+        generatedAt: '2026-01-01T00:00:00Z',
+        docs: [],
+        areas: [],
+        skippedDocs: [{ ref: 'docs/notes.md', reason: 'low relevance' }],
+        stats: { docsScanned: 4, docsKept: 0, ignoredNonMarkdown: {} },
+      },
+    };
+    const user = userEvent.setup();
+    render(<SpecCorpusView repoId="r1" corpus={state({ data: dropped })} activeKey={null} onOpen={vi.fn()} />);
+    // The banner explains the drop (shared wording) without the no-docs-found EmptyState.
+    expect(screen.getByText(/Scanned 4 docs but kept none/)).toBeInTheDocument();
+    expect(screen.queryByText('No spec documents found')).not.toBeInTheDocument();
+    // The force-include remedy is present: the dropped doc is includable from "Not included".
+    await user.click(screen.getByText('Not included'));
+    expect(screen.getByText('docs/notes.md')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'include' })).toBeInTheDocument();
+  });
+
+  it('a non-empty corpus (docs kept) never triggers the empty-corpus surfaces', () => {
+    render(<SpecCorpusView repoId="r1" corpus={state()} activeKey={null} onOpen={vi.fn()} />);
+    expect(screen.queryByText('No spec documents found')).not.toBeInTheDocument();
+    expect(screen.queryByText(/kept none/)).not.toBeInTheDocument();
+    expect(screen.getByText('Documents')).toBeInTheDocument();
   });
 
   it('renders a corpus carrying a legacy `relations` field without displaying it or crashing', () => {
@@ -443,6 +497,51 @@ describe('SpecCorpusView — conflict verdicts + orphaned housekeeping', () => {
     const del = calls.find((c) => c.method === 'DELETE');
     expect(JSON.parse(del!.body!)).toMatchObject({ docA: 'docs/gone.md', docB: 'docs/moved.md' });
     vi.unstubAllGlobals();
+  });
+});
+
+// Issue #807 — a scan that lands an empty corpus must WARN (with the shared flavor
+// message), never toast the false "nothing changed" success.
+describe('useSpecCorpus — empty-corpus scan warning (#807)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('warns with the flavor message (not a success) when a scan returns emptyCorpus', async () => {
+    const warn = vi.spyOn(toast, 'warning').mockReturnValue('id' as never);
+    const success = vi.spyOn(toast, 'success').mockReturnValue('id' as never);
+    const emptyResp: SpecCorpusResponse = {
+      corpus: {
+        version: 3,
+        generatedAt: '2026-01-01T00:00:00Z',
+        docs: [],
+        areas: [],
+        skippedDocs: [],
+        stats: { docsScanned: 0, docsKept: 0, ignoredNonMarkdown: { '.rst': 5 } },
+      },
+      emptyCorpus: 'no-docs-found',
+      noChanges: false,
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        // Mount read: no corpus yet (404 → null); the scan returns the empty corpus.
+        if (String(url).includes('/spec/corpus/scan')) return json(emptyResp);
+        return new Response('null', { status: 404 });
+      }),
+    );
+    const { result } = renderHook(() => useSpecCorpus('r1', true));
+    await waitFor(() => expect(result.current.hydrating).toBe(false));
+    await act(async () => {
+      await result.current.scan();
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [, opts] = warn.mock.calls[0] as [string, { description?: string }];
+    expect(opts.description).toMatch(/only markdown \(\.md\) documents are scanned/);
+    expect(opts.description).toMatch(/Ignored 5 \.rst files\./);
+    // Never the "nothing changed" success for an empty corpus.
+    expect(success).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/dashboard-server/spec-routes.test.ts
+++ b/tests/dashboard-server/spec-routes.test.ts
@@ -300,6 +300,39 @@ describe('corpus routes (spec-scan redesign)', () => {
     expect(res.body.corpus.skippedDocs).toContainEqual({ ref: 'docs/archived.md', reason: 'archived directory' });
   });
 
+  // Issue #807 — an empty corpus must not read as success. The scan route threads
+  // the driver's `emptyCorpus` flavor through so the client warns instead of
+  // toasting "nothing changed". Write an empty corpus.json (the mocked curate does
+  // not) so corpusPayload has something to return.
+  const seedEmptyCorpus = (
+    stats: { docsScanned: number; docsKept: number; ignoredNonMarkdown: Record<string, number> },
+  ): void => {
+    const specs = path.join(fixture.repoPath, '.truecourse', 'specs');
+    fs.mkdirSync(specs, { recursive: true });
+    fs.writeFileSync(
+      path.join(specs, 'corpus.json'),
+      JSON.stringify({ version: 3, generatedAt: '2026-01-01T00:00:00Z', docs: [], areas: [], skippedDocs: [], stats }),
+    );
+  };
+
+  it('GET /spec/corpus/scan threads emptyCorpus through and forces noChanges false', async () => {
+    seedEmptyCorpus({ docsScanned: 0, docsKept: 0, ignoredNonMarkdown: { '.rst': 23 } });
+    vi.mocked(curateInProcess).mockResolvedValueOnce({ noChanges: false, emptyCorpus: 'no-docs-found' } as never);
+    const res = await request(app).get(`/api/repos/${fixture.project.slug}/spec/corpus/scan`).expect(200);
+    expect(res.body.emptyCorpus).toBe('no-docs-found');
+    expect(res.body.noChanges).toBe(false);
+    // The persisted scan stats ride along so the client can render the flavor message.
+    expect(res.body.corpus.stats).toEqual({ docsScanned: 0, docsKept: 0, ignoredNonMarkdown: { '.rst': 23 } });
+  });
+
+  it('GET /spec/corpus/scan omits emptyCorpus on a non-empty scan (undefined is dropped)', async () => {
+    seedCorpus([]);
+    vi.mocked(curateInProcess).mockResolvedValueOnce({ noChanges: false } as never);
+    const res = await request(app).get(`/api/repos/${fixture.project.slug}/spec/corpus/scan`).expect(200);
+    expect(res.body).not.toHaveProperty('emptyCorpus');
+    expect(res.body.noChanges).toBe(false);
+  });
+
 });
 
 // EE (hosted): repo.path is a repoKey, the corpus lives in the store, and there

--- a/tests/guard-generator/generate.test.ts
+++ b/tests/guard-generator/generate.test.ts
@@ -1004,6 +1004,53 @@ describe('generateGuards — manifest rewrite + orphans', () => {
   })
 })
 
+// A present-but-empty corpus (#807) is a no-docs FAILURE with a DISTINCT reason — it
+// must never masquerade as "nothing changed", and must never point back at `spec
+// scan` (the corpus IS scanned, it just holds nothing).
+describe('generateGuards — empty corpus (#807)', () => {
+  /** Write a corpus.json with 0 kept docs + the given scan stats. */
+  function writeEmptyCorpus(
+    r: string,
+    stats?: { docsScanned: number; docsKept: number; ignoredNonMarkdown?: Record<string, number> },
+    skippedDocs: { ref: string; reason: string }[] = [],
+  ): void {
+    const target = path.join(r, '.truecourse', 'specs', 'corpus.json')
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    fs.writeFileSync(
+      target,
+      JSON.stringify({ version: 3, generatedAt: '2026-01-01T00:00:00Z', docs: [], areas: [], skippedDocs, ...(stats ? { stats } : {}) }),
+    )
+  }
+
+  it("'no-docs-found' (docsScanned 0) → no-docs with the empty-corpus reason incl. ignored counts, NOT a spec-scan loop", async () => {
+    const r = repo()
+    writeEmptyCorpus(r, { docsScanned: 0, docsKept: 0, ignoredNonMarkdown: { '.rst': 12 } })
+    const res = await generateGuards({ repoRoot: r })
+    expect(res.status).toBe('no-docs')
+    expect(res.noChanges).toBe(false)
+    expect(res.reason).toContain('No spec documents found')
+    expect(res.reason).toContain('Ignored 12 .rst files.')
+    expect(res.reason).not.toMatch(/spec scan/)
+  })
+
+  it("'all-docs-dropped' (docsScanned > 0, docsKept 0) → no-docs with the drop-reason wording", async () => {
+    const r = repo()
+    writeEmptyCorpus(r, { docsScanned: 4, docsKept: 0 }, [{ ref: 'docs/a.md', reason: 'not relevant' }])
+    const res = await generateGuards({ repoRoot: r })
+    expect(res.status).toBe('no-docs')
+    expect(res.reason).toContain('Scanned 4 docs but kept none')
+    expect(res.reason).not.toMatch(/spec scan/)
+  })
+
+  it('a legacy empty corpus without stats still reads as empty (all-docs-dropped from skippedDocs)', async () => {
+    const r = repo()
+    writeEmptyCorpus(r, undefined, [{ ref: 'docs/a.md', reason: 'dropped' }])
+    const res = await generateGuards({ repoRoot: r })
+    expect(res.status).toBe('no-docs')
+    expect(res.reason).toContain('kept none')
+  })
+})
+
 describe('generateGuards — universe + recipe discovery', () => {
   it('errors with a spec-scan hint when there is no corpus', async () => {
     const r = repo()

--- a/tests/server/guard-actions.test.ts
+++ b/tests/server/guard-actions.test.ts
@@ -138,6 +138,38 @@ describe('Guard action routes', () => {
     expect(vi.mocked(emitSpecComplete)).toHaveBeenCalledWith(fixture.project.slug, 'guard-generate');
   });
 
+  it('POST /guard/generate threads the no-docs reason through (issue #807)', async () => {
+    // An empty corpus generate returns status 'no-docs' with the empty-corpus
+    // explanation as `reason` — the route must forward it so the client can surface
+    // the reason instead of a false "wrote 0 scenarios" success.
+    vi.mocked(guardGenerateInProcess).mockResolvedValue({
+      guard: {
+        status: 'no-docs',
+        reason: 'The corpus is empty — the last scan found no spec documents.',
+        noChanges: false,
+        written: [],
+        birthFindings: [],
+      },
+    } as never);
+
+    const res = await request(app).post(url('generate')).send({ confirmed: true }).expect(200);
+    expect(res.body).toEqual({
+      status: 'no-docs',
+      noChanges: false,
+      written: 0,
+      birthFindings: 0,
+      reason: 'The corpus is empty — the last scan found no spec documents.',
+    });
+  });
+
+  it('POST /guard/generate omits reason on an ok generate (undefined is dropped)', async () => {
+    vi.mocked(guardGenerateInProcess).mockResolvedValue({
+      guard: { status: 'ok', noChanges: false, written: [{}], birthFindings: [] },
+    } as never);
+    const res = await request(app).post(url('generate')).send({ confirmed: true }).expect(200);
+    expect(res.body).not.toHaveProperty('reason');
+  });
+
   it('POST /guard/generate returns { cancelled } when the estimate gate declines', async () => {
     vi.mocked(guardGenerateInProcess).mockRejectedValue(new EstimateDeclined('guard'));
     const res = await request(app).post(url('generate')).send({ confirmed: false }).expect(200);

--- a/tests/shared/empty-corpus.test.ts
+++ b/tests/shared/empty-corpus.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The single empty-corpus derivation + formatter — ONE copy in
+ * @truecourse/shared, imported by the spec-scan CLI, the guard CLI, and the
+ * dashboard client so every surface explains an empty corpus identically.
+ * Two flavors: nothing discoverable ('no-docs-found') vs everything dropped by
+ * relevance ('all-docs-dropped').
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  deriveEmptyCorpus,
+  formatEmptyCorpus,
+  type EmptyCorpusFlavor,
+} from '../../packages/shared/src/spec/empty-corpus.js';
+
+describe('deriveEmptyCorpus', () => {
+  it('returns no-docs-found when nothing was discoverable', () => {
+    expect(deriveEmptyCorpus({ docsScanned: 0, docsKept: 0 })).toBe('no-docs-found');
+  });
+
+  it('returns all-docs-dropped when docs were scanned but relevance kept none', () => {
+    expect(deriveEmptyCorpus({ docsScanned: 5, docsKept: 0 })).toBe('all-docs-dropped');
+  });
+
+  it('returns undefined for a non-empty corpus (at least one kept doc)', () => {
+    expect(deriveEmptyCorpus({ docsScanned: 5, docsKept: 3 })).toBeUndefined();
+    expect(deriveEmptyCorpus({ docsScanned: 1, docsKept: 1 })).toBeUndefined();
+  });
+
+  it('no-docs-found wins when scanned is 0 regardless of kept', () => {
+    // Defensive: kept can never exceed scanned, but 0/0 must classify as
+    // no-docs-found (nothing discoverable), never all-docs-dropped.
+    expect(deriveEmptyCorpus({ docsScanned: 0, docsKept: 0 })).toBe('no-docs-found');
+  });
+});
+
+describe('formatEmptyCorpus — no-docs-found', () => {
+  const base = { flavor: 'no-docs-found' as EmptyCorpusFlavor, docsScanned: 0 };
+
+  it('states only markdown is scanned', () => {
+    const msg = formatEmptyCorpus(base);
+    expect(msg).toContain('No spec documents found');
+    expect(msg).toContain('markdown');
+    expect(msg).toContain('.md');
+  });
+
+  it('includes an ignored-by-extension breakdown when non-zero, ordered by count', () => {
+    const msg = formatEmptyCorpus({
+      ...base,
+      ignoredNonMarkdown: { '.rst': 23, '.adoc': 2 },
+    });
+    expect(msg).toContain('Ignored 23 .rst, 2 .adoc files.');
+  });
+
+  it('omits the breakdown when nothing doc-like was ignored', () => {
+    const msg = formatEmptyCorpus({ ...base, ignoredNonMarkdown: {} });
+    expect(msg).not.toContain('Ignored');
+  });
+
+  it('points at .truecourseignore and spec.include as remedies', () => {
+    const msg = formatEmptyCorpus(base);
+    expect(msg).toContain('.truecourseignore');
+    expect(msg).toContain('spec.include');
+  });
+
+  it('never points at guard generate', () => {
+    const msg = formatEmptyCorpus({ ...base, ignoredNonMarkdown: { '.rst': 5 } });
+    expect(msg.toLowerCase()).not.toContain('guard generate');
+  });
+});
+
+describe('formatEmptyCorpus — all-docs-dropped', () => {
+  const input = { flavor: 'all-docs-dropped' as EmptyCorpusFlavor, docsScanned: 7 };
+
+  it('reports the scanned count and that none were kept', () => {
+    const msg = formatEmptyCorpus(input);
+    expect(msg).toContain('7');
+    expect(msg).toContain('kept none');
+    expect(msg.toLowerCase()).toContain('spec-relevant');
+  });
+
+  it('points at drop reasons / manualIncludes as the remedy', () => {
+    const msg = formatEmptyCorpus(input);
+    expect(msg.toLowerCase()).toContain('force-include');
+    expect(msg).toContain('manualIncludes');
+  });
+
+  it('never points at guard generate', () => {
+    expect(formatEmptyCorpus(input).toLowerCase()).not.toContain('guard generate');
+  });
+
+  it('ignores any breakdown for the all-dropped flavor (docs were scanned, not ignored)', () => {
+    const msg = formatEmptyCorpus({ ...input, ignoredNonMarkdown: { '.rst': 9 } });
+    expect(msg).not.toContain('Ignored');
+  });
+});

--- a/tests/spec-consolidator/curate.test.ts
+++ b/tests/spec-consolidator/curate.test.ts
@@ -8,7 +8,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { resetKvCacheStore } from '@truecourse/llm';
 import { planDocChunks } from '@truecourse/shared';
-import { curate, readCorpus, OVERLAP_WINDOW_CHARS } from '../../packages/spec-consolidator/src/index.js';
+import { curate, readCorpus, writeCorpus, CuratedCorpusSchema, OVERLAP_WINDOW_CHARS } from '../../packages/spec-consolidator/src/index.js';
 import type {
   AreaTagRunner,
   DecisionsFile,
@@ -205,6 +205,103 @@ describe('curate', () => {
     });
     const usersArea = result.corpus.areas.find((a) => a.id === 'core/users-entity')!;
     expect(usersArea.docRefs).toEqual(['docs/users-v1.md', 'docs/users-v2.md']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Corpus stats persistence — docsScanned / docsKept / ignored-non-markdown are
+// written into corpus.json so `spec status`, the guard CLI, and the dashboard
+// can explain an empty corpus without re-running the scan.
+// ---------------------------------------------------------------------------
+
+describe('curate — persisted corpus stats', () => {
+  it('writes docsScanned/docsKept into corpus.json and round-trips', async () => {
+    const result = await run();
+    const read = readCorpus(repo);
+    expect(read!.stats).toBeDefined();
+    expect(read!.stats!.docsScanned).toBe(4);
+    expect(read!.stats!.docsKept).toBe(3);
+    // The in-memory corpus equals the persisted file (stats included).
+    expect(read!.stats).toEqual(result.corpus.stats);
+  });
+
+  it('defaults ignoredNonMarkdown to an empty record when discovery ran via docSource', async () => {
+    const result = await run();
+    // docSource bypasses the filesystem walk → no ignored-extension bookkeeping.
+    expect(result.corpus.stats!.ignoredNonMarkdown).toEqual({});
+  });
+
+  it('back-compat: an older corpus.json with no `stats` field still parses', () => {
+    const legacy = {
+      version: 3,
+      generatedAt: '2026-01-01T00:00:00Z',
+      docs: [],
+      areas: [],
+      skippedDocs: [],
+    };
+    const parsed = CuratedCorpusSchema.parse(legacy);
+    expect(parsed.stats).toBeUndefined();
+    // …and reading it off disk fails soft to the parsed shape (not null).
+    const dir = path.join(repo, '.truecourse', 'specs');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'corpus.json'), JSON.stringify(legacy));
+    const read = readCorpus(repo);
+    expect(read).not.toBeNull();
+    expect(read!.stats).toBeUndefined();
+  });
+
+  it('writeCorpus persists the stats it is given', () => {
+    writeCorpus(repo, {
+      docs: [],
+      areas: [],
+      stats: { docsScanned: 9, docsKept: 0, ignoredNonMarkdown: { '.rst': 4 } },
+    });
+    const read = readCorpus(repo);
+    expect(read!.stats).toEqual({ docsScanned: 9, docsKept: 0, ignoredNonMarkdown: { '.rst': 4 } });
+  });
+});
+
+describe('curate — ignored non-markdown from a real walk', () => {
+  const keepAll: RelevanceRunner = async ({ doc }) => ({ path: doc.path, include: true, reason: 'spec' });
+  const tagOne: AreaTagRunner = async () => ({ tags: [{ product: 'core', concern: 'x' }], status: 'shipped' });
+
+  function place(rel: string, body: string): void {
+    const full = path.join(repo, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body);
+  }
+
+  it('counts ignored doc-like files from the filesystem into stats.ignoredNonMarkdown', async () => {
+    place('README.md', '# kept');
+    place('docs/guide.rst', 'rst');
+    place('docs/other.rst', 'rst');
+    place('CHANGES.adoc', 'adoc');
+
+    const result = await curate(repo, {
+      decisions: EMPTY_DECISIONS,
+      relevanceRunner: keepAll,
+      areaTagRunner: tagOne,
+      disableOverlapDetection: true,
+      skipGit: true,
+    });
+    expect(result.stats.ignoredNonMarkdown).toEqual({ '.rst': 2, '.adoc': 1 });
+    expect(readCorpus(repo)!.stats!.ignoredNonMarkdown).toEqual({ '.rst': 2, '.adoc': 1 });
+  });
+
+  it('rst-only repo: docsScanned 0, ignored counts explain the empty corpus', async () => {
+    place('docs/guide.rst', 'rst');
+    place('docs/api.rst', 'rst');
+
+    const result = await curate(repo, {
+      decisions: EMPTY_DECISIONS,
+      relevanceRunner: keepAll,
+      areaTagRunner: tagOne,
+      disableOverlapDetection: true,
+      skipGit: true,
+    });
+    expect(result.stats.docsScanned).toBe(0);
+    expect(result.stats.docsKept).toBe(0);
+    expect(result.stats.ignoredNonMarkdown).toEqual({ '.rst': 2 });
   });
 });
 

--- a/tests/spec-consolidator/discovery.test.ts
+++ b/tests/spec-consolidator/discovery.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import {
   classifyDoc,
   discoverDocs,
+  discoverDocsWithStats,
 } from '../../packages/spec-consolidator/src/index.js';
 
 /**
@@ -312,6 +313,87 @@ describe('discoverDocs — walker', () => {
     // typical run still produces output. Manual mode of this path is
     // covered by inspection.
     expect(() => discoverDocs(root, { skipGit: true })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ignored doc-like non-markdown bookkeeping — free counts in the same walk, so
+// an rst-only repo (yamllint) reports WHY nothing was scanned instead of a
+// silent empty corpus. (rst support itself is #806; this is just the count.)
+// ---------------------------------------------------------------------------
+
+describe('discoverDocsWithStats — ignored non-markdown counts', () => {
+  it('returns the markdown docs plus a per-extension count of ignored doc-like files', () => {
+    place('README.md', '# md kept');
+    place('docs/guide.rst', 'restructured text');
+    place('docs/other.rst', 'more rst');
+    place('CHANGES.adoc', 'asciidoc');
+    place('notes.txt', 'plain');
+    place('outline.org', 'org mode');
+
+    const { docs, ignoredNonMarkdown } = discoverDocsWithStats(root, { skipGit: true });
+    expect(docs.map((d) => d.path)).toEqual(['README.md']);
+    expect(ignoredNonMarkdown).toEqual({
+      '.rst': 2,
+      '.adoc': 1,
+      '.txt': 1,
+      '.org': 1,
+    });
+  });
+
+  it('counts .asciidoc as well as .adoc', () => {
+    place('a.asciidoc', 'x');
+    place('b.adoc', 'y');
+    const { ignoredNonMarkdown } = discoverDocsWithStats(root, { skipGit: true });
+    expect(ignoredNonMarkdown['.asciidoc']).toBe(1);
+    expect(ignoredNonMarkdown['.adoc']).toBe(1);
+  });
+
+  it('does NOT count non-doc extensions (code, json, images)', () => {
+    place('app.ts', 'code');
+    place('data.json', '{}');
+    place('logo.png', 'binary');
+    const { ignoredNonMarkdown } = discoverDocsWithStats(root, { skipGit: true });
+    expect(ignoredNonMarkdown).toEqual({});
+  });
+
+  it('applies the SAME SKIP_DIRS / .truecourse exclusions to the count (no leaked build/dep rst)', () => {
+    place('docs/real.rst', 'kept-count');
+    place('node_modules/pkg/leaked.rst', 'must not count');
+    place('dist/leaked.rst', 'must not count');
+    place('.truecourse/specs/leaked.rst', 'must not count');
+    const { ignoredNonMarkdown } = discoverDocsWithStats(root, { skipGit: true });
+    expect(ignoredNonMarkdown['.rst']).toBe(1);
+  });
+
+  it('applies .truecourseignore to the count the same way it filters markdown', () => {
+    place('.truecourseignore', 'reference/\n');
+    place('docs/keep.rst', 'counted');
+    place('reference/answers.rst', 'ignored — must not count');
+    const { ignoredNonMarkdown } = discoverDocsWithStats(root, { skipGit: true });
+    expect(ignoredNonMarkdown['.rst']).toBe(1);
+  });
+
+  it('applies include-scope to the count (out-of-scope doc-like files are not counted)', () => {
+    place('.truecourse/config.json', JSON.stringify({ spec: { include: ['docs/**'] } }));
+    place('docs/in.rst', 'counted');
+    place('scratch/out.rst', 'out of scope — must not count');
+    const { ignoredNonMarkdown } = discoverDocsWithStats(root, { skipGit: true });
+    expect(ignoredNonMarkdown['.rst']).toBe(1);
+  });
+
+  it('returns an empty record when there are no doc-like non-markdown files', () => {
+    place('docs/real.md', '# md');
+    const { ignoredNonMarkdown } = discoverDocsWithStats(root, { skipGit: true });
+    expect(ignoredNonMarkdown).toEqual({});
+  });
+
+  it('discoverDocs stays the doc-array shape (delegates to the stats variant)', () => {
+    place('README.md', '# md');
+    place('guide.rst', 'rst');
+    const docs = discoverDocs(root, { skipGit: true });
+    expect(Array.isArray(docs)).toBe(true);
+    expect(docs.map((d) => d.path)).toEqual(['README.md']);
   });
 });
 

--- a/tools/cli/src/commands/guard.ts
+++ b/tools/cli/src/commands/guard.ts
@@ -26,6 +26,7 @@ import {
 import { composeGuardStatus, orderGuardDrifts, guardDriverIds } from "@truecourse/shared";
 import { registerProject } from "@truecourse/core/config/registry";
 import { createStdoutStepRenderer } from "../lib/stdout-step-renderer.js";
+import { emptyCorpusNotice } from "../lib/empty-corpus.js";
 import { requireGitRepo } from "./git-guard.js";
 import { preflightClaudeOrExit } from "../lib/claude-preflight.js";
 import { promptLlmEstimate } from "./llm-prompt.js";
@@ -86,6 +87,11 @@ export async function runGuardRun(opts: RunGuardRunOptions = {}): Promise<void> 
         p.log.error(runFailureMessage(result));
       } else {
         p.log.info(runFailureMessage(result));
+        // When the repo HAS a corpus but it curated no docs (#807), explain WHY
+        // there is nothing to run — the CLI reads the corpus so `runFailureMessage`
+        // stays pure. A missing / non-empty corpus adds no line.
+        const notice = emptyCorpusNotice(repoRoot);
+        if (notice) p.log.info(notice.message);
       }
       printLoadErrors(result.loadErrors);
       p.outro("Nothing ran.");
@@ -232,7 +238,10 @@ export async function runGuardGenerate(opts: RunGuardGenerateOptions = {}): Prom
 
   if (guard.status === "no-docs") {
     p.log.error(guard.reason ?? "No spec docs to guard.");
-    p.outro("Run `truecourse spec scan` first.");
+    // A present-but-empty corpus (#807) already carries the full explanation in
+    // `guard.reason`; don't loop the user back to `spec scan` (there is nothing to
+    // scan). A MISSING corpus keeps that pointer.
+    p.outro(emptyCorpusNotice(repoRoot) ? "Nothing to guard — the corpus is empty." : "Run `truecourse spec scan` first.");
     process.exit(1);
   }
   if (guard.status === "recipe-failed") {
@@ -390,7 +399,11 @@ export async function runGuardStatus(opts: RunGuardStatusOptions = {}): Promise<
 
   // Coverage — scenarios/manifest.json.
   if (!summary.coverage) {
-    p.log.info("coverage    (none) — run `truecourse guard generate`");
+    // With no manifest AND a present-but-empty corpus (#807), the "run guard
+    // generate" hint would loop (generate has nothing to do) — swap in the
+    // empty-corpus explanation. A missing corpus keeps the generate hint.
+    const notice = emptyCorpusNotice(repoRoot);
+    p.log.info(notice ? `coverage    (none) — ${notice.message}` : "coverage    (none) — run `truecourse guard generate`");
   } else {
     const c = summary.coverage;
     p.log.step(`coverage    ${c.withScenarios}/${c.totalSections} section${c.totalSections === 1 ? "" : "s"} guarded`);

--- a/tools/cli/src/commands/spec.ts
+++ b/tools/cli/src/commands/spec.ts
@@ -16,6 +16,7 @@ import * as p from "@clack/prompts";
 import { readCorpus, readCorpusDecisions } from "@truecourse/spec-consolidator";
 import {
   buildCorpusConflicts,
+  corpusScanCounts,
   deriveEmptyCorpus,
   formatEmptyCorpus,
   openConflicts,
@@ -154,16 +155,10 @@ export async function runSpecStatus(opts: RunSpecOptions = {}): Promise<void> {
   // A corpus present but holding no kept docs (#807): explain WHY (derived from the
   // persisted stats + skippedDocs) and DON'T point at `guard generate` — there is
   // nothing to guard.
-  const docsScanned = corpus.stats?.docsScanned ?? corpus.docs.length + corpus.skippedDocs.length;
-  const emptyFlavor = deriveEmptyCorpus({ docsScanned, docsKept: corpus.docs.length });
+  const counts = corpusScanCounts(corpus);
+  const emptyFlavor = deriveEmptyCorpus(counts);
   if (emptyFlavor) {
-    p.log.warn(
-      formatEmptyCorpus({
-        flavor: emptyFlavor,
-        docsScanned,
-        ignoredNonMarkdown: corpus.stats?.ignoredNonMarkdown ?? {},
-      }),
-    );
+    p.log.warn(formatEmptyCorpus({ flavor: emptyFlavor, ...counts }));
     p.outro("Done.");
     return;
   }

--- a/tools/cli/src/commands/spec.ts
+++ b/tools/cli/src/commands/spec.ts
@@ -14,7 +14,13 @@
 
 import * as p from "@clack/prompts";
 import { readCorpus, readCorpusDecisions } from "@truecourse/spec-consolidator";
-import { buildCorpusConflicts, openConflicts, orphanedConflictResolutions } from "@truecourse/shared";
+import {
+  buildCorpusConflicts,
+  deriveEmptyCorpus,
+  formatEmptyCorpus,
+  openConflicts,
+  orphanedConflictResolutions,
+} from "@truecourse/shared";
 import { StepTracker } from "@truecourse/core/progress";
 import {
   curateInProcess,
@@ -63,7 +69,7 @@ export async function runSpecScan(opts: RunSpecOptions = {}): Promise<void> {
   // Agent transport is headless (no TTY to confirm) → auto-approve the estimate.
   const autoApprove = !!opts.yes || opts.llm === "agent";
   const { renderer, tracker } = withTracker(CURATE_STEPS);
-  const { curate, noChanges } = await curateInProcess(root, {
+  const { curate, noChanges, emptyCorpus } = await curateInProcess(root, {
     tracker,
     source: "cli",
     llm: opts.llm,
@@ -79,6 +85,20 @@ export async function runSpecScan(opts: RunSpecOptions = {}): Promise<void> {
     process.exit(1);
   });
   renderer.dispose();
+  // An empty corpus (#807) is a LOUD warning, not the false "Nothing changed"
+  // success — and it never points at `guard generate` (nothing to guard). Exit 0:
+  // the scan ran fine, it just found nothing to curate.
+  if (emptyCorpus) {
+    p.log.warn(
+      formatEmptyCorpus({
+        flavor: emptyCorpus,
+        docsScanned: curate.stats.docsScanned,
+        ignoredNonMarkdown: curate.stats.ignoredNonMarkdown,
+      }),
+    );
+    p.outro("Done.");
+    return;
+  }
   if (noChanges) {
     p.log.success("Nothing changed — no new or updated docs since the last scan; corpus is up to date.");
     p.outro("Done.");
@@ -129,6 +149,22 @@ export async function runSpecStatus(opts: RunSpecOptions = {}): Promise<void> {
   if (!corpus) {
     p.log.warn("No corpus — run `truecourse spec scan`.");
     p.outro("");
+    return;
+  }
+  // A corpus present but holding no kept docs (#807): explain WHY (derived from the
+  // persisted stats + skippedDocs) and DON'T point at `guard generate` — there is
+  // nothing to guard.
+  const docsScanned = corpus.stats?.docsScanned ?? corpus.docs.length + corpus.skippedDocs.length;
+  const emptyFlavor = deriveEmptyCorpus({ docsScanned, docsKept: corpus.docs.length });
+  if (emptyFlavor) {
+    p.log.warn(
+      formatEmptyCorpus({
+        flavor: emptyFlavor,
+        docsScanned,
+        ignoredNonMarkdown: corpus.stats?.ignoredNonMarkdown ?? {},
+      }),
+    );
+    p.outro("Done.");
     return;
   }
   const decisions = readCorpusDecisions(root);

--- a/tools/cli/src/lib/empty-corpus.ts
+++ b/tools/cli/src/lib/empty-corpus.ts
@@ -9,7 +9,7 @@
  * doc — callers treat `null` as "no empty-corpus story to tell here".
  */
 import { readCorpus } from "@truecourse/spec-consolidator";
-import { deriveEmptyCorpus, formatEmptyCorpus, type EmptyCorpusFlavor } from "@truecourse/shared";
+import { corpusScanCounts, deriveEmptyCorpus, formatEmptyCorpus, type EmptyCorpusFlavor } from "@truecourse/shared";
 
 export interface EmptyCorpusNotice {
   flavor: EmptyCorpusFlavor;
@@ -20,17 +20,8 @@ export interface EmptyCorpusNotice {
 export function emptyCorpusNotice(repoRoot: string): EmptyCorpusNotice | null {
   const corpus = readCorpus(repoRoot);
   if (!corpus) return null;
-  const docsKept = corpus.docs.length;
-  // Back-compat: a corpus written before the stats block falls back to kept + skipped.
-  const docsScanned = corpus.stats?.docsScanned ?? docsKept + corpus.skippedDocs.length;
-  const flavor = deriveEmptyCorpus({ docsScanned, docsKept });
+  const counts = corpusScanCounts(corpus);
+  const flavor = deriveEmptyCorpus(counts);
   if (!flavor) return null;
-  return {
-    flavor,
-    message: formatEmptyCorpus({
-      flavor,
-      docsScanned,
-      ignoredNonMarkdown: corpus.stats?.ignoredNonMarkdown ?? {},
-    }),
-  };
+  return { flavor, message: formatEmptyCorpus({ flavor, ...counts }) };
 }

--- a/tools/cli/src/lib/empty-corpus.ts
+++ b/tools/cli/src/lib/empty-corpus.ts
@@ -1,0 +1,36 @@
+/**
+ * The empty-corpus notice for the guard CLI surfaces (#807). Reads the persisted
+ * corpus.json and, when it exists but holds no kept docs, derives the flavor and
+ * renders the ONE shared formatter (`@truecourse/shared`). Keeping this read in the
+ * CLI layer is deliberate: the guard-runner engine (`runFailureMessage`) stays pure
+ * and never reads the corpus.
+ *
+ * Returns `null` when there is no corpus at all OR the corpus holds at least one
+ * doc — callers treat `null` as "no empty-corpus story to tell here".
+ */
+import { readCorpus } from "@truecourse/spec-consolidator";
+import { deriveEmptyCorpus, formatEmptyCorpus, type EmptyCorpusFlavor } from "@truecourse/shared";
+
+export interface EmptyCorpusNotice {
+  flavor: EmptyCorpusFlavor;
+  /** The single user-facing explanation (WARNING/INFO channel — the wording is neutral). */
+  message: string;
+}
+
+export function emptyCorpusNotice(repoRoot: string): EmptyCorpusNotice | null {
+  const corpus = readCorpus(repoRoot);
+  if (!corpus) return null;
+  const docsKept = corpus.docs.length;
+  // Back-compat: a corpus written before the stats block falls back to kept + skipped.
+  const docsScanned = corpus.stats?.docsScanned ?? docsKept + corpus.skippedDocs.length;
+  const flavor = deriveEmptyCorpus({ docsScanned, docsKept });
+  if (!flavor) return null;
+  return {
+    flavor,
+    message: formatEmptyCorpus({
+      flavor,
+      docsScanned,
+      ignoredNonMarkdown: corpus.stats?.ignoredNonMarkdown ?? {},
+    }),
+  };
+}


### PR DESCRIPTION
Closes #807.

An empty spec corpus no longer reads as success anywhere in the pipeline.

## What changed

**Detection (one place)**
- Discovery now counts ignored doc-like non-markdown files (`.rst`, `.adoc`, `.asciidoc`, `.txt`, `.org`) that survive the same ignore/skip-dir/scope filters markdown does, grouped by extension, in the same walk. Persisted in `corpus.json`'s optional `stats` block (legacy corpora without it still parse; readers fall back to `kept + skipped`).
- Two flavors, distinguished at every surface: **`no-docs-found`** (0 docs discovered) vs **`all-docs-dropped`** (docs scanned, relevance filter kept none).
- `curateInProcess` returns `emptyCorpus` and forces `noChanges: false` when empty — fixing the root conflation (`noChanges` was derived as "zero LLM calls", which a 0-doc repo trivially satisfies on its first ever scan).
- One shared derivation + wording in `@truecourse/shared` (`corpusScanCounts` / `deriveEmptyCorpus` / `formatEmptyCorpus`) so the CLI and dashboard can never drift. No issue links in user output; nothing ever points at `guard generate`.

**Surfaces**
- `spec scan` — loud warning with the ignored-extension breakdown, exit 0 (replaces the false "Nothing changed" and the "Run `guard generate`" outro).
- `spec status` — same warning from persisted stats; no longer points at generate over nothing.
- `guard generate` — present-but-empty corpus exits 1 via the existing `no-docs` status with a distinct reason (missing corpus keeps its "run spec scan first" pointer — no loop).
- `guard run` — the `no-scenarios` path adds one info line explaining the empty corpus; `runFailureMessage` stays pure (the corpus read lives in the CLI layer).
- `guard status` — the "coverage (none) — run `guard generate`" hint is replaced by the explanation when the corpus is present-but-empty.
- Dashboard — warning toast replaces the success "Nothing changed"; `SpecCorpusView` gets a dedicated present-but-empty state (works for git-cloned corpora); the generate `no-docs` reason surfaces as an error toast.

**Not changed:** the EE GitHub gate. `no-docs`/`no-scenarios` still conclude neutral — an empty corpus never blocks PRs.

## Verification

- 1630/1630 tests green across the affected suites (`tests/shared`, `tests/spec-consolidator`, `tests/core`, `tests/cli`, `tests/server`, `tests/dashboard-server`, `tests/dashboard-client`, `tests/guard-generator`), including new coverage: rst-count flavor 1, flavor 2, generate exit-1 with distinct reason vs missing corpus, the legacy no-stats fallback, and the cache-hit "Nothing changed" regression for non-empty corpora.
- Two-axis review (standards + spec) ran twice; round 2 was a clean spec pass. Residual nits accepted knowingly: `runSpecStatus` inlines the derive-triple that `emptyCorpusNotice` wraps (avoids a second corpus read), persisted `stats.docsKept` is written-but-not-read (kept for human readability), and the client `api.ts` declares the stats shape inline.
- CLI screenshots demonstrating each fixed surface on an rst-only fixture repo follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)