### PR TITLE
feat(llm): retain exact context batch provenance

### DIFF
--- a/packages/core/src/services/llm/context-router.ts
+++ b/packages/core/src/services/llm/context-router.ts
@@ -14,6 +14,23 @@ export interface ContextBatch {
   estimatedTokens: number;
   /** Real file paths included in this batch (full-file/legacy tiers only). */
   filePaths?: string[];
+  /** Exact repository source scope represented by this batch. */
+  sources: ContextBatchSource[];
+}
+
+export interface ContextBatchSource {
+  path: string;
+  selection:
+    | { kind: 'metadata'; fields: MetadataField[] }
+    | { kind: 'full-file' }
+    | {
+        kind: 'targeted';
+        functions: Array<{
+          name: string;
+          startLine: number;
+          endLine: number;
+        }>;
+      };
 }
 
 export interface PreFlightEstimate {
@@ -186,7 +203,7 @@ function extractTargetedFunctions(
 // Metadata summary builder
 // ---------------------------------------------------------------------------
 
-type MetadataField = NonNullable<ContextRequirement['metadataFields']>[number];
+export type MetadataField = NonNullable<ContextRequirement['metadataFields']>[number];
 
 function buildMetadataSummary(fa: FileAnalysis, fields: MetadataField[]): string {
   const parts: string[] = [`=== ${fa.filePath} ===`];
@@ -312,7 +329,7 @@ function buildMetadataContent(
   group: { rules: RuleDto[]; requirement: ContextRequirement },
   fileAnalyses: FileAnalysis[],
   fileContents: Map<string, { content: string; lineCount: number }>,
-): { content: string; fileCount: number } {
+): { content: string; fileCount: number; sources: ContextBatchSource[] } {
   const matching = fileAnalyses.filter((fa) => {
     if (!group.requirement.fileFilter) return true;
     const fc = fileContents.get(fa.filePath);
@@ -322,17 +339,25 @@ function buildMetadataContent(
   const fields = (group.requirement.metadataFields || ['functions', 'imports', 'exports']) as MetadataField[];
   const summaries = matching.map((fa) => buildMetadataSummary(fa, fields));
 
-  return { content: summaries.join('\n\n'), fileCount: matching.length };
+  return {
+    content: summaries.join('\n\n'),
+    fileCount: matching.length,
+    sources: matching.map((fa) => ({
+      path: fa.filePath,
+      selection: { kind: 'metadata', fields },
+    })),
+  };
 }
 
 function buildTargetedContent(
   group: { rules: RuleDto[]; requirement: ContextRequirement },
   fileAnalyses: FileAnalysis[],
   fileContents: Map<string, { content: string; lineCount: number }>,
-): { content: string; fileCount: number; functionCount: number } {
+): { content: string; fileCount: number; functionCount: number; sources: ContextBatchSource[] } {
   const filter = group.requirement.functionFilter || {};
   let totalFunctions = 0;
   const parts: string[] = [];
+  const sources: ContextBatchSource[] = [];
 
   for (const fa of fileAnalyses) {
     const fc = fileContents.get(fa.filePath);
@@ -355,16 +380,23 @@ function buildTargetedContent(
       fileParts.push(`--- ${fn.name} (lines ${fn.startLine}-${fn.endLine}) ---\n${numbered}`);
     }
     parts.push(fileParts.join('\n'));
+    sources.push({
+      path: fa.filePath,
+      selection: {
+        kind: 'targeted',
+        functions: extracted.map(({ name, startLine, endLine }) => ({ name, startLine, endLine })),
+      },
+    });
   }
 
-  return { content: parts.join('\n\n'), fileCount: parts.length, functionCount: totalFunctions };
+  return { content: parts.join('\n\n'), fileCount: parts.length, functionCount: totalFunctions, sources };
 }
 
 function buildFullFileContent(
   group: { rules: RuleDto[]; requirement: ContextRequirement },
   fileAnalyses: FileAnalysis[],
   fileContents: Map<string, { content: string; lineCount: number }>,
-): { content: string; fileCount: number; filePaths: string[] } {
+): { content: string; fileCount: number; filePaths: string[]; sources: ContextBatchSource[] } {
   const parts: string[] = [];
   const filePaths: string[] = [];
 
@@ -384,7 +416,15 @@ function buildFullFileContent(
     filePaths.push(fa.filePath);
   }
 
-  return { content: parts.join('\n\n'), fileCount: parts.length, filePaths };
+  return {
+    content: parts.join('\n\n'),
+    fileCount: parts.length,
+    filePaths,
+    sources: filePaths.map((filePath) => ({
+      path: filePath,
+      selection: { kind: 'full-file' },
+    })),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -398,6 +438,7 @@ function splitIntoBatches(
   fileCount: number,
   functionCount?: number,
   filePaths?: string[],
+  sources: ContextBatchSource[] = [],
 ): ContextBatch[] {
   if (content.length === 0) return [];
 
@@ -412,6 +453,7 @@ function splitIntoBatches(
       functionCount,
       estimatedTokens,
       filePaths,
+      sources,
     }];
   }
 
@@ -421,6 +463,15 @@ function splitIntoBatches(
   let currentContent = '';
   let currentFileCount = 0;
   let currentFilePaths: string[] = [];
+  let currentSources: ContextBatchSource[] = [];
+
+  const targetedFunctionCount = (batchSources: ContextBatchSource[]): number | undefined => {
+    if (tier !== 'targeted') return undefined;
+    return batchSources.reduce(
+      (sum, source) => sum + (source.selection.kind === 'targeted' ? source.selection.functions.length : 0),
+      0,
+    );
+  };
 
   for (let si = 0; si < sections.length; si++) {
     const section = sections[si];
@@ -430,16 +481,20 @@ function splitIntoBatches(
         rules,
         content: currentContent,
         fileCount: currentFileCount,
+        functionCount: targetedFunctionCount(currentSources),
         estimatedTokens: Math.ceil(currentContent.length / CHARS_PER_TOKEN),
         filePaths: currentFilePaths.length > 0 ? currentFilePaths : undefined,
+        sources: currentSources,
       });
       currentContent = '';
       currentFileCount = 0;
       currentFilePaths = [];
+      currentSources = [];
     }
     currentContent += (currentContent ? '\n\n' : '') + section;
     currentFileCount++;
     if (filePaths && filePaths[si]) currentFilePaths.push(filePaths[si]);
+    if (sources[si]) currentSources.push(sources[si]);
   }
 
   if (currentContent.length > 0) {
@@ -448,8 +503,10 @@ function splitIntoBatches(
       rules,
       content: currentContent,
       fileCount: currentFileCount,
+      functionCount: targetedFunctionCount(currentSources),
       estimatedTokens: Math.ceil(currentContent.length / CHARS_PER_TOKEN),
       filePaths: currentFilePaths.length > 0 ? currentFilePaths : undefined,
+      sources: currentSources,
     });
   }
 
@@ -626,25 +683,25 @@ function routeContextInner(
 
   // Metadata batches
   for (const group of grouped.metadata) {
-    const { content, fileCount } = buildMetadataContent(group, fileAnalyses, fileContents);
+    const { content, fileCount, sources } = buildMetadataContent(group, fileAnalyses, fileContents);
     if (fileCount > 0) {
-      batches.push(...splitIntoBatches('metadata', group.rules, content, fileCount));
+      batches.push(...splitIntoBatches('metadata', group.rules, content, fileCount, undefined, undefined, sources));
     }
   }
 
   // Targeted batches
   for (const group of grouped.targeted) {
-    const { content, fileCount, functionCount } = buildTargetedContent(group, fileAnalyses, fileContents);
+    const { content, fileCount, functionCount, sources } = buildTargetedContent(group, fileAnalyses, fileContents);
     if (fileCount > 0) {
-      batches.push(...splitIntoBatches('targeted', group.rules, content, fileCount, functionCount));
+      batches.push(...splitIntoBatches('targeted', group.rules, content, fileCount, functionCount, undefined, sources));
     }
   }
 
   // Full-file batches
   for (const group of grouped.fullFile) {
-    const { content, fileCount, filePaths } = buildFullFileContent(group, fileAnalyses, fileContents);
+    const { content, fileCount, filePaths, sources } = buildFullFileContent(group, fileAnalyses, fileContents);
     if (fileCount > 0) {
-      batches.push(...splitIntoBatches('full-file', group.rules, content, fileCount, undefined, filePaths));
+      batches.push(...splitIntoBatches('full-file', group.rules, content, fileCount, undefined, filePaths, sources));
     }
   }
 

--- a/tests/core/llm-context-scope.test.ts
+++ b/tests/core/llm-context-scope.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'vitest';
+import type { AnalysisRule, FileAnalysis } from '@truecourse/shared';
+import { routeContext } from '../../packages/core/src/services/llm/context-router.js';
+
+describe('routeContext source scope', () => {
+  it('retains the exact function ranges represented by a targeted batch', () => {
+    const filePath = '/repo/src/orders.ts';
+    const content = [
+      'export async function placeOrder() {',
+      '  return await saveOrder();',
+      '}',
+      '',
+      'export function formatOrder() {',
+      "  return 'formatted';",
+      '}',
+    ].join('\n');
+    const fileAnalysis = {
+      filePath,
+      language: 'typescript',
+      functions: [
+        {
+          name: 'placeOrder',
+          isAsync: true,
+          isExported: true,
+          params: [],
+          returnType: 'Promise<void>',
+          location: { startLine: 1, endLine: 3 },
+        },
+        {
+          name: 'formatOrder',
+          isAsync: false,
+          isExported: true,
+          params: [],
+          returnType: 'string',
+          location: { startLine: 5, endLine: 7 },
+        },
+      ],
+      classes: [],
+      imports: [],
+      exports: [],
+      calls: [],
+      httpCalls: [],
+      routeRegistrations: [],
+    } as unknown as FileAnalysis;
+    const rule = {
+      key: 'reliability/llm/async-boundary',
+      name: 'Async boundary',
+      severity: 'high',
+      prompt: 'Review async error handling.',
+      category: 'code',
+      type: 'llm',
+      contextRequirement: {
+        tier: 'targeted',
+        fileFilter: { languages: ['typescript'] },
+        functionFilter: { isAsync: true },
+      },
+    } as unknown as AnalysisRule;
+    const excludedPath = '/repo/src/orders.py';
+    const excludedAnalysis = {
+      ...fileAnalysis,
+      filePath: excludedPath,
+      language: 'python',
+    } as unknown as FileAnalysis;
+
+    const batches = routeContext(
+      [rule],
+      [fileAnalysis, excludedAnalysis],
+      new Map([
+        [filePath, { content, lineCount: 7 }],
+        [excludedPath, { content, lineCount: 7 }],
+      ]),
+    );
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0].sources).toEqual([
+      {
+        path: filePath,
+        selection: {
+          kind: 'targeted',
+          functions: [
+            { name: 'placeOrder', startLine: 1, endLine: 3 },
+          ],
+        },
+      },
+    ]);
+    expect(batches[0].content).toContain('placeOrder');
+    expect(batches[0].content).not.toContain('formatOrder');
+    expect(batches[0].content).not.toContain(excludedPath);
+  });
+
+  it('retains the exact files and fields represented by a metadata batch', () => {
+    const filePath = '/repo/src/orders.ts';
+    const fileAnalysis = {
+      filePath,
+      language: 'typescript',
+      functions: [],
+      classes: [],
+      imports: [{ source: './db.js' }],
+      exports: [],
+      calls: [],
+      httpCalls: [],
+      routeRegistrations: [],
+    } as unknown as FileAnalysis;
+    const rule = {
+      key: 'architecture/llm/import-boundary',
+      name: 'Import boundary',
+      severity: 'medium',
+      prompt: 'Review import boundaries.',
+      category: 'code',
+      type: 'llm',
+      contextRequirement: {
+        tier: 'metadata',
+        fileFilter: { languages: ['typescript'] },
+        metadataFields: ['imports'],
+      },
+    } as unknown as AnalysisRule;
+    const excludedPath = '/repo/src/orders.py';
+    const excludedAnalysis = {
+      ...fileAnalysis,
+      filePath: excludedPath,
+      language: 'python',
+    } as unknown as FileAnalysis;
+
+    const batches = routeContext(
+      [rule],
+      [fileAnalysis, excludedAnalysis],
+      new Map([
+        [filePath, { content: "import './db.js';\n", lineCount: 1 }],
+        [excludedPath, { content: 'from db import save\n', lineCount: 1 }],
+      ]),
+    );
+
+    expect(batches[0].sources).toEqual([
+      {
+        path: filePath,
+        selection: { kind: 'metadata', fields: ['imports'] },
+      },
+    ]);
+    expect(batches[0].content).not.toContain(excludedPath);
+  });
+
+  it('retains the exact files represented by a full-file batch', () => {
+    const filePath = '/repo/src/orders.ts';
+    const fileAnalysis = {
+      filePath,
+      language: 'typescript',
+      functions: [],
+      classes: [],
+      imports: [],
+      exports: [],
+      calls: [],
+      httpCalls: [],
+      routeRegistrations: [],
+    } as unknown as FileAnalysis;
+    const rule = {
+      key: 'reliability/llm/file-review',
+      name: 'File review',
+      severity: 'medium',
+      prompt: 'Review this file.',
+      category: 'code',
+      type: 'llm',
+      contextRequirement: {
+        tier: 'full-file',
+        fileFilter: { languages: ['typescript'] },
+      },
+    } as unknown as AnalysisRule;
+    const excludedPath = '/repo/src/orders.py';
+    const excludedAnalysis = {
+      ...fileAnalysis,
+      filePath: excludedPath,
+      language: 'python',
+    } as unknown as FileAnalysis;
+
+    const batches = routeContext(
+      [rule],
+      [fileAnalysis, excludedAnalysis],
+      new Map([
+        [filePath, { content: 'export const order = 1;\n', lineCount: 1 }],
+        [excludedPath, { content: 'order = 1\n', lineCount: 1 }],
+      ]),
+    );
+
+    expect(batches[0].sources).toEqual([
+      { path: filePath, selection: { kind: 'full-file' } },
+    ]);
+    expect(batches[0].content).not.toContain(excludedPath);
+  });
+
+  it('keeps each oversized split tied to only the sources it contains', () => {
+    const firstPath = '/repo/src/first.ts';
+    const secondPath = '/repo/src/second.ts';
+    const fileAnalysis = (filePath: string) => ({
+      filePath,
+      language: 'typescript',
+      functions: [],
+      classes: [],
+      imports: [],
+      exports: [],
+      calls: [],
+      httpCalls: [],
+      routeRegistrations: [],
+    }) as unknown as FileAnalysis;
+    const rule = {
+      key: 'reliability/llm/file-review',
+      name: 'File review',
+      severity: 'medium',
+      prompt: 'Review this file.',
+      category: 'code',
+      type: 'llm',
+      contextRequirement: { tier: 'full-file' },
+    } as unknown as AnalysisRule;
+    const largeSource = 'x'.repeat(60_000);
+
+    const batches = routeContext(
+      [rule],
+      [fileAnalysis(firstPath), fileAnalysis(secondPath)],
+      new Map([
+        [firstPath, { content: largeSource, lineCount: 1 }],
+        [secondPath, { content: largeSource, lineCount: 1 }],
+      ]),
+    );
+
+    expect(batches).toHaveLength(2);
+    for (const [index, path] of [firstPath, secondPath].entries()) {
+      const otherPath = index === 0 ? secondPath : firstPath;
+      expect(batches[index]).toEqual(expect.objectContaining({
+        fileCount: 1,
+        filePaths: [path],
+        sources: [{ path, selection: { kind: 'full-file' } }],
+      }));
+      expect(batches[index].content).toContain(`=== ${path} ===`);
+      expect(batches[index].content).not.toContain(`=== ${otherPath} ===`);
+    }
+  });
+
+  it('keeps targeted scope and function counts aligned through oversized splits', () => {
+    const firstPath = '/repo/src/first.ts';
+    const secondPath = '/repo/src/second.ts';
+    const largeBody = 'x'.repeat(60_000);
+    const content = (name: string) => [
+      `export async function ${name}() {`,
+      `  return '${largeBody}';`,
+      '}',
+    ].join('\n');
+    const fileAnalysis = (filePath: string, name: string) => ({
+      filePath,
+      language: 'typescript',
+      functions: [{
+        name,
+        isAsync: true,
+        isExported: true,
+        params: [],
+        returnType: 'Promise<string>',
+        location: { startLine: 1, endLine: 3 },
+      }],
+      classes: [],
+      imports: [],
+      exports: [],
+      calls: [],
+      httpCalls: [],
+      routeRegistrations: [],
+    }) as unknown as FileAnalysis;
+    const rule = {
+      key: 'reliability/llm/async-boundary',
+      name: 'Async boundary',
+      severity: 'high',
+      prompt: 'Review async error handling.',
+      category: 'code',
+      type: 'llm',
+      contextRequirement: {
+        tier: 'targeted',
+        functionFilter: { isAsync: true },
+      },
+    } as unknown as AnalysisRule;
+
+    const batches = routeContext(
+      [rule],
+      [fileAnalysis(firstPath, 'first'), fileAnalysis(secondPath, 'second')],
+      new Map([
+        [firstPath, { content: content('first'), lineCount: 3 }],
+        [secondPath, { content: content('second'), lineCount: 3 }],
+      ]),
+    );
+
+    expect(batches).toHaveLength(2);
+    for (const [index, [path, name]] of [
+      [firstPath, 'first'],
+      [secondPath, 'second'],
+    ].entries()) {
+      const otherPath = index === 0 ? secondPath : firstPath;
+      expect(batches[index]).toEqual(expect.objectContaining({
+        fileCount: 1,
+        functionCount: 1,
+        sources: [{
+          path,
+          selection: {
+            kind: 'targeted',
+            functions: [{ name, startLine: 1, endLine: 3 }],
+          },
+        }],
+      }));
+      expect(batches[index].content).toContain(`=== ${path} ===`);
+      expect(batches[index].content).not.toContain(`=== ${otherPath} ===`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add structured source provenance to analyze LLM context batches
- retain requested metadata fields, exact targeted function ranges, and full-file membership
- keep provenance, content, file paths, and targeted function counts aligned through oversized file-boundary splits
- preserve the existing file and prompt order

## Why

The resumability work in #791 needs each future LLM work item to describe exactly which repository source it represents. Metadata and targeted batches currently carry only rendered text, while full-file batches carry paths separately. That is not a safe foundation for stable work identity or result ownership.

This focused slice records that scope structurally at the router boundary without changing execution or persistence.

## Scope boundary

This is an in-memory prerequisite only. The new `sources` field is not consumed by execution yet.

It does **not** add stable work IDs, fingerprints, repository-relative path normalization, deterministic routing, a durable journal, replay, token reuse, resume behavior, usage reconciliation, or any `LATEST.json`/canonical-analysis change. Successful calls from an interrupted run are still not reusable, so rerunning can still spend those tokens again.

The later #791 contributions still must add the provider identity seam, complete work manifest, exact lifecycle ownership, database and architecture failure ownership, durable per-work journaling, compatibility validation, pending/failed-only resume, exact-once usage, reset-aware continuation, and guarded finalization.

Part of #791. This PR does not resolve or close it.

## Validation

- `pnpm exec vitest run tests/core/llm-context-scope.test.ts` — 5 tests passed
- `pnpm lint` — 14/14 tasks passed
- `pnpm build` — 19/19 tasks passed
- `dotnet build -c Release tools/csharp-roslyn-host` — 0 errors; two NU1900 vulnerability-feed warnings
- fresh independent spec, correctness, and test audits — no remaining P1/P2 findings

The focused tests cover included and excluded metadata/targeted/full-file scope, plus full-file and targeted oversized-split alignment. GitHub Actions remains the authoritative broad-suite run; the restricted local broad run was not used as passing evidence because its socket-dependent route tests cannot listen in this environment.
