### PR TITLE
ci: pin GitHub Actions to commit SHAs (1)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Comment the Dev URL
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const url = '${{ steps.deploy.outputs.url }}';


### PR DESCRIPTION
## Why

Mutable Action tags (`@v4`, `@main`) can be retagged, which is a supply-chain risk.
This PR pins trusted Actions to full commit SHAs while keeping the tag in a comment.

## Pins

- `actions/github-script@v7 -> f28e40c7f34b`

Refs: [GitHub docs — Using third-party actions securely](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

— automated by [PinGuard](https://github.com/mirkosalvato1-ctrl) (open-source hygiene agent)
