### PR TITLE
fix(llm): certify code result ownership

### DIFF
--- a/packages/core/src/services/llm/cli-provider.ts
+++ b/packages/core/src/services/llm/cli-provider.ts
@@ -78,6 +78,94 @@ interface CLIUsage {
   costUsd?: string;
 }
 
+function certifyCodeResultOwnership(
+  context: CodeViolationContext,
+  violations: CodeViolationRaw[],
+): void {
+  const allowedRules = new Set(context.llmRules.map((rule) => rule.key));
+  const allowedSources = new Map<string, CodeViolationContext['sourceScopes'][number]['ranges']>();
+  for (const scope of context.sourceScopes) {
+    const ranges = allowedSources.get(scope.path) ?? [];
+    ranges.push(...scope.ranges);
+    allowedSources.set(scope.path, ranges);
+  }
+  const seenFindings = new Set<string>();
+
+  for (const violation of violations) {
+    if (!allowedRules.has(violation.ruleKey)) {
+      throw new Error(
+        `Code result rule "${violation.ruleKey}" is not owned by the originating batch`,
+      );
+    }
+
+    const ranges = allowedSources.get(violation.filePath);
+    if (!ranges) {
+      throw new Error(
+        `Code result source "${violation.filePath}" is not owned by the originating batch`,
+      );
+    }
+
+    const rangeIsOwned = violation.lineEnd >= violation.lineStart && ranges.some((range) =>
+      context.tier === 'metadata'
+        ? violation.lineStart === range.lineStart && violation.lineEnd === range.lineEnd
+        : violation.lineStart >= range.lineStart && violation.lineEnd <= range.lineEnd,
+    );
+    if (!rangeIsOwned) {
+      throw new Error(
+        `Code result range ${violation.lineStart}-${violation.lineEnd} for "${violation.filePath}" is not owned by the originating batch`,
+      );
+    }
+
+    const findingKey = `${violation.ruleKey}\0${violation.filePath}\0${violation.lineStart}\0${violation.lineEnd}\0${violation.title}`;
+    if (seenFindings.has(findingKey)) {
+      throw new Error('Code result cannot contain the same new finding more than once');
+    }
+    seenFindings.add(findingKey);
+  }
+}
+
+function certifyNoPriorCodeCollision(
+  context: CodeViolationContext,
+  newViolations: CodeViolationRaw[],
+): void {
+  const priorKeys = new Set((context.existingViolations ?? []).map((violation) =>
+    context.tier === 'metadata'
+      ? `${violation.ruleKey}\0${violation.filePath}\0${violation.title}`
+      : `${violation.ruleKey}\0${violation.filePath}\0${violation.lineStart}\0${violation.lineEnd}\0${violation.title}`,
+  ));
+
+  for (const violation of newViolations) {
+    const key = context.tier === 'metadata'
+      ? `${violation.ruleKey}\0${violation.filePath}\0${violation.title}`
+      : `${violation.ruleKey}\0${violation.filePath}\0${violation.lineStart}\0${violation.lineEnd}\0${violation.title}`;
+    if (priorKeys.has(key)) {
+      throw new Error(
+        'Code lifecycle result cannot classify a previous finding and reintroduce the same finding as new',
+      );
+    }
+  }
+}
+
+function certifyCodeLifecyclePartition(
+  resolvedViolationIds: string[],
+  unchangedViolationIds: string[],
+  idMap: PromptIdMap,
+): void {
+  const expectedIds = new Set(idMap.keys());
+  const classifiedIds = [...resolvedViolationIds, ...unchangedViolationIds];
+  const classifiedSet = new Set(classifiedIds);
+  const isExactPartition =
+    classifiedIds.length === expectedIds.size &&
+    classifiedSet.size === expectedIds.size &&
+    classifiedIds.every((id) => expectedIds.has(id));
+
+  if (!isExactPartition) {
+    throw new Error(
+      'Code lifecycle result must be an exact partition of the originating batch previous IDs',
+    );
+  }
+}
+
 export abstract class BaseCLIProvider implements LLMProvider {
   abstract get binaryName(): string;
   abstract get baseArgs(): string[];
@@ -770,6 +858,13 @@ export abstract class BaseCLIProvider implements LLMProvider {
       const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, CodeViolationLifecycleOutputSchema, {
         extraArgs: codeExtraArgs, label: 'code-lifecycle', timeoutMs: codeTimeoutMs, onStart: opts?.onStart,
       });
+      certifyCodeResultOwnership(context, object.newViolations);
+      certifyCodeLifecyclePartition(
+        object.resolvedViolationIds,
+        object.unchangedViolationIds,
+        idMap,
+      );
+      certifyNoPriorCodeCollision(context, object.newViolations);
       const dur = Date.now() - t0;
       log.info(`[CLI] Code violations call done in ${dur}ms — new: ${object.newViolations.length}, resolved: ${object.resolvedViolationIds.length}, unchanged: ${object.unchangedViolationIds.length}`);
       this.collectUsage('code', cliUsage, dur);
@@ -784,6 +879,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
           title: v.title,
           content: v.content,
           fixPrompt: v.fixPrompt ?? null,
+          sourceTier: context.tier ?? 'full-file',
         })),
         resolvedViolationIds: resolveIds(object.resolvedViolationIds, idMap),
         unchangedViolationIds: resolveIds(object.unchangedViolationIds, idMap),
@@ -793,6 +889,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
     const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, CodeViolationOutputSchema, {
       extraArgs: codeExtraArgs, label: 'code', timeoutMs: codeTimeoutMs, onStart: opts?.onStart,
     });
+    certifyCodeResultOwnership(context, object.violations);
     const dur = Date.now() - t0;
     log.info(`[CLI] Code violations call done in ${dur}ms — ${object.violations.length} violations`);
     this.collectUsage('code', cliUsage, dur);
@@ -807,6 +904,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
         title: v.title,
         content: v.content,
         fixPrompt: v.fixPrompt ?? null,
+        sourceTier: context.tier ?? 'full-file',
       })),
     };
   }

--- a/packages/core/src/services/llm/context-router.ts
+++ b/packages/core/src/services/llm/context-router.ts
@@ -1,5 +1,6 @@
 import type { AnalysisRule, FileAnalysis, ContextRequirement, ContextTier, FileFilter, FunctionFilter } from '@truecourse/shared';
 import { DATABASE_IMPORT_MAP, getAllTestPatterns } from '@truecourse/analyzer';
+import type { CodeSourceScope } from './provider.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -12,6 +13,8 @@ export interface ContextBatch {
   fileCount: number;
   functionCount?: number;
   estimatedTokens: number;
