### PR TITLE
perf(analyzer): split source into lines once per file, not per node

### DIFF
--- a/packages/analyzer/src/rules/_shared/source-lines.ts
+++ b/packages/analyzer/src/rules/_shared/source-lines.ts
@@ -1,0 +1,36 @@
+/**
+ * Split source text into lines, memoizing the most recent result.
+ *
+ * Rule visitors fire once per matching AST node, and many of them need the
+ * file's lines — to read the line above a statement, snippet a violation, scan
+ * for a nearby pattern, etc. Calling `sourceCode.split('\n')` inside each
+ * `visit()` re-scans the *entire* file on every node, so a file with N matching
+ * nodes pays O(N × file-size). On a large (often generated) file that is
+ * quadratic and looks exactly like a hang — the reason files fall into the
+ * per-file timeout that PR #820 added (see that PR's review, item #3). The
+ * timeout contains the damage; splitting once per file removes the reason the
+ * damage happens at all.
+ *
+ * The analyzer walks one file to completion before starting the next, and every
+ * `visit()`/`makeViolation()` call for a given file is handed the *same*
+ * `sourceCode` string instance. Memoizing on that identity collapses a whole
+ * file's worth of splits into a single O(file-size) split, with every later
+ * call an O(1) cache hit. When the next file begins, its distinct source string
+ * misses the cache and is split exactly once. The identity check makes the
+ * cache correct regardless of call order: a miss only ever costs a re-split, it
+ * can never return the wrong file's lines.
+ *
+ * The returned array is shared and cached — treat it as read-only. Callers only
+ * ever index, slice, or iterate it; never mutate (push/splice/sort/assign) the
+ * result, or later cache hits would observe the mutation.
+ */
+let cachedSource: string | undefined
+let cachedLines: readonly string[] | undefined
+
+export function splitLines(sourceCode: string): readonly string[] {
+  if (sourceCode !== cachedSource || cachedLines === undefined) {
+    cachedSource = sourceCode
+    cachedLines = sourceCode.split('\n')
+  }
+  return cachedLines
+}

