### PR TITLE
fix(analyzer): isolate deterministic scan in a killable worker so one file can't hang analyze (#814)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ TrueCourse ships with **1,200+ deterministic rules** and **100 LLM rules** acros
 
 **Deterministic rules** run via tree-sitter AST visitors — fast, zero-cost, no API calls. **LLM rules** send source code to the configured LLM for semantic analysis — deeper but requires an LLM provider.
 
+The deterministic scan runs in a worker thread with a per-file time budget, so a single pathological file (e.g. one that drives a rule's regex into catastrophic backtracking) is skipped-with-a-warning instead of freezing the whole run — the analysis always completes and writes its output. The budget defaults to 30s per file and is overridable with `TRUECOURSE_DET_FILE_TIMEOUT_MS` (milliseconds) for repos with unusually large legitimate sources.
+
 ## Commands
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.1.0",
+    "redos-detector": "^6.1.4",
     "sonner": "^2.0.7",
     "supertest": "^7.2.2",
     "tsx": "^4.19.0",

--- a/packages/analyzer/src/deterministic-scan/controller.ts
+++ b/packages/analyzer/src/deterministic-scan/controller.ts
@@ -22,18 +22,30 @@ export interface DeterministicScanResult {
 export interface ScanControllerOptions {
   /** Per-file wall-clock budget. A file exceeding it is terminated and skipped. */
   fileTimeoutMs: number
+  /**
+   * Budget for the worker's one-time setup (WASM parser init + whole-project
+   * TypeScript program build) — the phase before any file is processed. Bounds
+   * a hang there so it can't freeze the run the way per-file work can't.
+   * Generous by design; defaults to {@link DEFAULT_SETUP_TIMEOUT_MS}.
+   */
+  setupTimeoutMs?: number
   /** Cooperative cancellation (e.g. Ctrl+C). */
   signal?: AbortSignal
   /** Progress reporter — `processed` counts files finished OR skipped, out of `total`. */
   onProgress?(processed: number, total: number): void
   /** Called once per skipped file so the caller can warn. */
   onSkip?(filePath: string, reason: string): void
+  /** Called when no worker could be resolved and the scan runs in-thread (no hang protection). */
+  onFallback?(): void
   /**
    * Override the worker entry path. Normally resolved automatically for the
    * current packaging layout; provided for tests and advanced embedders.
    */
   workerPath?: string
 }
+
+/** Default worker-setup budget — generous, since a large repo's type program build takes minutes. */
+export const DEFAULT_SETUP_TIMEOUT_MS = 600_000
 
 /** Input for the controller — `startIndex` is managed internally across resume passes. */
 export type IsolatedScanInput = Omit<DeterministicScanInput, 'startIndex'>
@@ -78,21 +90,40 @@ function runOneWorkerPass(
     let inFlightIndex = input.startIndex
     let watchdog: ReturnType<typeof setTimeout> | undefined
 
+    const clearWatchdog = () => {
+      if (watchdog) {
+        clearTimeout(watchdog)
+        watchdog = undefined
+      }
+    }
+
     const finish = (outcome: PassOutcome) => {
       if (settled) return
       settled = true
-      if (watchdog) clearTimeout(watchdog)
+      clearWatchdog()
       opts.signal?.removeEventListener('abort', onAbort)
       void worker.terminate()
       resolve(outcome)
     }
 
-    // The watchdog only runs while a file is in flight. It is (re)armed on every
-    // message, so a file that stops producing messages for `fileTimeoutMs` is
-    // deemed stalled. The main thread is otherwise idle, so this timer fires
-    // reliably even while the worker is pinned in synchronous backtracking.
-    const armWatchdog = () => {
-      if (watchdog) clearTimeout(watchdog)
+    // Every phase of the worker's life is covered by a timer, so no hang can go
+    // unbounded. The main thread is otherwise idle, so these timers fire
+    // reliably even while the worker is pinned in synchronous work (regex
+    // backtracking, type-checking):
+    //  - setup (WASM parser init + whole-project TS program build) is bounded by
+    //    `setupTimeoutMs`, armed from spawn until the `setup-done` message.
+    //  - each file is bounded by `fileTimeoutMs`, (re)armed on every message.
+    const setupTimeoutMs = opts.setupTimeoutMs ?? DEFAULT_SETUP_TIMEOUT_MS
+    const armSetupWatchdog = () => {
+      clearWatchdog()
+      watchdog = setTimeout(
+        () => finish({ kind: 'error', message: `worker setup (parser init + type program build) exceeded ${setupTimeoutMs}ms` }),
+        setupTimeoutMs,
+      )
+      watchdog.unref?.()
+    }
+    const armFileWatchdog = () => {
+      clearWatchdog()
       watchdog = setTimeout(() => finish({ kind: 'stall', stalledIndex: inFlightIndex }), opts.fileTimeoutMs)
       watchdog.unref?.()
     }
@@ -106,16 +137,24 @@ function runOneWorkerPass(
       opts.signal.addEventListener('abort', onAbort, { once: true })
     }
 
+    // Cover setup immediately — before this, the worker sends no messages.
+    armSetupWatchdog()
+
     worker.on('message', (msg: WorkerToMainMessage) => {
       if (settled) return
       switch (msg.type) {
+        case 'setup-done':
+          // Setup finished; switch to per-file budgets. Arm the first file's
+          // watchdog now to cover the gap before its `file-start` arrives.
+          armFileWatchdog()
+          break
         case 'file-start':
           inFlightIndex = msg.index
-          armWatchdog()
+          armFileWatchdog()
           break
         case 'file-result':
           onResult(msg.index, msg.violations)
-          armWatchdog()
+          armFileWatchdog()
           break
         case 'complete':
           finish({ kind: 'complete' })
@@ -172,7 +211,13 @@ export async function runDeterministicScanIsolated(
   opts: ScanControllerOptions,
 ): Promise<DeterministicScanResult> {
   const workerPath = opts.workerPath ?? resolveWorkerPath()
-  if (!workerPath) return runInThread(input, opts)
+  if (!workerPath) {
+    // No worker entry for this layout — the scan still runs, but in-thread and
+    // therefore without the per-file hang protection. Surface it so a user's log
+    // shows which mode they were in (see onFallback → log.warn in the pipeline).
+    opts.onFallback?.()
+    return runInThread(input, opts)
+  }
 
   const total = input.files.length
   const violations: CodeViolation[] = []
@@ -199,6 +244,13 @@ export async function runDeterministicScanIsolated(
     }
 
     // Stall: skip the in-flight file and resume the scan just past it.
+    // Trade-off (accepted, not accidental): a fresh worker re-pays the whole
+    // one-time setup cost — notably the whole-project TypeScript program build,
+    // which dominates on large repos. That's fine because stalls are rare (a
+    // handful of pathological files at most); the run always finishing is worth
+    // more than avoiding the occasional rebuild. Keeping a worker alive across a
+    // stall isn't possible — the isolate holding the type program is exactly
+    // what we must terminate to unstick it.
     const bad = input.files[outcome.stalledIndex]
     const reason = `exceeded the ${opts.fileTimeoutMs}ms per-file budget (possible catastrophic regex backtracking)`
     skipped.push({ filePath: bad.filePath, reason })

--- a/packages/analyzer/src/deterministic-scan/controller.ts
+++ b/packages/analyzer/src/deterministic-scan/controller.ts
@@ -1,0 +1,212 @@
+import { Worker } from 'node:worker_threads'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import fs from 'node:fs'
+import type { CodeViolation } from '@truecourse/shared'
+import { initParsers } from '../parser.js'
+import { runDeterministicScan } from './run-scan.js'
+import type { DeterministicScanInput, WorkerToMainMessage } from './types.js'
+
+/** A file skipped because it exceeded the per-file budget. */
+export interface SkippedFile {
+  filePath: string
+  reason: string
+}
+
+export interface DeterministicScanResult {
+  violations: CodeViolation[]
+  /** Files skipped by the watchdog (empty on a clean run). */
+  skipped: SkippedFile[]
+}
+
+export interface ScanControllerOptions {
+  /** Per-file wall-clock budget. A file exceeding it is terminated and skipped. */
+  fileTimeoutMs: number
+  /** Cooperative cancellation (e.g. Ctrl+C). */
+  signal?: AbortSignal
+  /** Progress reporter — `processed` counts files finished OR skipped, out of `total`. */
+  onProgress?(processed: number, total: number): void
+  /** Called once per skipped file so the caller can warn. */
+  onSkip?(filePath: string, reason: string): void
+  /**
+   * Override the worker entry path. Normally resolved automatically for the
+   * current packaging layout; provided for tests and advanced embedders.
+   */
+  workerPath?: string
+}
+
+/** Input for the controller — `startIndex` is managed internally across resume passes. */
+export type IsolatedScanInput = Omit<DeterministicScanInput, 'startIndex'>
+
+/**
+ * Locate the worker entry for the current packaging layout:
+ *  - unbundled (tsc output, dev/tests): `worker.js` sits next to this module.
+ *  - bundled (esbuild `cli.mjs`/`server.mjs`): this module is inlined into the
+ *    entry bundle, and scripts/build.ts emits the worker as a sibling
+ *    `det-scan-worker.mjs`. `import.meta.url` then points at the bundle dir.
+ * Returns null when neither exists (the caller falls back to in-thread).
+ */
+function resolveWorkerPath(): string | null {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const candidates = [path.join(here, 'worker.js'), path.join(here, 'det-scan-worker.mjs')]
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+type PassOutcome =
+  | { kind: 'complete' }
+  | { kind: 'stall'; stalledIndex: number }
+  | { kind: 'error'; message: string }
+  | { kind: 'aborted' }
+
+/**
+ * Run one worker pass from `input.startIndex`, resolving when the worker
+ * completes, stalls on a single file, errors, or the run is aborted. The worker
+ * is always terminated before this resolves.
+ */
+function runOneWorkerPass(
+  workerPath: string,
+  input: DeterministicScanInput,
+  opts: ScanControllerOptions,
+  onResult: (index: number, violations: CodeViolation[]) => void,
+): Promise<PassOutcome> {
+  return new Promise<PassOutcome>((resolve) => {
+    const worker = new Worker(workerPath, { workerData: input })
+    let settled = false
+    let inFlightIndex = input.startIndex
+    let watchdog: ReturnType<typeof setTimeout> | undefined
+
+    const finish = (outcome: PassOutcome) => {
+      if (settled) return
+      settled = true
+      if (watchdog) clearTimeout(watchdog)
+      opts.signal?.removeEventListener('abort', onAbort)
+      void worker.terminate()
+      resolve(outcome)
+    }
+
+    // The watchdog only runs while a file is in flight. It is (re)armed on every
+    // message, so a file that stops producing messages for `fileTimeoutMs` is
+    // deemed stalled. The main thread is otherwise idle, so this timer fires
+    // reliably even while the worker is pinned in synchronous backtracking.
+    const armWatchdog = () => {
+      if (watchdog) clearTimeout(watchdog)
+      watchdog = setTimeout(() => finish({ kind: 'stall', stalledIndex: inFlightIndex }), opts.fileTimeoutMs)
+      watchdog.unref?.()
+    }
+
+    const onAbort = () => finish({ kind: 'aborted' })
+    if (opts.signal) {
+      if (opts.signal.aborted) {
+        finish({ kind: 'aborted' })
+        return
+      }
+      opts.signal.addEventListener('abort', onAbort, { once: true })
+    }
+
+    worker.on('message', (msg: WorkerToMainMessage) => {
+      if (settled) return
+      switch (msg.type) {
+        case 'file-start':
+          inFlightIndex = msg.index
+          armWatchdog()
+          break
+        case 'file-result':
+          onResult(msg.index, msg.violations)
+          armWatchdog()
+          break
+        case 'complete':
+          finish({ kind: 'complete' })
+          break
+        case 'error':
+          finish({ kind: 'error', message: msg.message })
+          break
+      }
+    })
+    worker.on('error', (err) => finish({ kind: 'error', message: err.message }))
+    worker.on('exit', (code) => {
+      // A clean exit after 'complete'/'stall' is already settled; anything else
+      // is an unexpected early death.
+      if (!settled) finish({ kind: 'error', message: `worker exited early (code ${code})` })
+    })
+  })
+}
+
+/** In-thread fallback used only when the worker entry can't be resolved. */
+async function runInThread(
+  input: IsolatedScanInput,
+  opts: ScanControllerOptions,
+): Promise<DeterministicScanResult> {
+  const total = input.files.length
+  const violations: CodeViolation[] = []
+  let processed = 0
+  await initParsers()
+  await runDeterministicScan(
+    { ...input, startIndex: 0 },
+    {
+      onFileResult: (_index, _filePath, v) => {
+        violations.push(...v)
+        processed++
+        opts.onProgress?.(processed, total)
+      },
+      shouldStop: () => opts.signal?.aborted ?? false,
+    },
+  )
+  if (opts.signal?.aborted) throw new DOMException('Analysis cancelled', 'AbortError')
+  return { violations, skipped: [] }
+}
+
+/**
+ * Run the deterministic per-file scan in a killable worker, enforcing a per-file
+ * timeout so a single pathological file (e.g. catastrophic regex backtracking)
+ * is skipped-with-a-warning instead of freezing the whole run. On a stall the
+ * worker is terminated and a fresh one resumes after the offending file.
+ *
+ * Falls back to an in-thread scan when no worker entry can be found — the run
+ * still completes; it just loses the per-file hang guarantee.
+ */
+export async function runDeterministicScanIsolated(
+  input: IsolatedScanInput,
+  opts: ScanControllerOptions,
+): Promise<DeterministicScanResult> {
+  const workerPath = opts.workerPath ?? resolveWorkerPath()
+  if (!workerPath) return runInThread(input, opts)
+
+  const total = input.files.length
+  const violations: CodeViolation[] = []
+  const skipped: SkippedFile[] = []
+  let nextIndex = 0
+  let processed = 0
+
+  while (nextIndex < total) {
+    const outcome = await runOneWorkerPass(
+      workerPath,
+      { ...input, startIndex: nextIndex },
+      opts,
+      (_index, v) => {
+        violations.push(...v)
+        processed++
+        opts.onProgress?.(processed, total)
+      },
+    )
+
+    if (outcome.kind === 'complete') break
+    if (outcome.kind === 'aborted') throw new DOMException('Analysis cancelled', 'AbortError')
+    if (outcome.kind === 'error') {
+      throw new Error(`deterministic scan worker failed: ${outcome.message}`)
+    }
+
+    // Stall: skip the in-flight file and resume the scan just past it.
+    const bad = input.files[outcome.stalledIndex]
+    const reason = `exceeded the ${opts.fileTimeoutMs}ms per-file budget (possible catastrophic regex backtracking)`
+    skipped.push({ filePath: bad.filePath, reason })
+    opts.onSkip?.(bad.filePath, reason)
+    processed++
+    opts.onProgress?.(processed, total)
+    nextIndex = outcome.stalledIndex + 1
+  }
+
+  return { violations, skipped }
+}

--- a/packages/analyzer/src/deterministic-scan/run-scan.ts
+++ b/packages/analyzer/src/deterministic-scan/run-scan.ts
@@ -11,6 +11,8 @@ import type { DeterministicScanInput } from './types.js'
 const YIELD_INTERVAL_MS = 25
 
 export interface ScanCallbacks {
+  /** After one-time setup (type program + schema index) is built, before the first file. */
+  onSetupDone?(): void
   /** Before a file is processed. Drives the watchdog and identifies the in-flight file. */
   onFileStart?(index: number, filePath: string): void
   /** After a file's violations are computed. */
@@ -48,6 +50,10 @@ export async function runDeterministicScan(input: DeterministicScanInput, cb: Sc
   if (hasSchemaAwareVisitors(keySet)) {
     schemaIndex = buildSchemaIndex(databaseResult)
   }
+
+  // Setup (the expensive, message-silent phase) is done — let the controller
+  // retire its setup watchdog and switch to per-file budgets.
+  cb.onSetupDone?.()
 
   let lastYield = Date.now()
   for (let i = startIndex; i < files.length; i++) {

--- a/packages/analyzer/src/deterministic-scan/run-scan.ts
+++ b/packages/analyzer/src/deterministic-scan/run-scan.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs'
+import type { AnalysisRule, CodeViolation } from '@truecourse/shared'
+import { detectLanguage } from '../language-config.js'
+import { withParsedTree } from '../parser.js'
+import { checkCodeRules, hasTypeAwareVisitors, hasSchemaAwareVisitors } from '../rules/combined-code-checker.js'
+import { buildScopedCompilerOptions, createTypeQueryService, type TypeQueryService } from '../ts-compiler.js'
+import { buildSchemaIndex, type SchemaIndex } from '../services/schema-index.js'
+import type { DeterministicScanInput } from './types.js'
+
+/** ~25ms of CPU-bound work between event-loop yields — same headroom the old loop used. */
+const YIELD_INTERVAL_MS = 25
+
+export interface ScanCallbacks {
+  /** Before a file is processed. Drives the watchdog and identifies the in-flight file. */
+  onFileStart?(index: number, filePath: string): void
+  /** After a file's violations are computed. */
+  onFileResult(index: number, filePath: string, violations: CodeViolation[]): void
+  /** Checked between files — return true to stop early (cooperative cancellation). */
+  shouldStop?(): boolean
+}
+
+/**
+ * The core deterministic per-file scan, extracted so it can run either inside a
+ * worker thread (the default, so a pathological file can be killed) or in-thread
+ * as a fallback. It builds the whole-project TypeQuery / schema index once, then
+ * walks each file's tree-sitter AST through the enabled visitors.
+ *
+ * It reports progress through `cb` rather than returning a big array so the
+ * controller can stream results and enforce a per-file timeout. Callers must
+ * have awaited {@link initParsers} before invoking this.
+ */
+export async function runDeterministicScan(input: DeterministicScanInput, cb: ScanCallbacks): Promise<void> {
+  const { files, enabledRuleKeys, tsFiles, databaseResult, repoPath, startIndex } = input
+  const keySet = new Set(enabledRuleKeys)
+
+  // `checkCodeRules` only reads `key`/`type`/`enabled` off each rule to compute
+  // the enabled-key set, so minimal stubs are sufficient (and fully serializable).
+  const rules = enabledRuleKeys.map(
+    (key) => ({ key, type: 'deterministic', enabled: true }) as unknown as AnalysisRule,
+  )
+
+  let typeQuery: TypeQueryService | undefined
+  if (hasTypeAwareVisitors(keySet) && tsFiles.length > 0) {
+    const scoped = buildScopedCompilerOptions(repoPath)
+    typeQuery = createTypeQueryService(tsFiles, scoped, repoPath)
+  }
+  let schemaIndex: SchemaIndex | undefined
+  if (hasSchemaAwareVisitors(keySet)) {
+    schemaIndex = buildSchemaIndex(databaseResult)
+  }
+
+  let lastYield = Date.now()
+  for (let i = startIndex; i < files.length; i++) {
+    if (cb.shouldStop?.()) return
+
+    const { filePath, absPath } = files[i]
+    cb.onFileStart?.(i, filePath)
+
+    let violations: CodeViolation[] = []
+    try {
+      const lang = detectLanguage(filePath)
+      if (lang) {
+        const content = fs.readFileSync(absPath, 'utf-8')
+        violations = withParsedTree(filePath, content, lang, (tree) =>
+          checkCodeRules(tree, filePath, content, rules, lang, typeQuery, schemaIndex),
+        )
+      }
+    } catch {
+      // Skip files that fail to read or parse — matches the prior loop's behavior.
+    }
+    cb.onFileResult(i, filePath, violations)
+
+    // Yield periodically so message delivery flushes and (in the fallback) the
+    // spinner keeps ticking. Cheap and bounded.
+    const now = Date.now()
+    if (now - lastYield >= YIELD_INTERVAL_MS) {
+      await new Promise((r) => setImmediate(r))
+      lastYield = now
+    }
+  }
+}

--- a/packages/analyzer/src/deterministic-scan/types.ts
+++ b/packages/analyzer/src/deterministic-scan/types.ts
@@ -1,0 +1,44 @@
+import type { CodeViolation, DatabaseDetectionResult } from '@truecourse/shared'
+
+/**
+ * One file to scan, pre-resolved by the caller so the worker never has to
+ * re-implement the pipeline's path/key logic.
+ */
+export interface ScanFileInput {
+  /**
+   * The identity used for the produced violations (what the old in-thread loop
+   * passed to `checkCodeRules` as `filePath`): the repo-relative path for a full
+   * analyze, or the absolute path in changed-file (diff) mode.
+   */
+  filePath: string
+  /** Absolute path the worker reads the file content from. */
+  absPath: string
+}
+
+/**
+ * Everything the deterministic scan needs. Every field is JSON-serializable so
+ * the whole object can cross the worker boundary via `workerData`.
+ */
+export interface DeterministicScanInput {
+  repoPath: string
+  files: ScanFileInput[]
+  /** Enabled deterministic code-rule keys (drives visitor selection + type/schema gating). */
+  enabledRuleKeys: string[]
+  /** Absolute paths of TS/JS files, for the whole-project TypeQuery program. */
+  tsFiles: string[]
+  /** Database detection result used to build the schema index (when schema-aware visitors are enabled). */
+  databaseResult: DatabaseDetectionResult | undefined
+  /** Resume point: index into `files` to start from (skips already-done files and any stalled one). */
+  startIndex: number
+}
+
+/** Messages the worker posts back to the controller on the main thread. */
+export type WorkerToMainMessage =
+  /** Emitted immediately before a file is processed — arms/identifies the per-file watchdog. */
+  | { type: 'file-start'; index: number; filePath: string }
+  /** Emitted after a file's violations are computed. */
+  | { type: 'file-result'; index: number; violations: CodeViolation[] }
+  /** All files in this pass processed. */
+  | { type: 'complete' }
+  /** Fatal error inside the worker (setup or an unexpected throw). */
+  | { type: 'error'; message: string }

--- a/packages/analyzer/src/deterministic-scan/types.ts
+++ b/packages/analyzer/src/deterministic-scan/types.ts
@@ -34,6 +34,8 @@ export interface DeterministicScanInput {
 
 /** Messages the worker posts back to the controller on the main thread. */
 export type WorkerToMainMessage =
+  /** Emitted once when one-time setup (parser init + type program build) is done — ends the setup watchdog. */
+  | { type: 'setup-done' }
   /** Emitted immediately before a file is processed — arms/identifies the per-file watchdog. */
   | { type: 'file-start'; index: number; filePath: string }
   /** Emitted after a file's violations are computed. */

--- a/packages/analyzer/src/deterministic-scan/worker.ts
+++ b/packages/analyzer/src/deterministic-scan/worker.ts
@@ -21,6 +21,7 @@ async function main(): Promise<void> {
   try {
     await initParsers()
     await runDeterministicScan(input, {
+      onSetupDone: () => post({ type: 'setup-done' }),
       onFileStart: (index, filePath) => post({ type: 'file-start', index, filePath }),
       onFileResult: (index, _filePath, violations) => post({ type: 'file-result', index, violations }),
     })

--- a/packages/analyzer/src/deterministic-scan/worker.ts
+++ b/packages/analyzer/src/deterministic-scan/worker.ts
@@ -1,0 +1,33 @@
+import { parentPort, workerData } from 'node:worker_threads'
+import { initParsers } from '../parser.js'
+import { runDeterministicScan } from './run-scan.js'
+import type { DeterministicScanInput, WorkerToMainMessage } from './types.js'
+
+/**
+ * Worker-thread entry for the deterministic per-file scan.
+ *
+ * Running the scan here — rather than on the main thread — is what lets the
+ * controller enforce a per-file timeout: a file that drives a visitor into
+ * catastrophic regex backtracking blocks THIS thread, but the main thread stays
+ * free to notice the stall and `terminate()` the worker. See ./controller.ts.
+ */
+async function main(): Promise<void> {
+  if (!parentPort) throw new Error('deterministic-scan worker must be spawned as a worker thread')
+  const port = parentPort
+  const input = workerData as DeterministicScanInput
+
+  const post = (msg: WorkerToMainMessage) => port.postMessage(msg)
+
+  try {
+    await initParsers()
+    await runDeterministicScan(input, {
+      onFileStart: (index, filePath) => post({ type: 'file-start', index, filePath }),
+      onFileResult: (index, _filePath, violations) => post({ type: 'file-result', index, violations }),
+    })
+    post({ type: 'complete' })
+  } catch (err) {
+    post({ type: 'error', message: err instanceof Error ? err.message : String(err) })
+  }
+}
+
+void main()

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -136,6 +136,15 @@ export { getAllDefaultRules } from './rule-engine.js'
 export { checkCodeRules, hasTypeAwareVisitors, hasSchemaAwareVisitors } from './rules/combined-code-checker.js'
 
 /**
+ * Killable deterministic per-file scan. Runs the tree-sitter code rules in a
+ * worker thread with a per-file timeout so one pathological file can't freeze
+ * the whole run (falls back to in-thread when no worker entry is available).
+ */
+export { runDeterministicScanIsolated, type DeterministicScanResult, type SkippedFile, type ScanControllerOptions, type IsolatedScanInput } from './deterministic-scan/controller.js'
+export { runDeterministicScan, type ScanCallbacks } from './deterministic-scan/run-scan.js'
+export type { DeterministicScanInput, ScanFileInput } from './deterministic-scan/types.js'
+
+/**
  * High-level function to analyze an entire repository
  * Orchestrates file discovery, analysis, dependency graph, service detection, and layer detection
  */

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -140,7 +140,7 @@ export { checkCodeRules, hasTypeAwareVisitors, hasSchemaAwareVisitors } from './
  * worker thread with a per-file timeout so one pathological file can't freeze
  * the whole run (falls back to in-thread when no worker entry is available).
  */
-export { runDeterministicScanIsolated, type DeterministicScanResult, type SkippedFile, type ScanControllerOptions, type IsolatedScanInput } from './deterministic-scan/controller.js'
+export { runDeterministicScanIsolated, DEFAULT_SETUP_TIMEOUT_MS, type DeterministicScanResult, type SkippedFile, type ScanControllerOptions, type IsolatedScanInput } from './deterministic-scan/controller.js'
 export { runDeterministicScan, type ScanCallbacks } from './deterministic-scan/run-scan.js'
 export type { DeterministicScanInput, ScanFileInput } from './deterministic-scan/types.js'
 

--- a/packages/core/src/services/violation-pipeline.service.ts
+++ b/packages/core/src/services/violation-pipeline.service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import { detectLanguage, initParsers, runRoslynHost, runRoslynWorkspace, RoslynHostUnavailableError, runDeterministicScanIsolated } from '@truecourse/analyzer';
+import { detectLanguage, initParsers, runRoslynHost, runRoslynWorkspace, RoslynHostUnavailableError, runDeterministicScanIsolated, DEFAULT_SETUP_TIMEOUT_MS } from '@truecourse/analyzer';
 import type { CodeViolation } from '@truecourse/shared';
 import type { ModuleViolation, ServiceViolation } from '@truecourse/analyzer';
 import { runDeterministicModuleChecks, runDeterministicMethodChecks, runDeterministicServiceChecks, type AnalysisResult } from './analyzer.service.js';
@@ -39,6 +39,22 @@ function getDeterministicFileTimeoutMs(): number {
     if (Number.isFinite(parsed) && parsed > 0) return parsed;
   }
   return DEFAULT_DET_FILE_TIMEOUT_MS;
+}
+
+/**
+ * Budget for the deterministic scan's one-time worker setup (parser init +
+ * whole-project TypeScript program build) — the phase before any file is
+ * processed. Bounds a hang there so it can't freeze the run. Generous, since the
+ * type program build takes minutes on large repos; override with
+ * `TRUECOURSE_DET_SETUP_TIMEOUT_MS`.
+ */
+function getDeterministicSetupTimeoutMs(): number {
+  const raw = process.env.TRUECOURSE_DET_SETUP_TIMEOUT_MS;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_SETUP_TIMEOUT_MS;
 }
 
 // Locate the C# project(s) to load for project-aware (MSBuildWorkspace) rules.
@@ -177,6 +193,12 @@ export interface ViolationPipelineResult {
   unchanged: ViolationRecord[];
   /** Compact refs for AnalysisSnapshot.violations.resolved (saves space in delta). */
   resolvedRefs: ResolvedViolationRef[];
+  /**
+   * Files the deterministic scan skipped because they exceeded the per-file time
+   * budget (empty on a clean run). Surfaced so callers can report them rather
+   * than the skip being visible only in the log.
+   */
+  skippedDeterministicFiles: { filePath: string; reason: string }[];
 }
 
 // ---------------------------------------------------------------------------
@@ -247,6 +269,9 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
   const unchanged: ViolationRecord[] = [];
   const resolved: ViolationRecord[] = [];
   const resolvedRefs: ResolvedViolationRef[] = [];
+  // Files the deterministic scan skipped because they blew the per-file time
+  // budget — surfaced in the result (not just the log) so callers/UI can show them.
+  const skippedDeterministicFiles: { filePath: string; reason: string }[] = [];
 
   // Accumulate names alongside the target IDs — the orchestrator needs them
   // to write LATEST.violations (denormalized) and they help downstream
@@ -447,6 +472,7 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
       },
       {
         fileTimeoutMs: getDeterministicFileTimeoutMs(),
+        setupTimeoutMs: getDeterministicSetupTimeoutMs(),
         signal,
         onProgress: (processed, total) => {
           const now = Date.now();
@@ -459,9 +485,13 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
         onSkip: (filePath, reason) => {
           log.warn(`[Pipeline] Skipped deterministic scan of ${filePath}: ${reason}`);
         },
+        onFallback: () => {
+          log.warn('[Pipeline] Deterministic scan worker unavailable — running in-thread WITHOUT per-file hang protection. A single pathological file can still stall this run.');
+        },
       },
     );
     allCodeViolations.push(...scanResult.violations);
+    skippedDeterministicFiles.push(...scanResult.skipped);
     if (scanResult.skipped.length > 0) {
       log.warn(`[Pipeline] Deterministic scan skipped ${scanResult.skipped.length} file(s) that exceeded the per-file time budget.`);
     }
@@ -1630,6 +1660,7 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
     unchanged,
     resolved,
     resolvedRefs,
+    skippedDeterministicFiles,
   };
 }
 

--- a/packages/core/src/services/violation-pipeline.service.ts
+++ b/packages/core/src/services/violation-pipeline.service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import { checkCodeRules, withParsedTree, detectLanguage, buildScopedCompilerOptions, createTypeQueryService, hasTypeAwareVisitors, hasSchemaAwareVisitors, buildSchemaIndex, initParsers, runRoslynHost, runRoslynWorkspace, RoslynHostUnavailableError, type TypeQueryService, type SchemaIndex } from '@truecourse/analyzer';
+import { detectLanguage, initParsers, runRoslynHost, runRoslynWorkspace, RoslynHostUnavailableError, runDeterministicScanIsolated } from '@truecourse/analyzer';
 import type { CodeViolation } from '@truecourse/shared';
 import type { ModuleViolation, ServiceViolation } from '@truecourse/analyzer';
 import { runDeterministicModuleChecks, runDeterministicMethodChecks, runDeterministicServiceChecks, type AnalysisResult } from './analyzer.service.js';
@@ -21,6 +21,24 @@ import type { ResolvedViolationRef, ViolationRecord } from '../types/snapshot.js
 /** Throw if the abort signal has been triggered. */
 function throwIfAborted(signal?: AbortSignal) {
   if (signal?.aborted) throw new DOMException('Analysis cancelled', 'AbortError');
+}
+
+/**
+ * Per-file wall-clock budget for the deterministic tree-sitter scan. A file that
+ * exceeds it (e.g. catastrophic regex backtracking) is skipped-with-a-warning
+ * instead of freezing the whole run. Generous by design — healthy files scan in
+ * milliseconds — and overridable via `TRUECOURSE_DET_FILE_TIMEOUT_MS` for repos
+ * with unusually large legitimate sources. This is a universal resource bound,
+ * not a per-file heuristic.
+ */
+const DEFAULT_DET_FILE_TIMEOUT_MS = 30_000;
+function getDeterministicFileTimeoutMs(): number {
+  const raw = process.env.TRUECOURSE_DET_FILE_TIMEOUT_MS;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_DET_FILE_TIMEOUT_MS;
 }
 
 // Locate the C# project(s) to load for project-aware (MSBuildWorkspace) rules.
@@ -302,24 +320,10 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
     }
   }
 
-  let typeQuery: TypeQueryService | undefined;
+  // TypeQuery / schema-index construction lives inside the deterministic scan
+  // now (it's built once per worker pass — see runDeterministicScanIsolated),
+  // so the pipeline only needs the enabled-key set here.
   const enabledCodeKeys = new Set(enabledCodeRules.filter(r => r.type === 'deterministic' && r.enabled).map(r => r.key));
-  if (hasTypeAwareVisitors(enabledCodeKeys)) {
-    const tsFiles = filesToScan
-      .filter(({ filePath: fp }) => /\.(ts|tsx|js|jsx)$/.test(fp))
-      .map(({ filePath: fp, resolve: res }) =>
-        res ? path.resolve(repoPath, fp) : (path.isAbsolute(fp) ? fp : path.join(repoPath, fp)),
-      );
-    if (tsFiles.length > 0) {
-      const scoped = buildScopedCompilerOptions(repoPath);
-      typeQuery = createTypeQueryService(tsFiles, scoped, repoPath);
-    }
-  }
-
-  let schemaIndex: SchemaIndex | undefined;
-  if (hasSchemaAwareVisitors(enabledCodeKeys)) {
-    schemaIndex = buildSchemaIndex(result.databaseResult);
-  }
 
   if (hasLlm) tracker?.done('scan', `${fileContents.size} files`);
 
@@ -413,56 +417,53 @@ export async function runViolationPipeline(input: ViolationPipelineInput): Promi
       }
     }
 
-    await new Promise((r) => setImmediate(r));
+    // Pre-resolve each file's read path + violation identity so the scan worker
+    // never has to re-implement the pipeline's path/key logic.
+    const scanFiles = filesToScan.map(({ filePath, resolve }) => {
+      const absPath = resolve ? path.resolve(repoPath, filePath) : (path.isAbsolute(filePath) ? filePath : path.join(repoPath, filePath));
+      return { filePath: changedFileSet ? absPath : filePath, absPath };
+    });
+    const tsFiles = filesToScan
+      .filter(({ filePath: fp }) => /\.(ts|tsx|js|jsx)$/.test(fp))
+      .map(({ filePath: fp, resolve: res }) =>
+        res ? path.resolve(repoPath, fp) : (path.isAbsolute(fp) ? fp : path.join(repoPath, fp)),
+      );
 
-    const totalFiles = filesToScan.length;
-    let processed = 0;
-    // Yield every ~25ms (≈40fps headroom against the 80ms spinner) and
-    // refresh the per-domain detail every ~100ms. Det work is CPU-bound,
-    // so we have to manufacture the same breathing room the LLM phase
-    // gets naturally from I/O-bound awaits.
-    const SPINNER_YIELD_MS = 25;
+    const totalFiles = scanFiles.length;
     const DETAIL_UPDATE_MS = 100;
-    let lastYieldMs = Date.now();
-    let lastDetailMs = lastYieldMs;
-    for (const { filePath, resolve } of filesToScan) {
-      try {
-        const lang = detectLanguage(filePath);
-        if (!lang) continue;
-        const absPath = resolve ? path.resolve(repoPath, filePath) : (path.isAbsolute(filePath) ? filePath : path.join(repoPath, filePath));
-        const key = changedFileSet ? absPath : filePath;
-        const fc = fileContents.get(key);
-        if (!fc) continue;
+    let lastDetailMs = Date.now();
 
-        const codeRuleViolations = withParsedTree(filePath, fc.content, lang, (tree) =>
-          checkCodeRules(tree, changedFileSet ? absPath : filePath, fc.content, enabledCodeRules, lang, typeQuery, schemaIndex),
-        );
-        allCodeViolations.push(...codeRuleViolations);
-      } catch {
-        // Skip files that fail to parse
-      }
-      processed++;
-
-      // Cheap abort check on every iteration — `signal.aborted` is just a
-      // boolean field flipped by the SIGINT handler, so this is safe to
-      // run per-file. Without it, Ctrl+C only takes effect after the
-      // entire scan finishes.
-      if (signal?.aborted) throw new DOMException('Analysis cancelled', 'AbortError');
-
-      const now = Date.now();
-      const isLast = processed === totalFiles;
-      if (isLast || now - lastDetailMs >= DETAIL_UPDATE_MS) {
-        const detail = `${processed}/${totalFiles} files`;
-        for (const domain of activeCodeDomains) tracker?.detail(domain, detail);
-        lastDetailMs = now;
-      }
-      if (isLast || now - lastYieldMs >= SPINNER_YIELD_MS) {
-        await new Promise((r) => setImmediate(r));
-        lastYieldMs = Date.now();
-        // Re-check after yielding — the SIGINT handler runs during the
-        // event-loop tick we just gave it, so the flag may have flipped.
-        if (signal?.aborted) throw new DOMException('Analysis cancelled', 'AbortError');
-      }
+    // Run the tree-sitter code rules in a killable worker with a per-file
+    // timeout. A single pathological file (e.g. catastrophic regex
+    // backtracking) is skipped-with-a-warning instead of freezing the whole
+    // run, and Ctrl+C now takes effect mid-scan because the main thread is free.
+    const scanResult = await runDeterministicScanIsolated(
+      {
+        repoPath,
+        files: scanFiles,
+        enabledRuleKeys: [...enabledCodeKeys],
+        tsFiles,
+        databaseResult: result.databaseResult,
+      },
+      {
+        fileTimeoutMs: getDeterministicFileTimeoutMs(),
+        signal,
+        onProgress: (processed, total) => {
+          const now = Date.now();
+          if (processed === total || now - lastDetailMs >= DETAIL_UPDATE_MS) {
+            const detail = `${processed}/${total} files`;
+            for (const domain of activeCodeDomains) tracker?.detail(domain, detail);
+            lastDetailMs = now;
+          }
+        },
+        onSkip: (filePath, reason) => {
+          log.warn(`[Pipeline] Skipped deterministic scan of ${filePath}: ${reason}`);
+        },
+      },
+    );
+    allCodeViolations.push(...scanResult.violations);
+    if (scanResult.skipped.length > 0) {
+      log.warn(`[Pipeline] Deterministic scan skipped ${scanResult.skipped.length} file(s) that exceeded the per-file time budget.`);
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       react-router-dom:
         specifier: ^7.1.0
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      redos-detector:
+        specifier: ^6.1.4
+        version: 6.1.4
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1452,11 +1455,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.24.2':
     resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
@@ -3050,6 +3053,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -5230,6 +5234,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -5237,6 +5242,15 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redos-detector@6.1.4:
+    resolution: {integrity: sha512-lPlka1rEH6kK42gtgokvvxMmpAvyc28DcRjQbGxeP5RJsJWgAduBOdGedVCDPdSyCr4ay/JDxq3nGYsJZyt8tA==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+
+  regjsparser@0.13.0:
+    resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
+    hasBin: true
 
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
@@ -10826,6 +10840,14 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redos-detector@6.1.4:
+    dependencies:
+      regjsparser: 0.13.0
+
+  regjsparser@0.13.0:
+    dependencies:
+      jsesc: 3.1.0
 
   rehype-raw@7.0.0:
     dependencies:

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -148,6 +148,30 @@ run(
 // Ensure CLI is executable
 fs.chmodSync(path.join(DIST, 'cli.mjs'), 0o755);
 
+// 5a. Bundle the deterministic-scan worker as a sibling of cli.mjs/server.mjs.
+// The tree-sitter code rules run in this worker so a single pathological file
+// (catastrophic regex backtracking) can be terminated instead of freezing the
+// whole run. It must be a separate file esbuild does NOT inline into the entry
+// bundles; the controller resolves it at runtime via `det-scan-worker.mjs` next
+// to the entry (see deterministic-scan/controller.ts resolveWorkerPath). Same
+// externals as the entries so web-tree-sitter WASM + typescript resolve from
+// node_modules, and BUNDLED_WASM_DIR (dist/wasm) is shared with the entries.
+console.log('\n=== Bundling deterministic-scan worker ===');
+run(
+  [
+    'npx esbuild packages/analyzer/src/deterministic-scan/worker.ts',
+    '--bundle',
+    '--platform=node',
+    '--target=node20',
+    '--format=esm',
+    '--outfile=dist/det-scan-worker.mjs',
+    '--external:web-tree-sitter',
+    '--external:pyright',
+    '--external:typescript',
+    '--banner:js="import { createRequire as __cRw } from \'node:module\'; const require = __cRw(import.meta.url);"',
+  ].join(' '),
+);
+
 // 5b. Build the C# Roslyn semantic host (framework-dependent, portable). Ships
 // as `dist/roslyn-host/csharp-roslyn-host.dll` and is launched via the user's
 // `dotnet` at runtime — one build runs on every OS (no per-platform matrix).

--- a/tests/analyzer/deterministic-scan.test.ts
+++ b/tests/analyzer/deterministic-scan.test.ts
@@ -69,6 +69,18 @@ describe('runDeterministicScanIsolated (controller)', () => {
     expect(result.violations.map((v: any) => v.marker)).toEqual(['a.ts', 'b.ts'])
   }, 20_000)
 
+  it('bounds a setup-phase hang with the setup watchdog', async () => {
+    // The worker pins the thread during setup (before `setup-done`), so only the
+    // setup watchdog — not the per-file one — can catch it. A generous per-file
+    // budget ensures it's the setup timer that fires.
+    const promise = runDeterministicScanIsolated(baseInput(['HANG_SETUP.ts']), {
+      fileTimeoutMs: 60_000,
+      setupTimeoutMs: 300,
+      workerPath: HANG_WORKER,
+    })
+    await expect(promise).rejects.toThrow(/setup/i)
+  }, 15_000)
+
   it('rejects with an AbortError when the signal fires mid-scan', async () => {
     const controller = new AbortController()
     const names = ['HANG.ts'] // worker will pin on the first file

--- a/tests/analyzer/deterministic-scan.test.ts
+++ b/tests/analyzer/deterministic-scan.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import path from 'node:path'
+import os from 'node:os'
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { runDeterministicScanIsolated, type IsolatedScanInput } from '../../packages/analyzer/src/deterministic-scan/controller'
+
+const HANG_WORKER = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../fixtures/deterministic-scan/hang-worker.mjs',
+)
+
+function fileList(names: string[]): IsolatedScanInput['files'] {
+  // absPath is unused by the test worker; keep it plausible.
+  return names.map((n) => ({ filePath: n, absPath: `/virtual/${n}` }))
+}
+
+function baseInput(names: string[]): IsolatedScanInput {
+  return {
+    repoPath: '/virtual',
+    files: fileList(names),
+    enabledRuleKeys: [],
+    tsFiles: [],
+    databaseResult: undefined,
+  }
+}
+
+describe('runDeterministicScanIsolated (controller)', () => {
+  it('collects every file’s results on a clean run', async () => {
+    const names = ['a.ts', 'b.ts', 'c.ts']
+    const progress: Array<[number, number]> = []
+    const result = await runDeterministicScanIsolated(baseInput(names), {
+      fileTimeoutMs: 5_000,
+      workerPath: HANG_WORKER,
+      onProgress: (p, t) => progress.push([p, t]),
+    })
+
+    expect(result.skipped).toEqual([])
+    expect(result.violations.map((v: any) => v.marker)).toEqual(names)
+    // Progress reaches the total.
+    expect(progress.at(-1)).toEqual([3, 3])
+  })
+
+  it('skips a stalled file with a warning and resumes past it', async () => {
+    const names = ['a.ts', 'b.ts', 'HANG.ts', 'c.ts', 'd.ts']
+    const skips: string[] = []
+    const result = await runDeterministicScanIsolated(baseInput(names), {
+      fileTimeoutMs: 300, // short budget so the busy-loop trips it quickly
+      workerPath: HANG_WORKER,
+      onSkip: (fp) => skips.push(fp),
+    })
+
+    // The hung file is skipped...
+    expect(skips).toEqual(['HANG.ts'])
+    expect(result.skipped).toHaveLength(1)
+    expect(result.skipped[0].filePath).toBe('HANG.ts')
+    expect(result.skipped[0].reason).toContain('per-file')
+    // ...and every other file is still scanned (resume worked).
+    expect(result.violations.map((v: any) => v.marker)).toEqual(['a.ts', 'b.ts', 'c.ts', 'd.ts'])
+  }, 15_000)
+
+  it('handles multiple stalled files', async () => {
+    const names = ['HANG1.ts', 'a.ts', 'HANG2.ts', 'b.ts']
+    const result = await runDeterministicScanIsolated(baseInput(names), {
+      fileTimeoutMs: 250,
+      workerPath: HANG_WORKER,
+    })
+    expect(result.skipped.map((s) => s.filePath)).toEqual(['HANG1.ts', 'HANG2.ts'])
+    expect(result.violations.map((v: any) => v.marker)).toEqual(['a.ts', 'b.ts'])
+  }, 20_000)
+
+  it('rejects with an AbortError when the signal fires mid-scan', async () => {
+    const controller = new AbortController()
+    const names = ['HANG.ts'] // worker will pin on the first file
+    const promise = runDeterministicScanIsolated(baseInput(names), {
+      fileTimeoutMs: 60_000, // long, so the abort wins the race, not the watchdog
+      workerPath: HANG_WORKER,
+      signal: controller.signal,
+    })
+    // Let the worker start and pin, then abort.
+    setTimeout(() => controller.abort(), 200)
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+  }, 15_000)
+
+  it('falls back to in-thread when no worker can be resolved', async () => {
+    // A bogus workerPath is ignored (falsey check is on resolve, not existence),
+    // so force the fallback by pointing resolution at a non-existent bundled
+    // layout: pass an empty override and rely on resolveWorkerPath returning null
+    // under vitest (source layout has no sibling worker.js / det-scan-worker.mjs).
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'det-scan-'))
+    const filePath = path.join(dir, 'empty-catch.ts')
+    fs.writeFileSync(filePath, 'try { doSomething(); } catch (e) {}\n')
+
+    const result = await runDeterministicScanIsolated(
+      {
+        repoPath: dir,
+        files: [{ filePath, absPath: filePath }],
+        enabledRuleKeys: ['bugs/deterministic/empty-catch'],
+        tsFiles: [],
+        databaseResult: undefined,
+      },
+      { fileTimeoutMs: 5_000 }, // no workerPath → resolveWorkerPath() returns null under source layout → in-thread
+    )
+
+    fs.rmSync(dir, { recursive: true, force: true })
+    expect(result.skipped).toEqual([])
+    expect(result.violations.some((v: any) => v.ruleKey === 'bugs/deterministic/empty-catch')).toBe(true)
+  })
+})

--- a/tests/analyzer/redos-regex-gate.test.ts
+++ b/tests/analyzer/redos-regex-gate.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+import { isSafePattern } from 'redos-detector'
+
+/**
+ * ReDoS regression gate (Layer 2 of the issue #814 fix).
+ *
+ * The analyzer runs hundreds of regexes against arbitrary source code. A single
+ * pattern that can backtrack catastrophically is what froze a whole `analyze`
+ * run in #814. Layer 1 (the killable per-file worker) is the runtime *guarantee*
+ * that no file can freeze the run; this gate is the *prevention* layer: it fails
+ * the build if anyone introduces a regex literal that is provably vulnerable to
+ * exponential backtracking.
+ *
+ * Scope & limits (documented on purpose):
+ *  - Only regex *literals* (`/.../`) are analyzable statically; dynamic
+ *    `new RegExp(`…${x}…`)` patterns can't be seen here and rely on Layer 1.
+ *  - Detects *exponential* backtracking. Polynomial (quadratic) blowup — e.g.
+ *    `[\s\S]*?` in an exec loop — is not flagged by the detector; Layer 1 bounds
+ *    those at runtime.
+ *  - "Inconclusive" patterns (the detector bails at the step/score budget) are
+ *    reported but do NOT fail the build, to avoid flaky false positives.
+ */
+
+const ANALYZER_SRC = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../packages/analyzer/src',
+)
+
+// Exponential ReDoS needs a quantified GROUP (a `)` immediately followed by a
+// quantifier) or an adjacent-quantifier pair. Char-class quantifiers (`[ab]+`)
+// are linear and skipped. This cheap superset keeps the precise (slower) analysis
+// to the few dozen patterns that could actually blow up.
+const RISKY_SHAPE = /\)(?:[*+?]|\{\d)|[*+?]\?{0,1}[*+]/
+
+// Generous budget so a genuinely-safe suspect resolves to `safe`, while a real
+// exponential pattern is still caught quickly.
+const DETECTOR_OPTS = { maxSteps: 200_000, maxScore: 35, timeout: 5_000 } as const
+
+interface RegexLiteral {
+  file: string
+  line: number
+  pattern: string
+  flags: string
+}
+
+function collectTsFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name)
+    if (entry.isDirectory()) collectTsFiles(p, acc)
+    else if (entry.name.endsWith('.ts')) acc.push(p)
+  }
+  return acc
+}
+
+function collectRegexLiterals(): RegexLiteral[] {
+  const literals: RegexLiteral[] = []
+  for (const file of collectTsFiles(ANALYZER_SRC)) {
+    const src = fs.readFileSync(file, 'utf-8')
+    const sf = ts.createSourceFile(file, src, ts.ScriptTarget.Latest, true)
+    const visit = (node: ts.Node) => {
+      if (ts.isRegularExpressionLiteral(node)) {
+        const m = /^\/(.*)\/([a-z]*)$/s.exec(node.getText(sf))
+        if (m) {
+          const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf))
+          literals.push({ file: path.relative(ANALYZER_SRC, file), line: line + 1, pattern: m[1], flags: m[2] })
+        }
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(sf)
+  }
+  return literals
+}
+
+describe('ReDoS regex gate (analyzer)', () => {
+  it('has no regex literal that is provably vulnerable to exponential backtracking', () => {
+    const literals = collectRegexLiterals()
+    // Sanity: enumeration actually found the corpus (guards against a broken walk).
+    expect(literals.length).toBeGreaterThan(500)
+
+    const vulnerable: string[] = []
+    for (const lit of literals) {
+      if (!RISKY_SHAPE.test(lit.pattern)) continue
+      const jsFlags = lit.flags.replace(/[^gimsuy]/g, '')
+      let result
+      try {
+        result = isSafePattern(lit.pattern, { flags: jsFlags, ...DETECTOR_OPTS })
+      } catch {
+        continue // detector couldn't parse it → inconclusive, don't fail
+      }
+      if (result.safe) continue
+      if (result.error) continue // bailed at budget → inconclusive, don't fail
+      vulnerable.push(`${lit.file}:${lit.line}  /${lit.pattern}/${lit.flags}`)
+    }
+
+    expect(
+      vulnerable,
+      `Regex literal(s) vulnerable to catastrophic (exponential) backtracking. ` +
+        `Rewrite with bounded/atomic quantifiers or a linear scan:\n  ${vulnerable.join('\n  ')}`,
+    ).toEqual([])
+  })
+})

--- a/tests/fixtures/deterministic-scan/hang-worker.mjs
+++ b/tests/fixtures/deterministic-scan/hang-worker.mjs
@@ -1,0 +1,26 @@
+// Test double for the deterministic-scan worker. Speaks the real message
+// protocol but lets us deterministically simulate a pathological file: any file
+// whose path contains "HANG" busy-loops forever, so the controller's per-file
+// watchdog must terminate this worker and resume past it.
+import { parentPort, workerData } from 'node:worker_threads'
+
+const { files, startIndex } = workerData
+
+for (let i = startIndex; i < files.length; i++) {
+  const f = files[i]
+  parentPort.postMessage({ type: 'file-start', index: i, filePath: f.filePath })
+  if (f.filePath.includes('HANG')) {
+    // Faithful reproduction of the real bug: drive V8's regex engine into
+    // catastrophic (exponential) backtracking so this thread is pinned in
+    // native regex code — exactly the failure mode from issue #814. The
+    // controller's watchdog + worker.terminate() must still kill it.
+    const evil = /(a+)+$/
+    evil.test('a'.repeat(50) + '!') // never returns in any realistic time
+  }
+  parentPort.postMessage({
+    type: 'file-result',
+    index: i,
+    violations: [{ marker: f.filePath }],
+  })
+}
+parentPort.postMessage({ type: 'complete' })

--- a/tests/fixtures/deterministic-scan/hang-worker.mjs
+++ b/tests/fixtures/deterministic-scan/hang-worker.mjs
@@ -1,26 +1,31 @@
 // Test double for the deterministic-scan worker. Speaks the real message
-// protocol but lets us deterministically simulate a pathological file: any file
-// whose path contains "HANG" busy-loops forever, so the controller's per-file
-// watchdog must terminate this worker and resume past it.
+// protocol but lets us deterministically simulate pathological behavior:
+//   - a file whose path contains "HANG" busy-loops in a catastrophic regex
+//     while processing that file → the per-file watchdog must kill + resume.
+//   - a run containing a file path with "HANG_SETUP" busy-loops during the
+//     setup phase (before `setup-done`) → the setup watchdog must catch it.
 import { parentPort, workerData } from 'node:worker_threads'
 
 const { files, startIndex } = workerData
 
+// Faithful reproduction of the real bug: drive V8's regex engine into
+// catastrophic (exponential) backtracking, pinning this thread in native regex
+// code — exactly the failure mode from issue #814.
+function pinThread() {
+  const evil = /(a+)+$/
+  evil.test('a'.repeat(50) + '!') // never returns in any realistic time
+}
+
+// Setup-phase hang: happens before any message is sent, so only the setup
+// watchdog can catch it.
+if (files.some((f) => f.filePath.includes('HANG_SETUP'))) pinThread()
+
+parentPort.postMessage({ type: 'setup-done' })
+
 for (let i = startIndex; i < files.length; i++) {
   const f = files[i]
   parentPort.postMessage({ type: 'file-start', index: i, filePath: f.filePath })
-  if (f.filePath.includes('HANG')) {
-    // Faithful reproduction of the real bug: drive V8's regex engine into
-    // catastrophic (exponential) backtracking so this thread is pinned in
-    // native regex code — exactly the failure mode from issue #814. The
-    // controller's watchdog + worker.terminate() must still kill it.
-    const evil = /(a+)+$/
-    evil.test('a'.repeat(50) + '!') // never returns in any realistic time
-  }
-  parentPort.postMessage({
-    type: 'file-result',
-    index: i,
-    violations: [{ marker: f.filePath }],
-  })
+  if (f.filePath.includes('HANG')) pinThread()
+  parentPort.postMessage({ type: 'file-result', index: i, violations: [{ marker: f.filePath }] })
 }
 parentPort.postMessage({ type: 'complete' })


### PR DESCRIPTION
## Summary

Fixes #814. `truecourse analyze` could hang **indefinitely** in the deterministic (tree-sitter) phase: a single source file drove a rule's regex into catastrophic backtracking, and because the per-file loop ran **synchronously on the main thread**, the whole run froze — no `LATEST.json` was ever written, and even `Ctrl+C` had no effect (the main thread never got a chance to check the abort flag).

The root cause is structural, not one bad regex: nothing could interrupt a single file's synchronous work. You cannot interrupt a running V8 regex from the same thread, so a real fix has to move the work across a thread boundary. This PR does that, and adds a regression gate so a provably-exponential pattern can't be introduced later.

## The fix — two layers

### Layer 1 — runtime guarantee (killable worker + per-file timeout)

The per-file tree-sitter scan now runs in a **worker thread** with a per-file wall-clock budget:

- A file that exceeds the budget is **terminated and skipped-with-a-warning** (the warning names the file), and the scan **resumes past it**, so the run always completes and writes its output.
- Because the main thread is now free, the watchdog fires reliably **even while the worker is pinned in native regex backtracking**, and `Ctrl+C` takes effect mid-scan.
- The budget defaults to **30s/file** and is overridable via `TRUECOURSE_DET_FILE_TIMEOUT_MS` (a universal resource bound, not a file-specific heuristic).
- Falls back to an in-thread scan when no worker entry can be resolved, so `analyze` never breaks.

This is input-agnostic: it bounds exponential backtracking, quadratic blowup, dynamically-built regexes, and any future non-regex CPU pathology alike. The skip warning also names the offending file, which is exactly the per-file tracing the issue said was still needed to pinpoint the culprit.

### Layer 2 — regression prevention (ReDoS gate)

A test enumerates the analyzer's regex **literals** (via the TypeScript compiler) and fails the build on any that are provably vulnerable to **exponential** backtracking (`redos-detector`). The current corpus has no such literal; the gate blocks future regressions. A cheap structural pre-filter keeps it fast (~6s). Documented limits: it can't see dynamic `new RegExp(...)` patterns and doesn't flag polynomial blowup — both are bounded at runtime by Layer 1.

## Changes

- **New module** `packages/analyzer/src/deterministic-scan/` (`types`, `run-scan`, `worker`, `controller`), exported from the analyzer index. `TypeQuery` / schema-index construction moves into the scan (they were loop-local).
- `violation-pipeline.service.ts` calls `runDeterministicScanIsolated` in place of the old synchronous loop, preserving the progress counter, abort behavior, and violation output.
- `scripts/build.ts` emits `dist/det-scan-worker.mjs` alongside the entry bundles (same externals + shared `dist/wasm` dir); the controller resolves the worker for both bundled and unbundled layouts.
- `README.md` documents the per-file budget and the env var.

## Testing

- **New** `tests/analyzer/deterministic-scan.test.ts`: clean run, stall → skip → resume, multiple stalls, mid-scan abort, and the in-thread fallback. The stall fixture drives a **real catastrophic regex** (`(a+)+$`), proving `worker.terminate()` kills a thread stuck in the native regex engine — the actual failure mode of #814.
- **New** `tests/analyzer/redos-regex-gate.test.ts`: the ReDoS gate.
- Verified the real built worker end-to-end (WASM init + TypeQuery build inside the worker) produces correct violations with `skipped=0`.
- Full suites green: analyzer + server (4615 passed), CLI e2e `analyze` for JS/TS + Python, and shared. The only failing test is the pre-existing `analyze-csharp` e2e, which requires the .NET SDK (`spawnSync dotnet ENOENT`) and is unrelated to this change.

## Note for reviewers

The **bundled** worker (`dist/det-scan-worker.mjs`) was confirmed to build via esbuild, but its runtime module resolution could not be fully exercised in this environment (that needs a full `pnpm build:dist`, i.e. `npm install` inside `dist/`). It uses the exact same externals, banner, output location, and WASM-dir convention as the already-shipping `cli.mjs`, and the identical *unbundled* worker was run end-to-end — so it is correct by construction, but a `pnpm build:dist` + analyze on a large repo in CI is worth a final check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
