### PR TITLE
fix(analyze): preserve repeated code finding lifecycles

### DIFF
--- a/packages/core/src/services/violation-lifecycle.service.ts
+++ b/packages/core/src/services/violation-lifecycle.service.ts
@@ -84,17 +84,52 @@ export function computeFileViolationLifecycle(
   const resolved: ViolationRecord[] = [];
   const resolvedRefs: ResolvedViolationRef[] = [];
 
-  const currentKeys = new Set(currentViolations.map((v) => `${v.ruleKey}::${v.filePath}`));
-  const previousByKey = new Map<string, ActiveViolation>();
+  const previousByKey = new Map<string, ActiveViolation[]>();
   for (const prev of previousViolations) {
-    if (prev.filePath) previousByKey.set(`${prev.ruleKey}::${prev.filePath}`, prev);
+    if (!prev.filePath) continue;
+    const key = `${prev.ruleKey}::${prev.filePath}`;
+    const group = previousByKey.get(key) ?? [];
+    group.push(prev);
+    previousByKey.set(key, group);
+  }
+
+  const previousForCurrent = new Map<FileViolationInput, ActiveViolation>();
+  const matchedPreviousIds = new Set<string>();
+
+  // Reserve exact source-span matches first so a newly inserted occurrence
+  // cannot consume the prior row belonging to a later unchanged occurrence.
+  for (const current of currentViolations) {
+    const key = `${current.ruleKey}::${current.filePath}`;
+    const candidates = previousByKey.get(key);
+    if (!candidates?.length) continue;
+    const exactIndex = candidates.findIndex((previous) =>
+      previous.lineStart === current.lineStart
+      && previous.lineEnd === current.lineEnd
+      && previous.columnStart === current.columnStart
+      && previous.columnEnd === current.columnEnd,
+    );
+    if (exactIndex < 0) continue;
+    const [matched] = candidates.splice(exactIndex, 1);
+    previousForCurrent.set(current, matched);
+    matchedPreviousIds.add(matched.id);
+  }
+
+  // Preserve the historical rule+file identity across source movement by
+  // pairing any remaining occurrences one-to-one in stable input order.
+  for (const current of currentViolations) {
+    if (previousForCurrent.has(current)) continue;
+    const key = `${current.ruleKey}::${current.filePath}`;
+    const candidates = previousByKey.get(key);
+    const matched = candidates?.shift();
+    if (!matched) continue;
+    previousForCurrent.set(current, matched);
+    matchedPreviousIds.add(matched.id);
   }
 
   // Previous file-level violations not in current → resolved
   for (const prev of previousViolations) {
     if (!prev.filePath) continue;
-    const key = `${prev.ruleKey}::${prev.filePath}`;
-    if (!currentKeys.has(key)) {
+    if (!matchedPreviousIds.has(prev.id)) {
       const row: ViolationRecord = {
         id: randomUUID(),
         type: 'code',
@@ -132,8 +167,7 @@ export function computeFileViolationLifecycle(
 
   // Current file-level violations
   for (const cv of currentViolations) {
-    const key = `${cv.ruleKey}::${cv.filePath}`;
-    const prev = previousByKey.get(key);
+    const prev = previousForCurrent.get(cv);
 
     const base: ViolationRecord = {
       id: randomUUID(),

--- a/tests/core/violation-lifecycle-repeated-findings.test.ts
+++ b/tests/core/violation-lifecycle-repeated-findings.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeFileViolationLifecycle,
+  type ActiveViolation,
+} from '../../packages/core/src/services/violation-lifecycle.service';
+
+describe('computeFileViolationLifecycle repeated findings', () => {
+  const previousAt = (...lines: number[]): ActiveViolation[] => lines.map((line, index) => ({
+    id: `prior-${index + 1}`,
+    type: 'code',
+    category: 'rule',
+    subcategory: null,
+    title: 'Environment access',
+    content: 'process.env in non-config code',
+    severity: 'medium',
+    status: 'new',
+    targetServiceId: null,
+    targetDatabaseId: null,
+    targetModuleId: null,
+    targetMethodId: null,
+    targetTable: null,
+    relatedServiceId: null,
+    relatedModuleId: null,
+    fixPrompt: null,
+    ruleKey: 'code-quality/deterministic/env-in-library-code',
+    firstSeenAnalysisId: 'analysis-1',
+    firstSeenAt: '2026-01-01T00:00:00.000Z',
+    previousViolationId: null,
+    resolvedAt: null,
+    filePath: 'src/config.ts',
+    lineStart: line,
+    lineEnd: line,
+    columnStart: 1,
+    columnEnd: 12,
+    snippet: 'process.env.VALUE',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    targetServiceName: null,
+    targetModuleName: null,
+    targetMethodName: null,
+    targetDatabaseName: null,
+  }));
+
+  const currentAt = (...lines: number[]) => lines.map((line) => ({
+    filePath: 'src/config.ts',
+    lineStart: line,
+    lineEnd: line,
+    columnStart: 1,
+    columnEnd: 12,
+    ruleKey: 'code-quality/deterministic/env-in-library-code',
+    severity: 'medium',
+    title: 'Environment access',
+    content: 'process.env in non-config code',
+    snippet: 'process.env.VALUE',
+  }));
+
+  const classify = (previous: ActiveViolation[], ...currentLines: number[]) =>
+    computeFileViolationLifecycle({
+      analysisId: 'analysis-2',
+      now: '2026-01-02T00:00:00.000Z',
+      previousViolations: previous,
+      currentViolations: currentAt(...currentLines),
+    });
+
+  it('pairs repeated findings in one file with distinct prior lifecycle rows', () => {
+    const result = classify(previousAt(10, 20), 10, 20);
+
+    expect(result.added).toEqual([]);
+    expect(result.resolved).toEqual([]);
+    expect(result.unchanged).toHaveLength(2);
+    expect(new Set(result.unchanged.map((violation) => violation.previousViolationId))).toEqual(
+      new Set(['prior-1', 'prior-2']),
+    );
+  });
+
+  it('reserves an exact old occurrence when a new earlier occurrence is inserted', () => {
+    const result = classify(previousAt(10), 5, 10);
+
+    expect(result.unchanged).toHaveLength(1);
+    expect(result.unchanged[0]).toMatchObject({ previousViolationId: 'prior-1', lineStart: 10 });
+    expect(result.added).toHaveLength(1);
+    expect(result.added[0]).toMatchObject({ previousViolationId: null, lineStart: 5 });
+    expect(result.resolved).toEqual([]);
+  });
+
+  it('resolves only the unmatched prior occurrence when one repeated finding disappears', () => {
+    const result = classify(previousAt(10, 20), 20);
+
+    expect(result.unchanged).toHaveLength(1);
+    expect(result.unchanged[0]).toMatchObject({ previousViolationId: 'prior-2', lineStart: 20 });
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0]).toMatchObject({ previousViolationId: 'prior-1', lineStart: 10 });
+    expect(result.added).toEqual([]);
+  });
+
+  it('pairs moved repeated findings in stable order when no source span remains exact', () => {
+    const result = classify(previousAt(10, 20), 30, 40);
+
+    expect(result.unchanged.map((violation) => ({
+      previousViolationId: violation.previousViolationId,
+      lineStart: violation.lineStart,
+    }))).toEqual([
+      { previousViolationId: 'prior-1', lineStart: 30 },
+      { previousViolationId: 'prior-2', lineStart: 40 },
+    ]);
+    expect(result.added).toEqual([]);
+    expect(result.resolved).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- pair repeated deterministic findings in one file with distinct prior lifecycle rows
- reserve exact source-span matches before stable-order fallback matching
- resolve or add only genuinely unmatched occurrences

## Problem

The file lifecycle used one map entry per rule key and file path. When one rule reported multiple findings in the same file, every current occurrence could inherit the same prior violation ID. That creates an invalid lifecycle chain and can make strict completed-analysis promotion reject an otherwise unchanged run.

This fixes the root cause with one-to-one matching while preserving the existing rule-and-file identity across line movement.

## Verification

- pnpm exec vitest run tests/core/violation-lifecycle-repeated-findings.test.ts tests/core/violation-lifecycle.test.ts (20 passed)
- pnpm build (19/19 workspace tasks)
- pnpm lint (14/14 workspace tasks)
- git diff --check

All four new regression scenarios were confirmed failing before the implementation.

## Relationship to #791

This latent lifecycle bug was exposed by the strict promotion validation added during the #791 resumability work. It is an independent prerequisite correctness fix and does not close or fully resolve #791.