### PR TITLE
fix(llm): stop analysis on Claude session limits

### DIFF
--- a/packages/core/src/commands/analyze-in-process.ts
+++ b/packages/core/src/commands/analyze-in-process.ts
@@ -15,6 +15,10 @@ import { persistFullAnalysis, type PersistFullResult } from './analyze-persist.j
 import { config } from '../config/index.js';
 import { log } from '../lib/logger.js';
 import {
+  isLlmSessionLimitError,
+  LlmSessionLimitError,
+} from '@truecourse/shared/llm';
+import {
   bucketDuration,
   bucketFileCount,
   detectLanguages,
@@ -60,6 +64,14 @@ export interface AnalyzeInProcessOptions {
 
 export type AnalyzeInProcessResult = PersistFullResult;
 
+export class AnalysisSessionLimitError extends LlmSessionLimitError {
+  constructor(error: LlmSessionLimitError) {
+    super(error.resetHint);
+    this.name = 'AnalysisSessionLimitError';
+    this.message = `${this.message} The interrupted run was not saved, so LATEST.json was not updated and any previous completed analysis remains unchanged. Successful LLM calls from this interrupted run cannot be resumed yet and may be repeated when you rerun.`;
+  }
+}
+
 export async function analyzeInProcess(
   project: RegistryEntry,
   options: AnalyzeInProcessOptions = {},
@@ -68,7 +80,13 @@ export async function analyzeInProcess(
   log.info(
     `[LLM] Provider: claude-code, model: ${config.claudeCodeModel || 'default'}, maxConcurrency: ${config.claudeCodeMaxConcurrency}`,
   );
-  const core = await analyzeCore(project, { ...options, mode: 'full' });
+  let core: Awaited<ReturnType<typeof analyzeCore>>;
+  try {
+    core = await analyzeCore(project, { ...options, mode: 'full' });
+  } catch (error) {
+    if (isLlmSessionLimitError(error)) throw new AnalysisSessionLimitError(error);
+    throw error;
+  }
   const result = await persistFullAnalysis(project, core, startedAt);
 
   if (options.source) {

--- a/packages/core/src/services/llm/cli-provider.ts
+++ b/packages/core/src/services/llm/cli-provider.ts
@@ -10,7 +10,12 @@ import { registerChildProcess, unregisterChildProcess } from '../analysis-regist
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { ZodType } from 'zod';
 import type { Violation } from '@truecourse/shared';
-import type { LlmTransport } from '@truecourse/shared/llm';
+import {
+  isLlmSessionLimitError,
+  parseLlmSessionLimitError,
+  type LlmSessionLimitError,
+  type LlmTransport,
+} from '@truecourse/shared/llm';
 import { config } from '../../config/index.js';
 import {
   getPrompt,
@@ -91,6 +96,8 @@ export abstract class BaseCLIProvider implements LLMProvider {
   private _repoId: string | null = null;
   private _repoPath: string | null = null;
   private _abortSignal: AbortSignal | null = null;
+  private _sessionLimitError: LlmSessionLimitError | null = null;
+  private _sessionLimitHandler: ((error: LlmSessionLimitError) => void) | null = null;
   private _usageRecords: UsageRecord[] = [];
   /**
    * When set, LLM calls go through this transport (the agent file-mailbox)
@@ -102,10 +109,15 @@ export abstract class BaseCLIProvider implements LLMProvider {
   setAnalysisId(id: string): void {
     this._analysisId = id;
     this._usageRecords = [];
+    this._sessionLimitError = null;
   }
 
   setAbortSignal(signal: AbortSignal): void {
     this._abortSignal = signal;
+  }
+
+  setSessionLimitHandler(handler: (error: LlmSessionLimitError) => void): void {
+    this._sessionLimitHandler = handler;
   }
 
   /** Set repoId for child process tracking in the analysis registry. */
@@ -259,6 +271,12 @@ export abstract class BaseCLIProvider implements LLMProvider {
           return;
         }
         if (code !== 0) {
+          const sessionLimit =
+            parseLlmSessionLimitError(stdout) ?? parseLlmSessionLimitError(stderr);
+          if (sessionLimit) {
+            reject(sessionLimit);
+            return;
+          }
           const detail = stderr.trim() || stdout.trim().slice(0, 500);
           reject(new Error(`[CLI] ${this.binaryName} exited with code ${code}: ${detail}`));
           return;
@@ -317,6 +335,8 @@ export abstract class BaseCLIProvider implements LLMProvider {
     const usage = this.extractCLIUsage(parsed);
 
     if (parsed.is_error) {
+      const sessionLimit = parseLlmSessionLimitError(parsed);
+      if (sessionLimit) throw sessionLimit;
       throw new Error(`[CLI] Agent returned error: ${parsed.result || parsed.subtype}`);
     }
 
@@ -346,6 +366,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
       if (this._abortSignal?.aborted) {
         throw this._abortSignal.reason ?? new DOMException('Analysis cancelled', 'AbortError');
       }
+      if (this._sessionLimitError) throw this._sessionLimitError;
       opts?.onStart?.();
 
       const jsonSchemaStr = this.toJsonSchema(schema);
@@ -360,6 +381,24 @@ export abstract class BaseCLIProvider implements LLMProvider {
         } catch (err) {
           lastError = err as Error;
           if (this._abortSignal?.aborted) throw lastError; // don't retry on cancel
+          if (isLlmSessionLimitError(lastError)) {
+            if (!this._sessionLimitError) {
+              this._sessionLimitError = lastError;
+              log.warn(`[CLI] ${lastError.message} Queued LLM calls will be stopped.`);
+              try {
+                this._sessionLimitHandler?.(lastError);
+              } catch (handlerError) {
+                log.warn(
+                  `[CLI] Session-limit notification failed: ${handlerError instanceof Error ? handlerError.message : String(handlerError)}`,
+                );
+              }
+            }
+            throw this._sessionLimitError;
+          }
+          // Another admitted call may have opened the provider-wide circuit
+          // while this call was awaiting a generic failure. Do not start a
+          // retry after that terminal state is known.
+          if (this._sessionLimitError) throw this._sessionLimitError;
           if (attempt < this.maxRetries) {
             log.warn(`[CLI] Attempt ${attempt + 1} failed, retrying... (${lastError.message})`);
           }
@@ -523,6 +562,11 @@ export abstract class BaseCLIProvider implements LLMProvider {
       )
     ));
 
+    const sessionLimit = settled.find(
+      (outcome) => outcome.status === 'rejected' && isLlmSessionLimitError(outcome.reason),
+    );
+    if (sessionLimit?.status === 'rejected') throw sessionLimit.reason;
+
     const result: AllViolationsResult = {};
     for (let i = 0; i < promises.length; i++) {
       const [key] = promises[i];
@@ -657,6 +701,11 @@ export abstract class BaseCLIProvider implements LLMProvider {
         (err) => { onCallDone?.(baseKey(key), false); throw err; },
       )
     ));
+
+    const sessionLimit = settled.find(
+      (outcome) => outcome.status === 'rejected' && isLlmSessionLimitError(outcome.reason),
+    );
+    if (sessionLimit?.status === 'rejected') throw sessionLimit.reason;
 
     for (let i = 0; i < promises.length; i++) {
       const [key] = promises[i];
@@ -820,6 +869,11 @@ export abstract class BaseCLIProvider implements LLMProvider {
     const results = await Promise.allSettled(
       batches.map((batch) => this.generateCodeViolations(batch))
     );
+
+    const sessionLimit = results.find(
+      (result) => result.status === 'rejected' && isLlmSessionLimitError(result.reason),
+    );
+    if (sessionLimit?.status === 'rejected') throw sessionLimit.reason;
 
     const allViolations: CodeViolationRaw[] = [];
     const allResolved: string[] = [];

--- a/packages/core/src/services/llm/cli-provider.ts
+++ b/packages/core/src/services/llm/cli-provider.ts
@@ -381,12 +381,15 @@ export abstract class BaseCLIProvider implements LLMProvider {
         } catch (err) {
           lastError = err as Error;
           if (this._abortSignal?.aborted) throw lastError; // don't retry on cancel
-          if (isLlmSessionLimitError(lastError)) {
+          const sessionLimit = isLlmSessionLimitError(lastError)
+            ? lastError
+            : parseLlmSessionLimitError(lastError);
+          if (sessionLimit) {
             if (!this._sessionLimitError) {
-              this._sessionLimitError = lastError;
-              log.warn(`[CLI] ${lastError.message} Queued LLM calls will be stopped.`);
+              this._sessionLimitError = sessionLimit;
+              log.warn(`[CLI] ${sessionLimit.message} Queued LLM calls will be stopped.`);
               try {
-                this._sessionLimitHandler?.(lastError);
+                this._sessionLimitHandler?.(sessionLimit);
               } catch (handlerError) {
                 log.warn(
                   `[CLI] Session-limit notification failed: ${handlerError instanceof Error ? handlerError.message : String(handlerError)}`,

--- a/packages/core/src/services/llm/provider.ts
+++ b/packages/core/src/services/llm/provider.ts
@@ -1,6 +1,10 @@
 import type { Violation } from '@truecourse/shared';
 import { ClaudeCodeProvider } from './cli-provider.js';
-import { getDefaultTransport, type LlmTransport } from '@truecourse/shared/llm';
+import {
+  getDefaultTransport,
+  type LlmSessionLimitError,
+  type LlmTransport,
+} from '@truecourse/shared/llm';
 import type { FlowEnrichmentContext } from './prompts.js';
 import type { UsageData } from '../usage.service.js';
 
@@ -253,6 +257,8 @@ export interface LLMProvider {
   setRepoId(repoId: string): void;
   setRepoPath(path: string): void;
   setAbortSignal(signal: AbortSignal): void;
+  /** Report the first provider-wide session limit as soon as its circuit opens. */
+  setSessionLimitHandler?(handler: (error: LlmSessionLimitError) => void): void;
   /**
    * Return the usage records accumulated since the last `setAnalysisId`
    * call and clear the internal buffer. The orchestrator puts these on

--- a/packages/core/src/services/violation-pipeline.service.ts
+++ b/packages/core/src/services/violation-pipeline.service.ts
@@ -8,6 +8,7 @@ import { runDeterministicModuleChecks, runDeterministicMethodChecks, runDetermin
 import { DOMAIN_ORDER, CODE_DOMAINS } from '../progress.js';
 import { getEnabledRules } from './rules.service.js';
 import { createLLMProvider, type LLMProvider, type CodeViolationContext, type CodeViolationRaw, type DiffViolationItem } from './llm/provider.js';
+import { isLlmSessionLimitError } from '@truecourse/shared/llm';
 import { routeContext, estimateContext } from './llm/context-router.js';
 import { generateViolations, generateViolationsWithLifecycle } from './violation.service.js';
 import {
@@ -826,6 +827,11 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
 
   const provider = externalProvider ?? createLLMProvider();
   provider.setRepoPath(repoPath);
+  provider.setSessionLimitHandler?.((error) => {
+    const detail = `${error.message} Queued LLM calls stopped; waiting for active calls to finish before ending this run.`;
+    tracker?.ensureStep('llm-session-limit', 'LLM session limit');
+    tracker?.error('llm-session-limit', detail);
+  });
   const allNewLlmItems: DiffViolationItem[] = [];
   const allResolvedLlmIds: string[] = [];
 
@@ -1141,6 +1147,11 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
         }),
       );
 
+      const sessionLimit = codeResults.find(
+        (result) => result.status === 'rejected' && isLlmSessionLimitError(result.reason),
+      );
+      if (sessionLimit?.status === 'rejected') throw sessionLimit.reason;
+
       const rawViolations: CodeViolationRaw[] = [];
       const resolvedIds: string[] = [];
       const unchangedIds: string[] = [];
@@ -1227,6 +1238,7 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
         return { domain: 'database-schema', violations: [], resolvedIds: [], unchangedIds: [] };
       } catch (err) {
         schemaLl?.onCallDone(started);
+        if (isLlmSessionLimitError(err)) throw err;
         const dur = Date.now() - t0;
         log.warn(`[LLM] database-schema: failed in ${dur}ms — ${err instanceof Error ? err.message : String(err)}`);
         if (!domainCodeBatches.has('database')) tracker?.error('database', `Schema LLM failed`);
@@ -1339,6 +1351,11 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
     llmRulePromise,
     ...domainLlmPromises,
   ]);
+
+  const sessionLimit = [llmResult, ...domainLlmResults].find(
+    (result) => result.status === 'rejected' && isLlmSessionLimitError(result.reason),
+  );
+  if (sessionLimit?.status === 'rejected') throw sessionLimit.reason;
 
   if (detResult.status === 'rejected') {
     log.error(`[Violations] Deterministic lifecycle tracking failed: ${detResult.reason instanceof Error ? detResult.reason.message : String(detResult.reason)}`);

--- a/packages/shared/src/llm/errors.ts
+++ b/packages/shared/src/llm/errors.ts
@@ -1,0 +1,65 @@
+export class LlmSessionLimitError extends Error {
+  readonly code = 'LLM_SESSION_LIMIT' as const;
+  readonly statusCode = 429;
+
+  constructor(readonly resetHint?: string) {
+    super(
+      resetHint
+        ? `Claude session limit reached; resets ${resetHint}. Wait until the limit resets before retrying.`
+        : 'Claude session limit reached. Wait until the limit resets before retrying.',
+    );
+    this.name = 'LlmSessionLimitError';
+  }
+}
+
+interface ClaudeErrorEnvelope {
+  is_error?: unknown;
+  api_error_status?: unknown;
+  result?: unknown;
+}
+
+const SESSION_LIMIT_PATTERN = /\byou(?:['’]ve)\s+hit\s+your\s+session\s+limit\b/i;
+const RESET_HINT_PATTERN = /(?:^|[·—-]\s*|\s+)resets?\s+(.+?)\s*$/i;
+
+function asClaudeEnvelope(value: unknown): ClaudeErrorEnvelope | null {
+  if (typeof value === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(value.trim());
+      return asClaudeEnvelope(parsed);
+    } catch {
+      return null;
+    }
+  }
+  if (!value || typeof value !== 'object') return null;
+  return value as ClaudeErrorEnvelope;
+}
+
+/**
+ * Recognize only the definite Claude session-limit response observed in real
+ * analyze runs. A bare 429 is deliberately not enough: ordinary throttling
+ * remains eligible for the caller's bounded retry policy.
+ */
+export function parseLlmSessionLimitError(value: unknown): LlmSessionLimitError | null {
+  const envelope = asClaudeEnvelope(value);
+  if (
+    envelope?.is_error !== true ||
+    Number(envelope.api_error_status) !== 429 ||
+    typeof envelope.result !== 'string' ||
+    !SESSION_LIMIT_PATTERN.test(envelope.result)
+  ) {
+    return null;
+  }
+
+  const resetHint = RESET_HINT_PATTERN.exec(envelope.result)?.[1];
+  return new LlmSessionLimitError(resetHint);
+}
+
+export function isLlmSessionLimitError(value: unknown): value is LlmSessionLimitError {
+  return (
+    value instanceof LlmSessionLimitError ||
+    (!!value &&
+      typeof value === 'object' &&
+      'code' in value &&
+      (value as { code?: unknown }).code === 'LLM_SESSION_LIMIT')
+  );
+}

--- a/packages/shared/src/llm/errors.ts
+++ b/packages/shared/src/llm/errors.ts
@@ -20,6 +20,7 @@ interface ClaudeErrorEnvelope {
 
 const SESSION_LIMIT_PATTERN = /\byou(?:['’]ve)\s+hit\s+your\s+session\s+limit\b/i;
 const RESET_HINT_PATTERN = /(?:^|[·—-]\s*|\s+)resets?\s+(.+?)\s*$/i;
+const WRAPPED_CLAUDE_429_PATTERN = /\bclaude\s+api\s+error\s*\(\s*api\s+429\s*\)\s*:\s*(.+)$/i;
 
 function asClaudeEnvelope(value: unknown): ClaudeErrorEnvelope | null {
   if (typeof value === 'string') {
@@ -42,15 +43,25 @@ function asClaudeEnvelope(value: unknown): ClaudeErrorEnvelope | null {
 export function parseLlmSessionLimitError(value: unknown): LlmSessionLimitError | null {
   const envelope = asClaudeEnvelope(value);
   if (
-    envelope?.is_error !== true ||
-    Number(envelope.api_error_status) !== 429 ||
-    typeof envelope.result !== 'string' ||
-    !SESSION_LIMIT_PATTERN.test(envelope.result)
+    envelope?.is_error === true &&
+    Number(envelope.api_error_status) === 429 &&
+    typeof envelope.result === 'string' &&
+    SESSION_LIMIT_PATTERN.test(envelope.result)
+  ) {
+    const resetHint = RESET_HINT_PATTERN.exec(envelope.result)?.[1];
+    return new LlmSessionLimitError(resetHint);
+  }
+
+  const message = value instanceof Error ? value.message : typeof value === 'string' ? value : null;
+  const wrappedDetail = message ? WRAPPED_CLAUDE_429_PATTERN.exec(message)?.[1] : undefined;
+  if (
+    typeof wrappedDetail !== 'string' ||
+    !SESSION_LIMIT_PATTERN.test(wrappedDetail)
   ) {
     return null;
   }
 
-  const resetHint = RESET_HINT_PATTERN.exec(envelope.result)?.[1];
+  const resetHint = RESET_HINT_PATTERN.exec(wrappedDetail)?.[1];
   return new LlmSessionLimitError(resetHint);
 }
 

--- a/packages/shared/src/llm/transport.ts
+++ b/packages/shared/src/llm/transport.ts
@@ -28,6 +28,12 @@ import { resolveClaudeBinary } from '../claude-binary.js';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { ZodTypeAny } from 'zod';
 
+export {
+  LlmSessionLimitError,
+  isLlmSessionLimitError,
+  parseLlmSessionLimitError,
+} from './errors.js';
+
 // Re-exported here so every output-only prompt reaches it through the same
 // `@truecourse/shared/llm` entry it already imports the transport from.
 export { OUTPUT_ONLY_GUARDRAIL } from './guardrail.js';

--- a/packages/shared/src/llm/transport.ts
+++ b/packages/shared/src/llm/transport.ts
@@ -27,12 +27,13 @@ import { StringDecoder } from 'node:string_decoder';
 import { resolveClaudeBinary } from '../claude-binary.js';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { ZodTypeAny } from 'zod';
+import { parseLlmSessionLimitError } from './errors.js';
 
 export {
   LlmSessionLimitError,
   isLlmSessionLimitError,
-  parseLlmSessionLimitError,
 } from './errors.js';
+export { parseLlmSessionLimitError };
 
 // Re-exported here so every output-only prompt reaches it through the same
 // `@truecourse/shared/llm` entry it already imports the transport from.
@@ -653,6 +654,12 @@ export function cliTransport(opts: CliTransportOptions = {}): LlmTransport {
         pending = '';
         clearTimers();
 
+        const sessionLimit = resultEvent ? parseLlmSessionLimitError(resultEvent) : null;
+        if (sessionLimit) {
+          fail(sessionLimit.message, code);
+          reject(sessionLimit);
+          return;
+        }
         if (code !== 0) {
           const msg = `claude exited ${code}: ${Buffer.concat(err).toString('utf-8')}`;
           fail(msg, code);
@@ -675,12 +682,10 @@ export function cliTransport(opts: CliTransportOptions = {}): LlmTransport {
           reject(new Error(msg));
           return;
         }
+        const envelope = resultEvent;
         try {
-          const envelope = resultEvent;
-          // An API error can surface as exit 0 WITH `is_error: true` in the
-          // result event (e.g. 429 usage-limit, 5xx). Treat that as a transport
-          // failure too — so callers (the batch runner) see a thrown error and
-          // do NOT fan out into per-block retries against a degraded API.
+          // Non-session API errors retain the existing exit/stream checks
+          // above. Only a definite session limit is terminal before them.
           if (envelope.is_error === true) {
             const status = envelope.api_error_status ? ` (api ${envelope.api_error_status})` : '';
             const detail = typeof envelope.result === 'string' ? `: ${envelope.result}` : '';
@@ -769,7 +774,7 @@ export function agentTransport(ioDir: string, opts: AgentTransportOptions = {}):
     const deadline = Date.now() + (req.timeoutMs ?? defaultTimeout) * resolveTimeoutScale();
     for (;;) {
       if (fs.existsSync(resPath)) {
-        let parsed: { text?: string; error?: string };
+        let parsed: { text?: string; error?: unknown };
         try {
           parsed = JSON.parse(fs.readFileSync(resPath, 'utf-8'));
         } catch {
@@ -777,7 +782,12 @@ export function agentTransport(ioDir: string, opts: AgentTransportOptions = {}):
           await sleep(pollMs);
           continue;
         }
-        if (parsed.error) throw new Error(`agent answer error for ${id}: ${parsed.error}`);
+        if (parsed.error) {
+          const sessionLimit = parseLlmSessionLimitError(parsed.error);
+          if (sessionLimit) throw sessionLimit;
+          const detail = typeof parsed.error === 'string' ? parsed.error : JSON.stringify(parsed.error);
+          throw new Error(`agent answer error for ${id}: ${detail}`);
+        }
         if (typeof parsed.text === 'string') return parsed.text;
         throw new Error(`agent answer for ${id} missing "text"`);
       }

--- a/tests/core/analyze-session-limit-integrity.test.ts
+++ b/tests/core/analyze-session-limit-integrity.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { analyzeInProcess } from '../../packages/core/src/commands/analyze-in-process.js';
+import { clearLatestCache, listAnalyses } from '../../packages/core/src/lib/analysis-store.js';
+import { registerProject, unregisterProject, type RegistryEntry } from '../../packages/core/src/config/registry.js';
+import { buildAnalysisSteps, StepTracker, type AnalysisProgressPayload } from '../../packages/core/src/progress.js';
+import { createLLMProvider } from '../../packages/core/src/services/llm/provider.js';
+import { LlmSessionLimitError, type LlmTransport } from '../../packages/shared/src/llm/transport.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixture = path.resolve(__dirname, '../fixtures/sample-js-project-negative');
+const originalTruecourseHome = process.env.TRUECOURSE_HOME;
+
+function copyDir(source: string, destination: string): void {
+  fs.mkdirSync(destination, { recursive: true });
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    if (entry.name === '.git' || entry.name === '.truecourse' || entry.name === 'node_modules') continue;
+    const from = path.join(source, entry.name);
+    const to = path.join(destination, entry.name);
+    if (entry.isDirectory()) copyDir(from, to);
+    else fs.copyFileSync(from, to);
+  }
+}
+
+describe('analyze session-limit integrity', () => {
+  let workDir: string;
+  let truecourseHome: string;
+  let project: RegistryEntry;
+
+  beforeAll(async () => {
+    truecourseHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-session-limit-home-'));
+    process.env.TRUECOURSE_HOME = truecourseHome;
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-session-limit-analysis-'));
+    copyDir(fixture, workDir);
+    const env = {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'test',
+      GIT_AUTHOR_EMAIL: 't@t',
+      GIT_COMMITTER_NAME: 'test',
+      GIT_COMMITTER_EMAIL: 't@t',
+    };
+    execSync('git init -q -b main', { cwd: workDir, env });
+    execSync('git add -A', { cwd: workDir, env });
+    execSync('git -c commit.gpgsign=false commit -q -m init', { cwd: workDir, env });
+    project = await registerProject(workDir);
+    clearLatestCache();
+  });
+
+  afterAll(async () => {
+    if (project) await unregisterProject(project.slug);
+    if (workDir) fs.rmSync(workDir, { recursive: true, force: true });
+    if (truecourseHome) fs.rmSync(truecourseHome, { recursive: true, force: true });
+    if (originalTruecourseHome === undefined) delete process.env.TRUECOURSE_HOME;
+    else process.env.TRUECOURSE_HOME = originalTruecourseHome;
+    clearLatestCache();
+  });
+
+  it.each([
+    'analyze.service',
+    'analyze.code',
+    'analyze.database',
+  ])('keeps the previous completed analysis unchanged when %s reaches the session limit', async (targetStage) => {
+    await analyzeInProcess(project, {
+      enableLlmRulesOverride: false,
+      skipStash: true,
+    });
+
+    const latestPath = path.join(workDir, '.truecourse', 'LATEST.json');
+    const historyPath = path.join(workDir, '.truecourse', 'history.json');
+    const digest = (file: string): string =>
+      createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+    const latestBefore = digest(latestPath);
+    const historyBefore = digest(historyPath);
+    const analysesBefore = await listAnalyses(workDir);
+
+    const transport: LlmTransport = async (request) => {
+      if (request.stage === targetStage) {
+        throw new LlmSessionLimitError('7pm (Africa/Cairo)');
+      }
+      if (request.stage === 'analyze.service') {
+        return JSON.stringify({ violations: [], serviceDescriptions: [] });
+      }
+      return JSON.stringify({ violations: [] });
+    };
+    const progress: AnalysisProgressPayload[] = [];
+    const tracker = new StepTracker(
+      (payload) => progress.push(payload),
+      buildAnalysisSteps(undefined, true),
+    );
+    const outcome = await analyzeInProcess(project, {
+      enableLlmRulesOverride: true,
+      skipStash: true,
+      provider: createLLMProvider(transport),
+      tracker,
+      onLlmEstimate: async () => true,
+    }).then(
+      () => ({ ok: true as const, error: null }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+
+    expect.soft(outcome).toMatchObject({
+      ok: false,
+      error: {
+        code: 'LLM_SESSION_LIMIT',
+        resetHint: '7pm (Africa/Cairo)',
+      },
+    });
+    const message = outcome.error instanceof Error ? outcome.error.message : '';
+    expect.soft(message).toMatch(/LATEST\.json was not updated/i);
+    expect.soft(message).toMatch(/previous completed analysis remains unchanged/i);
+    expect.soft(message).toMatch(/successful LLM calls.*may be repeated/i);
+    expect.soft(progress.some((payload) => payload.steps?.some((step) =>
+      step.key === 'llm-session-limit' &&
+      step.status === 'error' &&
+      /resets 7pm.*queued LLM calls stopped.*active calls/i.test(step.detail ?? ''),
+    ))).toBe(true);
+    expect.soft(digest(latestPath)).toBe(latestBefore);
+    expect.soft(digest(historyPath)).toBe(historyBefore);
+    expect.soft(await listAnalyses(workDir)).toEqual(analysesBefore);
+  }, 120_000);
+});

--- a/tests/core/cli-provider-session-limit-circuit.test.ts
+++ b/tests/core/cli-provider-session-limit-circuit.test.ts
@@ -23,6 +23,44 @@ const serviceContext = {
 };
 
 describe('ClaudeCodeProvider session-limit circuit', () => {
+  it('normalizes a definite Claude 429 wrapped by an installed transport before retrying', async () => {
+    let calls = 0;
+    let notifications = 0;
+    const provider = createLLMProvider(async () => {
+      calls++;
+      throw new Error(
+        "claude API error (api 429): You've hit your session limit · resets 7pm (Africa/Cairo)",
+      );
+    });
+    provider.setSessionLimitHandler?.(() => { notifications++; });
+
+    await expect(provider.generateServiceViolations(serviceContext)).rejects.toMatchObject({
+      code: 'LLM_SESSION_LIMIT',
+      resetHint: '7pm (Africa/Cairo)',
+    });
+    await expect(provider.generateServiceViolations(serviceContext)).rejects.toMatchObject({
+      code: 'LLM_SESSION_LIMIT',
+    });
+
+    expect(calls).toBe(1);
+    expect(notifications).toBe(1);
+  });
+
+  it('keeps bounded retries for a wrapped generic 429 from an installed transport', async () => {
+    let calls = 0;
+    let notifications = 0;
+    const provider = createLLMProvider(async () => {
+      calls++;
+      throw new Error('claude API error (api 429): Rate limited. Please retry shortly.');
+    });
+    provider.setSessionLimitHandler?.(() => { notifications++; });
+
+    await expect(provider.generateServiceViolations(serviceContext)).rejects.toThrow(/Rate limited/);
+
+    expect(calls).toBe(3);
+    expect(notifications).toBe(0);
+  });
+
   it('does not start queued requests after one active call reaches the session limit', async () => {
     const concurrency = config.claudeCodeMaxConcurrency;
     const submitted = concurrency * 2;

--- a/tests/core/cli-provider-session-limit-circuit.test.ts
+++ b/tests/core/cli-provider-session-limit-circuit.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { createLLMProvider } from '../../packages/core/src/services/llm/provider.js';
+import { config } from '../../packages/core/src/config/index.js';
+import {
+  LlmSessionLimitError,
+  type LlmTransport,
+} from '../../packages/shared/src/llm/transport.js';
+
+const serviceContext = {
+  architecture: 'monolith',
+  services: [
+    {
+      id: 'service-1',
+      name: 'orders',
+      type: 'backend',
+      framework: 'express',
+      fileCount: 1,
+      layers: [],
+    },
+  ],
+  dependencies: [],
+  llmRules: [],
+};
+
+describe('ClaudeCodeProvider session-limit circuit', () => {
+  it('does not start queued requests after one active call reaches the session limit', async () => {
+    const concurrency = config.claudeCodeMaxConcurrency;
+    const submitted = concurrency * 2;
+    let calls = 0;
+    let starts = 0;
+    let firstWaveReady!: () => void;
+    let terminalThrown!: () => void;
+    let releaseActive!: () => void;
+    const firstWave = new Promise<void>((resolve) => { firstWaveReady = resolve; });
+    const terminal = new Promise<void>((resolve) => { terminalThrown = resolve; });
+    const release = new Promise<void>((resolve) => { releaseActive = resolve; });
+
+    const transport: LlmTransport = async () => {
+      const call = ++calls;
+      if (call === concurrency) firstWaveReady();
+      await firstWave;
+      if (call === 1) {
+        terminalThrown();
+        throw new LlmSessionLimitError('7pm (Africa/Cairo)');
+      }
+      await release;
+      return JSON.stringify({ violations: [], serviceDescriptions: [] });
+    };
+    const provider = createLLMProvider(transport);
+
+    const results = Promise.allSettled(
+      Array.from({ length: submitted }, () =>
+        provider.generateServiceViolations(serviceContext, {
+          onStart: () => { starts++; },
+        }),
+      ),
+    );
+
+    await terminal;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    releaseActive();
+    await results;
+
+    expect(calls).toBe(concurrency);
+    expect(starts).toBe(concurrency);
+  });
+
+  it('does not retry an active peer after another call opens the circuit', async () => {
+    const concurrency = config.claudeCodeMaxConcurrency;
+    let calls = 0;
+    let firstWaveReady!: () => void;
+    let peerFailed!: () => void;
+    let releaseActive!: () => void;
+    const firstWave = new Promise<void>((resolve) => { firstWaveReady = resolve; });
+    const peerFailure = new Promise<void>((resolve) => { peerFailed = resolve; });
+    const release = new Promise<void>((resolve) => { releaseActive = resolve; });
+
+    const transport: LlmTransport = async () => {
+      const call = ++calls;
+      if (call === concurrency) firstWaveReady();
+      await firstWave;
+      if (call === 1) throw new LlmSessionLimitError('7pm (Africa/Cairo)');
+      if (call === 2) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        peerFailed();
+        throw new Error('transient peer failure');
+      }
+      await release;
+      return JSON.stringify({ violations: [], serviceDescriptions: [] });
+    };
+    const provider = createLLMProvider(transport);
+
+    const results = Promise.allSettled(
+      Array.from({ length: concurrency }, () =>
+        provider.generateServiceViolations(serviceContext),
+      ),
+    );
+
+    await peerFailure;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    releaseActive();
+    await results;
+
+    expect(calls).toBe(concurrency);
+  });
+
+  it('keeps cancellation separate and does not start an external request', async () => {
+    let calls = 0;
+    let starts = 0;
+    const transport: LlmTransport = async () => {
+      calls++;
+      return JSON.stringify({ violations: [], serviceDescriptions: [] });
+    };
+    const provider = createLLMProvider(transport);
+    const controller = new AbortController();
+    provider.setAbortSignal(controller.signal);
+    controller.abort(new DOMException('Analysis cancelled', 'AbortError'));
+
+    const failure = provider.generateServiceViolations(serviceContext, {
+      onStart: () => { starts++; },
+    });
+
+    await expect(failure).rejects.toMatchObject({ name: 'AbortError' });
+    expect(calls).toBe(0);
+    expect(starts).toBe(0);
+  });
+
+  it('clears a tripped circuit when a new analysis starts', async () => {
+    let calls = 0;
+    let notifications = 0;
+    const transport: LlmTransport = async () => {
+      calls++;
+      if (calls === 1) throw new LlmSessionLimitError('7pm (Africa/Cairo)');
+      return JSON.stringify({ violations: [], serviceDescriptions: [] });
+    };
+    const provider = createLLMProvider(transport);
+    provider.setSessionLimitHandler?.(() => { notifications++; });
+    provider.setAnalysisId('analysis-1');
+
+    await expect(provider.generateServiceViolations(serviceContext)).rejects.toMatchObject({
+      code: 'LLM_SESSION_LIMIT',
+    });
+    await expect(provider.generateServiceViolations(serviceContext)).rejects.toMatchObject({
+      code: 'LLM_SESSION_LIMIT',
+    });
+    expect(calls).toBe(1);
+    expect(notifications).toBe(1);
+
+    provider.setAnalysisId('analysis-2');
+    await expect(provider.generateServiceViolations(serviceContext)).resolves.toEqual({
+      violations: [],
+      serviceDescriptions: [],
+    });
+    expect(calls).toBe(2);
+    expect(notifications).toBe(1);
+  });
+});

--- a/tests/core/cli-provider-session-limit.test.ts
+++ b/tests/core/cli-provider-session-limit.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const originalBinary = process.env.CLAUDE_CODE_BINARY;
+const originalCallsFile = process.env.TC_CLAUDE_CALLS_FILE;
+
+afterEach(() => {
+  if (originalBinary === undefined) delete process.env.CLAUDE_CODE_BINARY;
+  else process.env.CLAUDE_CODE_BINARY = originalBinary;
+  if (originalCallsFile === undefined) delete process.env.TC_CLAUDE_CALLS_FILE;
+  else process.env.TC_CLAUDE_CALLS_FILE = originalCallsFile;
+  vi.resetModules();
+});
+
+function fakeSessionLimitClaude(
+  resetHint: string,
+  exitCode = 1,
+): { binary: string; callsFile: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-session-limit-'));
+  const binary = path.join(dir, 'claude-session-limit.js');
+  const callsFile = path.join(dir, 'calls.txt');
+  fs.writeFileSync(
+    binary,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const callsFile = process.env.TC_CLAUDE_CALLS_FILE;
+const calls = fs.existsSync(callsFile) ? Number(fs.readFileSync(callsFile, 'utf8')) : 0;
+fs.writeFileSync(callsFile, String(calls + 1));
+process.stdout.write(JSON.stringify({
+  type: 'result',
+  subtype: 'success',
+  is_error: true,
+  api_error_status: 429,
+  result: "You've hit your session limit · resets ${resetHint}",
+  total_cost_usd: 0,
+  usage: { input_tokens: 0, output_tokens: 0 }
+}));
+process.exit(${exitCode});
+`,
+  );
+  fs.chmodSync(binary, 0o755);
+  return { binary, callsFile };
+}
+
+function fakeTransient429Claude(): { binary: string; callsFile: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-transient-429-'));
+  const binary = path.join(dir, 'claude-transient-429.js');
+  const callsFile = path.join(dir, 'calls.txt');
+  fs.writeFileSync(
+    binary,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const callsFile = process.env.TC_CLAUDE_CALLS_FILE;
+const calls = fs.existsSync(callsFile) ? Number(fs.readFileSync(callsFile, 'utf8')) : 0;
+fs.writeFileSync(callsFile, String(calls + 1));
+if (calls === 0) {
+  process.stdout.write(JSON.stringify({
+    type: 'result', subtype: 'error', is_error: true, api_error_status: 429,
+    result: 'Rate limited. Please retry shortly.'
+  }));
+  process.exit(1);
+}
+process.stdout.write(JSON.stringify({
+  type: 'result', subtype: 'success', is_error: false,
+  structured_output: { violations: [], serviceDescriptions: [] }
+}));
+process.exit(0);
+`,
+  );
+  fs.chmodSync(binary, 0o755);
+  return { binary, callsFile };
+}
+
+const serviceContext = {
+  architecture: 'monolith',
+  services: [
+    {
+      id: 'service-1',
+      name: 'orders',
+      type: 'backend',
+      framework: 'express',
+      fileCount: 1,
+      layers: [],
+    },
+  ],
+  dependencies: [],
+  llmRules: [],
+};
+
+describe('ClaudeCodeProvider session-limit handling', () => {
+  it.each(['6:40pm (Africa/Cairo)', '7pm (Africa/Cairo)'])(
+    'surfaces the observed reset hint %s and does not retry a definite session limit',
+    async (resetHint) => {
+      const fake = fakeSessionLimitClaude(resetHint);
+      process.env.CLAUDE_CODE_BINARY = fake.binary;
+      process.env.TC_CLAUDE_CALLS_FILE = fake.callsFile;
+      vi.resetModules();
+      const { ClaudeCodeProvider } = await import(
+        '../../packages/core/src/services/llm/cli-provider.js'
+      );
+
+      const provider = new ClaudeCodeProvider();
+      const failure = provider.generateServiceViolations(serviceContext).catch((error: unknown) => error);
+
+      await expect(failure).resolves.toMatchObject({
+        name: 'LlmSessionLimitError',
+        code: 'LLM_SESSION_LIMIT',
+        statusCode: 429,
+        resetHint,
+      });
+      expect(fs.readFileSync(fake.callsFile, 'utf8')).toBe('1');
+    },
+  );
+
+  it('classifies the same error envelope when Claude exits successfully', async () => {
+    const resetHint = '6:40pm (Africa/Cairo)';
+    const fake = fakeSessionLimitClaude(resetHint, 0);
+    process.env.CLAUDE_CODE_BINARY = fake.binary;
+    process.env.TC_CLAUDE_CALLS_FILE = fake.callsFile;
+    vi.resetModules();
+    const { ClaudeCodeProvider } = await import(
+      '../../packages/core/src/services/llm/cli-provider.js'
+    );
+
+    const failure = new ClaudeCodeProvider()
+      .generateServiceViolations(serviceContext)
+      .catch((error: unknown) => error);
+
+    await expect(failure).resolves.toMatchObject({
+      code: 'LLM_SESSION_LIMIT',
+      resetHint,
+    });
+    expect(fs.readFileSync(fake.callsFile, 'utf8')).toBe('1');
+  });
+
+  it('keeps bounded retry behavior for a generic 429 without a session-limit signal', async () => {
+    const fake = fakeTransient429Claude();
+    process.env.CLAUDE_CODE_BINARY = fake.binary;
+    process.env.TC_CLAUDE_CALLS_FILE = fake.callsFile;
+    vi.resetModules();
+    const { ClaudeCodeProvider } = await import(
+      '../../packages/core/src/services/llm/cli-provider.js'
+    );
+
+    const result = await new ClaudeCodeProvider().generateServiceViolations(serviceContext);
+
+    expect(result).toEqual({ violations: [], serviceDescriptions: [] });
+    expect(fs.readFileSync(fake.callsFile, 'utf8')).toBe('2');
+  });
+});

--- a/tests/shared/llm-transport.test.ts
+++ b/tests/shared/llm-transport.test.ts
@@ -108,6 +108,43 @@ process.exit(0);
   );
 }
 
+function fakeSessionLimitStreamBin(exitCode: number, includeInit: boolean): string {
+  return fakeNodeBin(
+    `claude-session-limit-${exitCode}-${includeInit ? 'stream' : 'result'}.js`,
+    `
+const w = (o) => process.stdout.write(JSON.stringify(o) + '\\n');
+${includeInit ? "w({ type: 'system', subtype: 'init', session_id: 's' });" : ''}
+w({
+  type: 'result',
+  subtype: 'error',
+  is_error: true,
+  api_error_status: 429,
+  result: "You've hit your session limit · resets 7pm (Africa/Cairo)"
+});
+process.exit(${exitCode});
+`,
+  );
+}
+
+function fakeGenericApiErrorBin(exitCode: number, includeInit: boolean): string {
+  return fakeNodeBin(
+    `claude-generic-error-${exitCode}-${includeInit ? 'stream' : 'result'}.js`,
+    `
+const w = (o) => process.stdout.write(JSON.stringify(o) + '\\n');
+${includeInit ? "w({ type: 'system', subtype: 'init', session_id: 's' });" : ''}
+w({
+  type: 'result',
+  subtype: 'error',
+  is_error: true,
+  api_error_status: 429,
+  result: 'Rate limited. Please retry shortly.'
+});
+process.stderr.write('transport-stderr');
+process.exit(${exitCode});
+`,
+  );
+}
+
 /** Capture the single call record the transport emits, restoring the sink. */
 async function captureRecord(run: () => Promise<unknown>): Promise<{ rec?: LlmCallRecord; error?: unknown }> {
   let rec: LlmCallRecord | undefined;
@@ -209,6 +246,41 @@ describe('agentTransport (filesystem mailbox)', () => {
     fs.mkdirSync(path.join(io, 'responses'), { recursive: true });
     fs.writeFileSync(path.join(io, 'responses', 'err-1.json'), JSON.stringify({ error: 'boom' }));
     await expect(agentTransport(io, { pollMs: 5 })({ id: 'err-1', system: 's', user: 'u' })).rejects.toThrow(/boom/);
+  });
+
+  it('preserves a native Claude session-limit envelope reported through the mailbox', async () => {
+    const io = tmpIo();
+    fs.mkdirSync(path.join(io, 'responses'), { recursive: true });
+    fs.writeFileSync(
+      path.join(io, 'responses', 'limit-1.json'),
+      JSON.stringify({
+        error: {
+          is_error: true,
+          api_error_status: 429,
+          result: "You've hit your session limit · resets 7pm (Africa/Cairo)",
+        },
+      }),
+    );
+
+    await expect(
+      agentTransport(io, { pollMs: 5 })({ id: 'limit-1', system: 's', user: 'u' }),
+    ).rejects.toMatchObject({
+      code: 'LLM_SESSION_LIMIT',
+      resetHint: '7pm (Africa/Cairo)',
+    });
+  });
+
+  it('keeps accepting a successful mailbox response with a nullable error field', async () => {
+    const io = tmpIo();
+    fs.mkdirSync(path.join(io, 'responses'), { recursive: true });
+    fs.writeFileSync(
+      path.join(io, 'responses', 'nullable-error.json'),
+      JSON.stringify({ text: 'ok', error: null }),
+    );
+
+    await expect(
+      agentTransport(io, { pollMs: 5 })({ id: 'nullable-error', system: 's', user: 'u' }),
+    ).resolves.toBe('ok');
   });
 
   it('reuses an existing response without re-writing the request (resume)', async () => {
@@ -352,6 +424,44 @@ describe('cliTransport streaming (stream-json)', () => {
     expect(rec?.cacheCreateTokens).toBe(10);
     expect(rec?.costUsd).toBeCloseTo(0.002);
     expect(rec?.model).toBe('claude-test-1');
+  });
+
+  it('preserves a streamed Claude session-limit envelope when the CLI exits nonzero', async () => {
+    const transport = cliTransport({ bin: fakeSessionLimitStreamBin(1, true) });
+
+    await expect(
+      transport({ id: 'limit-exit-1', stage: 'test', system: 's', user: 'u', timeoutMs: 5000 }),
+    ).rejects.toMatchObject({
+      code: 'LLM_SESSION_LIMIT',
+      resetHint: '7pm (Africa/Cairo)',
+    });
+  });
+
+  it('classifies a lone exit-zero Claude error result before enforcing successful streaming', async () => {
+    const transport = cliTransport({ bin: fakeSessionLimitStreamBin(0, false) });
+
+    await expect(
+      transport({ id: 'limit-exit-0', stage: 'test', system: 's', user: 'u', timeoutMs: 5000 }),
+    ).rejects.toMatchObject({
+      code: 'LLM_SESSION_LIMIT',
+      resetHint: '7pm (Africa/Cairo)',
+    });
+  });
+
+  it('keeps nonzero generic API failures on the existing stderr-rich exit path', async () => {
+    const transport = cliTransport({ bin: fakeGenericApiErrorBin(1, true) });
+
+    await expect(
+      transport({ id: 'generic-exit-1', stage: 'test', system: 's', user: 'u', timeoutMs: 5000 }),
+    ).rejects.toThrow(/claude exited 1: transport-stderr/);
+  });
+
+  it('still rejects a lone exit-zero generic API error as non-streaming output', async () => {
+    const transport = cliTransport({ bin: fakeGenericApiErrorBin(0, false) });
+
+    await expect(
+      transport({ id: 'generic-exit-0', stage: 'test', system: 's', user: 'u', timeoutMs: 5000 }),
+    ).rejects.toThrow(/did not stream.*stream-json/);
   });
 
   it('kills a started-then-silent stream as a stall, distinct from the ceiling', async () => {


### PR DESCRIPTION
## Summary

- recognize definite Claude session-limit responses across direct CLI, installed, streaming, and agent-mailbox transports while preserving retries and diagnostics for generic 429 responses
- open a provider-wide circuit on the first definite limit so queued calls and retries from already-admitted peers do not make unnecessary external requests
- surface the reset hint immediately through the existing analysis tracker, including that queued work stopped while active calls finish
- propagate the terminal failure through LLM aggregation so the interrupted run does not update `LATEST.json`, history, or the canonical analysis chain

## Root cause

Claude reports an exhausted session with an error result whose API status is 429. Depending on the transport, that result can arrive as a native error envelope or the installed CLI wrapper `claude API error (api 429): ...`. The provider previously treated the wrapped response like every other process/parse failure and retried it, while streaming and agent-mailbox adapters could replace or generically wrap the native envelope before it reached the provider.

Concurrent calls were already queued behind the provider limiter, and several `Promise.allSettled()` aggregation points logged and omitted rejected LLM work. That combination could keep spending attempts after the session was unavailable and then persist an incomplete run as completed.

This change matches the structural error fields or the exact wrapped Claude API-429 shape together with the session-limit phrase, extracts the variable reset hint, and leaves a bare/generic 429 on the existing bounded-retry path. Cancellation remains a separate, higher-priority path.

## Scope and tradeoff

This is the first damage-containment slice for #791, not the complete fix, and it must not close the issue.

The interrupted run is deliberately not written into `LATEST.json` or the completed-analysis chain. Successful LLM calls from that interrupted run are not reusable yet, so rerunning can spend those tokens again. This PR limits additional waste after a definite session-limit response and protects the last completed baseline; it does not claim token preservation or resumability.

The complete design distinguishes the **latest attempted run** from the **latest completed analysis**. This PR protects only the latter: a blocked attempt cannot replace the trustworthy completed findings baseline. Later slices will store the attempted run in a separate durable journal with explicit `running`, `blocked`, `failed`, `finalizing`, and `completed` states; expose completed/pending/failed counts, reset time, and Resume through the CLI/dashboard/API; and atomically promote that run to the completed baseline only after its full certified plan succeeds. It will not be implemented by adding `status: "incomplete"` to the current canonical `LATEST.json`; an envelope redesign would require a migration of every reader.

Checkpoints are not being rushed into this slice because current LLM outputs can contain analysis graph IDs that change between runs. Saving and replaying those resolved outputs without stable work identity and semantic fingerprints could attach findings to the wrong nodes or falsely resolve findings.

Required follow-up contributions in the same #791 plan will:

- assign every LLM work unit a stable identity and sufficient input fingerprint
- durably store each successful result in a separate run journal outside `LATEST.json` and the canonical chain
- validate repository content, baseline, rules, configuration, prompts/schemas, provider, and model before reuse
- resume only pending or failed work and preserve usage accounting without double-counting reused results
- finalize `LATEST.json` only after the complete work plan succeeds, or report mixed success/failure and explicitly ask whether to bypass the integrity gate and save anyway
- allow interrupted runs to resume and/or restart their interrupted provider sessions after the reported limit reset

## Validation

- `pnpm lint` — 14/14 tasks passed
- `pnpm build` — 19/19 tasks passed
- focused provider, shared/agent transport, and production analysis-integrity matrix — 5 files and 52/52 tests passed
- `dotnet build -c Release tools/csharp-roslyn-host` — succeeded with 0 errors; two NU1900 warnings because the NuGet vulnerability feed was unavailable
- `git diff --check`
- fresh independent spec and standards audits — no P0-P3 findings

The focused tests cover the observed Claude response variants, native and exact installed-wrapper forms, exit-code 0 and nonzero streaming envelopes, structured and nullable mailbox responses, generic-429 retries and existing generic diagnostics, queued and already-admitted circuit behavior, cancellation precedence, circuit reset/one-shot notification, visible reset communication, and isolated service/code/database failures with unchanged canonical files.

One full-suite run was attempted after the required builds but did not pass in this restricted environment. Its visible failures were dominated by sandbox-denied socket listeners and home-directory writes, fixture URL paths under a checkout path containing spaces, unavailable experimental Node `localStorage`, the known unrestored .NET fixture, and production-test hook timeouts under the large concurrent run. The same production integrity file passed 3/3 in isolation and in the combined focused matrix above. CI remains the authoritative broad-suite run.

Part of #791