--- a/packages/analyzer/src/rules/architecture/visitors/javascript/unused-import.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/javascript/unused-import.ts
@@ -1,5 +1,6 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { splitLines } from '../../../_shared/source-lines.js'
 
 export const unusedImportVisitor: CodeRuleVisitor = {
   ruleKey: 'architecture/deterministic/unused-import',
@@ -36,7 +37,7 @@ export const unusedImportVisitor: CodeRuleVisitor = {
     // Remove the import line itself from the search
     const importLineStart = node.startPosition.row
     const importLineEnd = node.endPosition.row
-    const lines = sourceCode.split('\n')
+    const lines = splitLines(sourceCode)
     const codeWithoutImport = [
       ...lines.slice(0, importLineStart),
       ...lines.slice(importLineEnd + 1),

--- a/packages/analyzer/src/rules/architecture/visitors/python/unused-import.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/python/unused-import.ts
@@ -1,6 +1,7 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { splitLines } from '../../../_shared/source-lines.js'
 import { getPythonModuleNode } from '../../../_shared/python-helpers.js'
 
 /**
@@ -48,7 +49,7 @@ export const pythonUnusedImportVisitor: CodeRuleVisitor = {
     // Skip imports with a `# noqa` comment on the same line — these are
     // intentional side-effect imports (e.g., importing a module to register
     // event handlers, signal receivers, or plugins).
-    const importLine = sourceCode.split('\n')[node.startPosition.row] ?? ''
+    const importLine = splitLines(sourceCode)[node.startPosition.row] ?? ''
     if (/# *noqa\b/.test(importLine)) return null
 
     // Check if names are used in the rest of the file via AST walk

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/async-void-function.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/async-void-function.ts
@@ -1,5 +1,6 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { splitLines } from '../../../_shared/source-lines.js'
 import { JS_LANGUAGES } from './_helpers.js'
 
 export const asyncVoidFunctionVisitor: CodeRuleVisitor = {
@@ -19,7 +20,7 @@ export const asyncVoidFunctionVisitor: CodeRuleVisitor = {
     // floating promise (e.g. application entrypoints that fire-and-forget).
     const startRow = parent.startPosition.row
     if (startRow > 0) {
-      const prevLine = sourceCode.split('\n')[startRow - 1] ?? ''
+      const prevLine = splitLines(sourceCode)[startRow - 1] ?? ''
       if (/eslint-disable-next-line[^\n]*no-floating-promises/.test(prevLine)) return null
     }
 

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/unhandled-promise.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/unhandled-promise.ts
@@ -1,5 +1,6 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { splitLines } from '../../../_shared/source-lines.js'
 import { TS_LANGUAGES } from './_helpers.js'
 
 /**
@@ -21,7 +22,7 @@ export const unhandledPromiseVisitor: CodeRuleVisitor = {
     // (e.g. application entrypoints that intentionally fire-and-forget).
     const startRow = node.startPosition.row
     if (startRow > 0) {
-      const prevLine = sourceCode.split('\n')[startRow - 1] ?? ''
+      const prevLine = splitLines(sourceCode)[startRow - 1] ?? ''
       if (/eslint-disable-next-line[^\n]*no-floating-promises/.test(prevLine)) return null
     }
 

--- a/packages/analyzer/src/rules/bugs/visitors/javascript/useeffect-missing-deps.ts
+++ b/packages/analyzer/src/rules/bugs/visitors/javascript/useeffect-missing-deps.ts
@@ -1,6 +1,7 @@
 import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { splitLines } from '../../../_shared/source-lines.js'
 import { JS_LANGUAGES } from './_helpers.js'
 
 // Detect: useEffect(() => { uses variable X }, []) where X is not in deps array
@@ -270,7 +271,7 @@ export const useeffectMissingDepsVisitor: CodeRuleVisitor = {
     // whole node, not just the lines around its opening.
     const nodeStartLine = node.startPosition.row
     const nodeEndLine = node.endPosition.row
-    const sourceLines = sourceCode.split('\n')
+    const sourceLines = splitLines(sourceCode)
     const windowLines = sourceLines.slice(Math.max(0, nodeStartLine - 2), nodeEndLine + 2)
     if (windowLines.some(line => line.includes('eslint-disable'))) return null
 

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/missing-env-validation.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/missing-env-validation.ts
@@ -1,5 +1,6 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { splitLines } from '../../../_shared/source-lines.js'
 
 // Zod / valibot / yup / class-validator chain methods that take an env-var
 // argument as the fallback or transform input. Reading `process.env.X` here
@@ -82,7 +83,7 @@ export const missingEnvValidationVisitor: CodeRuleVisitor = {
     if (envVarRegex.test(sourceCode)) {
       // Found a reference to the env var in an if-condition somewhere in the file.
       // Now check if there's also a throw or return near it.
-      const lines = sourceCode.split('\n')
+      const lines = splitLines(sourceCode)
       for (let i = 0; i < lines.length; i++) {
         if (lines[i].includes(envVarName) && /\bif\s*\(/.test(lines[i])) {
           // Check the next few lines for throw/return
@@ -119,7 +120,7 @@ export const missingEnvValidationVisitor: CodeRuleVisitor = {
       assignTarget = directParent.parent.childForFieldName('name')?.text ?? null
     }
     if (assignTarget) {
-      const lines = sourceCode.split('\n')
+      const lines = splitLines(sourceCode)
       for (let i = 0; i < lines.length; i++) {
         // Check if there's an if-statement referencing the assigned variable with throw/return
         if (/\bif\s*\(/.test(lines[i]) && lines[i].includes(assignTarget)) {
@@ -144,7 +145,7 @@ export const missingEnvValidationVisitor: CodeRuleVisitor = {
     // Final fallback: search for ANY if-statement that references the env var name
     // (by variable or env var name) followed by throw/return within 10 lines
     {
-      const lines = sourceCode.split('\n')
+      const lines = splitLines(sourceCode)
       const searchTerms = [envVarName]
       if (assignTarget) searchTerms.push(assignTarget)
       for (const term of searchTerms) {

--- a/packages/analyzer/src/rules/code-quality/visitors/python/torch-model-eval-train.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/python/torch-model-eval-train.ts
@@ -1,5 +1,6 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { splitLines } from '../../../_shared/source-lines.js'
 
 /**
  * Detects torch model state loading (load_state_dict) without a subsequent
@@ -22,7 +23,7 @@ export const pythonTorchModelEvalTrainVisitor: CodeRuleVisitor = {
 
     // Check if .eval() or .train() is called on the same object in nearby code
     const nodeStart = node.startPosition.row
-    const lines = sourceCode.split('\n')
+    const lines = splitLines(sourceCode)
     const searchRange = lines.slice(nodeStart, nodeStart + 10).join('\n')
 
     if (searchRange.includes(`${modelName}.eval()`) || searchRange.includes(`${modelName}.train()`)) {

--- a/packages/analyzer/src/rules/reliability/visitors/javascript/floating-promise.ts
+++ b/packages/analyzer/src/rules/reliability/visitors/javascript/floating-promise.ts
@@ -1,5 +1,6 @@
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
+import { splitLines } from '../../../_shared/source-lines.js'
 import { containsJsx } from '../../../_shared/javascript-helpers.js'
 
 export const floatingPromiseVisitor: CodeRuleVisitor = {
@@ -17,7 +18,7 @@ export const floatingPromiseVisitor: CodeRuleVisitor = {
     // (e.g. application entrypoints that intentionally fire-and-forget).
     const startRow = node.startPosition.row
     if (startRow > 0) {
-      const prevLine = sourceCode.split('\n')[startRow - 1] ?? ''
+      const prevLine = splitLines(sourceCode)[startRow - 1] ?? ''
       if (/eslint-disable-next-line[^\n]*no-floating-promises/.test(prevLine)) return null
     }
 

--- a/packages/analyzer/src/rules/security/secret-scanner.ts
+++ b/packages/analyzer/src/rules/security/secret-scanner.ts
@@ -8,6 +8,7 @@ import { shannonEntropy } from './entropy.js'
 import { STOPWORDS } from './stopwords.js'
 import { GLOBAL_ALLOWLIST } from './exclusions.js'
 import { SECRET_PATTERNS, type SecretPattern } from './secret-rules.js'
+import { splitLines } from '../_shared/source-lines.js'
 
 export interface SecretMatch {
   patternId: string
@@ -140,7 +141,7 @@ export function scanForSecrets(value: string, context?: ScanContext): SecretMatc
     // Composite rule: require a second pattern nearby
     if (rule.requireNearby && context?.sourceCode && context.lineNumber) {
       const withinLines = rule.requireNearby.withinLines ?? 5
-      const lines = context.sourceCode.split('\n')
+      const lines = splitLines(context.sourceCode)
       const startLine = Math.max(0, context.lineNumber - 1 - withinLines)
       const endLine = Math.min(lines.length, context.lineNumber + withinLines)
       const nearbyText = lines.slice(startLine, endLine).join('\n')

--- a/packages/analyzer/src/rules/types.ts
+++ b/packages/analyzer/src/rules/types.ts
@@ -5,6 +5,7 @@ import { buildDataFlowContext } from '../data-flow/index.js'
 import type { DataFlowContext } from '../data-flow/index.js'
 import type { TypeQueryService } from '../ts-compiler.js'
 import type { SchemaIndex } from '../services/schema-index.js'
+import { splitLines } from './_shared/source-lines.js'
 
 export interface CodeRuleVisitor {
   ruleKey: string
@@ -43,7 +44,7 @@ export function makeViolation(
 ): CodeViolation {
   const lineStart = node.startPosition.row + 1
   const lineEnd = node.endPosition.row + 1
-  const lines = sourceCode.split('\n')
+  const lines = splitLines(sourceCode)
   const snippetLines = lines.slice(node.startPosition.row, Math.min(node.endPosition.row + 1, node.startPosition.row + 3))
   const snippet = snippetLines.join('\n')
 

--- a/tests/analyzer/source-lines.test.ts
+++ b/tests/analyzer/source-lines.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { splitLines } from '../../packages/analyzer/src/rules/_shared/source-lines';
+
+describe('splitLines', () => {
+  it('splits source into lines identically to String.split', () => {
+    const source = 'const a = 1\nconst b = 2\n\nconst c = 3';
+    expect([...splitLines(source)]).toEqual(source.split('\n'));
+  });
+
+  it('returns a single trailing empty entry for a trailing newline', () => {
+    const source = 'a\nb\n';
+    expect([...splitLines(source)]).toEqual(['a', 'b', '']);
+  });
+
+  it('handles empty and single-line sources', () => {
+    expect([...splitLines('')]).toEqual(['']);
+    expect([...splitLines('only one line')]).toEqual(['only one line']);
+  });
+
+  it('memoizes: repeated calls with the same source return the same cached array', () => {
+    // This is the fix for PR #820 review item #3: rule visitors fire once per
+    // matching AST node and re-split the whole file each time. Handing back the
+    // same cached array for the same file collapses O(nodes) splits into one.
+    const source = Array.from({ length: 500 }, (_, i) => `line ${i}`).join('\n');
+    const first = splitLines(source);
+    const second = splitLines(source);
+    expect(second).toBe(first); // same instance, not a re-split
+  });
+
+  it('re-splits when the source changes', () => {
+    const a = 'alpha\nbeta';
+    const b = 'gamma\ndelta';
+    const linesA = splitLines(a);
+    const linesB = splitLines(b);
+    expect(linesB).not.toBe(linesA);
+    expect([...linesA]).toEqual(['alpha', 'beta']);
+    expect([...linesB]).toEqual(['gamma', 'delta']);
+  });
+
+  it('stays correct when two sources are queried alternately (cache miss, never wrong lines)', () => {
+    const a = 'a1\na2';
+    const b = 'b1\nb2\nb3';
+    // Identity-keyed cache: alternating inputs only costs re-splits, it can
+    // never return the wrong source's lines.
+    expect([...splitLines(a)]).toEqual(['a1', 'a2']);
+    expect([...splitLines(b)]).toEqual(['b1', 'b2', 'b3']);
+    expect([...splitLines(a)]).toEqual(['a1', 'a2']);
+    expect([...splitLines(b)]).toEqual(['b1', 'b2', 'b3']);
+  });
+});


### PR DESCRIPTION
## What & why

Follow-up to the review of #820 (item **#3**). That PR added a per-file scan timeout, which **contains** the hang but doesn't **cure** the reason files hang — and files that trip the timeout silently lose analysis coverage. This PR removes the reason.

The root cause is a quadratic pattern: many rule visitors fire **once per matching AST node** and called `sourceCode.split('\n')` inside each `visit()` (and `makeViolation` split once per violation). That re-scans the **entire file** on every node, so a file with N matching nodes pays **O(N × file-size)**. On a large, often generated, file that is quadratic and looks exactly like a hang. The offenders named in the review — `floating-promise.ts:20` and `makeViolation` in `rules/types.ts:46` — are both here.

## The fix

Split the file into lines **once per file and reuse it** — via a memoized helper, so no visitor logic or signature changes:

- New `packages/analyzer/src/rules/_shared/source-lines.ts` — `splitLines(source)` memoizes the most recent source by **string identity**. The analyzer walks one file to completion before the next, so every `visit()`/`makeViolation()` call for a file is handed the *same* source string instance. Memoizing on that identity collapses a whole file's worth of splits into a single one, with every later call an O(1) cache hit. The identity check keeps the cache correct regardless of call order — a miss only costs a re-split, it can never return the wrong file's lines.
- Routed all per-node whole-file splitters through it: `makeViolation`, `floating-promise`, `async-void-function`, `unhandled-promise`, `missing-env-validation` (which split 3× per node), `useeffect-missing-deps`, `unused-import` (JS + Python), `torch-model-eval-train`, and `secret-scanner`.
- Program-level once-per-file splitters (whitespace, shebang) are left as-is — no quadratic cost, no churn.

Why a memoized helper rather than threading a `lines` array through every visitor: threading touches the visitor interface and dozens of `makeViolation` call sites, misses the standalone helper functions, and a future visitor that forgets the parameter silently reintroduces the bug. This fixes the root cause at one point and protects current and future call sites.

## Behavior & testing

- Behavior is unchanged — the memoized split returns the same lines the inline `.split('\n')` did.
- Full analyzer suite passes (4540 passed; skips are the unbuilt C# Roslyn host). Positive-detection tests confirm violations and code snippets are byte-for-byte identical.
- Added `tests/analyzer/source-lines.test.ts` pinning the split-once contract so nobody can quietly revert to a fresh split per call.

## Relation to #820

This is the follow-up #820's review asked for: #820 is the safety net (timeout so nothing freezes), this PR removes the quadratic re-splitting that made files fall into it in the first place.