### PR TITLE
fix(fp): resolve 5 FPs from OrchardCMS/OrchardCore

### DIFF
--- a/packages/analyzer/src/data-flow/known-globals.ts
+++ b/packages/analyzer/src/data-flow/known-globals.ts
@@ -31,6 +31,9 @@ export const JS_GLOBALS = new Set([
   // Browser — workers / messaging
   'Worker', 'SharedWorker', 'ServiceWorker', 'BroadcastChannel', 'MessageChannel', 'MessagePort',
   'postMessage',
+  // Function-implicit bindings — available inside every non-arrow function, so
+  // referencing them never throws a ReferenceError at runtime.
+  'arguments',
   // Node.js
   'process', 'global', 'globalThis', '__dirname', '__filename', 'require', 'module', 'exports',
   'Buffer', 'setImmediate', 'clearImmediate', 'queueMicrotask',

--- a/packages/analyzer/src/rules/code-quality/visitors/javascript/implicit-global-declaration.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/javascript/implicit-global-declaration.ts
@@ -15,6 +15,11 @@ export const implicitGlobalDeclarationVisitor: CodeRuleVisitor = {
       const kind = node.children[0]
       if (!kind || kind.text !== 'var') return null
 
+      // In ES modules, a top-level `var` is module-scoped, not a global — it
+      // never pollutes the global namespace. Only a classic (non-module) script
+      // leaks its top-level `var` into global scope.
+      if (isEsModule(parent)) return null
+
       return makeViolation(
         this.ruleKey, node, filePath, 'medium',
         'Implicit global var declaration',
@@ -26,14 +31,7 @@ export const implicitGlobalDeclarationVisitor: CodeRuleVisitor = {
 
     if (node.type === 'function_declaration') {
       // In ES modules, top-level declarations are module-scoped, not global.
-      // Detect modules by presence of import/export statements.
-      const program = parent
-      for (let i = 0; i < program.namedChildCount; i++) {
-        const child = program.namedChild(i)
-        if (child && (child.type === 'import_statement' || child.type === 'export_statement')) {
-          return null // ES module — function is module-scoped
-        }
-      }
+      if (isEsModule(parent)) return null // ES module — function is module-scoped
 
       const name = node.childForFieldName('name')
       return makeViolation(
@@ -47,4 +45,16 @@ export const implicitGlobalDeclarationVisitor: CodeRuleVisitor = {
 
     return null
   },
+}
+
+// An ES module scopes its top-level declarations to the module, not the global
+// object. Detect one by the presence of any top-level import/export statement.
+function isEsModule(program: import('web-tree-sitter').Node): boolean {
+  for (let i = 0; i < program.namedChildCount; i++) {
+    const child = program.namedChild(i)
+    if (child && (child.type === 'import_statement' || child.type === 'export_statement')) {
+      return true
+    }
+  }
+  return false
 }

--- a/packages/analyzer/src/rules/performance/visitors/javascript/event-listener-no-remove.ts
+++ b/packages/analyzer/src/rules/performance/visitors/javascript/event-listener-no-remove.ts
@@ -13,6 +13,8 @@ const LIFECYCLE_EVENT_TYPES = new Set([
   'beforeunload',   // window — page unload tears down all listeners
   'unload',         // window — same
   'visibilitychange', // document — bound to page lifecycle
+  'DOMContentLoaded', // document — fires once during page bootstrap; removing it is pointless
+  'load',           // window/document/resource — one-shot bootstrap event, no leak
 ])
 
 // Receiver text patterns suggesting an object whose listeners are managed by

--- a/tests/analyzer/bugs-rules.test.ts
+++ b/tests/analyzer/bugs-rules.test.ts
@@ -8706,6 +8706,16 @@ function greet() {
     expect(matches).toHaveLength(0);
   });
 
+  it('does not flag the function-implicit `arguments` object', () => {
+    const violations = check(`
+function collect() {
+  return Array.prototype.slice.call(arguments);
+}
+`, 'javascript');
+    const matches = violations.filter((v) => v.ruleKey === 'bugs/deterministic/no-undef');
+    expect(matches).toHaveLength(0);
+  });
+
   it('does not flag known globals', () => {
     const violations = check(`
 function run() {

--- a/tests/analyzer/code-quality-rules.test.ts
+++ b/tests/analyzer/code-quality-rules.test.ts
@@ -5233,6 +5233,18 @@ describe('code-quality/deterministic/implicit-global-declaration', () => {
     const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/implicit-global-declaration');
     expect(matches).toHaveLength(0);
   });
+
+  it('does not flag a top-level var in an ES module (module-scoped, not global)', () => {
+    const violations = check(`var cache = {};\nexport function get() { return cache; }`, 'javascript');
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/implicit-global-declaration');
+    expect(matches).toHaveLength(0);
+  });
+
+  it('still flags a top-level var in a classic (non-module) script', () => {
+    const violations = check(`var cache = {};\nfunction get() { return cache; }`, 'javascript');
+    const matches = violations.filter((v) => v.ruleKey === 'code-quality/deterministic/implicit-global-declaration');
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
 });
 
 describe('code-quality/deterministic/undef-init', () => {

--- a/tests/analyzer/performance-rules.test.ts
+++ b/tests/analyzer/performance-rules.test.ts
@@ -235,6 +235,24 @@ function setup() {
     const violations = only(check(code), KEY);
     expect(violations).toHaveLength(0);
   });
+
+  it('does not flag a one-shot DOMContentLoaded bootstrap listener', () => {
+    const code = `
+function init() {
+  document.addEventListener('DOMContentLoaded', () => start());
+}`;
+    const violations = only(check(code), KEY);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('does not flag a one-shot window load listener', () => {
+    const code = `
+function init() {
+  window.addEventListener('load', onReady);
+}`;
+    const violations = only(check(code), KEY);
+    expect(violations).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/analyzer/roslyn-rules-code-quality.test.ts
+++ b/tests/analyzer/roslyn-rules-code-quality.test.ts
@@ -215,6 +215,18 @@ namespace App {
 }`
       expect(await keys(src, K)).not.toContain(K)
     })
+    it('does not flag a DI/builder extension co-located in a framework namespace', async () => {
+      // The documented ASP.NET convention: a builder type and its extensions both
+      // live in Microsoft.Extensions.DependencyInjection so they are always in scope.
+      const src = `
+namespace Microsoft.Extensions.DependencyInjection {
+  public class AppBuilder {}
+  public static class AppBuilderExtensions {
+    public static AppBuilder AddFeature(this AppBuilder b, string id) => b;
+  }
+}`
+      expect(await keys(src, K)).not.toContain(K)
+    })
   })
 
   // ---- field-can-be-readonly ---------------------------------------------

--- a/tests/analyzer/roslyn-workspace.test.ts
+++ b/tests/analyzer/roslyn-workspace.test.ts
@@ -69,6 +69,19 @@ public sealed class OrderRepository
 }
 `,
     )
+    // Deliberate framework namespace for extension discoverability — the folder
+    // convention does not apply, so this must NOT be flagged.
+    mkdirSync(join(dir, 'Extensions'))
+    writeFileSync(
+      join(dir, 'Extensions', 'ServiceCollectionExtensions.cs'),
+      `namespace Microsoft.Extensions.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+    public static int CountShopServices() => 0;
+}
+`,
+    )
     execFileSync('dotnet', ['restore', csproj], { stdio: 'ignore' })
   }, 120_000)
 
@@ -87,6 +100,11 @@ public sealed class OrderRepository
   it('does not flag a correctly-placed namespace (no false positive on a custom root)', async () => {
     const violations = await runRoslynWorkspace(csproj, [NS_RULE])
     expect(violations.some((v) => v.path.includes('Order.cs') && !v.path.includes('OrderRepository'))).toBe(false)
+  }, 60_000)
+
+  it('does not flag a deliberate framework namespace (Microsoft.*) that ignores its folder', async () => {
+    const violations = await runRoslynWorkspace(csproj, [NS_RULE])
+    expect(violations.some((v) => v.path.includes('ServiceCollectionExtensions.cs'))).toBe(false)
   }, 60_000)
 })
 

--- a/tests/fixtures/sample-js-project-positive/shared/utils/src/event-listener-lifecycle.ts
+++ b/tests/fixtures/sample-js-project-positive/shared/utils/src/event-listener-lifecycle.ts
@@ -1,0 +1,13 @@
+// One-shot page-bootstrap events (DOMContentLoaded / load) fire once during the
+// page lifecycle and never leak, so pairing them with removeEventListener is
+// pointless — the rule must not ask for it.
+
+export function bootstrap(start: () => void): void {
+  document.addEventListener('DOMContentLoaded', () => {
+    start();
+  });
+}
+
+export function onReady(handler: () => void): void {
+  window.addEventListener('load', handler);
+}

--- a/tools/csharp-roslyn-host/Rules/Architecture/NamespaceFolderMismatch.cs
+++ b/tools/csharp-roslyn-host/Rules/Architecture/NamespaceFolderMismatch.cs
@@ -40,6 +40,13 @@ internal sealed class NamespaceFolderMismatch : IProjectAwareRule
         var actual = ns.Name.ToString();
         if (NamespaceEndsWith(actual, folders)) yield break;
 
+        // A namespace deliberately rooted at a framework namespace (Microsoft.*/System.*)
+        // is an intentional framework-integration choice, not a folder-derived name:
+        // extension methods placed in the extended type's namespace for discoverability,
+        // or a type that replaces a framework type and must live in that type's namespace.
+        // The folder convention does not apply to these.
+        if (IsFrameworkNamespace(actual)) yield break;
+
         var pos = ns.Name.GetLocation().GetLineSpan().StartLinePosition;
         yield return new Violation(
             RuleKey, tree.FilePath, pos.Line + 1, pos.Character + 1,
@@ -64,6 +71,13 @@ internal sealed class NamespaceFolderMismatch : IProjectAwareRule
             segments.Add(seg);
         }
         return segments.ToArray();
+    }
+
+    // A framework-owned namespace, rooted at Microsoft or System.
+    private static bool IsFrameworkNamespace(string ns)
+    {
+        var root = ns.Split('.')[0];
+        return root is "Microsoft" or "System";
     }
 
     private static bool NamespaceEndsWith(string ns, string[] folders)

--- a/tools/csharp-roslyn-host/Rules/CodeQuality/ExtensionMethodNamespace.cs
+++ b/tools/csharp-roslyn-host/Rules/CodeQuality/ExtensionMethodNamespace.cs
@@ -33,10 +33,29 @@ internal sealed class ExtensionMethodNamespace : ISemanticRule
             if (extNs.IsGlobalNamespace || recvNs.IsGlobalNamespace) continue;
             if (!SymbolEqualityComparer.Default.Equals(extNs, recvNs)) continue;
 
+            // Placing an extension in the same namespace as its receiver is the *documented*
+            // .NET convention when that namespace is framework-owned — e.g. DI/builder
+            // extensions declared in Microsoft.Extensions.DependencyInjection so they are
+            // always in scope wherever that namespace is imported. Always-in-scope is the
+            // intent there, not a defect. Only flag app-owned namespaces, where a consumer
+            // opting out of the extension is a real concern.
+            if (IsFrameworkNamespace(extNs)) continue;
+
             var pos = method.Identifier.GetLocation().GetLineSpan().StartLinePosition;
             yield return new Violation(
                 RuleKey, tree.FilePath, pos.Line + 1, pos.Character + 1,
                 $"Extension method '{sym.Name}' is in the same namespace ('{extNs.ToDisplayString()}') as the type it extends ('{named.Name}'), so consumers cannot opt out of it.");
         }
+    }
+
+    // A framework-owned namespace (rooted at Microsoft or System). Extension methods
+    // are deliberately co-located with framework types there for discoverability, so
+    // the "cannot opt out" concern does not apply.
+    private static bool IsFrameworkNamespace(INamespaceSymbol ns)
+    {
+        var current = ns;
+        while (current.ContainingNamespace is { IsGlobalNamespace: false } parent)
+            current = parent;
+        return current.Name is "Microsoft" or "System";
     }
 }


### PR DESCRIPTION
## Human review required

These fixes intentionally go **over the in-bounds boundary** (they touch modules outside `packages/analyzer/src/rules` + `patterns` + `tests/fixtures`), so `fp-next-fix-review` will review but **not** auto-merge — a human must review and merge.

Non-rule modules touched:
- **Roslyn semantic host** (`tools/csharp-roslyn-host/…`) — for #766 and #767 (`ExtensionMethodNamespace.cs`, `NamespaceFolderMismatch.cs`).
- **Data-flow module** (`packages/analyzer/src/data-flow/known-globals.ts`) — for #770.

#775 and #776 are in-bounds (rule visitors only) but ship in this human-review batch because the normal queue was empty.

Closes #766
Closes #767
Closes #770
Closes #775
Closes #776

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| code-quality/deterministic/extension-method-namespace | #766 | unit: `roslyn-rules-code-quality.test.ts` (framework-namespace case) | existing `AccountStringExtensions.cs` + unit "flags same-namespace extension" |
| architecture/deterministic/namespace-folder-mismatch | #767 | unit: `roslyn-workspace.test.ts` (framework-namespace file) | existing `EmptyNamespaceResidue.cs` + unit "flags namespace ignoring its folder" |
| bugs/deterministic/no-undef | #770 | unit: `bugs-rules.test.ts` (`arguments`) | existing `legacy.js` + unit "detects undeclared variable" |
| performance/deterministic/event-listener-no-remove | #775 | `sample-js-project-positive/.../event-listener-lifecycle.ts` + unit | existing + unit "detects addEventListener without removeEventListener" |
| code-quality/deterministic/implicit-global-declaration | #776 | unit: `code-quality-rules.test.ts` (ES-module var) | existing `legacy.js` + unit "still flags var in a classic script" |

> **Fixture note.** The reported FP shapes for the JS rules (`var`, `arguments`) inherently trip *other* analyzer rules (`js-style-preference`, `prefer-rest-params`), so they cannot live in the zero-all-rules positive project. Their positive regressions are the dedicated per-rule unit tests instead (which scope to the single rule key); the one shape that is clean (`DOMContentLoaded`) also gets a positive-project fixture. Recall for every rule is guarded by existing negative fixtures + the new "still flags …" unit tests. Each fix is a **pure narrowing** (adds an exemption), so it cannot introduce new violations.

## code-quality/deterministic/extension-method-namespace (#766)

OSS sources (OrchardCMS/OrchardCore):
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore/Modules/Extensions/OrchardCoreBuilderExtensions.cs#L18``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore/Modules/Extensions/OrchardCoreBuilderExtensions.cs#L31``

Added a framework-namespace allow-list to the Roslyn host rule: when the extension method and its receiver type share a namespace that is framework-owned (rooted at `Microsoft` or `System`), the extension is deliberately always-in-scope per the documented .NET convention — e.g. DI/builder extensions declared in `Microsoft.Extensions.DependencyInjection` — so it is no longer flagged. App-owned namespaces (the real "consumer can't opt out" case) still fire. **Over-the-boundary:** edited `tools/csharp-roslyn-host/Rules/CodeQuality/ExtensionMethodNamespace.cs`.

## architecture/deterministic/namespace-folder-mismatch (#767)

OSS sources (OrchardCMS/OrchardCore):
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Mvc.Core/Extensions/ControllerBaseExtensions.cs#L3``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Mvc.Core/Overrides/Razor/TenantCompiledRazorAssemblyPart.cs#L7``

Exempt a namespace deliberately rooted at a framework namespace (`Microsoft.*`/`System.*`) from the folder-match check. Such a namespace is chosen for extension-method discoverability on the extended type, or because the type replaces a framework type and must live in that type's namespace — it is not derived from the folder. **Over-the-boundary:** edited `tools/csharp-roslyn-host/Rules/Architecture/NamespaceFolderMismatch.cs`.

## bugs/deterministic/no-undef (#770)

OSS sources (OrchardCMS/OrchardCore):
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore.Modules/OrchardCore.ContentFields/Assets/js/vue-multiselect-userpicker.js#L4``

Added the function-implicit `arguments` object to the JS known-globals set, so referencing it inside a function is no longer reported as an undeclared variable — `arguments` is bound in every non-arrow function and never throws a `ReferenceError`. **Over-the-boundary:** edited `packages/analyzer/src/data-flow/known-globals.ts` (data-flow module, outside the rules directory). Note: cross-file script-tag globals (`Vue`, `$`, `mediaApp`) reported on the same issue are a separate single-file-analysis limitation and are not addressed here — this fix targets the unambiguous `arguments` false positive.

## performance/deterministic/event-listener-no-remove (#775)

OSS sources (OrchardCMS/OrchardCore):
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore.Modules/OrchardCore.Contents/Assets/js/content-type-check-all.js#L2``

Added the one-shot page-bootstrap events `DOMContentLoaded` and `load` to the visitor's lifecycle-event set. These fire once during page bootstrap and never leak, so requiring a paired `removeEventListener` would be wrong. In-bounds (rule visitor only).

## code-quality/deterministic/implicit-global-declaration (#776)

OSS sources (OrchardCMS/OrchardCore):
- https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/.scripts/bloom/helpers/removeDiacritics.ts#L14

Apply the existing ES-module check (already used for the function-declaration branch) to the top-level `var` branch: a `var` in a file that has `import`/`export` is module-scoped, not a global, so it does not pollute the global namespace. Classic (non-module) scripts still fire. In-bounds (rule visitor only).

## Skipped this batch

- #763 `global-statement` — **terminal-skip** (needs a human design decision). A data-flow redesign (flag reassignment of a module-scoped binding from inside a function) removes the reported FPs but introduces a new FP on the idiomatic lazy-init/memoization pattern; deciding the rule's contract needs a human. Fully reverted. https://github.com/truecourse-ai/truecourse/issues/763
- #765 `unsafe-any-usage` — **terminal-skip**. No syntactic/semantic signal separates deliberate public `dynamic` API surface from accidental type-erasure; narrowing needs a human design decision. https://github.com/truecourse-ai/truecourse/issues/765
- #769 `params-overload-ambiguity` — **terminal-skip**. Rule works as designed (S3220); rejecting it for convenience-overload ladders is a rejection of the rule's premise, not an encodable FP. https://github.com/truecourse-ai/truecourse/issues/769

## FP-count delta (vs `1d0ae14413f10e2b3c1a65927db463b30a6892fe` on `OrchardCMS/OrchardCore`)

`unavailable`: the full-target `node dist/cli.mjs analyze --no-llm` crashes at "Saving results" with `RangeError: Invalid string length`. OrchardCore produces enough deterministic violations (observed pre-crash: 57,345 code-quality + 21,619 style + 1,076 architecture + others, before the C# semantic pass) that the serialized result JSON exceeds V8's maximum string length. This is a target-scale limit in the store's JSON serialization, independent of these fixes; the before and after runs fail identically at the same step, so before/after counts cannot be materialized. A scoped re-count over just the JS assets was also impractically slow on this target (the same large/minified files that make the full analyze slow). Each fix is instead verified by targeted analyzer unit tests + the zero-FP positive projects — see the per-rule sections and the Fixes table above; every change is a pure narrowing that only removes false positives.

cc @mushgev