### PR TITLE
fix(analyze): resolve LLM model through per-stage config (#799)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Claude Code CLI settings (optional — the `claude` binary is the only supported provider)
-# CLAUDE_CODE_MODEL=
+# TRUECOURSE_MODEL=            # global model override; per-stage vars win over it
+# CLAUDE_CODE_MODEL=           # deprecated alias for TRUECOURSE_MODEL (still honored)
 # CLAUDE_CODE_TIMEOUT_MS=120000
 
 # ---------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ For packaged installs (`npx truecourse` or `npm install -g truecourse`), the sim
 
 ```
 CLAUDE_CODE_BINARY=claude             # override the `claude` binary on PATH (CLAUDE_CODE_BIN also accepted)
-CLAUDE_CODE_MODEL=                    # Claude Code --model flag (empty = default)
+TRUECOURSE_MODEL=                     # global model override (see "Per-stage model selection")
 CLAUDE_CODE_TIMEOUT_MS=120000         # per-call timeout (ms)
 CLAUDE_CODE_MAX_RETRIES=2             # retry attempts on parse/validation failure
 CLAUDE_CODE_MAX_CONCURRENCY=10        # max concurrent `claude` processes per run
@@ -419,6 +419,8 @@ Each LLM-powered pipeline stage resolves its model independently, so you can run
 | guard section classify/extract | `TRUECOURSE_MODEL_GUARD_EXTRACT` | sonnet |
 | guard scenario generate | `TRUECOURSE_MODEL_GUARD_GENERATE` | opus |
 | guard recipe derivation | `TRUECOURSE_MODEL_GUARD_RECIPE` | sonnet |
+| analyze LLM violation rules | `TRUECOURSE_MODEL_RULES_VIOLATION_GEN` | sonnet |
+| analyze flow enrichment | `TRUECOURSE_MODEL_RULES_FLOW_ENRICH` | haiku |
 
 `TRUECOURSE_FALLBACK_MODEL` sets the `--fallback-model` used when the primary is overloaded. `TRUECOURSE_MAX_CONCURRENCY` caps concurrent LLM calls across every stage (default `min(cpus, 4)`). `TRUECOURSE_LLM_TIMEOUT_SCALE` multiplies every stage's per-call timeout by a float (default `1`); a slow model or proxy that trips the built-in ceilings can widen them all with one knob — e.g. `TRUECOURSE_LLM_TIMEOUT_SCALE=3` for a slow proxy. `TRUECOURSE_LLM_LOG` / `TRUECOURSE_LLM_DUMP` enable per-call logging.
 

--- a/README.md
+++ b/README.md
@@ -422,6 +422,8 @@ Each LLM-powered pipeline stage resolves its model independently, so you can run
 | analyze LLM violation rules | `TRUECOURSE_MODEL_RULES_VIOLATION_GEN` | sonnet |
 | analyze flow enrichment | `TRUECOURSE_MODEL_RULES_FLOW_ENRICH` | haiku |
 
+`CLAUDE_CODE_MODEL` is a deprecated alias for `TRUECOURSE_MODEL`. It is still honored as a global override (with a one-time warning on stderr), but `TRUECOURSE_MODEL` wins when both are set.
+
 `TRUECOURSE_FALLBACK_MODEL` sets the `--fallback-model` used when the primary is overloaded. `TRUECOURSE_MAX_CONCURRENCY` caps concurrent LLM calls across every stage (default `min(cpus, 4)`). `TRUECOURSE_LLM_TIMEOUT_SCALE` multiplies every stage's per-call timeout by a float (default `1`); a slow model or proxy that trips the built-in ceilings can widen them all with one knob — e.g. `TRUECOURSE_LLM_TIMEOUT_SCALE=3` for a slow proxy. `TRUECOURSE_LLM_LOG` / `TRUECOURSE_LLM_DUMP` enable per-call logging.
 
 ### Excluding files from analysis

--- a/packages/core/src/commands/analyze-in-process.ts
+++ b/packages/core/src/commands/analyze-in-process.ts
@@ -13,6 +13,8 @@ import type { StepTracker } from '../progress.js';
 import { analyzeCore, type LlmEstimate } from './analyze-core.js';
 import { persistFullAnalysis, type PersistFullResult } from './analyze-persist.js';
 import { config } from '../config/index.js';
+import { resolveModel } from '../config/llm-models.js';
+import { resolveRepoDir } from '../config/paths.js';
 import { log } from '../lib/logger.js';
 import {
   bucketDuration,
@@ -65,8 +67,13 @@ export async function analyzeInProcess(
   options: AnalyzeInProcessOptions = {},
 ): Promise<AnalyzeInProcessResult> {
   const startedAt = Date.now();
+  // Report the models the run will actually use — resolved through the same
+  // per-stage chain the provider uses, against this project's config.json.
+  const repoDir = resolveRepoDir(project.path);
   log.info(
-    `[LLM] Provider: claude-code, model: ${config.claudeCodeModel || 'default'}, maxConcurrency: ${config.claudeCodeMaxConcurrency}`,
+    `[LLM] Provider: claude-code, violationGen: ${resolveModel('rules.violationGen', undefined, repoDir)}, ` +
+      `flowEnrich: ${resolveModel('rules.flowEnrich', undefined, repoDir)}, ` +
+      `maxConcurrency: ${config.claudeCodeMaxConcurrency}`,
   );
   const core = await analyzeCore(project, { ...options, mode: 'full' });
   const result = await persistFullAnalysis(project, core, startedAt);

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -16,7 +16,9 @@ export const config = {
   // `resolveClaudeBinary` (@truecourse/shared) so every command, the LLM
   // provider, and the extraction runners agree on the same target.
   claudeCodeBinary: resolveClaudeBinary(),
-  claudeCodeModel: process.env.CLAUDE_CODE_MODEL || '',
+  // Model selection is NOT here — it is per-stage and repo-scoped, so it lives
+  // in `config/llm-models.ts`. `CLAUDE_CODE_MODEL` is still honored there as a
+  // deprecated global override.
   claudeCodeTimeoutMs: parseInt(process.env.CLAUDE_CODE_TIMEOUT_MS || '120000', 10),
   claudeCodeMaxRetries: parseInt(process.env.CLAUDE_CODE_MAX_RETRIES || '2', 10),
   claudeCodeMaxConcurrency: parsePositiveInt(

--- a/packages/core/src/config/llm-models.ts
+++ b/packages/core/src/config/llm-models.ts
@@ -46,7 +46,9 @@ export type StageId =
   | 'guard.retry'
   | 'guard.fidelity'
   | 'guard.recipe'
-  | 'rules.violationGen';
+  // --- analyze (LLM rules) ---
+  | 'rules.violationGen'
+  | 'rules.flowEnrich';
 
 /**
  * Default model per stage when the user hasn't configured an override.
@@ -93,7 +95,13 @@ export const STAGE_DEFAULTS: Record<StageId, string> = {
   'guard.fidelity': 'sonnet',
   // Proposing a build/entry recipe is a modest structured task — sonnet.
   'guard.recipe': 'sonnet',
-  'rules.violationGen': 'opus',
+  // Binding a rule to a line range in already-written code is an audit, not
+  // authoring — the same family as `contract.gapJudge`, so sonnet. (Was 'opus',
+  // an aspirational value that never actually ran; see #799.)
+  'rules.violationGen': 'sonnet',
+  // Naming + describing an already-computed flow graph — no judgement, nothing
+  // load-bearing downstream. Same tier as spec.vocab.
+  'rules.flowEnrich': 'haiku',
 };
 
 export interface LlmConfigBlock {
@@ -191,6 +199,45 @@ export function resolveFallbackModel(
 }
 
 /**
+ * A stage's resolved model choice. Both fields are optional: `undefined`
+ * means "send no flag / no field", i.e. let the downstream CLI or transport
+ * pick. Callers that need CLI flags run this through `modelArgs`; callers
+ * that speak the transport protocol copy the fields onto the request.
+ */
+export interface ModelSelection {
+  /** Primary model. `undefined` ⇒ send no `--model`. */
+  model?: string;
+  /** Overload retry model. `undefined` ⇒ send no `--fallback-model`. */
+  fallbackModel?: string;
+}
+
+/**
+ * Resolve both models for a stage in one pass. This is the single entry point
+ * for "what should this stage run on" — spawning and transport callers share it
+ * so a stage can't be routed differently depending on which path it takes.
+ */
+export function resolveStageModels(
+  stageId: StageId,
+  defaultModel: string = STAGE_DEFAULTS[stageId],
+  repoDir: string | null = resolveRepoDir(process.cwd()),
+): ModelSelection {
+  const sel: ModelSelection = {};
+  const model = resolveModel(stageId, defaultModel, repoDir);
+  if (model) sel.model = model;
+  const fallback = resolveFallbackModel(repoDir);
+  if (fallback) sel.fallbackModel = fallback;
+  return sel;
+}
+
+/** Render a selection as `claude -p` flags. */
+export function modelArgs(sel: ModelSelection): string[] {
+  const args: string[] = [];
+  if (sel.model) args.push('--model', sel.model);
+  if (sel.fallbackModel) args.push('--fallback-model', sel.fallbackModel);
+  return args;
+}
+
+/**
  * Convenience for spawning code: returns the `--model X` (and
  * `--fallback-model Y` if configured) args to append to a `claude -p`
  * invocation. Returns `[]` when the caller wants the CLI default —
@@ -203,16 +250,7 @@ export function modelArgsForStage(
   defaultModel: string = STAGE_DEFAULTS[stageId],
   repoDir: string | null = resolveRepoDir(process.cwd()),
 ): string[] {
-  const args: string[] = [];
-  const model = resolveModel(stageId, defaultModel, repoDir);
-  if (model) {
-    args.push('--model', model);
-  }
-  const fallback = resolveFallbackModel(repoDir);
-  if (fallback) {
-    args.push('--fallback-model', fallback);
-  }
-  return args;
+  return modelArgs(resolveStageModels(stageId, defaultModel, repoDir));
 }
 
 /**

--- a/packages/core/src/services/flow.service.ts
+++ b/packages/core/src/services/flow.service.ts
@@ -308,6 +308,10 @@ export async function enrichFlowWithLLM(repoPath: string, flowId: string): Promi
   if (!flow) return;
 
   const provider = createLLMProvider();
+  // Without this the spawned CLI inherits the server's cwd (so its Read tool
+  // resolves against the wrong tree), the child isn't registered for
+  // cancellation, and model config under this repo is ignored.
+  provider.setRepoPath(repoPath);
   const enriched = await provider.enrichFlow({
     flowName: flow.name,
     entryService: flow.entryService,

--- a/packages/core/src/services/llm/cli-provider.ts
+++ b/packages/core/src/services/llm/cli-provider.ts
@@ -75,10 +75,12 @@ interface SpawnOptions {
   /** Fires once the concurrency limiter grants a slot, before spawnCLI runs. */
   onStart?: () => void;
   /**
-   * Which model-config stage this call bills to. Analyze has two: the
-   * violation rules and the far cheaper flow enrichment.
+   * Which model-config stage this call resolves its model from. Analyze has
+   * two: the violation rules and the far cheaper flow enrichment. Named
+   * `modelStage` to keep it distinct from the transport's own `stage` field
+   * (`analyze.<label>`), which is a finer-grained call-log taxonomy.
    */
-  stage?: StageId;
+  modelStage?: StageId;
 }
 
 interface CLIUsage {
@@ -226,7 +228,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
 
     const timeout = opts?.timeoutMs ?? config.claudeCodeTimeoutMs ?? 120_000;
     const label = opts?.label ?? 'call';
-    const sel = this.resolvedModelSelection(opts?.stage ?? 'rules.violationGen');
+    const sel = this.resolvedModelSelection(opts?.modelStage ?? 'rules.violationGen');
 
     // Agent transport: hand the prompt + schema to the mailbox instead of
     // spawning the CLI. The answer is the raw JSON the model produced; wrap it
@@ -891,7 +893,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
     log.info(`[CLI] Flow enrichment call starting for ${context.flowName}...`);
     const t0 = Date.now();
     const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, FlowEnrichmentOutputSchema, {
-      extraArgs: ['--tools', ''], label: 'flow', stage: 'rules.flowEnrich',
+      extraArgs: ['--tools', ''], label: 'flow', modelStage: 'rules.flowEnrich',
     });
     const dur = Date.now() - t0;
     log.info(`[CLI] Flow enrichment done in ${dur}ms`);

--- a/packages/core/src/services/llm/cli-provider.ts
+++ b/packages/core/src/services/llm/cli-provider.ts
@@ -13,6 +13,13 @@ import type { Violation } from '@truecourse/shared';
 import type { LlmTransport } from '@truecourse/shared/llm';
 import { config } from '../../config/index.js';
 import {
+  modelArgs,
+  resolveStageModels,
+  type ModelSelection,
+  type StageId,
+} from '../../config/llm-models.js';
+import { resolveRepoDir } from '../../config/paths.js';
+import {
   getPrompt,
   buildServiceTemplateVars,
   buildDatabaseTemplateVars,
@@ -67,6 +74,11 @@ interface SpawnOptions {
   extraArgs?: string[];
   /** Fires once the concurrency limiter grants a slot, before spawnCLI runs. */
   onStart?: () => void;
+  /**
+   * Which model-config stage this call bills to. Analyze has two: the
+   * violation rules and the far cheaper flow enrichment.
+   */
+  stage?: StageId;
 }
 
 interface CLIUsage {
@@ -81,7 +93,13 @@ interface CLIUsage {
 export abstract class BaseCLIProvider implements LLMProvider {
   abstract get binaryName(): string;
   abstract get baseArgs(): string[];
-  abstract get modelFlag(): string[];
+
+  /**
+   * Which model this provider runs `stage` on. `repoDir` is the already-resolved
+   * repo root (or `null` when there is none) — the base class owns that
+   * resolution so subclasses can't derive it inconsistently.
+   */
+  abstract modelSelection(stage: StageId, repoDir: string | null): ModelSelection;
 
   private maxRetries = config.claudeCodeMaxRetries ?? 2;
   private limit: LimitFunction = pLimit(config.claudeCodeMaxConcurrency);
@@ -91,6 +109,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
   private _repoId: string | null = null;
   private _repoPath: string | null = null;
   private _abortSignal: AbortSignal | null = null;
+  private _modelSelections = new Map<StageId, ModelSelection>();
   private _usageRecords: UsageRecord[] = [];
   /**
    * When set, LLM calls go through this transport (the agent file-mailbox)
@@ -116,6 +135,28 @@ export abstract class BaseCLIProvider implements LLMProvider {
   /** Set target repo path — used as cwd when spawning CLI so Read tool accesses the right files. */
   setRepoPath(path: string): void {
     this._repoPath = path;
+    // Model config lives in `<repo>/.truecourse/config.json` — a new repo means
+    // a new answer, so drop the memoized selections.
+    this._modelSelections.clear();
+  }
+
+  /**
+   * The model selection for `stage`, memoized. `resolveModel` stats and reads
+   * config.json on every call and analyze fires up to `claudeCodeMaxConcurrency`
+   * calls, so resolving once per stage matters.
+   */
+  protected resolvedModelSelection(stage: StageId): ModelSelection {
+    let sel = this._modelSelections.get(stage);
+    if (!sel) {
+      // Explicit null when unset — `resolveStageModels`' default parameter is
+      // `resolveRepoDir(process.cwd())`, which is wrong for a long-lived
+      // dashboard server: cwd is '/' under launchd or a stale repo in console
+      // mode, while it analyzes arbitrary repos from the registry.
+      const repoDir = this._repoPath ? resolveRepoDir(this._repoPath) : null;
+      sel = this.modelSelection(stage, repoDir);
+      this._modelSelections.set(stage, sel);
+    }
+    return sel;
   }
 
   flushUsage(): UsageData[] {
@@ -185,6 +226,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
 
     const timeout = opts?.timeoutMs ?? config.claudeCodeTimeoutMs ?? 120_000;
     const label = opts?.label ?? 'call';
+    const sel = this.resolvedModelSelection(opts?.stage ?? 'rules.violationGen');
 
     // Agent transport: hand the prompt + schema to the mailbox instead of
     // spawning the CLI. The answer is the raw JSON the model produced; wrap it
@@ -197,14 +239,15 @@ export abstract class BaseCLIProvider implements LLMProvider {
         system: '',
         schema: jsonSchemaStr,
         responseFormat: 'json',
-        model: this.modelFlag[1],
+        model: sel.model,
+        fallbackModel: sel.fallbackModel,
         timeoutMs: timeout,
       }).then((text) => JSON.stringify({ result: text }));
     }
 
     const args = [
       ...this.baseArgs,
-      ...this.modelFlag,
+      ...modelArgs(sel),
       '--json-schema', jsonSchemaStr,
       ...(opts?.extraArgs ?? []),
     ];
@@ -848,7 +891,7 @@ export abstract class BaseCLIProvider implements LLMProvider {
     log.info(`[CLI] Flow enrichment call starting for ${context.flowName}...`);
     const t0 = Date.now();
     const { data: object, usage: cliUsage } = await this.spawnAndParse(prompt, FlowEnrichmentOutputSchema, {
-      extraArgs: ['--tools', ''], label: 'flow',
+      extraArgs: ['--tools', ''], label: 'flow', stage: 'rules.flowEnrich',
     });
     const dur = Date.now() - t0;
     log.info(`[CLI] Flow enrichment done in ${dur}ms`);
@@ -880,8 +923,12 @@ export class ClaudeCodeProvider extends BaseCLIProvider {
     ];
   }
 
-  get modelFlag(): string[] {
-    const model = config.claudeCodeModel;
-    return model ? ['--model', model] : [];
+  /**
+   * Resolves through the documented precedence chain, same as spec and guard.
+   * Legacy `CLAUDE_CODE_MODEL` still works — `resolveModel` honors it as a
+   * global override.
+   */
+  modelSelection(stage: StageId, repoDir: string | null): ModelSelection {
+    return resolveStageModels(stage, undefined, repoDir);
   }
 }

--- a/tests/core/cli-provider-concurrency.test.ts
+++ b/tests/core/cli-provider-concurrency.test.ts
@@ -3,6 +3,7 @@ import { BaseCLIProvider } from '../../packages/core/src/services/llm/cli-provid
 import { ServiceViolationOutputSchema } from '../../packages/core/src/services/llm/schemas.js';
 import { config } from '../../packages/core/src/config/index.js';
 import type { LlmTransport } from '@truecourse/shared/llm';
+import type { ModelSelection } from '../../packages/core/src/config/llm-models.js';
 
 /**
  * Counting transport: a fake `LlmTransport` (no real `claude` spawn). Each call
@@ -39,8 +40,8 @@ class TestProvider extends BaseCLIProvider {
   get baseArgs() {
     return ['-p', '--output-format', 'json'];
   }
-  get modelFlag() {
-    return ['--model', 'test-model'];
+  modelSelection(): ModelSelection {
+    return { model: 'test-model' };
   }
   async runTask(onStart?: () => void) {
     return (

--- a/tests/core/cli-provider-model-argv.test.ts
+++ b/tests/core/cli-provider-model-argv.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
+import { modelConfigSandbox } from '../helpers/model-config.js';
 
 // OSS installs no default transport (`getDefaultTransport()` is undefined unless
 // EE called `setDefaultTransport`), so the spawn branch is what real users hit —
@@ -11,44 +11,12 @@ import path from 'node:path';
 // real executable that records its argv and emits the buffered
 // `--output-format json` envelope this provider parses.
 
-const ENV_KEYS = [
-  'CLAUDE_CODE_BINARY',
-  'CLAUDE_CODE_BIN',
-  'TRUECOURSE_MODEL',
-  'CLAUDE_CODE_MODEL',
-  'TRUECOURSE_FALLBACK_MODEL',
-  'TRUECOURSE_MODEL_RULES_VIOLATION_GEN',
-  'TRUECOURSE_MODEL_RULES_FLOW_ENRICH',
-  'TC_ARGV_OUT',
-] as const;
-
-const originals = new Map<string, string | undefined>();
-for (const k of ENV_KEYS) originals.set(k, process.env[k]);
-
-const tmpDirs: string[] = [];
-
-function tmp(prefix: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  tmpDirs.push(dir);
-  return dir;
-}
-
-function makeRepo(config?: unknown): string {
-  const dir = tmp('tc-argv-repo-');
-  fs.mkdirSync(path.join(dir, '.truecourse'), { recursive: true });
-  if (config !== undefined) {
-    fs.writeFileSync(
-      path.join(dir, '.truecourse', 'config.json'),
-      JSON.stringify(config),
-      'utf-8',
-    );
-  }
-  return dir;
-}
+const sandbox = modelConfigSandbox(['CLAUDE_CODE_BINARY', 'CLAUDE_CODE_BIN', 'TC_ARGV_OUT']);
+const { makeRepo, makeTmpDir } = sandbox;
 
 /** Records argv to `$TC_ARGV_OUT`, then emits the buffered JSON envelope. */
 function fakeArgvBin(): string {
-  const dir = tmp('tc-argv-bin-');
+  const dir = makeTmpDir('tc-argv-bin-');
   const p = path.join(dir, 'claude-argv.js');
   fs.writeFileSync(
     p,
@@ -71,7 +39,7 @@ const SERVICE_CTX = { architecture: 'monolith', services: [], dependencies: [], 
 
 /** Spawn one violation call against the fake binary and return its argv. */
 async function argvFor(repoPath: string | null): Promise<string[]> {
-  const argvOut = path.join(tmp('tc-argv-out-'), 'argv.json');
+  const argvOut = path.join(makeTmpDir('tc-argv-out-'), 'argv.json');
   process.env.TC_ARGV_OUT = argvOut;
   process.env.CLAUDE_CODE_BINARY = fakeArgvBin();
 
@@ -86,18 +54,8 @@ async function argvFor(repoPath: string | null): Promise<string[]> {
   return JSON.parse(fs.readFileSync(argvOut, 'utf-8')) as string[];
 }
 
-beforeEach(() => {
-  for (const k of ENV_KEYS) delete process.env[k];
-});
-
-afterEach(() => {
-  for (const k of ENV_KEYS) {
-    const v = originals.get(k);
-    if (v === undefined) delete process.env[k];
-    else process.env[k] = v;
-  }
-  while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
-});
+beforeEach(() => sandbox.reset());
+afterEach(() => sandbox.cleanup());
 
 describe('ClaudeCodeProvider — spawned argv carries the resolved model', () => {
   it('passes the stage default as --model (regression for #799)', async () => {

--- a/tests/core/cli-provider-model-argv.test.ts
+++ b/tests/core/cli-provider-model-argv.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// OSS installs no default transport (`getDefaultTransport()` is undefined unless
+// EE called `setDefaultTransport`), so the spawn branch is what real users hit —
+// it needs its own coverage that the resolved model actually reaches argv.
+//
+// We do NOT mock cross-spawn (see tests/core/cli-binary.test.ts): the fake is a
+// real executable that records its argv and emits the buffered
+// `--output-format json` envelope this provider parses.
+
+const ENV_KEYS = [
+  'CLAUDE_CODE_BINARY',
+  'CLAUDE_CODE_BIN',
+  'TRUECOURSE_MODEL',
+  'CLAUDE_CODE_MODEL',
+  'TRUECOURSE_FALLBACK_MODEL',
+  'TRUECOURSE_MODEL_RULES_VIOLATION_GEN',
+  'TRUECOURSE_MODEL_RULES_FLOW_ENRICH',
+  'TC_ARGV_OUT',
+] as const;
+
+const originals = new Map<string, string | undefined>();
+for (const k of ENV_KEYS) originals.set(k, process.env[k]);
+
+const tmpDirs: string[] = [];
+
+function tmp(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function makeRepo(config?: unknown): string {
+  const dir = tmp('tc-argv-repo-');
+  fs.mkdirSync(path.join(dir, '.truecourse'), { recursive: true });
+  if (config !== undefined) {
+    fs.writeFileSync(
+      path.join(dir, '.truecourse', 'config.json'),
+      JSON.stringify(config),
+      'utf-8',
+    );
+  }
+  return dir;
+}
+
+/** Records argv to `$TC_ARGV_OUT`, then emits the buffered JSON envelope. */
+function fakeArgvBin(): string {
+  const dir = tmp('tc-argv-bin-');
+  const p = path.join(dir, 'claude-argv.js');
+  fs.writeFileSync(
+    p,
+    `#!/usr/bin/env node
+const fs = require('fs');
+fs.writeFileSync(process.env.TC_ARGV_OUT, JSON.stringify(process.argv.slice(2)));
+process.stdout.write(JSON.stringify({
+  type: 'result', subtype: 'success', is_error: false,
+  structured_output: { violations: [], serviceDescriptions: [] },
+  usage: { input_tokens: 1, output_tokens: 1 },
+}));
+process.exit(0);
+`,
+  );
+  fs.chmodSync(p, 0o755);
+  return p;
+}
+
+const SERVICE_CTX = { architecture: 'monolith', services: [], dependencies: [], llmRules: [] };
+
+/** Spawn one violation call against the fake binary and return its argv. */
+async function argvFor(repoPath: string | null): Promise<string[]> {
+  const argvOut = path.join(tmp('tc-argv-out-'), 'argv.json');
+  process.env.TC_ARGV_OUT = argvOut;
+  process.env.CLAUDE_CODE_BINARY = fakeArgvBin();
+
+  // `config.claudeCodeBinary` is snapshotted at import time.
+  vi.resetModules();
+  const { ClaudeCodeProvider } = await import('../../packages/core/src/services/llm/cli-provider.js');
+  const provider = new ClaudeCodeProvider();
+  if (repoPath) provider.setRepoPath(repoPath);
+
+  await provider.generateServiceViolations(SERVICE_CTX);
+
+  return JSON.parse(fs.readFileSync(argvOut, 'utf-8')) as string[];
+}
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    const v = originals.get(k);
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+describe('ClaudeCodeProvider — spawned argv carries the resolved model', () => {
+  it('passes the stage default as --model (regression for #799)', async () => {
+    const argv = await argvFor(makeRepo());
+
+    expect(argv).toContain('--model');
+    expect(argv[argv.indexOf('--model') + 1]).toBe('sonnet');
+    expect(argv).not.toContain('--fallback-model');
+  });
+
+  it('passes both --model and --fallback-model from config.json', async () => {
+    const repo = makeRepo({
+      llm: { stages: { 'rules.violationGen': 'opus' }, fallbackModel: 'haiku' },
+    });
+    const argv = await argvFor(repo);
+
+    expect(argv[argv.indexOf('--model') + 1]).toBe('opus');
+    expect(argv[argv.indexOf('--fallback-model') + 1]).toBe('haiku');
+  });
+
+  it('honors the per-stage env var with no repo path set', async () => {
+    process.env.TRUECOURSE_MODEL_RULES_VIOLATION_GEN = 'haiku';
+    const argv = await argvFor(null);
+
+    expect(argv[argv.indexOf('--model') + 1]).toBe('haiku');
+  });
+});

--- a/tests/core/cli-provider-model-selection.test.ts
+++ b/tests/core/cli-provider-model-selection.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
+import fs from 'node:fs';
+import { modelConfigSandbox } from '../helpers/model-config.js';
 import { ClaudeCodeProvider } from '../../packages/core/src/services/llm/cli-provider.js';
 import type { LlmRequest, LlmTransport } from '../../packages/shared/src/llm/transport.js';
 
@@ -9,30 +9,8 @@ import type { LlmRequest, LlmTransport } from '../../packages/shared/src/llm/tra
 // to whatever each developer's ~/.claude/settings.json said. These tests pin the
 // resolved selection to the documented precedence chain instead.
 
-const ENV_KEYS = [
-  'TRUECOURSE_MODEL',
-  'CLAUDE_CODE_MODEL',
-  'TRUECOURSE_FALLBACK_MODEL',
-  'TRUECOURSE_MODEL_RULES_VIOLATION_GEN',
-  'TRUECOURSE_MODEL_RULES_FLOW_ENRICH',
-] as const;
-
-const originals = new Map<string, string | undefined>();
-for (const k of ENV_KEYS) originals.set(k, process.env[k]);
-
-const tmpDirs: string[] = [];
-
-function makeRepo(config?: unknown): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-provider-model-'));
-  tmpDirs.push(dir);
-  fs.mkdirSync(path.join(dir, '.truecourse'), { recursive: true });
-  if (config !== undefined) writeConfig(dir, config);
-  return dir;
-}
-
-function writeConfig(repoDir: string, config: unknown): void {
-  fs.writeFileSync(path.join(repoDir, '.truecourse', 'config.json'), JSON.stringify(config), 'utf-8');
-}
+const sandbox = modelConfigSandbox();
+const { makeRepo, writeConfig, makeTmpDir } = sandbox;
 
 /** Records every request and answers with a schema-valid payload for the call. */
 function captureTransport(seen: LlmRequest[]): LlmTransport {
@@ -60,18 +38,8 @@ const FLOW_CTX = {
   steps: [],
 };
 
-beforeEach(() => {
-  for (const k of ENV_KEYS) delete process.env[k];
-});
-
-afterEach(() => {
-  for (const k of ENV_KEYS) {
-    const v = originals.get(k);
-    if (v === undefined) delete process.env[k];
-    else process.env[k] = v;
-  }
-  while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
-});
+beforeEach(() => sandbox.reset());
+afterEach(() => sandbox.cleanup());
 
 describe('ClaudeCodeProvider — per-stage model selection', () => {
   it('sends the stage default when nothing is configured (regression for #799)', async () => {
@@ -148,8 +116,7 @@ describe('ClaudeCodeProvider — per-stage model selection', () => {
   });
 
   it('degrades to env + defaults when the repo path has no .truecourse marker', async () => {
-    const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-provider-bare-'));
-    tmpDirs.push(bare);
+    const bare = makeTmpDir('tc-provider-bare-');
     process.env.TRUECOURSE_MODEL_RULES_VIOLATION_GEN = 'opus';
 
     const seen: LlmRequest[] = [];

--- a/tests/core/cli-provider-model-selection.test.ts
+++ b/tests/core/cli-provider-model-selection.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ClaudeCodeProvider } from '../../packages/core/src/services/llm/cli-provider.js';
+import type { LlmRequest, LlmTransport } from '../../packages/shared/src/llm/transport.js';
+
+// #799: `analyze` never sent a `--model` flag, so the spawned `claude` fell back
+// to whatever each developer's ~/.claude/settings.json said. These tests pin the
+// resolved selection to the documented precedence chain instead.
+
+const ENV_KEYS = [
+  'TRUECOURSE_MODEL',
+  'CLAUDE_CODE_MODEL',
+  'TRUECOURSE_FALLBACK_MODEL',
+  'TRUECOURSE_MODEL_RULES_VIOLATION_GEN',
+  'TRUECOURSE_MODEL_RULES_FLOW_ENRICH',
+] as const;
+
+const originals = new Map<string, string | undefined>();
+for (const k of ENV_KEYS) originals.set(k, process.env[k]);
+
+const tmpDirs: string[] = [];
+
+function makeRepo(config?: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-provider-model-'));
+  tmpDirs.push(dir);
+  fs.mkdirSync(path.join(dir, '.truecourse'), { recursive: true });
+  if (config !== undefined) writeConfig(dir, config);
+  return dir;
+}
+
+function writeConfig(repoDir: string, config: unknown): void {
+  fs.writeFileSync(path.join(repoDir, '.truecourse', 'config.json'), JSON.stringify(config), 'utf-8');
+}
+
+/** Records every request and answers with a schema-valid payload for the call. */
+function captureTransport(seen: LlmRequest[]): LlmTransport {
+  return async (req) => {
+    seen.push(req);
+    if (req.stage === 'analyze.flow') {
+      return JSON.stringify({ name: 'F', description: 'D', stepDescriptions: [] });
+    }
+    return JSON.stringify({ violations: [], serviceDescriptions: [] });
+  };
+}
+
+const SERVICE_CTX = {
+  architecture: 'monolith',
+  services: [],
+  dependencies: [],
+  llmRules: [],
+};
+
+const FLOW_CTX = {
+  flowName: 'f',
+  entryService: 's',
+  entryMethod: 'm',
+  trigger: 't',
+  steps: [],
+};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    const v = originals.get(k);
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+describe('ClaudeCodeProvider — per-stage model selection', () => {
+  it('sends the stage default when nothing is configured (regression for #799)', async () => {
+    const seen: LlmRequest[] = [];
+    const provider = new ClaudeCodeProvider(captureTransport(seen));
+    provider.setRepoPath(makeRepo());
+
+    await provider.generateServiceViolations(SERVICE_CTX);
+
+    // Pre-fix this was `undefined` — no --model, no reproducibility.
+    expect(seen[0].model).toBe('sonnet');
+    expect(seen[0].fallbackModel).toBeUndefined();
+  });
+
+  it('honors config.json per-stage model and fallbackModel', async () => {
+    const seen: LlmRequest[] = [];
+    const provider = new ClaudeCodeProvider(captureTransport(seen));
+    provider.setRepoPath(
+      makeRepo({ llm: { stages: { 'rules.violationGen': 'opus' }, fallbackModel: 'haiku' } }),
+    );
+
+    await provider.generateServiceViolations(SERVICE_CTX);
+
+    expect(seen[0].model).toBe('opus');
+    // Structurally impossible pre-fix: the transport path never set a fallback.
+    expect(seen[0].fallbackModel).toBe('haiku');
+  });
+
+  it('routes enrichFlow to rules.flowEnrich while violation calls stay on rules.violationGen', async () => {
+    const seen: LlmRequest[] = [];
+    const provider = new ClaudeCodeProvider(captureTransport(seen));
+    provider.setRepoPath(makeRepo());
+
+    await provider.generateServiceViolations(SERVICE_CTX);
+    await provider.enrichFlow(FLOW_CTX);
+
+    expect(seen[0].model).toBe('sonnet');
+    expect(seen[1].model).toBe('haiku');
+  });
+
+  it('lets the two analyze stages be configured independently', async () => {
+    const seen: LlmRequest[] = [];
+    const provider = new ClaudeCodeProvider(captureTransport(seen));
+    provider.setRepoPath(makeRepo({ llm: { stages: { 'rules.flowEnrich': 'sonnet' } } }));
+
+    await provider.generateServiceViolations(SERVICE_CTX);
+    await provider.enrichFlow(FLOW_CTX);
+
+    expect(seen[0].model).toBe('sonnet'); // default, untouched
+    expect(seen[1].model).toBe('sonnet'); // config override
+  });
+
+  it('walks up from a scan root that is a subdirectory of the repo', async () => {
+    const repo = makeRepo({ llm: { stages: { 'rules.violationGen': 'opus' } } });
+    const sub = path.join(repo, 'src', 'sub');
+    fs.mkdirSync(sub, { recursive: true });
+
+    const seen: LlmRequest[] = [];
+    const provider = new ClaudeCodeProvider(captureTransport(seen));
+    provider.setRepoPath(sub);
+
+    await provider.generateServiceViolations(SERVICE_CTX);
+
+    expect(seen[0].model).toBe('opus');
+  });
+
+  it('falls back to the stage default when no repo path was set — never process.cwd()', async () => {
+    const seen: LlmRequest[] = [];
+    const provider = new ClaudeCodeProvider(captureTransport(seen));
+
+    await provider.generateServiceViolations(SERVICE_CTX);
+
+    expect(seen[0].model).toBe('sonnet');
+  });
+
+  it('degrades to env + defaults when the repo path has no .truecourse marker', async () => {
+    const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-provider-bare-'));
+    tmpDirs.push(bare);
+    process.env.TRUECOURSE_MODEL_RULES_VIOLATION_GEN = 'opus';
+
+    const seen: LlmRequest[] = [];
+    const provider = new ClaudeCodeProvider(captureTransport(seen));
+    provider.setRepoPath(bare);
+
+    await provider.generateServiceViolations(SERVICE_CTX);
+
+    expect(seen[0].model).toBe('opus');
+  });
+
+  it('memoizes the selection per stage, and re-resolves on setRepoPath', async () => {
+    const repo = makeRepo({ llm: { stages: { 'rules.violationGen': 'opus' } } });
+    const seen: LlmRequest[] = [];
+    const provider = new ClaudeCodeProvider(captureTransport(seen));
+    provider.setRepoPath(repo);
+
+    await provider.generateServiceViolations(SERVICE_CTX);
+    writeConfig(repo, { llm: { stages: { 'rules.violationGen': 'haiku' } } });
+    await provider.generateServiceViolations(SERVICE_CTX);
+
+    expect(seen.map((r) => r.model)).toEqual(['opus', 'opus']);
+
+    provider.setRepoPath(repo);
+    await provider.generateServiceViolations(SERVICE_CTX);
+    expect(seen[2].model).toBe('haiku');
+  });
+
+  it('still honors legacy CLAUDE_CODE_MODEL', async () => {
+    process.env.CLAUDE_CODE_MODEL = 'legacy-model';
+    const seen: LlmRequest[] = [];
+    const provider = new ClaudeCodeProvider(captureTransport(seen));
+    provider.setRepoPath(makeRepo());
+
+    await provider.generateServiceViolations(SERVICE_CTX);
+
+    expect(seen[0].model).toBe('legacy-model');
+  });
+});

--- a/tests/core/llm-agent-transport.test.ts
+++ b/tests/core/llm-agent-transport.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { BaseCLIProvider } from '../../packages/core/src/services/llm/cli-provider.js';
+import type { ModelSelection } from '../../packages/core/src/config/llm-models.js';
 import { agentTransport, type LlmTransport } from '../../packages/shared/src/llm/transport.js';
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -16,8 +17,8 @@ class TestProvider extends BaseCLIProvider {
   get baseArgs(): string[] {
     return [];
   }
-  get modelFlag(): string[] {
-    return [];
+  modelSelection(): ModelSelection {
+    return {};
   }
   run<T>(prompt: string, schema: z.ZodType<T>): Promise<{ data: T }> {
     return this.spawnAndParse(prompt, schema, { label: 'unit' });

--- a/tests/core/llm-models.test.ts
+++ b/tests/core/llm-models.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
+import { modelConfigSandbox } from '../helpers/model-config.js';
 import {
   STAGE_DEFAULTS,
   resolveModel,
@@ -16,47 +14,11 @@ import {
 // itself a `.truecourse` project, so an accidental default-parameter call would
 // read the repo's own config.json and pass/fail by machine state.
 
-const ENV_KEYS = [
-  'TRUECOURSE_MODEL',
-  'CLAUDE_CODE_MODEL',
-  'TRUECOURSE_FALLBACK_MODEL',
-  'TRUECOURSE_MODEL_RULES_VIOLATION_GEN',
-  'TRUECOURSE_MODEL_RULES_FLOW_ENRICH',
-  'TRUECOURSE_MODEL_SPEC_AREA_TAG',
-] as const;
+const sandbox = modelConfigSandbox();
+const { makeRepo } = sandbox;
 
-const originals = new Map<string, string | undefined>();
-for (const k of ENV_KEYS) originals.set(k, process.env[k]);
-
-const tmpDirs: string[] = [];
-
-/** A repo root with a `.truecourse/` marker and optional config.json body. */
-function makeRepo(config?: unknown): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-llm-models-'));
-  tmpDirs.push(dir);
-  fs.mkdirSync(path.join(dir, '.truecourse'), { recursive: true });
-  if (config !== undefined) {
-    fs.writeFileSync(
-      path.join(dir, '.truecourse', 'config.json'),
-      typeof config === 'string' ? config : JSON.stringify(config),
-      'utf-8',
-    );
-  }
-  return dir;
-}
-
-beforeEach(() => {
-  for (const k of ENV_KEYS) delete process.env[k];
-});
-
-afterEach(() => {
-  for (const k of ENV_KEYS) {
-    const v = originals.get(k);
-    if (v === undefined) delete process.env[k];
-    else process.env[k] = v;
-  }
-  while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
-});
+beforeEach(() => sandbox.reset());
+afterEach(() => sandbox.cleanup());
 
 describe('STAGE_DEFAULTS — analyze rule stages', () => {
   it('declares both analyze stages with their re-tiered defaults', () => {

--- a/tests/core/llm-models.test.ts
+++ b/tests/core/llm-models.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  STAGE_DEFAULTS,
+  resolveModel,
+  resolveFallbackModel,
+  resolveStageModels,
+  modelArgs,
+  modelArgsForStage,
+  describeStageResolutions,
+} from '../../packages/core/src/config/llm-models.js';
+
+// Every call below passes `repoDir` explicitly. The repo this suite runs in is
+// itself a `.truecourse` project, so an accidental default-parameter call would
+// read the repo's own config.json and pass/fail by machine state.
+
+const ENV_KEYS = [
+  'TRUECOURSE_MODEL',
+  'CLAUDE_CODE_MODEL',
+  'TRUECOURSE_FALLBACK_MODEL',
+  'TRUECOURSE_MODEL_RULES_VIOLATION_GEN',
+  'TRUECOURSE_MODEL_RULES_FLOW_ENRICH',
+  'TRUECOURSE_MODEL_SPEC_AREA_TAG',
+] as const;
+
+const originals = new Map<string, string | undefined>();
+for (const k of ENV_KEYS) originals.set(k, process.env[k]);
+
+const tmpDirs: string[] = [];
+
+/** A repo root with a `.truecourse/` marker and optional config.json body. */
+function makeRepo(config?: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-llm-models-'));
+  tmpDirs.push(dir);
+  fs.mkdirSync(path.join(dir, '.truecourse'), { recursive: true });
+  if (config !== undefined) {
+    fs.writeFileSync(
+      path.join(dir, '.truecourse', 'config.json'),
+      typeof config === 'string' ? config : JSON.stringify(config),
+      'utf-8',
+    );
+  }
+  return dir;
+}
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    const v = originals.get(k);
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+describe('STAGE_DEFAULTS — analyze rule stages', () => {
+  it('declares both analyze stages with their re-tiered defaults', () => {
+    // Violation detection is judgement, not authoring — the house rubric puts
+    // that on sonnet. Flow enrichment only names an already-computed graph.
+    expect(STAGE_DEFAULTS['rules.violationGen']).toBe('sonnet');
+    expect(STAGE_DEFAULTS['rules.flowEnrich']).toBe('haiku');
+  });
+});
+
+describe('resolveModel precedence', () => {
+  it('falls back to the in-code default when nothing is configured', () => {
+    const repo = makeRepo();
+    expect(resolveModel('rules.violationGen', undefined, repo)).toBe('sonnet');
+    expect(resolveModel('rules.flowEnrich', undefined, repo)).toBe('haiku');
+  });
+
+  it('reads config.json llm.stages.<id> over the default', () => {
+    const repo = makeRepo({ llm: { stages: { 'rules.violationGen': 'opus' } } });
+    expect(resolveModel('rules.violationGen', undefined, repo)).toBe('opus');
+    // Sibling stage is untouched.
+    expect(resolveModel('rules.flowEnrich', undefined, repo)).toBe('haiku');
+  });
+
+  it('TRUECOURSE_MODEL beats config.json', () => {
+    const repo = makeRepo({ llm: { stages: { 'rules.violationGen': 'opus' } } });
+    process.env.TRUECOURSE_MODEL = 'haiku';
+    expect(resolveModel('rules.violationGen', undefined, repo)).toBe('haiku');
+  });
+
+  it('the per-stage env var beats TRUECOURSE_MODEL', () => {
+    const repo = makeRepo({ llm: { stages: { 'rules.violationGen': 'opus' } } });
+    process.env.TRUECOURSE_MODEL = 'haiku';
+    process.env.TRUECOURSE_MODEL_RULES_VIOLATION_GEN = 'sonnet-1m';
+    expect(resolveModel('rules.violationGen', undefined, repo)).toBe('sonnet-1m');
+    // ...and only for that stage.
+    expect(resolveModel('rules.flowEnrich', undefined, repo)).toBe('haiku');
+  });
+
+  it('derives the camelCase stage env var name with an underscore split', () => {
+    const repo = makeRepo();
+    process.env.TRUECOURSE_MODEL_RULES_FLOW_ENRICH = 'opus';
+    expect(resolveModel('rules.flowEnrich', undefined, repo)).toBe('opus');
+  });
+
+  it('honors legacy CLAUDE_CODE_MODEL as a global override', () => {
+    const repo = makeRepo();
+    process.env.CLAUDE_CODE_MODEL = 'legacy-model';
+    expect(resolveModel('rules.violationGen', undefined, repo)).toBe('legacy-model');
+  });
+
+  it('TRUECOURSE_MODEL beats legacy CLAUDE_CODE_MODEL', () => {
+    const repo = makeRepo();
+    process.env.CLAUDE_CODE_MODEL = 'legacy-model';
+    process.env.TRUECOURSE_MODEL = 'new-model';
+    expect(resolveModel('rules.violationGen', undefined, repo)).toBe('new-model');
+  });
+
+  it('repoDir null skips the config file entirely', () => {
+    process.env.TRUECOURSE_MODEL_RULES_VIOLATION_GEN = 'opus';
+    expect(resolveModel('rules.violationGen', undefined, null)).toBe('opus');
+    delete process.env.TRUECOURSE_MODEL_RULES_VIOLATION_GEN;
+    expect(resolveModel('rules.violationGen', undefined, null)).toBe('sonnet');
+  });
+
+  it('a malformed config.json falls through to the default without throwing', () => {
+    const repo = makeRepo('{ not json');
+    expect(resolveModel('rules.violationGen', undefined, repo)).toBe('sonnet');
+  });
+
+  it('an explicit defaultModel argument wins over STAGE_DEFAULTS', () => {
+    const repo = makeRepo();
+    expect(resolveModel('rules.violationGen', 'caller-default', repo)).toBe('caller-default');
+  });
+});
+
+describe('resolveFallbackModel', () => {
+  it('returns null when nothing is configured', () => {
+    expect(resolveFallbackModel(makeRepo())).toBeNull();
+  });
+
+  it('reads llm.fallbackModel from config.json', () => {
+    expect(resolveFallbackModel(makeRepo({ llm: { fallbackModel: 'haiku' } }))).toBe('haiku');
+  });
+
+  it('TRUECOURSE_FALLBACK_MODEL beats config.json', () => {
+    process.env.TRUECOURSE_FALLBACK_MODEL = 'sonnet';
+    expect(resolveFallbackModel(makeRepo({ llm: { fallbackModel: 'haiku' } }))).toBe('sonnet');
+  });
+});
+
+describe('resolveStageModels / modelArgs', () => {
+  it('bundles the primary and (absent) fallback', () => {
+    expect(resolveStageModels('rules.violationGen', undefined, makeRepo())).toEqual({
+      model: 'sonnet',
+    });
+  });
+
+  it('carries the fallback when one is configured', () => {
+    const repo = makeRepo({ llm: { stages: { 'rules.violationGen': 'opus' }, fallbackModel: 'haiku' } });
+    expect(resolveStageModels('rules.violationGen', undefined, repo)).toEqual({
+      model: 'opus',
+      fallbackModel: 'haiku',
+    });
+  });
+
+  it('modelArgs emits --model then --fallback-model, and nothing for an empty selection', () => {
+    expect(modelArgs({})).toEqual([]);
+    expect(modelArgs({ model: 'opus' })).toEqual(['--model', 'opus']);
+    expect(modelArgs({ model: 'opus', fallbackModel: 'haiku' })).toEqual([
+      '--model',
+      'opus',
+      '--fallback-model',
+      'haiku',
+    ]);
+    // A fallback with no primary still emits its own flag.
+    expect(modelArgs({ fallbackModel: 'haiku' })).toEqual(['--fallback-model', 'haiku']);
+  });
+
+  it('modelArgsForStage is the composition of the two', () => {
+    const repo = makeRepo({ llm: { fallbackModel: 'haiku' } });
+    expect(modelArgsForStage('rules.flowEnrich', undefined, repo)).toEqual([
+      '--model',
+      'haiku',
+      '--fallback-model',
+      'haiku',
+    ]);
+  });
+});
+
+describe('describeStageResolutions', () => {
+  it('reports every stage, including both analyze stages', () => {
+    const { stages } = describeStageResolutions(makeRepo());
+    const ids = stages.map((s) => s.stageId);
+    expect(ids).toContain('rules.violationGen');
+    expect(ids).toContain('rules.flowEnrich');
+    expect(ids).toHaveLength(Object.keys(STAGE_DEFAULTS).length);
+  });
+
+  it('labels the source for each rung of the precedence chain', () => {
+    const repo = makeRepo({ llm: { stages: { 'rules.flowEnrich': 'sonnet' } } });
+
+    const byId = (r: ReturnType<typeof describeStageResolutions>, id: string) =>
+      r.stages.find((s) => s.stageId === id)!;
+
+    let out = describeStageResolutions(repo);
+    expect(byId(out, 'rules.violationGen')).toMatchObject({ effectiveModel: 'sonnet', source: 'default' });
+    expect(byId(out, 'rules.flowEnrich')).toMatchObject({ effectiveModel: 'sonnet', source: 'config' });
+
+    process.env.CLAUDE_CODE_MODEL = 'legacy';
+    out = describeStageResolutions(repo);
+    expect(byId(out, 'rules.violationGen')).toMatchObject({
+      effectiveModel: 'legacy',
+      source: 'env-legacy',
+      envVar: 'CLAUDE_CODE_MODEL',
+    });
+
+    process.env.TRUECOURSE_MODEL = 'global';
+    out = describeStageResolutions(repo);
+    expect(byId(out, 'rules.violationGen')).toMatchObject({
+      effectiveModel: 'global',
+      source: 'env-global',
+      envVar: 'TRUECOURSE_MODEL',
+    });
+
+    process.env.TRUECOURSE_MODEL_RULES_VIOLATION_GEN = 'staged';
+    out = describeStageResolutions(repo);
+    expect(byId(out, 'rules.violationGen')).toMatchObject({
+      effectiveModel: 'staged',
+      source: 'env-stage',
+      envVar: 'TRUECOURSE_MODEL_RULES_VIOLATION_GEN',
+    });
+    // The sibling stage still reports the global env, not the per-stage one.
+    expect(byId(out, 'rules.flowEnrich')).toMatchObject({ effectiveModel: 'global', source: 'env-global' });
+  });
+
+  it('carries the resolved fallback model', () => {
+    const repo = makeRepo({ llm: { fallbackModel: 'haiku' } });
+    expect(describeStageResolutions(repo).fallbackModel).toBe('haiku');
+  });
+});

--- a/tests/helpers/model-config.ts
+++ b/tests/helpers/model-config.ts
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Scaffolding shared by the per-stage model-selection tests: env vars that must
+ * be saved/cleared/restored around each case, and throwaway repos carrying a
+ * `.truecourse/config.json`.
+ *
+ * Every model resolution in those suites passes `repoDir` explicitly — the repo
+ * the suite runs in is itself a `.truecourse` project, so a defaulted call would
+ * read the repo's own config and pass/fail by machine state.
+ */
+
+/** Env vars that steer model resolution. Cleared before each case. */
+export const MODEL_ENV_KEYS = [
+  'TRUECOURSE_MODEL',
+  'CLAUDE_CODE_MODEL',
+  'TRUECOURSE_FALLBACK_MODEL',
+  'TRUECOURSE_MODEL_RULES_VIOLATION_GEN',
+  'TRUECOURSE_MODEL_RULES_FLOW_ENRICH',
+  'TRUECOURSE_MODEL_SPEC_AREA_TAG',
+] as const;
+
+export interface ModelConfigSandbox {
+  /** Clear the tracked env vars — call from `beforeEach`. */
+  reset(): void;
+  /** Restore the originals and delete every temp dir — call from `afterEach`. */
+  cleanup(): void;
+  /** A repo root with a `.truecourse/` marker and optional config.json body. */
+  makeRepo(config?: unknown): string;
+  /** (Over)write `<repo>/.truecourse/config.json`. */
+  writeConfig(repoDir: string, config: unknown): void;
+  /** A tracked temp dir with no `.truecourse/` marker. */
+  makeTmpDir(prefix: string): string;
+}
+
+/**
+ * @param extraEnvKeys env vars beyond MODEL_ENV_KEYS this suite also mutates
+ *   (e.g. `CLAUDE_CODE_BINARY` for the spawn-path suite).
+ */
+export function modelConfigSandbox(extraEnvKeys: readonly string[] = []): ModelConfigSandbox {
+  const keys = [...MODEL_ENV_KEYS, ...extraEnvKeys];
+  // Captured once at construction, i.e. before any case has mutated them.
+  const originals = new Map<string, string | undefined>(keys.map((k) => [k, process.env[k]]));
+  const tmpDirs: string[] = [];
+
+  const makeTmpDir = (prefix: string): string => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tmpDirs.push(dir);
+    return dir;
+  };
+
+  const writeConfig = (repoDir: string, config: unknown): void => {
+    fs.writeFileSync(
+      path.join(repoDir, '.truecourse', 'config.json'),
+      // A string body is written verbatim so tests can plant malformed JSON.
+      typeof config === 'string' ? config : JSON.stringify(config),
+      'utf-8',
+    );
+  };
+
+  return {
+    reset() {
+      for (const k of keys) delete process.env[k];
+    },
+    cleanup() {
+      for (const k of keys) {
+        const v = originals.get(k);
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      while (tmpDirs.length) fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+    },
+    makeTmpDir,
+    writeConfig,
+    makeRepo(config?: unknown) {
+      const dir = makeTmpDir('tc-model-repo-');
+      fs.mkdirSync(path.join(dir, '.truecourse'), { recursive: true });
+      if (config !== undefined) writeConfig(dir, config);
+      return dir;
+    },
+  };
+}

--- a/tools/cli/src/commands/config.ts
+++ b/tools/cli/src/commands/config.ts
@@ -38,6 +38,7 @@ const STAGE_LABEL: Record<StageId, string> = {
   "guard.fidelity": "Guard  · fidelity review",
   "guard.recipe": "Guard  · recipe discover",
   "rules.violationGen": "Rules  · violation gen",
+  "rules.flowEnrich": "Rules  · flow enrich",
 };
 
 const SOURCE_LABEL: Record<string, string> = {


### PR DESCRIPTION
Closes #799.

## Problem

`analyze` never sent a `--model` flag. `modelArgsForStage` was written for exactly this and had zero callers, so the provider read a legacy `CLAUDE_CODE_MODEL` env var that is normally unset and returned `[]`.

With no flag the spawned `claude` falls back to its own resolution, which reads `~/.claude/settings.json`. `getCleanEnv()` strips `CLAUDE_CODE*` from the child but cannot strip a settings file — so the analyze model came from each developer's personal Claude Code preference. Same repo, same `config.json`, different model per machine, while `truecourse config llm --show` confidently reported a value that never ran.

## Change

- **Split the stage.** `rules.violationGen` covered both violation generation and `enrichFlow`, which are ~2 tiers apart. Added `rules.flowEnrich`.
- **Re-tiered the defaults** to match the house rubric (opus is reserved for authoring): `rules.violationGen` opus → `sonnet`, `rules.flowEnrich` → `haiku`.
- **Added `resolveStageModels` / `modelArgs`** and re-expressed `modelArgsForStage` on top, so flag-building lives in one place.
- **Replaced `BaseCLIProvider.modelFlag` with `modelSelection(stage, repoDir)`.** The base class owns `_repoPath → repoDir → ModelSelection` and memoizes per stage (`resolveModel` stats config.json on every call, and analyze fires up to 10 concurrent calls). This also removes `this.modelFlag[1]`, a positional index into a variable-length argv array.
- Both call paths now carry the selection: the spawn path gets `--model` / `--fallback-model`, and the transport path gets `model` **and** `fallbackModel` (previously missing entirely).
- **`enrichFlowWithLLM` now calls `setRepoPath`** — a pre-existing latent bug: without it the spawned CLI inherited the server's cwd, so its Read tool resolved against the wrong tree and the child was never registered for cancellation.
- Surfacing: `config llm --show` gains both `rules.*` rows; the analyze startup log now prints the models the run will actually use; README/`.env.example` document the stages and the deprecated `CLAUDE_CODE_MODEL` alias.

## Behavior change

Analyze goes from "whatever each developer's `~/.claude/settings.json` says" to a declared `sonnet` — a decrease for anyone whose personal setting was Opus, possibly an increase for anyone on the CLI default. Either way it is now deterministic and overridable per stage.

One precedence shift: a user with **both** `CLAUDE_CODE_MODEL` and a different `TRUECOURSE_MODEL` previously got the former on analyze; now the latter wins, as it already does everywhere else. Users with only `CLAUDE_CODE_MODEL` are unaffected.

## Tests

`llm-models.ts` had zero coverage. Three new suites, 33 cases:

- `tests/core/llm-models.test.ts` — the full precedence chain, legacy alias, `repoDir: null`, malformed config, fallback resolution, and `describeStageResolutions` sources (what `config llm` prints must agree with what ships).
- `tests/core/cli-provider-model-selection.test.ts` — the regression test for #799 (unconfigured → `sonnet`, previously `undefined`), the fallback assertion that was structurally impossible pre-fix, the stage split, `resolveRepoDir` walk-up, and memoization.
- `tests/core/cli-provider-model-argv.test.ts` — OSS installs no default transport, so the spawn branch is what real users hit; a real fake executable records argv and asserts the flags land.

Full suite green: 351 files, 8145 tests.