### PR TITLE
fix(llm): preserve database violation lifecycle

### DIFF
--- a/packages/core/src/services/llm/cli-provider.ts
+++ b/packages/core/src/services/llm/cli-provider.ts
@@ -26,6 +26,7 @@ import {
 } from './prompts.js';
 import {
   ServiceViolationOutputSchema,
+  DatabaseLifecycleViolationOutputSchema,
   DatabaseViolationOutputSchema,
   ModuleViolationOutputSchema,
   DiffViolationOutputSchema,
@@ -53,6 +54,7 @@ import type {
   FlowEnrichmentResult,
   DiffViolationItem,
   DiffViolationsResult,
+  DatabaseViolationsLifecycleResult,
   ServiceDescription,
 } from './provider.js';
 
@@ -443,6 +445,40 @@ export abstract class BaseCLIProvider implements LLMProvider {
     };
   }
 
+  async generateDatabaseViolationsWithLifecycle(
+    context: DatabaseViolationContext,
+    opts?: { onStart?: () => void },
+  ): Promise<DatabaseViolationsLifecycleResult> {
+    const { vars, idMap } = buildDatabaseTemplateVars(context);
+    const prompt = getPrompt('violations-database-lifecycle', vars);
+
+    log.info('[CLI] Lifecycle database call starting...');
+    const t0 = Date.now();
+    const { data: object, usage: cliUsage } = await this.spawnAndParse(
+      prompt,
+      DatabaseLifecycleViolationOutputSchema,
+      {
+        extraArgs: ['--tools', ''],
+        label: 'database-lifecycle',
+        onStart: opts?.onStart,
+      },
+    );
+    const dur = Date.now() - t0;
+    log.info(`[CLI] Lifecycle database call done in ${dur}ms — resolved: ${object.resolvedViolationIds.length}, new: ${object.newViolations.length}`);
+    this.collectUsage('database', cliUsage, dur);
+
+    return {
+      resolvedViolationIds: resolveIds(object.resolvedViolationIds, idMap),
+      unchangedViolationIds: resolveIds(object.unchangedViolationIds, idMap),
+      newViolations: object.newViolations.map((violation) => ({
+        ...violation,
+        targetDatabaseId: violation.targetDatabaseId?.startsWith('db-')
+          ? idMap.get(violation.targetDatabaseId) ?? null
+          : null,
+      })),
+    };
+  }
+
   async generateModuleViolations(
     context: ModuleViolationContext,
     opts?: { onStart?: () => void },
@@ -543,6 +579,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
   ): Promise<AllViolationsLifecycleResult> {
     const onCallStart = contexts.onCallStart;
     const allResolved: string[] = [];
+    const allUnchanged: string[] = [];
     const allNew: DiffViolationItem[] = [];
     let serviceDescriptions: ServiceDescription[] = [];
 
@@ -578,20 +615,9 @@ export abstract class BaseCLIProvider implements LLMProvider {
     if (contexts.database) {
       const ctx = contexts.database;
       if (ctx.existingViolations && ctx.existingViolations.length > 0) {
-        promises.push(['database', (async () => {
-          const { vars, idMap } = buildDatabaseTemplateVars(ctx);
-          idMaps.database = idMap;
-          const prompt = getPrompt('violations-database-lifecycle', vars);
-          log.info('[CLI] Lifecycle database call starting...');
-          const t0 = Date.now();
-          const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, DiffViolationOutputSchema, {
-            extraArgs: ['--tools', ''], label: 'database-lifecycle', onStart: () => onCallStart?.('database'),
-          });
-          const dur = Date.now() - t0;
-          log.info(`[CLI] Lifecycle database call done in ${dur}ms — resolved: ${object.resolvedViolationIds.length}, new: ${object.newViolations.length}`);
-          this.collectUsage('database', cliUsage, dur);
-          return object;
-        })()]);
+        promises.push(['database', this.generateDatabaseViolationsWithLifecycle(ctx, {
+          onStart: () => onCallStart?.('database'),
+        })]);
       } else {
         promises.push(['database-normal', this.generateDatabaseViolations(ctx, {
           onStart: () => onCallStart?.('database'),
@@ -620,6 +646,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
           this.collectUsage('module', cliUsage, dur);
           return {
             resolvedViolationIds: resolveIds(object.resolvedViolationIds, idMap),
+            unchangedViolationIds: resolveIds(object.unchangedViolationIds, idMap),
             newViolations: object.newViolations.map((i) => {
               const realModuleId = resolveId(i.targetModuleId, idMap);
               return {
@@ -668,8 +695,9 @@ export abstract class BaseCLIProvider implements LLMProvider {
 
       if (key === 'service') {
         const idMap = idMaps.service;
-        const result = outcome.value as { resolvedViolationIds: string[]; newViolations: DiffViolationItem[]; serviceDescriptions: ServiceDescription[] };
+        const result = outcome.value as { resolvedViolationIds: string[]; unchangedViolationIds: string[]; newViolations: DiffViolationItem[]; serviceDescriptions: ServiceDescription[] };
         allResolved.push(...resolveIds(result.resolvedViolationIds, idMap));
+        allUnchanged.push(...resolveIds(result.unchangedViolationIds, idMap));
         allNew.push(...result.newViolations.map((v) => ({
           ...v,
           targetServiceId: resolveId(v.targetServiceId, idMap) ?? null,
@@ -696,21 +724,24 @@ export abstract class BaseCLIProvider implements LLMProvider {
           });
         }
       } else if (key === 'database') {
-        const idMap = idMaps.database;
-        const result = outcome.value as DiffViolationsResult;
-        allResolved.push(...resolveIds(result.resolvedViolationIds, idMap));
+        const result = outcome.value as DatabaseViolationsLifecycleResult;
+        allResolved.push(...result.resolvedViolationIds);
+        allUnchanged.push(...result.unchangedViolationIds);
         allNew.push(...result.newViolations.map((v) => ({
           ...v,
-          targetServiceId: v.targetServiceId ?? null,
-          targetModuleId: v.targetModuleId ?? null,
-          targetMethodId: v.targetMethodId ?? null,
-          targetServiceName: v.targetServiceName ?? null,
-          targetModuleName: v.targetModuleName ?? null,
-          targetMethodName: v.targetMethodName ?? null,
+          targetServiceId: null,
+          targetDatabaseId: v.targetDatabaseId,
+          targetModuleId: null,
+          targetMethodId: null,
+          targetTable: v.targetTable ?? null,
+          targetServiceName: null,
+          targetModuleName: null,
+          targetMethodName: null,
         })));
       } else if (key === 'module') {
         const result = outcome.value as DiffViolationsResult;
         allResolved.push(...result.resolvedViolationIds);
+        allUnchanged.push(...result.unchangedViolationIds);
         allNew.push(...result.newViolations.map((v) => ({
           ...v,
           targetServiceId: v.targetServiceId ?? null,
@@ -736,7 +767,12 @@ export abstract class BaseCLIProvider implements LLMProvider {
       }
     }
 
-    return { resolvedViolationIds: allResolved, newViolations: allNew, serviceDescriptions };
+    return {
+      resolvedViolationIds: allResolved,
+      unchangedViolationIds: allUnchanged,
+      newViolations: allNew,
+      serviceDescriptions,
+    };
   }
 
   async generateCodeViolations(

--- a/packages/core/src/services/llm/provider.ts
+++ b/packages/core/src/services/llm/provider.ts
@@ -147,6 +147,8 @@ export interface DiffViolationItem {
   targetServiceId: string | null;
   targetModuleId: string | null;
   targetMethodId: string | null;
+  targetDatabaseId?: string | null;
+  targetTable?: string | null;
   targetServiceName: string | null;
   targetModuleName: string | null;
   targetMethodName: string | null;
@@ -156,7 +158,23 @@ export interface DiffViolationItem {
 
 export interface DiffViolationsResult {
   resolvedViolationIds: string[];
+  unchangedViolationIds: string[];
   newViolations: DiffViolationItem[];
+}
+
+export interface DatabaseViolationsLifecycleResult {
+  resolvedViolationIds: string[];
+  unchangedViolationIds: string[];
+  newViolations: Array<{
+    type: 'database';
+    title: string;
+    content: string;
+    severity: string;
+    targetDatabaseId: string | null;
+    targetTable: string | null;
+    fixPrompt: string | null;
+    ruleKey: string;
+  }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -206,6 +224,7 @@ export interface AllViolationsResult {
 /** Result when existing violations are provided — lifecycle mode */
 export interface AllViolationsLifecycleResult {
   resolvedViolationIds: string[];
+  unchangedViolationIds: string[];
   newViolations: DiffViolationItem[];
   serviceDescriptions: ServiceDescription[];
 }
@@ -237,6 +256,10 @@ export interface LLMProvider {
     context: DatabaseViolationContext,
     opts?: { onStart?: () => void },
   ): Promise<DatabaseViolationsResult>;
+  generateDatabaseViolationsWithLifecycle(
+    context: DatabaseViolationContext,
+    opts?: { onStart?: () => void },
+  ): Promise<DatabaseViolationsLifecycleResult>;
   generateModuleViolations(
     context: ModuleViolationContext,
     opts?: { onStart?: () => void },

--- a/packages/core/src/services/llm/schemas.ts
+++ b/packages/core/src/services/llm/schemas.ts
@@ -25,19 +25,25 @@ export const ServiceViolationOutputSchema = z.object({
   ),
 });
 
+export const DatabaseViolationItemSchema = z.object({
+  type: z.literal('database'),
+  title: z.string(),
+  content: z.string(),
+  severity: z.enum(['low', 'medium', 'high', 'critical']),
+  targetDatabaseId: z.string().nullable().describe('The id of the database this violation applies to, must be an exact id from the Databases list'),
+  targetTable: z.string().nullable().describe('The exact table name this violation applies to'),
+  fixPrompt: z.string().nullable(),
+  ruleKey: z.string().describe('The exact key from the Analysis Rules list that triggered this violation — must match one of the rule keys.'),
+});
+
 export const DatabaseViolationOutputSchema = z.object({
-  violations: z.array(
-    z.object({
-      type: z.literal('database'),
-      title: z.string(),
-      content: z.string(),
-      severity: z.enum(['low', 'medium', 'high', 'critical']),
-      targetDatabaseId: z.string().nullable().describe('The id of the database this violation applies to, must be an exact id from the Databases list'),
-      targetTable: z.string().nullable().describe('The exact table name this violation applies to'),
-      fixPrompt: z.string().nullable(),
-      ruleKey: z.string().describe('The exact key from the Analysis Rules list that triggered this violation — must match one of the rule keys.'),
-    })
-  ),
+  violations: z.array(DatabaseViolationItemSchema),
+});
+
+export const DatabaseLifecycleViolationOutputSchema = z.object({
+  resolvedViolationIds: z.array(z.string()).describe('IDs of previous violations that are now resolved — the issue no longer exists'),
+  unchangedViolationIds: z.array(z.string()).describe('IDs of previous violations that still exist unchanged — every previous violation ID must appear in either resolvedViolationIds or unchangedViolationIds'),
+  newViolations: z.array(DatabaseViolationItemSchema),
 });
 
 export const ModuleViolationOutputSchema = z.object({

--- a/packages/core/src/services/violation-lifecycle.service.ts
+++ b/packages/core/src/services/violation-lifecycle.service.ts
@@ -195,6 +195,7 @@ export interface ViolationLifecycleParams {
   previousActiveViolations: ActiveViolation[];
   /** Maps for resolving names to IDs on new violations (targets in current graph) */
   serviceNameToId?: Map<string, string>;
+  databaseNameToId?: Map<string, string>;
   moduleNameToId?: Map<string, string>;
   methodNameToId?: Map<string, string>;
 }
@@ -209,6 +210,7 @@ export function computeViolationLifecycle(
     resolvedViolationIds,
     previousActiveViolations,
     serviceNameToId,
+    databaseNameToId,
     moduleNameToId,
     methodNameToId,
   } = params;
@@ -230,7 +232,10 @@ export function computeViolationLifecycle(
         prev.targetServiceName && serviceNameToId
           ? serviceNameToId.get(prev.targetServiceName) ?? null
           : null,
-      targetDatabaseId: null,            // databases get new IDs each run
+      targetDatabaseId:
+        prev.targetDatabaseName && databaseNameToId
+          ? databaseNameToId.get(prev.targetDatabaseName) ?? null
+          : null,
       targetModuleId:
         prev.targetModuleName && moduleNameToId
           ? moduleNameToId.get(prev.targetModuleName) ?? null
@@ -333,10 +338,10 @@ export function computeViolationLifecycle(
       severity: v.severity as ViolationRecord['severity'],
       status: 'new',
       targetServiceId,
-      targetDatabaseId: null,
+      targetDatabaseId: v.targetDatabaseId ?? null,
       targetModuleId,
       targetMethodId,
-      targetTable: null,
+      targetTable: v.targetTable ?? null,
       relatedServiceId: null,
       relatedModuleId: null,
       fixPrompt: v.fixPrompt ?? null,

--- a/packages/core/src/services/violation-pipeline.service.ts
+++ b/packages/core/src/services/violation-pipeline.service.ts
@@ -112,6 +112,39 @@ function createLlmTracker(
   };
 }
 
+/**
+ * Lifecycle prompts require every supplied prior finding to be classified
+ * exactly once. Treat an omitted, duplicated, conflicting, or foreign ID as
+ * a failed batch so malformed output cannot mutate the completed baseline.
+ */
+function hasExactDatabaseLifecyclePartition(
+  batch: { existingViolations?: readonly { id: string; title: string }[] },
+  result: {
+    resolvedViolationIds?: string[];
+    unchangedViolationIds?: string[];
+    newViolations?: readonly { title: string }[];
+  },
+): boolean {
+  const expectedIds = batch.existingViolations?.map((violation) => violation.id) ?? [];
+  const returnedIds = [
+    ...(result.resolvedViolationIds ?? []),
+    ...(result.unchangedViolationIds ?? []),
+  ];
+  const expectedSet = new Set(expectedIds);
+  const returnedSet = new Set(returnedIds);
+  const hasExactIds = expectedSet.size === expectedIds.length
+    && returnedSet.size === returnedIds.length
+    && returnedIds.length === expectedIds.length
+    && returnedIds.every((id) => expectedSet.has(id));
+  if (!hasExactIds) return false;
+
+  const newTitles = new Set(
+    (result.newViolations ?? []).map((violation) => violation.title.toLowerCase().trim()),
+  );
+  return !(batch.existingViolations ?? []).some(
+    (violation) => newTitles.has(violation.title.toLowerCase().trim()),
+  );
+}
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -1028,6 +1061,8 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
   });
 
   const llmOnlyPreviousViolations = previousActiveViolations.filter((v) => v.ruleKey.includes('/llm/'));
+  const previousDatabaseLlmViolations = llmOnlyPreviousViolations.filter((v) => v.type === 'database');
+  const previousAggregateLlmViolations = llmOnlyPreviousViolations.filter((v) => v.type !== 'database');
   const existingServiceViolations = llmOnlyPreviousViolations
     .filter((v) => v.type === 'service')
     .map((v) => ({ id: v.id, type: v.type, title: v.title, content: v.content, severity: v.severity }));
@@ -1038,7 +1073,7 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
     .filter((v) => v.type === 'module' || v.type === 'function')
     .map((v) => ({ id: v.id, type: v.type, title: v.title, content: v.content, severity: v.severity }));
 
-  const hasLlmOnlyExistingViolations = llmOnlyPreviousViolations.length > 0;
+  const hasAggregateLlmExistingViolations = previousAggregateLlmViolations.length > 0;
 
   const dbSchemaContext = (dbSchemaLlmRules.length > 0 && result.databaseResult?.databases.length)
     ? {
@@ -1067,7 +1102,7 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
           })),
         })),
         llmRules: dbSchemaLlmRules,
-        existingViolations: hasLlmOnlyExistingViolations ? existingDatabaseViolations : undefined,
+        existingViolations: existingDatabaseViolations.length > 0 ? existingDatabaseViolations : undefined,
       }
     : undefined;
 
@@ -1087,9 +1122,9 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
       calleeModule: d.calleeModule,
       callCount: d.callCount,
     })),
-    existingServiceViolations: hasLlmOnlyExistingViolations ? existingServiceViolations : undefined,
+    existingServiceViolations: existingServiceViolations.length > 0 ? existingServiceViolations : undefined,
     existingDatabaseViolations: undefined,
-    existingModuleViolations: hasLlmOnlyExistingViolations ? existingModuleViolations : undefined,
+    existingModuleViolations: existingModuleViolations.length > 0 ? existingModuleViolations : undefined,
   };
 
   // ---------- Build LLM trackers (one shared instance per tracker key) ----------
@@ -1166,7 +1201,22 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
   }
 
   // Database schema LLM (separate from code batches)
-  let dbSchemaViolations: ViolationRecord[] = [];
+  const dbSchemaViolations: ViolationRecord[] = [];
+  let databaseSchemaFailed = false;
+  const carryPreviousDatabaseViolationsForward = () => {
+    const lifecycle = computeViolationLifecycle({
+      analysisId,
+      now,
+      newViolations: [],
+      resolvedViolationIds: [],
+      previousActiveViolations: previousDatabaseLlmViolations,
+      databaseNameToId: dbIdMap,
+    });
+    unchanged.push(...lifecycle.unchanged);
+  };
+  if ((!dbSchemaContext || llmSkipped) && previousDatabaseLlmViolations.length > 0) {
+    carryPreviousDatabaseViolationsForward();
+  }
   if (dbSchemaContext && !llmSkipped) {
     // Shared tracker exists only when schema is the sole database LLM path.
     // When code batches also exist, the code-batch tracker dominates and
@@ -1178,58 +1228,96 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
       const t0 = Date.now();
       let started = false;
       try {
-        const dbResult = await provider.generateDatabaseViolations(dbSchemaContext, {
-          onStart: () => { started = true; schemaLl?.onCallStart(); },
-        });
-        schemaLl?.onCallDone(started);
-        const dur = Date.now() - t0;
-        log.info(`[LLM] database-schema: done in ${dur}ms — ${dbResult.violations.length} violations`);
-
-        for (const v of dbResult.violations) {
-          dbSchemaViolations.push({
-            id: randomUUID(),
-            type: 'database',
-            category: 'rule',
-            subcategory: null,
-            title: v.title,
-            content: v.content,
-            severity: v.severity as ViolationRecord['severity'],
-            status: 'new',
+        const hasLifecycle = Boolean(dbSchemaContext.existingViolations?.length);
+        let databaseViolationCount: number;
+        if (hasLifecycle) {
+          const dbResult = await provider.generateDatabaseViolationsWithLifecycle(
+            dbSchemaContext,
+            { onStart: () => { started = true; schemaLl?.onCallStart(); } },
+          );
+          if (!hasExactDatabaseLifecyclePartition(dbSchemaContext, dbResult)) {
+            throw new Error('Database lifecycle returned an invalid prior-finding partition');
+          }
+          databaseViolationCount = dbResult.newViolations.length
+            + dbResult.unchangedViolationIds.length;
+          const newDatabaseViolations = dbResult.newViolations.map((violation) => ({
+            ...violation,
             targetServiceId: null,
-            targetDatabaseId: v.targetDatabaseId || null,
             targetModuleId: null,
             targetMethodId: null,
-            targetTable: v.targetTable || null,
-            relatedServiceId: null,
-            relatedModuleId: null,
-            fixPrompt: v.fixPrompt || null,
-            ruleKey: v.ruleKey || 'unknown',
-            firstSeenAnalysisId: analysisId,
-            firstSeenAt: now,
-            previousViolationId: null,
-            resolvedAt: null,
-            filePath: null,
-            lineStart: null,
-            lineEnd: null,
-            columnStart: null,
-            columnEnd: null,
-            snippet: null,
-            createdAt: now,
+            targetServiceName: null,
+            targetModuleName: null,
+            targetMethodName: null,
+          }));
+          const lifecycle = computeViolationLifecycle({
+            analysisId,
+            now,
+            newViolations: newDatabaseViolations,
+            resolvedViolationIds: dbResult.resolvedViolationIds,
+            previousActiveViolations: previousDatabaseLlmViolations,
+            databaseNameToId: dbIdMap,
           });
+          added.push(...lifecycle.added);
+          unchanged.push(...lifecycle.unchanged);
+          resolved.push(...lifecycle.resolved);
+          resolvedRefs.push(...lifecycle.resolvedRefs);
+        } else {
+          const dbResult = await provider.generateDatabaseViolations(dbSchemaContext, {
+            onStart: () => { started = true; schemaLl?.onCallStart(); },
+          });
+          databaseViolationCount = dbResult.violations.length;
+          for (const v of dbResult.violations) {
+            dbSchemaViolations.push({
+              id: randomUUID(),
+              type: 'database',
+              category: 'rule',
+              subcategory: null,
+              title: v.title,
+              content: v.content,
+              severity: v.severity as ViolationRecord['severity'],
+              status: 'new',
+              targetServiceId: null,
+              targetDatabaseId: v.targetDatabaseId || null,
+              targetModuleId: null,
+              targetMethodId: null,
+              targetTable: v.targetTable || null,
+              relatedServiceId: null,
+              relatedModuleId: null,
+              fixPrompt: v.fixPrompt || null,
+              ruleKey: v.ruleKey || 'unknown',
+              firstSeenAnalysisId: analysisId,
+              firstSeenAt: now,
+              previousViolationId: null,
+              resolvedAt: null,
+              filePath: null,
+              lineStart: null,
+              lineEnd: null,
+              columnStart: null,
+              columnEnd: null,
+              snippet: null,
+              createdAt: now,
+            });
+          }
         }
+        schemaLl?.onCallDone(started);
+        const dur = Date.now() - t0;
+        log.info(`[LLM] database-schema: done in ${dur}ms — ${databaseViolationCount} violations`);
 
         if (!domainCodeBatches.has('database')) {
           const detCount = violationsByDomain.get('database') ?? 0;
-          const total = detCount + dbResult.violations.length;
+          const total = detCount + databaseViolationCount;
           tracker?.done('database', total > 0 ? `${total} violations` : 'Clean');
         }
 
         return { domain: 'database-schema', violations: [], resolvedIds: [], unchangedIds: [] };
       } catch (err) {
         schemaLl?.onCallDone(started);
+        databaseSchemaFailed = true;
         const dur = Date.now() - t0;
         log.warn(`[LLM] database-schema: failed in ${dur}ms — ${err instanceof Error ? err.message : String(err)}`);
-        if (!domainCodeBatches.has('database')) tracker?.error('database', `Schema LLM failed`);
+        if (dbSchemaContext.existingViolations?.length) {
+          carryPreviousDatabaseViolationsForward();
+        }
         return { domain: 'database-schema', violations: [], resolvedIds: [], unchangedIds: [] };
       }
     })());
@@ -1252,7 +1340,7 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
     const archOnCallDone = (key: 'service' | 'database' | 'module') => {
       archLl?.onCallDone(archStarted.has(key));
     };
-    if (hasLlmOnlyExistingViolations) {
+    if (hasAggregateLlmExistingViolations) {
       const archResult = await generateViolationsWithLifecycle(
         violationInput,
         undefined,
@@ -1277,7 +1365,7 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
         now,
         newViolations: archResult.newViolations,
         resolvedViolationIds: archResult.resolvedViolationIds,
-        previousActiveViolations: llmOnlyPreviousViolations,
+        previousActiveViolations: previousAggregateLlmViolations,
         serviceNameToId,
         moduleNameToId: moduleNameToIdLocal,
         methodNameToId,
@@ -1347,6 +1435,9 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
     const msg = llmResult.reason instanceof Error ? llmResult.reason.message : String(llmResult.reason);
     log.error(`[Violations] LLM architecture analysis failed: ${msg}`);
     tracker?.error('architecture', `LLM failed: ${msg.slice(0, 80)}`);
+  }
+  if (databaseSchemaFailed) {
+    tracker?.error('database', 'Schema LLM failed');
   }
 
   // Merge database schema LLM violations into the main lists.

--- a/tests/core/database-violation-lifecycle.test.ts
+++ b/tests/core/database-violation-lifecycle.test.ts
@@ -1,0 +1,458 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AnalysisRule, FileAnalysis } from '@truecourse/shared';
+
+vi.mock('../../packages/core/src/services/rules.service.js', () => ({
+  getEnabledRules: vi.fn(),
+}));
+
+import type { AnalysisResult } from '../../packages/core/src/services/analyzer.service.js';
+import type { DatabaseViolationContext } from '../../packages/core/src/services/llm/provider.js';
+import { ClaudeCodeProvider } from '../../packages/core/src/services/llm/cli-provider.js';
+import { getEnabledRules } from '../../packages/core/src/services/rules.service.js';
+import type { ActiveViolation } from '../../packages/core/src/services/violation-lifecycle.service.js';
+import { runViolationPipeline } from '../../packages/core/src/services/violation-pipeline.service.js';
+import {
+  StepTracker,
+  type AnalysisProgressPayload,
+} from '../../packages/core/src/progress.js';
+
+const DATABASE_RULE_KEY = 'database/llm/schema-review';
+
+const databaseRule: AnalysisRule = {
+  key: DATABASE_RULE_KEY,
+  category: 'database',
+  domain: 'database',
+  name: 'Database schema review',
+  description: 'Review database schemas.',
+  prompt: 'Review database schemas.',
+  enabled: true,
+  severity: 'high',
+  type: 'llm',
+};
+
+const databaseCodeRule: AnalysisRule = {
+  key: 'database/llm/query-review',
+  category: 'code',
+  domain: 'database',
+  name: 'Database query review',
+  description: 'Review database query code.',
+  prompt: 'Review database query code.',
+  enabled: true,
+  severity: 'high',
+  type: 'llm',
+  contextRequirement: { tier: 'metadata' },
+};
+
+function databaseContext(): DatabaseViolationContext {
+  return {
+    databases: [{
+      id: 'current-database-runtime-id',
+      name: 'orders-db',
+      type: 'postgres',
+      driver: 'pg',
+      tableCount: 1,
+      connectedServices: ['orders-service'],
+      tables: [{
+        name: 'orders',
+        columns: [{ name: 'id', type: 'uuid', isPrimaryKey: true }],
+      }],
+      relations: [],
+    }],
+    llmRules: [{
+      key: DATABASE_RULE_KEY,
+      name: 'Database schema review',
+      severity: 'high',
+      prompt: 'Review database schemas.',
+    }],
+    existingViolations: [{
+      id: 'previous-database-review',
+      type: 'database',
+      title: 'Previous database review',
+      content: 'Previously detected database problem.',
+      severity: 'high',
+    }],
+  };
+}
+
+type DatabaseLifecycleMode =
+  | 'resolved'
+  | 'unchanged'
+  | 'overlap'
+  | 'outsider'
+  | 'unchanged-duplicate'
+  | 'resolved-duplicate'
+  | 'targets'
+  | 'failed';
+
+class DatabaseLifecycleProvider extends ClaudeCodeProvider {
+  normalDatabaseCalls = 0;
+  lifecycleDatabaseCalls = 0;
+
+  constructor(private readonly mode: DatabaseLifecycleMode) {
+    super();
+  }
+
+  protected override async spawnCLI(
+    _prompt: string,
+    _schemaJson: string,
+    opts?: { label?: string },
+  ): Promise<string> {
+    const label = opts?.label ?? 'call';
+    if (label === 'database') {
+      this.normalDatabaseCalls++;
+      return JSON.stringify({ result: JSON.stringify({ violations: [] }) });
+    }
+    if (label === 'code') {
+      return JSON.stringify({ result: JSON.stringify({ violations: [] }) });
+    }
+    if (label !== 'database-lifecycle') {
+      throw new Error(`Unexpected LLM call: ${label}`);
+    }
+
+    this.lifecycleDatabaseCalls++;
+    if (this.mode === 'failed') {
+      throw new Error('database lifecycle transport failed');
+    }
+
+    const resolvedViolationIds = ['resolved', 'overlap', 'resolved-duplicate'].includes(this.mode)
+      ? ['prev-0']
+      : [];
+    const unchangedViolationIds = this.mode === 'outsider'
+      ? ['prev-99']
+      : ['unchanged', 'overlap', 'targets', 'unchanged-duplicate'].includes(this.mode)
+        ? ['prev-0']
+        : [];
+    const newViolations = this.mode === 'targets'
+      ? [{
+          type: 'database',
+          title: 'Orders need an index',
+          content: 'The `orders` table lacks a required index.',
+          severity: 'high',
+          targetDatabaseId: 'db-0',
+          targetTable: 'orders',
+          fixPrompt: 'Add the index to `orders`.',
+          ruleKey: DATABASE_RULE_KEY,
+        }, {
+          type: 'database',
+          title: 'Unknown database target',
+          content: 'This target was not present in the prompt.',
+          severity: 'medium',
+          targetDatabaseId: 'db-99',
+          targetTable: 'unknown_table',
+          fixPrompt: null,
+          ruleKey: DATABASE_RULE_KEY,
+        }, {
+          type: 'database',
+          title: 'Wrong alias namespace',
+          content: 'A previous-finding alias is not a database target.',
+          severity: 'medium',
+          targetDatabaseId: 'prev-0',
+          targetTable: 'orders',
+          fixPrompt: null,
+          ruleKey: DATABASE_RULE_KEY,
+        }]
+      : ['unchanged-duplicate', 'resolved-duplicate'].includes(this.mode)
+        ? [{
+            type: 'database',
+            title: 'Previous database review',
+            content: 'This recreates an explicitly unchanged finding.',
+            severity: 'high',
+            targetDatabaseId: 'db-0',
+            targetTable: 'orders',
+            fixPrompt: null,
+            ruleKey: DATABASE_RULE_KEY,
+          }]
+        : [];
+
+    return JSON.stringify({
+      result: JSON.stringify({ resolvedViolationIds, unchangedViolationIds, newViolations }),
+    });
+  }
+}
+
+function createDatabaseAnalysis(repoPath: string, includeCodeFile = false): AnalysisResult {
+  const filePath = path.join(repoPath, 'src', 'orders.ts');
+  if (includeCodeFile) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'export const orders = [] as const;\n');
+  }
+  return {
+    architecture: 'monolith',
+    services: [],
+    dependencies: [],
+    layerDetails: [],
+    databaseResult: {
+      databases: [{
+        name: 'orders-db',
+        type: 'postgres',
+        driver: 'pg',
+        tables: [{
+          name: 'orders',
+          columns: [{ name: 'id', type: 'uuid', isPrimaryKey: true }],
+        }],
+        relations: [],
+        connectedServices: ['orders-service'],
+      }],
+      connections: [],
+    },
+    modules: [],
+    methods: [],
+    moduleLevelDependencies: [],
+    methodLevelDependencies: [],
+    fileAnalyses: includeCodeFile
+      ? [{
+          filePath,
+          language: 'typescript',
+          functions: [],
+          classes: [],
+          imports: [],
+          exports: [],
+          calls: [],
+          httpCalls: [],
+          routeRegistrations: [],
+        } as unknown as FileAnalysis]
+      : [],
+    moduleDependencies: [],
+    entryPointFiles: new Set(),
+    metadata: {},
+  };
+}
+
+function previousDatabaseViolation(): ActiveViolation {
+  return {
+    id: 'previous-database-review',
+    type: 'database',
+    category: 'rule',
+    subcategory: null,
+    title: 'Previous database review',
+    content: 'Previously detected database problem.',
+    severity: 'high',
+    status: 'unchanged',
+    targetServiceId: null,
+    targetDatabaseId: 'previous-database-runtime-id',
+    targetModuleId: null,
+    targetMethodId: null,
+    targetTable: 'orders',
+    relatedServiceId: null,
+    relatedModuleId: null,
+    fixPrompt: null,
+    ruleKey: DATABASE_RULE_KEY,
+    firstSeenAnalysisId: 'previous-analysis',
+    firstSeenAt: '2026-07-01T00:00:00.000Z',
+    previousViolationId: null,
+    resolvedAt: null,
+    filePath: null,
+    lineStart: null,
+    lineEnd: null,
+    columnStart: null,
+    columnEnd: null,
+    snippet: null,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    targetServiceName: null,
+    targetModuleName: null,
+    targetMethodName: null,
+    targetDatabaseName: 'orders-db',
+  };
+}
+
+async function runDatabasePipeline(
+  repoPath: string,
+  provider: DatabaseLifecycleProvider,
+  proceedWithLlm = true,
+  tracker?: StepTracker,
+  includeCodeFile = false,
+) {
+  return runViolationPipeline({
+    repoPath,
+    analysisId: 'current-analysis',
+    now: '2026-07-18T00:00:00.000Z',
+    result: createDatabaseAnalysis(repoPath, includeCodeFile),
+    serviceIdMap: new Map(),
+    moduleIdMap: new Map(),
+    methodIdMap: new Map(),
+    dbIdMap: new Map([['orders-db', 'current-database-runtime-id']]),
+    previousActiveViolations: [previousDatabaseViolation()],
+    enableLlmRules: true,
+    provider,
+    tracker,
+    onLlmEstimate: async () => proceedWithLlm,
+  });
+}
+
+let repoPath: string;
+
+beforeEach(() => {
+  repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-database-lifecycle-'));
+  vi.mocked(getEnabledRules).mockResolvedValue([databaseRule]);
+});
+
+afterEach(() => {
+  fs.rmSync(repoPath, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe('database violation lifecycle', () => {
+  it('rebinds current database aliases and rejects unknown alias namespaces', async () => {
+    const provider = new DatabaseLifecycleProvider('targets');
+
+    const result = await provider.generateDatabaseViolationsWithLifecycle(databaseContext());
+
+    expect(result.newViolations.map((violation) => ({
+      targetDatabaseId: violation.targetDatabaseId,
+      targetTable: violation.targetTable,
+    }))).toEqual([
+      { targetDatabaseId: 'current-database-runtime-id', targetTable: 'orders' },
+      { targetDatabaseId: null, targetTable: 'unknown_table' },
+      { targetDatabaseId: null, targetTable: 'orders' },
+    ]);
+  });
+
+  it('surfaces an ordinary database lifecycle transport failure', async () => {
+    const provider = new DatabaseLifecycleProvider('failed');
+
+    await expect(provider.generateDatabaseViolationsWithLifecycle(
+      databaseContext(),
+    )).rejects.toThrow('database lifecycle transport failed');
+  });
+
+  it('routes a prior database finding through lifecycle exactly once', async () => {
+    const provider = new DatabaseLifecycleProvider('resolved');
+
+    const result = await runDatabasePipeline(repoPath, provider);
+
+    expect(provider.normalDatabaseCalls).toBe(0);
+    expect(provider.lifecycleDatabaseCalls).toBe(1);
+    expect(result.added.filter((violation) => violation.type === 'database')).toEqual([]);
+    expect(result.unchanged.filter((violation) => violation.type === 'database')).toEqual([]);
+    expect(result.resolved.filter((violation) => violation.type === 'database')).toEqual([
+      expect.objectContaining({
+        previousViolationId: 'previous-database-review',
+        status: 'resolved',
+        targetDatabaseId: 'current-database-runtime-id',
+        targetTable: 'orders',
+      }),
+    ]);
+  });
+
+  it.each(['overlap', 'outsider'] as const)(
+    'fails closed when database lifecycle returns an invalid %s partition',
+    async (mode) => {
+      const result = await runDatabasePipeline(repoPath, new DatabaseLifecycleProvider(mode));
+
+      expect(result.added.filter((violation) => violation.type === 'database')).toEqual([]);
+      expect(result.resolved.filter((violation) => violation.type === 'database')).toEqual([]);
+      expect(result.unchanged.filter((violation) => violation.type === 'database')).toEqual([
+        expect.objectContaining({
+          previousViolationId: 'previous-database-review',
+          status: 'unchanged',
+        }),
+      ]);
+    },
+  );
+
+  it.each(['unchanged-duplicate', 'resolved-duplicate'] as const)(
+    'fails closed when a %s prior is recreated under the same title',
+    async (mode) => {
+      const result = await runDatabasePipeline(
+        repoPath,
+        new DatabaseLifecycleProvider(mode),
+      );
+
+      expect(result.added.filter((violation) => violation.type === 'database')).toEqual([]);
+      expect(result.resolved.filter((violation) => violation.type === 'database')).toEqual([]);
+      expect(result.unchanged.filter((violation) => violation.type === 'database')).toEqual([
+        expect.objectContaining({ previousViolationId: 'previous-database-review' }),
+      ]);
+    },
+  );
+
+  it('persists new lifecycle targets while retaining an explicitly unchanged prior', async () => {
+    const result = await runDatabasePipeline(
+      repoPath,
+      new DatabaseLifecycleProvider('targets'),
+    );
+
+    expect(result.unchanged.filter((violation) => violation.type === 'database')).toHaveLength(1);
+    expect(result.added.filter((violation) => violation.type === 'database')).toEqual([
+      expect.objectContaining({
+        targetDatabaseId: 'current-database-runtime-id',
+        targetTable: 'orders',
+      }),
+      expect.objectContaining({ targetDatabaseId: null, targetTable: 'unknown_table' }),
+      expect.objectContaining({ targetDatabaseId: null, targetTable: 'orders' }),
+    ]);
+  });
+
+  it('reports unchanged active database findings instead of calling the step clean', async () => {
+    const payloads: AnalysisProgressPayload[] = [];
+    const tracker = new StepTracker(
+      (payload) => payloads.push(payload),
+      [{ key: 'database', label: 'Database checks' }, { key: 'persist', label: 'Saving' }],
+    );
+
+    await runDatabasePipeline(repoPath, new DatabaseLifecycleProvider('unchanged'), true, tracker);
+
+    const databaseStep = payloads.at(-1)?.steps?.find((step) => step.key === 'database');
+    expect(databaseStep).toEqual(expect.objectContaining({
+      status: 'done',
+      detail: '1 violations',
+    }));
+  });
+
+  it('carries the prior database finding when the user skips LLM checks', async () => {
+    const provider = new DatabaseLifecycleProvider('unchanged');
+
+    const result = await runDatabasePipeline(repoPath, provider, false);
+
+    expect(provider.normalDatabaseCalls).toBe(0);
+    expect(provider.lifecycleDatabaseCalls).toBe(0);
+    expect(result.unchanged.filter((violation) => violation.type === 'database')).toEqual([
+      expect.objectContaining({
+        previousViolationId: 'previous-database-review',
+        targetDatabaseId: 'current-database-runtime-id',
+        targetTable: 'orders',
+      }),
+    ]);
+  });
+
+  it('carries the prior database finding when lifecycle execution fails', async () => {
+    const result = await runDatabasePipeline(
+      repoPath,
+      new DatabaseLifecycleProvider('failed'),
+    );
+
+    expect(result.resolved.filter((violation) => violation.type === 'database')).toEqual([]);
+    expect(result.unchanged.filter((violation) => violation.type === 'database')).toEqual([
+      expect.objectContaining({
+        previousViolationId: 'previous-database-review',
+        status: 'unchanged',
+      }),
+    ]);
+  });
+
+  it('keeps a schema lifecycle failure visible when database code batches also finish', async () => {
+    vi.mocked(getEnabledRules).mockResolvedValue([databaseRule, databaseCodeRule]);
+    const payloads: AnalysisProgressPayload[] = [];
+    const tracker = new StepTracker(
+      (payload) => payloads.push(payload),
+      [{ key: 'database', label: 'Database checks' }, { key: 'persist', label: 'Saving' }],
+    );
+
+    await runDatabasePipeline(
+      repoPath,
+      new DatabaseLifecycleProvider('failed'),
+      true,
+      tracker,
+      true,
+    );
+
+    const databaseStep = payloads.at(-1)?.steps?.find((step) => step.key === 'database');
+    expect(databaseStep).toEqual(expect.objectContaining({
+      status: 'error',
+      detail: 'Schema LLM failed',
+    }));
+  });
+});


### PR DESCRIPTION
## Summary

- add a database-specific lifecycle schema and provider method so lifecycle results retain database and table targets
- strictly rebind current `db-*` prompt aliases while discarding unknown or wrong-namespace targets
- route prior database LLM findings through one lifecycle owner with fail-closed partition validation
- conservatively carry prior findings across skipped, malformed, or failed lifecycle work while keeping schema failures visible in progress

## Why

This is a correctness prerequisite for safe checkpointing and replay in #791. Database lifecycle results previously used the generic aggregate schema, which stripped `targetDatabaseId` and `targetTable`. The pipeline also ran the normal database path even when prior database LLM findings existed, so an old finding could be carried forward while an equivalent new finding was added.

The change gives database lifecycle work an explicit contract before those results can be journaled or reused. It does **not** implement durable run journals, checkpoint reuse, token preservation, Resume, usage reconciliation, latest-attempted-run pointers, or final promotion. It does not resolve or close #791.

PR #815 remains the separate session-limit damage-containment slice. If the two changes are merged in an order that causes conflicts in the provider or pipeline, both the terminal session-limit propagation from #815 and the database lifecycle behavior here must be preserved.

## Validation

- `pnpm exec vitest run tests/core/database-violation-lifecycle.test.ts tests/core/violation-lifecycle.test.ts tests/core/cli-provider.test.ts` — 31/31 passed
- `pnpm --filter @truecourse/core build` — passed
- `pnpm build` — 19/19 tasks passed
- `pnpm lint` — 14/14 tasks passed
- fresh independent final audit — no actionable P0–P2 findings; its expanded focused matrix passed 37/37

Refs #791
