### PR TITLE
Fix #813: C# Roslyn host runs on the SDK's runtime (analyze-project MSBuildLocator failure)

### DIFF
--- a/docs/fp-automation/README.md
+++ b/docs/fp-automation/README.md
@@ -298,8 +298,11 @@ support to produce findings; the `drift-fp` loop verifies C# via the contract-ve
 **C# account .NET prerequisites** (default account needs none):
 - The session must have the **.NET SDK — 10.x** recommended (or ≥ 9.0.2xx). It
   builds the Roslyn host during `build:dist` and, at analyze time, opens `.slnx`
-  solutions (common in modern C# repos) and modern targets. The host itself is
-  `net8.0` with roll-forward, so it *runs* on any ≥ 8 runtime.
+  solutions (common in modern C# repos) and modern targets. The host itself is a
+  `net8.0` DLL with `RollForward=LatestMajor`, so it *runs* on the newest runtime
+  present — deliberately the SDK's own runtime, so `analyze-project`'s
+  MSBuildLocator always finds a usable MSBuild. Loose-text analysis stays on a
+  pinned net8 reference set regardless of that runtime (issue #813).
 - Each C# target must be **`dotnet restore`d before analyze** (see the discover /
   next-fix prompts). The project-aware Roslyn tier **fails-hard** on an
   unrestored project or a missing/unsatisfiable SDK — it aborts the run rather
@@ -645,9 +648,9 @@ One-time, before the first run:
      .NET CDN — so a mid-session install returns 403 from the egress proxy):
      1. **Setup script.** Give the C# account its **own** environment whose
         setup script runs `docs/fp-automation/setup-csharp-env.sh` — it
-        installs the 10.x SDK plus a net8 runtime for the host, once per
-        container, and is idempotent. (The routine prompts also run it as a
-        fallback when `dotnet` is missing.)
+        installs the 10.x SDK (whose runtime the `net8.0` host rolls forward
+        onto), once per container, and is idempotent. (The routine prompts also
+        run it as a fallback when `dotnet` is missing.)
      2. **Network policy.** Widen that environment's egress allowlist to the
         .NET download + NuGet hosts — at least `dot.net`,
         `builds.dotnet.microsoft.com`, `dotnetcli.azureedge.net`,

--- a/docs/fp-automation/setup-csharp-env.sh
+++ b/docs/fp-automation/setup-csharp-env.sh
@@ -45,13 +45,15 @@ fi
 chmod +x /tmp/dotnet-install.sh
 
 # .NET 10 SDK — abp's global.json pins 10.0.100 (rollForward latestFeature); the
-# roslyn-workspace tier restores abp's real solution with this SDK.
+# roslyn-workspace tier restores abp's real solution with this SDK. Installing the
+# SDK also lays down its matching runtime, which is all the host needs: the host is
+# a net8.0 DLL with RollForward=LatestMajor, so it runs on this SDK's runtime, and
+# `analyze-project`'s MSBuildLocator finds the SDK's MSBuild (running on a separate
+# net8 runtime while only a net10 SDK is present cannot — issue #813). No standalone
+# net8 runtime is installed: the loose-text `analyze` op no longer depends on the
+# runtime BCL (it uses a pinned net8 reference pack), so the host is free to run on
+# the SDK's runtime.
 /tmp/dotnet-install.sh --channel 10.0 --install-dir "$DOTNET_DIR"
-
-# .NET 8 runtime — the Roslyn host targets net8.0 and is launched framework-
-# dependent (`dotnet <dll>`); .NET does not roll forward across majors by default,
-# so a net8 app will not run on a net10-only runtime.
-/tmp/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir "$DOTNET_DIR"
 
 export DOTNET_ROOT="$DOTNET_DIR"
 export PATH="$DOTNET_DIR:$PATH"

--- a/tests/analyzer/roslyn-host.test.ts
+++ b/tests/analyzer/roslyn-host.test.ts
@@ -48,7 +48,7 @@ describe.skipIf(!hostBuilt)('Roslyn host client (semantic C#)', () => {
 
   // Regression for #658: a C# repo whose root global.json pins an uninstalled SDK
   // must not break loose-text analysis. The host runs read-only over file texts
-  // with the runtime's reference set — it never builds the target — so the SDK pin
+  // with a pinned net8 reference set — it never builds the target — so the SDK pin
   // is irrelevant to it. Before the fix, the host inherited the analyze cwd, the
   // .NET SDK resolver found this global.json, and the host aborted at startup
   // (manifesting as `write EPIPE` on the Node side). The client now spawns the host

--- a/tools/csharp-roslyn-host/CSharpRoslynHost.csproj
+++ b/tools/csharp-roslyn-host/CSharpRoslynHost.csproj
@@ -9,15 +9,18 @@
     <RootNamespace>TrueCourse.RoslynHost</RootNamespace>
     <InvariantGlobalization>true</InvariantGlobalization>
     <!-- The published host ships as a portable net8.0 DLL run via the user's
-         `dotnet`. RollForward=Major PREFERS an installed net8 runtime (so the
-         loose-text reference set — which is the *runtime's* BCL — stays net8 and
-         analysis is deterministic), yet still starts on a newer major (9/10/11)
-         when net8 is absent, e.g. a dev box that only has .NET 10. NOT
-         LatestMajor: that always jumps to the newest runtime present, so on a CI
-         runner image carrying both net8 and net9 the BCL shifted under analysis
-         and version-sensitive semantic rules (e.g. the CallerArgumentExpression
-         overload of Debug.Assert) misfired. -->
-    <RollForward>Major</RollForward>
+         `dotnet`. RollForward=LatestMajor runs it on the NEWEST runtime present,
+         which is deliberately the same runtime that ships with the installed SDK
+         — so `analyze-project`'s MSBuildLocator always finds a usable MSBuild
+         (running on net8 while only a net10 SDK is installed cannot; see #813).
+         This is safe for the loose-text `analyze` op because its reference set is
+         NOT the running runtime's BCL: it is a pinned net8 reference-assembly pack
+         (Basic.Reference.Assemblies.Net80 — see Program.BuildReferences). That
+         decoupling is what lets the process float to the SDK's runtime without
+         shifting the BCL under version-sensitive semantic rules (e.g. the
+         CallerArgumentExpression overload of Debug.Assert), the regression that
+         previously forced a net8 pin. -->
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,10 +35,19 @@
          reports "language 'C#' is not supported". -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
+    <!-- Pinned net8.0 reference-assembly pack for the loose-text `analyze` op.
+         Program.BuildReferences uses THIS as the BCL reference set instead of the
+         running runtime's TRUSTED_PLATFORM_ASSEMBLIES, so loose-text results are
+         deterministic no matter which runtime the host rolls forward onto (see the
+         RollForward note above and #813). Embedded reference assemblies — no
+         targeting pack needs to be installed at run time. -->
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.8.9" />
     <!-- Referenced so the loose-text `analyze` mode resolves common framework
          types in analyzed code (ILogger, Newtonsoft.Json) for the rules that
-         need them. In `analyze-project` mode the project's own references cover
-         these. Cross-platform only. -->
+         need them. These are pinned package versions (stable regardless of the
+         host runtime), added to the reference set explicitly in BuildReferences.
+         In `analyze-project` mode the project's own references cover these.
+         Cross-platform only. -->
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/tools/csharp-roslyn-host/Program.cs
+++ b/tools/csharp-roslyn-host/Program.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Basic.Reference.Assemblies;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -15,7 +16,7 @@ namespace TrueCourse.RoslynHost;
 // that need a semantic model. See README.md.
 //
 // Two analysis modes:
-//   "analyze"         loose file texts compiled with the runtime's reference
+//   "analyze"         loose file texts compiled against a pinned net8 reference
 //                     set — fast, no restore needed (build-free host rules).
 //   "analyze-project" a real .csproj/.sln opened via MSBuildWorkspace with its
 //                     actual references — full fidelity, unlocks the rules that
@@ -248,18 +249,26 @@ internal static class Program
         if (seen.Add($"{v.RuleKey}\0{v.Path}\0{v.Line}\0{v.Column}")) acc.Add(v);
     }
 
-    // Reference set for the loose-text `analyze` mode = the running runtime's
-    // trusted platform assemblies, so the semantic model resolves System.* /
-    // framework types. `analyze-project` uses the project's real references.
+    // Reference set for the loose-text `analyze` mode. Deliberately a PINNED
+    // net8.0 reference-assembly pack (Basic.Reference.Assemblies.Net80), NOT the
+    // running runtime's TRUSTED_PLATFORM_ASSEMBLIES. Decoupling the BCL from the
+    // process runtime keeps loose-text results deterministic even though the host
+    // rolls forward onto whatever runtime the installed SDK ships (see the
+    // RollForward note in the .csproj and #813) — version-sensitive rules always
+    // bind against net8 metadata. `analyze-project` uses the project's real
+    // references instead, so it is unaffected by this set.
     private static List<MetadataReference> BuildReferences()
     {
-        var tpa = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? string.Empty)
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
-        var refs = new List<MetadataReference>();
-        foreach (var path in tpa)
+        var refs = new List<MetadataReference>(Net80.References.All);
+
+        // A couple of ubiquitous framework types the loose-text rules resolve in
+        // analyzed code (ILogger, Newtonsoft.Json). These come from pinned package
+        // versions (see the .csproj), so their location is stable regardless of
+        // which runtime the host runs on.
+        foreach (var t in new[] { typeof(Microsoft.Extensions.Logging.ILogger), typeof(Newtonsoft.Json.JsonConvert) })
         {
-            try { refs.Add(MetadataReference.CreateFromFile(path)); }
-            catch { /* skip unreadable assemblies */ }
+            try { refs.Add(MetadataReference.CreateFromFile(t.Assembly.Location)); }
+            catch { /* skip if unreadable */ }
         }
         return refs;
     }

--- a/tools/csharp-roslyn-host/README.md
+++ b/tools/csharp-roslyn-host/README.md
@@ -21,7 +21,7 @@ One JSON request per line in, one JSON response per line out. Two analysis modes
 // ping
 {"op":"ping"}                                  -> {"ok":true}
 
-// analyze: compile the given file texts with the runtime's reference set and run
+// analyze: compile the given file texts with a pinned net8 reference set and run
 // the enabled rules. Fast, no restore needed — the build-free host rules.
 {"op":"analyze","files":[{"path":"A.cs","text":"..."}],"rules":["bugs/deterministic/referenceequals-on-value-type"]}
 // -> {"ok":true,"violations":[{"ruleKey":"...","path":"A.cs","line":1,"column":52,"message":"..."}]}
@@ -37,8 +37,9 @@ One JSON request per line in, one JSON response per line out. Two analysis modes
 reference set — `System.Object` unresolved) is reported as an error, not analyzed.
 
 ## Working directory & SDK resolution
-`ping` and `analyze` need only the .NET **runtime** — they compile file texts with
-the runtime's own reference set and never build the target. So MSBuild/SDK resolution
+`ping` and `analyze` need only the .NET **runtime** — they compile file texts against
+a pinned net8 reference pack (`Basic.Reference.Assemblies.Net80`, so results are
+runtime-independent) and never build the target. So MSBuild/SDK resolution
 is deferred and **guarded**: it runs lazily only for `analyze-project`, and an
 SDK-resolution failure comes back as a normal `{"ok":false,...}` error rather than
 aborting the process. The Node client also spawns the host in a neutral working


### PR DESCRIPTION
## Summary

Fixes #813. The project-aware C# tier (`engine: 'roslyn-workspace'`, op `analyze-project`) aborted **fatally** in the `cs-` environment: the host is a `net8.0` DLL and, with `RollForward=Major` preferring an installed net8 runtime, ran on net8 while only a net10 SDK was present, so `MSBuildLocator` found no compatible MSBuild (`"No instances of MSBuild could be detected."`). That failure is fatal in the workspace tier, so no `LATEST.json` was produced and the whole analyze aborted.

## Root cause

A single host process had **two conflicting runtime requirements**:

- The loose-text `analyze` op derived its reference set from the *running runtime's* `TRUSTED_PLATFORM_ASSEMBLIES` (the runtime's BCL). That is why the host was pinned to net8 — to keep the BCL deterministic for version-sensitive semantic rules (e.g. the `CallerArgumentExpression` overload of `Debug.Assert`).
- The `analyze-project` op needs the process runtime major to match the installed SDK's runtime so `MSBuildLocator` can register it.

net8 (for loose-text) and net10 (to match the SDK) cannot both be satisfied by one process — so `analyze-project` broke.

## Fix (decouple the two requirements at the root)

1. **`BuildReferences()` no longer uses the live runtime's TPA.** It uses a pinned net8 reference-assembly pack (`Basic.Reference.Assemblies.Net80`), so loose-text results are deterministic regardless of which runtime the host runs on. `ILogger` / `Newtonsoft.Json` references (previously implicit via TPA) are added explicitly from their pinned package assemblies.
2. **`RollForward=Major` → `LatestMajor`.** The host now runs on the SDK's own runtime, so `MSBuildLocator` always finds a usable MSBuild. This is safe now because the BCL no longer follows the process runtime — the regression that previously forced a net8 pin is gone.
3. **`setup-csharp-env.sh` no longer installs a standalone net8 runtime.** The host rolls forward onto the SDK's runtime, removing the exact net8-runtime + net10-SDK trap that triggered the failure.
4. **Docs / comments** updated to match (host README, fp-automation README, one test comment).

The host runtime and the installed SDK now stay in lock-step by construction, and target repos that pin newer SDKs via `global.json` are tracked automatically.

## Not changed (by design)

When the required SDK is *genuinely absent* (e.g. a net8-only box analyzing a net10-pinned repo), `analyze-project` still fails **loudly** with an actionable message (`"Restore the project (dotnet restore) and ensure its pinned .NET SDK is installed."`). That is the intended fail-hard behavior — a missing SDK is an operator/provisioning issue, not something the host can synthesize, and a silent half-analysis is worse than a clear error. This is a distinct concern from #813 (where the correct SDK *was* installed but unusable) and is intentionally left as-is.

## Verification

- Confirmed the exact API by unpacking the NuGet package: `Basic.Reference.Assemblies.Net80.References.All` (→ `ImmutableArray<PortableExecutableReference>`).
- CI (`test.yml` / `publish.yml`) builds the host and runs the Roslyn tests on a net8 SDK, which compile-checks the new `BuildReferences` code and exercises both analyze ops. CI does not reproduce the exact net10-SDK / net8-runtime mismatch (that is the production `cs-` environment); the structural fix covers it. A net10 CI matrix could be added later as a regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJkekx28SQ4S6M3xUNn2xr)_