+  /** Exact source ranges represented by this batch. */
+  sourceScopes: CodeSourceScope[];
   /** Real file paths included in this batch (full-file/legacy tiers only). */
   filePaths?: string[];
 }
@@ -188,8 +191,8 @@ function extractTargetedFunctions(
 
 type MetadataField = NonNullable<ContextRequirement['metadataFields']>[number];
 
-function buildMetadataSummary(fa: FileAnalysis, fields: MetadataField[]): string {
-  const parts: string[] = [`=== ${fa.filePath} ===`];
+function buildMetadataSummary(fa: FileAnalysis, fields: MetadataField[], lineCount: number): string {
+  const parts: string[] = [`=== ${fa.filePath} (lines 1-${Math.max(1, lineCount)}) ===`];
 
   for (const field of fields) {
     switch (field) {
@@ -312,7 +315,7 @@ function buildMetadataContent(
   group: { rules: RuleDto[]; requirement: ContextRequirement },
   fileAnalyses: FileAnalysis[],
   fileContents: Map<string, { content: string; lineCount: number }>,
-): { content: string; fileCount: number } {
+): { content: string; fileCount: number; sourceScopes: CodeSourceScope[] } {
   const matching = fileAnalyses.filter((fa) => {
     if (!group.requirement.fileFilter) return true;
     const fc = fileContents.get(fa.filePath);
@@ -320,19 +323,26 @@ function buildMetadataContent(
   });
 
   const fields = (group.requirement.metadataFields || ['functions', 'imports', 'exports']) as MetadataField[];
-  const summaries = matching.map((fa) => buildMetadataSummary(fa, fields));
+  const summaries = matching.map((fa) =>
+    buildMetadataSummary(fa, fields, fileContents.get(fa.filePath)?.lineCount ?? 1),
+  );
+  const sourceScopes = matching.map((fa) => ({
+    path: fa.filePath,
+    ranges: [{ lineStart: 1, lineEnd: Math.max(1, fileContents.get(fa.filePath)?.lineCount ?? 1) }],
+  }));
 
-  return { content: summaries.join('\n\n'), fileCount: matching.length };
+  return { content: summaries.join('\n\n'), fileCount: matching.length, sourceScopes };
 }
 
 function buildTargetedContent(
   group: { rules: RuleDto[]; requirement: ContextRequirement },
   fileAnalyses: FileAnalysis[],
   fileContents: Map<string, { content: string; lineCount: number }>,
-): { content: string; fileCount: number; functionCount: number } {
+): { content: string; fileCount: number; functionCount: number; sourceScopes: CodeSourceScope[] } {
   const filter = group.requirement.functionFilter || {};
   let totalFunctions = 0;
   const parts: string[] = [];
+  const sourceScopes: CodeSourceScope[] = [];
 
   for (const fa of fileAnalyses) {
     const fc = fileContents.get(fa.filePath);
@@ -355,18 +365,23 @@ function buildTargetedContent(
       fileParts.push(`--- ${fn.name} (lines ${fn.startLine}-${fn.endLine}) ---\n${numbered}`);
     }
     parts.push(fileParts.join('\n'));
+    sourceScopes.push({
+      path: fa.filePath,
+      ranges: extracted.map((fn) => ({ lineStart: fn.startLine, lineEnd: fn.endLine })),
+    });
   }
 
-  return { content: parts.join('\n\n'), fileCount: parts.length, functionCount: totalFunctions };
+  return { content: parts.join('\n\n'), fileCount: parts.length, functionCount: totalFunctions, sourceScopes };
 }
 
 function buildFullFileContent(
   group: { rules: RuleDto[]; requirement: ContextRequirement },
   fileAnalyses: FileAnalysis[],
   fileContents: Map<string, { content: string; lineCount: number }>,
-): { content: string; fileCount: number; filePaths: string[] } {
+): { content: string; fileCount: number; filePaths: string[]; sourceScopes: CodeSourceScope[] } {
   const parts: string[] = [];
   const filePaths: string[] = [];
+  const sourceScopes: CodeSourceScope[] = [];
 
   for (const fa of fileAnalyses) {
     const fc = fileContents.get(fa.filePath);
@@ -382,9 +397,13 @@ function buildFullFileContent(
       .join('\n');
     parts.push(`=== ${fa.filePath} ===\n${numbered}`);
     filePaths.push(fa.filePath);
+    sourceScopes.push({
+      path: fa.filePath,
+      ranges: [{ lineStart: 1, lineEnd: Math.max(1, fc.lineCount) }],
+    });
   }
 
-  return { content: parts.join('\n\n'), fileCount: parts.length, filePaths };
+  return { content: parts.join('\n\n'), fileCount: parts.length, filePaths, sourceScopes };
 }
 
 // ---------------------------------------------------------------------------
@@ -396,6 +415,7 @@ function splitIntoBatches(
   rules: RuleDto[],
   content: string,
   fileCount: number,
+  sourceScopes: CodeSourceScope[],
   functionCount?: number,
   filePaths?: string[],
 ): ContextBatch[] {
@@ -411,6 +431,7 @@ function splitIntoBatches(
       fileCount,
       functionCount,
       estimatedTokens,
+      sourceScopes,
       filePaths,
     }];
   }
@@ -421,6 +442,7 @@ function splitIntoBatches(
   let currentContent = '';
   let currentFileCount = 0;
   let currentFilePaths: string[] = [];
+  let currentSourceScopes: CodeSourceScope[] = [];
 
   for (let si = 0; si < sections.length; si++) {
     const section = sections[si];
@@ -431,15 +453,18 @@ function splitIntoBatches(
         content: currentContent,
         fileCount: currentFileCount,
         estimatedTokens: Math.ceil(currentContent.length / CHARS_PER_TOKEN),
+        sourceScopes: currentSourceScopes,
         filePaths: currentFilePaths.length > 0 ? currentFilePaths : undefined,
       });
       currentContent = '';
       currentFileCount = 0;
       currentFilePaths = [];
+      currentSourceScopes = [];
     }
     currentContent += (currentContent ? '\n\n' : '') + section;
     currentFileCount++;
     if (filePaths && filePaths[si]) currentFilePaths.push(filePaths[si]);
+    if (sourceScopes[si]) currentSourceScopes.push(sourceScopes[si]);
   }
 
   if (currentContent.length > 0) {
@@ -449,6 +474,7 @@ function splitIntoBatches(
       content: currentContent,
       fileCount: currentFileCount,
       estimatedTokens: Math.ceil(currentContent.length / CHARS_PER_TOKEN),
+      sourceScopes: currentSourceScopes,
       filePaths: currentFilePaths.length > 0 ? currentFilePaths : undefined,
     });
   }
@@ -626,25 +652,25 @@ function routeContextInner(
 
   // Metadata batches
   for (const group of grouped.metadata) {
-    const { content, fileCount } = buildMetadataContent(group, fileAnalyses, fileContents);
+    const { content, fileCount, sourceScopes } = buildMetadataContent(group, fileAnalyses, fileContents);
     if (fileCount > 0) {
-      batches.push(...splitIntoBatches('metadata', group.rules, content, fileCount));
+      batches.push(...splitIntoBatches('metadata', group.rules, content, fileCount, sourceScopes));
     }
   }
 
   // Targeted batches
   for (const group of grouped.targeted) {
-    const { content, fileCount, functionCount } = buildTargetedContent(group, fileAnalyses, fileContents);
+    const { content, fileCount, functionCount, sourceScopes } = buildTargetedContent(group, fileAnalyses, fileContents);
     if (fileCount > 0) {
-      batches.push(...splitIntoBatches('targeted', group.rules, content, fileCount, functionCount));
+      batches.push(...splitIntoBatches('targeted', group.rules, content, fileCount, sourceScopes, functionCount));
     }
   }
 
   // Full-file batches
   for (const group of grouped.fullFile) {
-    const { content, fileCount, filePaths } = buildFullFileContent(group, fileAnalyses, fileContents);
+    const { content, fileCount, filePaths, sourceScopes } = buildFullFileContent(group, fileAnalyses, fileContents);
     if (fileCount > 0) {
-      batches.push(...splitIntoBatches('full-file', group.rules, content, fileCount, undefined, filePaths));
+      batches.push(...splitIntoBatches('full-file', group.rules, content, fileCount, sourceScopes, undefined, filePaths));
     }
   }
 

--- a/packages/core/src/services/llm/prompts.ts
+++ b/packages/core/src/services/llm/prompts.ts
@@ -257,6 +257,7 @@ IMPORTANT:
 - Only report issues from the rules listed above. Do not invent new rule categories or report issues outside the provided rules.
 - For each violation, set ruleKey to the exact key from the rules list. Every violation MUST have a ruleKey.
 - filePath must exactly match one of the file paths provided above.
+- Metadata findings are file-level: use the exact lineStart and lineEnd bounds shown in that file's header. Do not invent narrower line coordinates without source text.
 - Since you only see metadata (signatures, imports, calls), focus on structural patterns — missing capabilities, dependency issues, and configuration problems detectable without reading function bodies.
 - Only report genuine issues. Do not flag trivial style preferences.
 
@@ -306,6 +307,7 @@ IMPORTANT:
 - Only report issues from the rules listed above. Do not invent new rule categories or report issues outside the provided rules.
 - For each violation, set ruleKey to the exact key from the rules list. Every violation MUST have a ruleKey.
 - filePath must exactly match one of the file paths provided above.
+- Metadata findings are file-level: use the exact lineStart and lineEnd bounds shown in that file's header. Do not invent narrower line coordinates without source text.
 - Since you only see metadata (signatures, imports, calls), focus on structural patterns — missing capabilities, dependency issues, and configuration problems detectable without reading function bodies.
 - Only report genuine issues. Do not flag trivial style preferences.
 

--- a/packages/core/src/services/llm/provider.ts
+++ b/packages/core/src/services/llm/provider.ts
@@ -104,8 +104,20 @@ export interface ExistingViolation {
   severity: string;
 }
 
+export interface CodeSourceRange {
+  lineStart: number;
+  lineEnd: number;
+}
+
+export interface CodeSourceScope {
+  path: string;
+  ranges: CodeSourceRange[];
+}
+
 export interface CodeViolationContext {
   files: { path: string; content: string }[];
+  /** Exact source ranges supplied to this work unit and therefore owned by its result. */
+  sourceScopes: CodeSourceScope[];
   llmRules: { key: string; name: string; severity: string; prompt: string }[];
   /** Context tier — determines which prompt template to use */
   tier?: 'metadata' | 'targeted' | 'full-file';
@@ -131,6 +143,8 @@ export interface CodeViolationRaw {
   title: string;
   content: string;
   fixPrompt: string | null;
+  /** Input tier that owns this finding; metadata findings are file-level and have no source snippet. */
+  sourceTier?: 'metadata' | 'targeted' | 'full-file';
 }
 
 export interface CodeViolationsResult {

--- a/packages/core/src/services/llm/schemas.ts
+++ b/packages/core/src/services/llm/schemas.ts
@@ -119,8 +119,8 @@ export const CodeViolationOutputSchema = z.object({
     z.object({
       ruleKey: z.string().describe('The exact key from the rules list'),
       filePath: z.string().describe('The exact file path from the files list'),
-      lineStart: z.number().describe('The starting line number of the violation'),
-      lineEnd: z.number().describe('The ending line number of the violation'),
+      lineStart: z.number().int().positive().describe('The starting line number of the violation'),
+      lineEnd: z.number().int().positive().describe('The ending line number of the violation'),
       severity: z.enum(['low', 'medium', 'high', 'critical']),
       title: z.string().describe('A concise title for the violation'),
       content: z.string().describe('A detailed description of the issue and why it matters'),
@@ -136,8 +136,8 @@ export const CodeViolationLifecycleOutputSchema = z.object({
     z.object({
       ruleKey: z.string().describe('The exact key from the rules list'),
       filePath: z.string().describe('The exact file path from the files list'),
-      lineStart: z.number().describe('The starting line number of the violation'),
-      lineEnd: z.number().describe('The ending line number of the violation'),
+      lineStart: z.number().int().positive().describe('The starting line number of the violation'),
+      lineEnd: z.number().int().positive().describe('The ending line number of the violation'),
       severity: z.enum(['low', 'medium', 'high', 'critical']),
       title: z.string().describe('A concise title for the violation'),
       content: z.string().describe('A detailed description of the issue and why it matters'),

--- a/packages/core/src/services/violation-pipeline.service.ts
+++ b/packages/core/src/services/violation-pipeline.service.ts
@@ -7,7 +7,7 @@ import type { ModuleViolation, ServiceViolation } from '@truecourse/analyzer';
 import { runDeterministicModuleChecks, runDeterministicMethodChecks, runDeterministicServiceChecks, type AnalysisResult } from './analyzer.service.js';
 import { DOMAIN_ORDER, CODE_DOMAINS } from '../progress.js';
 import { getEnabledRules } from './rules.service.js';
-import { createLLMProvider, type LLMProvider, type CodeViolationContext, type CodeViolationRaw, type DiffViolationItem } from './llm/provider.js';
+import { createLLMProvider, type LLMProvider, type CodeViolationContext, type CodeViolationRaw, type CodeViolationsResult, type CodeSourceScope, type DiffViolationItem } from './llm/provider.js';
 import { routeContext, estimateContext } from './llm/context-router.js';
 import { generateViolations, generateViolationsWithLifecycle } from './violation.service.js';
 import {
@@ -201,6 +201,105 @@ export function compareDeterministicViolations<
   }
 
   return { newDetections, unchangedDetections, resolvedDetections };
+}
+
+export function isPreviousCodeViolationOwnedByBatch(
+  violation: Pick<ActiveViolation, 'ruleKey' | 'filePath' | 'lineStart' | 'lineEnd'>,
+  ruleKeys: ReadonlySet<string>,
+  sourceScopes: CodeSourceScope[],
+): boolean {
+  if (
+    !ruleKeys.has(violation.ruleKey) ||
+    !violation.filePath ||
+    violation.lineStart == null ||
+    violation.lineEnd == null
+  ) {
+    return false;
+  }
+
+  return sourceScopes.some((scope) =>
+    scope.path === violation.filePath && scope.ranges.some((range) =>
+      violation.lineStart! >= range.lineStart && violation.lineEnd! <= range.lineEnd,
+    ),
+  );
+}
+
+export function aggregateCodeBatchOutcomes(
+  batches: Pick<CodeViolationContext, 'existingViolations'>[],
+  results: PromiseSettledResult<CodeViolationsResult>[],
+): {
+  violations: CodeViolationRaw[];
+  resolvedIds: string[];
+  unchangedIds: string[];
+  failures: unknown[];
+} {
+  const violations: CodeViolationRaw[] = [];
+  const resolvedIds: string[] = [];
+  const unchangedIds: string[] = [];
+  const failures: unknown[] = [];
+
+  for (let index = 0; index < results.length; index++) {
+    const result = results[index];
+    if (result.status === 'fulfilled') {
+      violations.push(...result.value.violations);
+      resolvedIds.push(...(result.value.resolvedViolationIds ?? []));
+      unchangedIds.push(...(result.value.unchangedViolationIds ?? []));
+    } else {
+      failures.push(result.reason);
+      unchangedIds.push(...(batches[index]?.existingViolations?.map((violation) => violation.id) ?? []));
+    }
+  }
+
+  return {
+    violations,
+    resolvedIds: [...new Set(resolvedIds)],
+    unchangedIds: [...new Set(unchangedIds)],
+    failures,
+  };
+}
+
+export function hasCodeLifecycleResults(
+  violations: CodeViolation[],
+  resolvedIds: string[],
+  unchangedIds: string[],
+): boolean {
+  return violations.length > 0 || resolvedIds.length > 0 || unchangedIds.length > 0;
+}
+
+export function reconcileCodePriorClassifications(
+  previousIds: string[],
+  resolvedIds: string[],
+  unchangedIds: string[],
+): { resolvedIds: string[]; unchangedIds: string[] } {
+  const unchanged = new Set(unchangedIds);
+  const resolved = new Set(resolvedIds.filter((id) => !unchanged.has(id)));
+
+  for (const id of previousIds) {
+    if (!resolved.has(id) && !unchanged.has(id)) unchanged.add(id);
+  }
+
+  return {
+    resolvedIds: [...resolved],
+    unchangedIds: [...unchanged],
+  };
+}
+
+export function codeDomainViolationTotal(
+  deterministicCount: number,
+  newViolationCount: number,
+  unchangedIds: string[],
+): number {
+  return deterministicCount + newViolationCount + new Set(unchangedIds).size;
+}
+
+export function buildLlmCodeSnippet(
+  sourceTier: CodeViolationRaw['sourceTier'],
+  fileContent: string,
+  lineStart: number,
+  lineEnd: number,
+): string {
+  if (sourceTier === 'metadata') return '';
+  return fileContent.split('\n').slice(lineStart - 1, lineEnd).join('\n');
 }
 
 // ---------------------------------------------------------------------------
@@ -694,20 +793,6 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
     const contextBatches = routeContext(enabledLlmCodeRules, result.fileAnalyses || [], fileContents);
 
     for (const batch of contextBatches) {
-      const existing = [...prevLlmCodeByFile.entries()]
-        .filter(([fp]) => batch.content.includes(fp))
-        .flatMap(([, violations]) => violations)
-        .map((v) => ({
-          id: v.id,
-          filePath: v.filePath!,
-          lineStart: v.lineStart!,
-          lineEnd: v.lineEnd!,
-          ruleKey: v.ruleKey,
-          severity: v.severity,
-          title: v.title,
-          content: v.content,
-        }));
-
       const rulesByDomain = new Map<string, typeof batch.rules>();
       for (const rule of batch.rules) {
         const domain = rule.key.split('/')[0];
@@ -722,9 +807,25 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
 
       for (const [domain, rules] of rulesByDomain) {
         if (!domainCodeBatches.has(domain)) domainCodeBatches.set(domain, []);
-        const domainExisting = existing.filter((v) => v.ruleKey.startsWith(`${domain}/`));
+        const ruleKeys = new Set(rules.map((rule) => rule.key));
+        const domainExisting = [...prevLlmCodeByFile.values()]
+          .flat()
+          .filter((violation) =>
+            isPreviousCodeViolationOwnedByBatch(violation, ruleKeys, batch.sourceScopes),
+          )
+          .map((violation) => ({
+            id: violation.id,
+            filePath: violation.filePath!,
+            lineStart: violation.lineStart!,
+            lineEnd: violation.lineEnd!,
+            ruleKey: violation.ruleKey,
+            severity: violation.severity,
+            title: violation.title,
+            content: violation.content,
+          }));
         domainCodeBatches.get(domain)!.push({
           files,
+          sourceScopes: batch.sourceScopes,
           llmRules: rules,
           tier: batch.tier,
           existingViolations: domainExisting.length > 0 ? domainExisting : undefined,
@@ -1141,27 +1242,28 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
         }),
       );
 
-      const rawViolations: CodeViolationRaw[] = [];
-      const resolvedIds: string[] = [];
-      const unchangedIds: string[] = [];
-      for (const r of codeResults) {
-        if (r.status === 'fulfilled') {
-          rawViolations.push(...r.value.violations);
-          if (r.value.resolvedViolationIds) resolvedIds.push(...r.value.resolvedViolationIds);
-          if (r.value.unchangedViolationIds) unchangedIds.push(...r.value.unchangedViolationIds);
-        } else {
-          log.warn(`[LLM] ${domain}: batch failed — ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`);
-        }
+      const aggregate = aggregateCodeBatchOutcomes(batches, codeResults);
+      for (const failure of aggregate.failures) {
+        log.warn(`[LLM] ${domain}: batch failed; previous findings preserved — ${failure instanceof Error ? failure.message : String(failure)}`);
       }
 
       const dur = Date.now() - t0;
       const processed: CodeViolation[] = [];
-      processLlmCodeViolations({ violations: rawViolations }, validFilePaths, fileContents, processed, repoPath);
-      const total = detCount + processed.length;
+      processLlmCodeViolations({ violations: aggregate.violations }, validFilePaths, fileContents, processed, repoPath);
+      const total = codeDomainViolationTotal(detCount, processed.length, aggregate.unchangedIds);
       log.info(`[LLM] ${domain}: done in ${dur}ms — ${processed.length} LLM violations (${total} total)`);
-      tracker?.done(domain, total > 0 ? `${total} violations` : 'Clean');
+      if (aggregate.failures.length > 0) {
+        tracker?.error(domain, `${aggregate.failures.length} LLM check${aggregate.failures.length === 1 ? '' : 's'} failed; previous findings preserved`);
+      } else {
+        tracker?.done(domain, total > 0 ? `${total} violations` : 'Clean');
+      }
 
-      return { domain, violations: processed, resolvedIds, unchangedIds };
+      return {
+        domain,
+        violations: processed,
+        resolvedIds: aggregate.resolvedIds,
+        unchangedIds: aggregate.unchangedIds,
+      };
     })());
   }
 
@@ -1471,7 +1573,17 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
     }
   }
 
-  if (allLlmCodeViolations.length > 0 || allLlmResolvedIds.length > 0) {
+  const priorClassifications = reconcileCodePriorClassifications(
+    previousActiveCodeViolations
+      .filter((previous) => previous.ruleKey.includes('/llm/'))
+      .map((previous) => previous.id),
+    allLlmResolvedIds,
+    allLlmUnchangedIds,
+  );
+  allLlmResolvedIds.splice(0, allLlmResolvedIds.length, ...priorClassifications.resolvedIds);
+  allLlmUnchangedIds.splice(0, allLlmUnchangedIds.length, ...priorClassifications.unchangedIds);
+
+  if (hasCodeLifecycleResults(allLlmCodeViolations, allLlmResolvedIds, allLlmUnchangedIds)) {
     log.info(`[Pipeline] LLM code totals: ${allLlmCodeViolations.length} new, ${allLlmResolvedIds.length} resolved, ${allLlmUnchangedIds.length} unchanged`);
 
     for (const prevId of allLlmUnchangedIds) {
@@ -1583,42 +1695,6 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
       );
     }
 
-    // Carry forward LLM violations for unchanged files
-    const llmPrevUnchangedFiles = previousActiveCodeViolations.filter(
-      (v) => v.ruleKey.includes('/llm/') && v.filePath && !scannedFilePaths.has(v.filePath),
-    );
-    for (const prev of llmPrevUnchangedFiles) {
-      unchanged.push({
-        id: randomUUID(),
-        type: 'code',
-        category: prev.category ?? 'rule',
-        subcategory: prev.subcategory ?? null,
-        title: prev.title,
-        content: prev.content,
-        severity: prev.severity,
-        status: 'unchanged',
-        targetServiceId: null,
-        targetDatabaseId: null,
-        targetModuleId: null,
-        targetMethodId: null,
-        targetTable: null,
-        relatedServiceId: null,
-        relatedModuleId: null,
-        fixPrompt: prev.fixPrompt,
-        ruleKey: prev.ruleKey,
-        firstSeenAnalysisId: prev.firstSeenAnalysisId,
-        firstSeenAt: prev.firstSeenAt,
-        previousViolationId: prev.id,
-        resolvedAt: null,
-        filePath: prev.filePath,
-        lineStart: prev.lineStart,
-        lineEnd: prev.lineEnd,
-        columnStart: prev.columnStart,
-        columnEnd: prev.columnEnd,
-        snippet: prev.snippet,
-        createdAt: now,
-      });
-    }
   }
 
   tracker?.done('persist', 'Done');
@@ -1637,7 +1713,7 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
 // ---------------------------------------------------------------------------
 
 function processLlmCodeViolations(
-  codeResult: { violations: { ruleKey: string; filePath: string; lineStart: number; lineEnd: number; severity: string; title: string; content: string; fixPrompt: string | null }[] },
+  codeResult: { violations: { ruleKey: string; filePath: string; lineStart: number; lineEnd: number; severity: string; title: string; content: string; fixPrompt: string | null; sourceTier?: CodeViolationRaw['sourceTier'] }[] },
   validFilePaths: Set<string>,
   fileContents: Map<string, { content: string; lineCount: number }>,
   allCodeViolations: CodeViolation[],
@@ -1663,8 +1739,7 @@ function processLlmCodeViolations(
     const fileInfo = fileContents.get(filePath)!;
     const lineStart = Math.max(1, Math.min(v.lineStart, fileInfo.lineCount));
     const lineEnd = Math.max(lineStart, Math.min(v.lineEnd, fileInfo.lineCount));
-    const lines = fileInfo.content.split('\n');
-    const snippet = lines.slice(lineStart - 1, lineEnd).join('\n');
+    const snippet = buildLlmCodeSnippet(v.sourceTier, fileInfo.content, lineStart, lineEnd);
     allCodeViolations.push({
       ruleKey: v.ruleKey,
       filePath,

--- a/tests/core/code-batch-lifecycle.test.ts
+++ b/tests/core/code-batch-lifecycle.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateCodeBatchOutcomes,
+  buildLlmCodeSnippet,
+  codeDomainViolationTotal,
+  hasCodeLifecycleResults,
+  isPreviousCodeViolationOwnedByBatch,
+  reconcileCodePriorClassifications,
+} from '../../packages/core/src/services/violation-pipeline.service.js';
+import type { CodeViolationContext, CodeViolationRaw } from '../../packages/core/src/services/llm/provider.js';
+import type { ActiveViolation } from '../../packages/core/src/services/violation-lifecycle.service.js';
+
+const sourceScopes = [{ path: '/repo/a.ts', ranges: [{ lineStart: 10, lineEnd: 20 }] }];
+
+const prior = {
+  id: 'prior-1',
+  ruleKey: 'security/llm/no-eval',
+  filePath: '/repo/a.ts',
+  lineStart: 12,
+  lineEnd: 13,
+} as ActiveViolation;
+
+describe('code batch lifecycle ownership', () => {
+  it('assigns a prior only when its exact rule and complete source range belong to the batch', () => {
+    expect(isPreviousCodeViolationOwnedByBatch(
+      prior,
+      new Set(['security/llm/no-eval']),
+      sourceScopes,
+    )).toBe(true);
+
+    expect(isPreviousCodeViolationOwnedByBatch(
+      prior,
+      new Set(['security/llm/no-secrets']),
+      sourceScopes,
+    )).toBe(false);
+
+    expect(isPreviousCodeViolationOwnedByBatch(
+      { ...prior, lineStart: 9 },
+      new Set(['security/llm/no-eval']),
+      sourceScopes,
+    )).toBe(false);
+  });
+
+  it('carries a rejected batch prior unchanged while retaining successful sibling results', () => {
+    const existing = [{
+      id: prior.id,
+      filePath: prior.filePath!,
+      lineStart: prior.lineStart!,
+      lineEnd: prior.lineEnd!,
+      ruleKey: prior.ruleKey,
+      severity: 'high',
+      title: 'Prior finding',
+      content: 'Prior content',
+    }];
+    const batches: Pick<CodeViolationContext, 'existingViolations'>[] = [
+      { existingViolations: existing },
+      { existingViolations: undefined },
+    ];
+    const successfulViolation: CodeViolationRaw = {
+      ruleKey: 'security/llm/no-secrets',
+      filePath: '/repo/b.ts',
+      lineStart: 4,
+      lineEnd: 4,
+      severity: 'high',
+      title: 'Embedded secret',
+      content: 'A secret is embedded in source.',
+      fixPrompt: null,
+    };
+    const results: PromiseSettledResult<{
+      violations: CodeViolationRaw[];
+      resolvedViolationIds?: string[];
+      unchangedViolationIds?: string[];
+    }>[] = [
+      { status: 'rejected', reason: new Error('ownership rejected') },
+      { status: 'fulfilled', value: { violations: [successfulViolation] } },
+    ];
+
+    const aggregate = aggregateCodeBatchOutcomes(batches, results);
+
+    expect(aggregate.violations).toEqual([successfulViolation]);
+    expect(aggregate.resolvedIds).toEqual([]);
+    expect(aggregate.unchangedIds).toEqual(['prior-1']);
+    expect(aggregate.failures).toHaveLength(1);
+  });
+
+  it('treats an unchanged-only response as lifecycle work that must be persisted', () => {
+    expect(hasCodeLifecycleResults([], [], ['prior-1'])).toBe(true);
+  });
+
+  it('preserves unclassified priors and lets unchanged win any cross-batch conflict', () => {
+    expect(reconcileCodePriorClassifications(
+      ['prior-1', 'prior-2', 'prior-3'],
+      ['prior-1', 'prior-2'],
+      ['prior-2'],
+    )).toEqual({
+      resolvedIds: ['prior-1'],
+      unchangedIds: ['prior-2', 'prior-3'],
+    });
+  });
+
+  it('counts active unchanged findings in the domain tracker total', () => {
+    expect(codeDomainViolationTotal(2, 1, ['prior-1', 'prior-1', 'prior-2'])).toBe(5);
+  });
+
+  it('does not persist source snippets for metadata-only findings', () => {
+    const wholeFile = 'first line\nsecret implementation\nlast line';
+
+    expect(buildLlmCodeSnippet('metadata', wholeFile, 1, 3)).toBe('');
+    expect(buildLlmCodeSnippet('targeted', wholeFile, 2, 2)).toBe('secret implementation');
+  });
+});

--- a/tests/core/code-result-ownership.test.ts
+++ b/tests/core/code-result-ownership.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from 'vitest';
+import type { LlmTransport } from '@truecourse/shared/llm';
+import { BaseCLIProvider } from '../../packages/core/src/services/llm/cli-provider.js';
+import type { CodeViolationContext } from '../../packages/core/src/services/llm/provider.js';
+
+class CodeResultProvider extends BaseCLIProvider {
+  get binaryName() {
+    return 'claude';
+  }
+
+  get baseArgs() {
+    return ['-p', '--output-format', 'json'];
+  }
+
+  get modelFlag() {
+    return ['--model', 'test-model'];
+  }
+}
+
+const rule = {
+  key: 'security/llm/no-eval',
+  name: 'No eval',
+  severity: 'high',
+  prompt: 'Report unsafe eval calls.',
+};
+
+const violation = {
+  ruleKey: rule.key,
+  filePath: '/repo/a.ts',
+  lineStart: 2,
+  lineEnd: 2,
+  severity: 'high',
+  title: 'Unsafe `eval` call',
+  content: '`eval` executes untrusted input.',
+  fixPrompt: null,
+};
+
+function providerReturning(output: unknown): CodeResultProvider {
+  const transport: LlmTransport = async () => JSON.stringify(output);
+  return new CodeResultProvider(transport);
+}
+
+function fullFileContext(): CodeViolationContext {
+  return {
+    files: [{ path: '/repo/a.ts', content: 'const a = 1;\neval(input);\nreturn a;' }],
+    sourceScopes: [{ path: '/repo/a.ts', ranges: [{ lineStart: 1, lineEnd: 3 }] }],
+    llmRules: [rule],
+    tier: 'full-file',
+  };
+}
+
+describe('code-result ownership certification', () => {
+  it('accepts a finding owned by the originating rule, source, and range', async () => {
+    const result = await providerReturning({ violations: [violation] })
+      .generateCodeViolations(fullFileContext());
+
+    expect(result.violations).toEqual([{ ...violation, sourceTier: 'full-file' }]);
+  });
+
+  it('rejects a duplicate new finding instead of persisting it twice', async () => {
+    await expect(providerReturning({ violations: [violation, { ...violation }] })
+      .generateCodeViolations(fullFileContext()))
+      .rejects.toThrow(/same new finding more than once/i);
+  });
+
+  it('rejects a rule key that was not assigned to the originating batch', async () => {
+    const output = {
+      violations: [{ ...violation, ruleKey: 'reliability/llm/no-retry' }],
+    };
+
+    await expect(providerReturning(output).generateCodeViolations(fullFileContext()))
+      .rejects.toThrow(/rule.*originating batch/i);
+  });
+
+  it('rejects a source path owned by a different batch', async () => {
+    const output = {
+      violations: [{ ...violation, filePath: '/repo/b.ts' }],
+    };
+
+    await expect(providerReturning(output).generateCodeViolations(fullFileContext()))
+      .rejects.toThrow(/source.*originating batch/i);
+  });
+
+  it('rejects a line range outside the originating source scope', async () => {
+    const output = {
+      violations: [{ ...violation, lineStart: 3, lineEnd: 4 }],
+    };
+
+    await expect(providerReturning(output).generateCodeViolations(fullFileContext()))
+      .rejects.toThrow(/range.*originating batch/i);
+  });
+
+  it.each([
+    { name: 'fractional', lineStart: 1.5, lineEnd: 2 },
+    { name: 'non-positive', lineStart: 0, lineEnd: 2 },
+  ])('rejects $name line coordinates before ownership certification', async ({ lineStart, lineEnd }) => {
+    const output = {
+      violations: [{ ...violation, lineStart, lineEnd }],
+    };
+
+    await expect(providerReturning(output).generateCodeViolations(fullFileContext()))
+      .rejects.toThrow();
+  });
+
+  it('rejects a reversed line range', async () => {
+    const output = {
+      violations: [{ ...violation, lineStart: 3, lineEnd: 2 }],
+    };
+
+    await expect(providerReturning(output).generateCodeViolations(fullFileContext()))
+      .rejects.toThrow(/range.*originating batch/i);
+  });
+
+  it('rejects a range spanning two separately supplied targeted functions', async () => {
+    const context: CodeViolationContext = {
+      files: [{ path: 'context', content: '=== /repo/a.ts ===\n10: first();\n20: second();' }],
+      sourceScopes: [{
+        path: '/repo/a.ts',
+        ranges: [
+          { lineStart: 10, lineEnd: 12 },
+          { lineStart: 20, lineEnd: 25 },
+        ],
+      }],
+      llmRules: [rule],
+      tier: 'targeted',
+    };
+    const output = {
+      violations: [{ ...violation, lineStart: 12, lineEnd: 20 }],
+    };
+
+    await expect(providerReturning(output).generateCodeViolations(context))
+      .rejects.toThrow(/range.*originating batch/i);
+  });
+
+  it('requires metadata findings to use the supplied file-level bounds', async () => {
+    const context: CodeViolationContext = {
+      files: [{ path: 'context', content: '=== /repo/a.ts (lines 1-30) ===\nImports: node:fs' }],
+      sourceScopes: [{ path: '/repo/a.ts', ranges: [{ lineStart: 1, lineEnd: 30 }] }],
+      llmRules: [rule],
+      tier: 'metadata',
+    };
+    const fabricatedNarrowRange = {
+      violations: [{ ...violation, lineStart: 10, lineEnd: 12 }],
+    };
+
+    await expect(providerReturning(fabricatedNarrowRange).generateCodeViolations(context))
+      .rejects.toThrow(/range.*originating batch/i);
+
+    const accepted = await providerReturning({
+      violations: [{ ...violation, lineStart: 1, lineEnd: 30 }],
+    }).generateCodeViolations(context);
+    expect(accepted.violations[0]).toMatchObject({ lineStart: 1, lineEnd: 30 });
+  });
+});
+
+describe('code lifecycle ownership certification', () => {
+  function lifecycleContext(): CodeViolationContext {
+    return {
+      ...fullFileContext(),
+      existingViolations: [
+        {
+          id: 'real-1',
+          filePath: '/repo/a.ts',
+          lineStart: 1,
+          lineEnd: 1,
+          ruleKey: rule.key,
+          severity: 'high',
+          title: 'First prior finding',
+          content: 'First prior finding content.',
+        },
+        {
+          id: 'real-2',
+          filePath: '/repo/a.ts',
+          lineStart: 3,
+          lineEnd: 3,
+          ruleKey: rule.key,
+          severity: 'high',
+          title: 'Second prior finding',
+          content: 'Second prior finding content.',
+        },
+      ],
+    };
+  }
+
+  it('accepts an exact prior-ID partition and rebinds prompt IDs', async () => {
+    const output = {
+      resolvedViolationIds: ['cv-0'],
+      unchangedViolationIds: ['cv-1'],
+      newViolations: [],
+    };
+
+    const result = await providerReturning(output).generateCodeViolations(lifecycleContext());
+
+    expect(result.resolvedViolationIds).toEqual(['real-1']);
+    expect(result.unchangedViolationIds).toEqual(['real-2']);
+  });
+
+  it.each([
+    {
+      name: 'an unknown ID',
+      resolvedViolationIds: ['cv-0'],
+      unchangedViolationIds: ['cv-99'],
+    },
+    {
+      name: 'an omitted ID',
+      resolvedViolationIds: ['cv-0'],
+      unchangedViolationIds: [],
+    },
+    {
+      name: 'an ID in both outcomes',
+      resolvedViolationIds: ['cv-0', 'cv-1'],
+      unchangedViolationIds: ['cv-1'],
+    },
+    {
+      name: 'a duplicate ID',
+      resolvedViolationIds: ['cv-0', 'cv-0'],
+      unchangedViolationIds: ['cv-1'],
+    },
+  ])('rejects $name instead of accepting an ambiguous lifecycle result', async (output) => {
+    await expect(providerReturning({ ...output, newViolations: [] })
+      .generateCodeViolations(lifecycleContext()))
+      .rejects.toThrow(/exact partition/i);
+  });
+
+  it.each([
+    {
+      resolvedViolationIds: ['cv-0'],
+      unchangedViolationIds: ['cv-1'],
+    },
+    {
+      resolvedViolationIds: ['cv-1'],
+      unchangedViolationIds: ['cv-0'],
+    },
+  ])('rejects a prior finding reintroduced as new regardless of its classification', async (partition) => {
+    const duplicatePrior = {
+      ...violation,
+      lineStart: 1,
+      lineEnd: 1,
+      title: 'First prior finding',
+    };
+
+    await expect(providerReturning({
+      ...partition,
+      newViolations: [duplicatePrior],
+    }).generateCodeViolations(lifecycleContext()))
+      .rejects.toThrow(/reintroduce.*same finding/i);
+  });
+
+  it('allows the same rule and title at a distinct full-file location', async () => {
+    const result = await providerReturning({
+      resolvedViolationIds: ['cv-0'],
+      unchangedViolationIds: ['cv-1'],
+      newViolations: [{ ...violation, title: 'First prior finding' }],
+    }).generateCodeViolations(lifecycleContext());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]).toMatchObject({ lineStart: 2, title: 'First prior finding' });
+  });
+
+  it('rejects a legacy narrow metadata prior reintroduced as the same file-level finding', async () => {
+    const context: CodeViolationContext = {
+      ...lifecycleContext(),
+      files: [{ path: 'context', content: '=== /repo/a.ts (lines 1-3) ===\nImports: node:fs' }],
+      sourceScopes: [{ path: '/repo/a.ts', ranges: [{ lineStart: 1, lineEnd: 3 }] }],
+      tier: 'metadata',
+    };
+
+    await expect(providerReturning({
+      resolvedViolationIds: ['cv-0'],
+      unchangedViolationIds: ['cv-1'],
+      newViolations: [{
+        ...violation,
+        lineStart: 1,
+        lineEnd: 3,
+        title: 'First prior finding',
+      }],
+    }).generateCodeViolations(context))
+      .rejects.toThrow(/reintroduce.*same finding/i);
+  });
+
+  it('rejects duplicate new findings in lifecycle mode too', async () => {
+    await expect(providerReturning({
+      resolvedViolationIds: ['cv-0'],
+      unchangedViolationIds: ['cv-1'],
+      newViolations: [violation, { ...violation }],
+    }).generateCodeViolations(lifecycleContext()))
+      .rejects.toThrow(/same new finding more than once/i);
+  });
+});

--- a/tests/core/context-router-source-scopes.test.ts
+++ b/tests/core/context-router-source-scopes.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { AnalysisRule, FileAnalysis } from '@truecourse/shared';
+import { routeContext } from '../../packages/core/src/services/llm/context-router.js';
+
+function ruleFor(tier: 'metadata' | 'targeted' | 'full-file'): AnalysisRule {
+  return {
+    key: `security/llm/${tier}`,
+    name: `${tier} rule`,
+    severity: 'high',
+    prompt: `Check ${tier} input.`,
+    contextRequirement: {
+      tier,
+      metadataFields: tier === 'metadata' ? ['imports'] : undefined,
+    },
+  } as AnalysisRule;
+}
+
+function fileAnalysis(path: string, functions: unknown[] = []): FileAnalysis {
+  return {
+    filePath: path,
+    functions,
+    classes: [],
+    imports: [],
+    exports: [],
+    calls: [],
+    httpCalls: [],
+    routeRegistrations: [],
+  } as unknown as FileAnalysis;
+}
+
+describe('context router source scopes', () => {
+  it('records whole-file bounds for metadata batches', () => {
+    const files = [fileAnalysis('/repo/a.ts'), fileAnalysis('/repo/b.ts')];
+    const contents = new Map([
+      ['/repo/a.ts', { content: 'a\n'.repeat(12), lineCount: 12 }],
+      ['/repo/b.ts', { content: 'b\n'.repeat(7), lineCount: 7 }],
+    ]);
+
+    const [batch] = routeContext([ruleFor('metadata')], files, contents);
+
+    expect(batch.sourceScopes).toEqual([
+      { path: '/repo/a.ts', ranges: [{ lineStart: 1, lineEnd: 12 }] },
+      { path: '/repo/b.ts', ranges: [{ lineStart: 1, lineEnd: 7 }] },
+    ]);
+  });
+
+  it('records only the extracted function ranges for targeted batches', () => {
+    const functions = [
+      { name: 'first', location: { startLine: 10, endLine: 12 } },
+      { name: 'second', location: { startLine: 20, endLine: 25 } },
+    ];
+    const files = [fileAnalysis('/repo/a.ts', functions)];
+    const contents = new Map([
+      ['/repo/a.ts', { content: Array.from({ length: 30 }, (_, i) => `line ${i + 1}`).join('\n'), lineCount: 30 }],
+    ]);
+
+    const [batch] = routeContext([ruleFor('targeted')], files, contents);
+
+    expect(batch.sourceScopes).toEqual([{
+      path: '/repo/a.ts',
+      ranges: [
+        { lineStart: 10, lineEnd: 12 },
+        { lineStart: 20, lineEnd: 25 },
+      ],
+    }]);
+  });
+
+  it('keeps each source scope attached to the correct oversized split batch', () => {
+    const files = [fileAnalysis('/repo/a.ts'), fileAnalysis('/repo/b.ts')];
+    const contents = new Map([
+      ['/repo/a.ts', { content: 'a'.repeat(60_000), lineCount: 1 }],
+      ['/repo/b.ts', { content: 'b'.repeat(60_000), lineCount: 1 }],
+    ]);
+
+    const batches = routeContext([ruleFor('full-file')], files, contents);
+
+    expect(batches).toHaveLength(2);
+    expect(batches.map((batch) => batch.sourceScopes)).toEqual([
+      [{ path: '/repo/a.ts', ranges: [{ lineStart: 1, lineEnd: 1 }] }],
+      [{ path: '/repo/b.ts', ranges: [{ lineStart: 1, lineEnd: 1 }] }],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Certify each LLM code-check result against the exact work unit that produced it before the result can enter violation lifecycle reconciliation.

- carry an explicit rule/source/range ledger through metadata, targeted, full-file, and oversized split batches;
- reject results that reference another batch's rule, file, range, or lifecycle IDs;
- require exact, duplicate-free lifecycle ID partitions and reject prior/new or duplicate-new collisions;
- preserve priors from failed or unclassified work units instead of inferring that they resolved;
- persist unchanged-only lifecycle results and count them in progress;
- keep metadata findings honestly file-level without copying whole source files into persisted snippets.

## Why

Safe checkpoint replay requires more than a stable work-unit ID. A saved result must also be provably owned by that work unit's exact inputs. Previously, concurrent code responses were flattened and validated only against the repository-wide file set, so a result could escape its originating batch and later be attached to the wrong rule, source, range, or prior lifecycle record.

This is a correctness prerequisite for the durable journal and resumability work planned in #791.

## Failure behavior

If a code batch fails schema or ownership certification, successful sibling calls may still report their findings, but the failed batch's prior findings are preserved as unchanged and the domain is shown as errored. Findings that no current certified work unit classified are also preserved. The pipeline does not treat absence of a certified response as evidence that a prior finding resolved.

## Tests

- 52 focused provider, ownership, router, batch-lifecycle, concurrency, and lifecycle tests
- `pnpm lint` — 14/14 tasks
- `pnpm build` — 19/19 tasks
- `git diff --check`
- fresh independent release audit: no P0–P2 findings

## Scope and follow-ups

Refs #791.

This PR does **not** resolve or close #791. It does not add stable work-unit IDs/fingerprints, a durable latest-attempted-run journal, token-preserving checkpoints, usage reconciliation, reset-aware resume, latest-run APIs/UI, or atomic completed-baseline promotion. Those remain required follow-up contributions in the accepted issue plan.

The current damage-containment tradeoff also remains: until the journal/checkpoint slices land, successful calls from an interrupted run are not reusable and a rerun can spend those tokens again.

## Interaction with PR #816

PR #816 and this PR both extend context-router provenance. If one lands first, the later rebase must preserve both contracts: #816's structured metadata/targeted/full-file source selections and this PR's exact rule/source/range result certification. The ownership ranges should be derived from the structured source selections; neither contract should replace the other.
