### PR TITLE
fix(fp): resolve 3 FPs from OrchardCMS/OrchardCore

### DIFF
--- a/packages/analyzer/src/rules/architecture/visitors/csharp/_uri-helpers.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/csharp/_uri-helpers.ts
@@ -26,3 +26,62 @@ export function nameLooksLikeUri(name: string): boolean {
 export function isStringType(typeNode: SyntaxNode | null): boolean {
   return typeNode?.type === 'predefined_type' && typeNode.text === 'string'
 }
+
+const TYPE_DECL_TYPES = new Set([
+  'class_declaration', 'record_declaration', 'struct_declaration', 'record_struct_declaration',
+])
+
+/** The simple (unqualified) name of a base-type entry node. */
+function baseTypeSimpleName(node: SyntaxNode): string | null {
+  switch (node.type) {
+    case 'identifier':
+      return node.text
+    case 'qualified_name':
+      // `A.B.Base` → the trailing segment.
+      return node.childForFieldName('name')?.text ?? node.lastNamedChild?.text ?? null
+    case 'generic_name':
+      // `Base<T>` → `Base`.
+      return node.namedChildren.find((c) => c?.type === 'identifier')?.text ?? null
+    default:
+      return null
+  }
+}
+
+/**
+ * The simple names of the types the property's enclosing type derives from
+ * (base class + implemented interfaces), or an empty array when it derives from
+ * nothing. Walks up to the nearest type declaration and reads its `base_list`.
+ */
+export function enclosingTypeBaseNames(node: SyntaxNode): string[] {
+  let current: SyntaxNode | null = node.parent
+  while (current && !TYPE_DECL_TYPES.has(current.type)) current = current.parent
+  if (!current) return []
+  const baseList = current.namedChildren.find((c) => c?.type === 'base_list')
+  if (!baseList) return []
+  const names: string[] = []
+  for (const entry of baseList.namedChildren) {
+    if (!entry) continue
+    const name = baseTypeSimpleName(entry)
+    if (name) names.push(name)
+  }
+  return names
+}
+
+// Framework base types whose URI-named string properties are the framework's
+// contract, not an absolute System.Uri: persistence index rows map a property to
+// a database column (must stay string), and CMS content-model fields hold
+// user-entered links that are routinely relative (`~/…`), anchors (`#…`) or
+// `mailto:` — all invalid as an absolute Uri.
+const CONTENT_MODEL_BASES = new Set(['ContentField', 'ContentPart', 'ContentElement', 'FieldSettings'])
+
+/**
+ * True when the property's declaring type derives from a persistence-index base
+ * (a simple name ending in `Index`, e.g. `MapIndex`/`ReduceIndex`) or a
+ * content-model base. Properties there hold a DB-column string or user-entered
+ * (often relative) link, so `uri-property-as-string` must not fire.
+ */
+export function declaringTypeIsFrameworkModel(node: SyntaxNode): boolean {
+  return enclosingTypeBaseNames(node).some(
+    (base) => base.endsWith('Index') || CONTENT_MODEL_BASES.has(base),
+  )
+}

--- a/packages/analyzer/src/rules/architecture/visitors/csharp/uri-property-as-string.ts
+++ b/packages/analyzer/src/rules/architecture/visitors/csharp/uri-property-as-string.ts
@@ -2,7 +2,7 @@ import type { Node as SyntaxNode } from 'web-tree-sitter'
 import type { CodeRuleVisitor } from '../../../types.js'
 import { makeViolation } from '../../../types.js'
 import { getCSharpAttributeNames, getCSharpStringText, hasCSharpModifier, isCSharpStringNode } from '../../../_shared/csharp-helpers.js'
-import { isStringType, nameLooksLikeUri } from './_uri-helpers.js'
+import { declaringTypeIsFrameworkModel, isStringType, nameLooksLikeUri } from './_uri-helpers.js'
 
 // Attributes that bind the property from an inbound request. A model-bound
 // value is frequently a relative path (a `ReturnUrl`, a route segment) that
@@ -44,6 +44,10 @@ export const csharpUriPropertyAsStringVisitor: CodeRuleVisitor = {
     // Request-bound properties are populated by the model binder from strings
     // (often relative), where System.Uri would break binding.
     if (getCSharpAttributeNames(node).some((a) => BINDING_ATTRIBUTES.has(a))) return null
+    // Properties on a persistence-index row (DB column) or a CMS content-model
+    // field hold a string by the framework's contract — a relative/anchor/mailto
+    // link or a stored column value — not an absolute System.Uri.
+    if (declaringTypeIsFrameworkModel(node)) return null
     // A concrete non-URI literal value proves the property isn't an absolute URI.
     if (initializerProvesNotUri(node.childForFieldName('value'))) return null
 

--- a/packages/analyzer/src/rules/code-quality/visitors/csharp/no-extraneous-class.ts
+++ b/packages/analyzer/src/rules/code-quality/visitors/csharp/no-extraneous-class.ts
@@ -33,6 +33,14 @@ export const csharpNoExtraneousClassVisitor: CodeRuleVisitor = {
     const members = body.namedChildren.filter((c) => c && MEMBER_TYPES.has(c.type))
     if (members.length === 0) return null
 
+    // A `protected` (or `protected internal` / `private protected`) member only
+    // makes sense on a type meant to be inherited. A `static class` is sealed and
+    // abstract — it cannot be subclassed and C# forbids protected members on it —
+    // so a class exposing protected members is an inheritance base (typically a
+    // `…Base` type providing `protected static` helpers to its subclasses), not an
+    // extraneous static holder. Suggesting `static` there would not compile.
+    if (members.some((m) => hasCSharpModifier(m!, 'protected'))) return null
+
     const allStatic = members.every((m) =>
       hasCSharpModifier(m!, 'static')
       // `const` fields are implicitly static.

--- a/tests/fixtures/sample-csharp-project-negative/expected-graph.json
+++ b/tests/fixtures/sample-csharp-project-negative/expected-graph.json
@@ -2017,6 +2017,12 @@
       "layer": "service"
     },
     {
+      "name": "FeedSubscription",
+      "service": "UserService",
+      "kind": "class",
+      "layer": "service"
+    },
+    {
       "name": "FileBackedCache",
       "service": "UserService",
       "kind": "class",
@@ -2038,6 +2044,12 @@
       "name": "GenericReturnOnlyFactory",
       "service": "UserService",
       "kind": "standalone",
+      "layer": "service"
+    },
+    {
+      "name": "GeometryHelpers",
+      "service": "UserService",
+      "kind": "class",
       "layer": "service"
     },
     {

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/FeedSubscription.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/Architecture/FeedSubscription.cs
@@ -1,0 +1,10 @@
+namespace UserServiceApp.Violations.Architecture;
+
+/// <summary>A registered feed the poller fetches on a schedule.</summary>
+public sealed class FeedSubscription
+{
+    // A URL-named property typed as a bare string on a standalone class, losing the
+    // parsing and validation System.Uri would give — the rule should still flag it.
+    // VIOLATION: architecture/deterministic/uri-property-as-string
+    public string FeedUrl { get; set; } = string.Empty;
+}

--- a/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/GeometryHelpers.cs
+++ b/tests/fixtures/sample-csharp-project-negative/services/UserService/Violations/CodeQuality/GeometryHelpers.cs
@@ -1,0 +1,17 @@
+namespace UserService.Violations.CodeQuality;
+
+/// <summary>
+/// A plain helper bag holding nothing but static members, with no protected
+/// members and no marker attribute — it is pointlessly instantiable and
+/// subclassable, so both rules should still fire after the protected-member
+/// exemption.
+/// </summary>
+// VIOLATION: code-quality/deterministic/no-extraneous-class
+// VIOLATION: code-quality/deterministic/static-holder-type-not-sealed
+internal class GeometryHelpers
+{
+    internal static int Doubled(int side)
+    {
+        return side * 2;
+    }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/BookmarkFieldSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/BookmarkFieldSafe.cs
@@ -1,0 +1,19 @@
+namespace Positive.Boundary.Architecture;
+
+/// <summary>Base type for a content-model field.</summary>
+public class ContentField { }
+
+/// <summary>
+/// A content-model field whose link is user-entered: routinely relative
+/// (<c>~/page</c>), an anchor (<c>#section</c>) or <c>mailto:</c> — none valid as an
+/// absolute <see cref="System.Uri"/>. The property is a string by the framework's
+/// contract, so uri-property-as-string must not fire on a content-model type.
+/// </summary>
+public sealed class BookmarkFieldSafe : ContentField
+{
+    // SAFE: architecture/deterministic/uri-property-as-string
+    public string Url { get; set; }
+
+    // SAFE: architecture/deterministic/uri-property-as-string
+    public string PreviewUrl { get; set; }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/BookmarkIndexSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/ArchitectureSamples/BookmarkIndexSafe.cs
@@ -1,0 +1,15 @@
+namespace Positive.Boundary.Architecture;
+
+/// <summary>Base type for a persistence-index row (one property per DB column).</summary>
+public class MapIndex { }
+
+/// <summary>
+/// A persistence-index row: each property maps to a database column, so the link
+/// column must stay a string for storage and indexing. uri-property-as-string must
+/// not fire on a type deriving from an index base.
+/// </summary>
+public sealed class BookmarkIndexSafe : MapIndex
+{
+    // SAFE: architecture/deterministic/uri-property-as-string
+    public string RedirectUri { get; set; }
+}

--- a/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/ProtectedHelperBaseSafe.cs
+++ b/tests/fixtures/sample-csharp-project-positive/services/CodeQualitySamples1/ProtectedHelperBaseSafe.cs
@@ -1,0 +1,23 @@
+namespace Positive.Boundary.CodeQuality;
+
+/// <summary>
+/// An inheritance base that hands <c>protected static</c> helpers to its
+/// subclasses. A <c>static</c> class is sealed and abstract — C# forbids protected
+/// members on it and it cannot be subclassed — and marking the type <c>sealed</c>
+/// would likewise break its subclasses. So neither no-extraneous-class nor
+/// static-holder-type-not-sealed may fire on a type exposing protected members.
+/// </summary>
+public class ProtectedHelperBaseSafe
+{
+    // SAFE: code-quality/deterministic/no-extraneous-class
+    // SAFE: code-quality/deterministic/static-holder-type-not-sealed
+    protected static bool HasPayload(object context)
+    {
+        return context != null;
+    }
+
+    protected static object GetPayload(object context)
+    {
+        return HasPayload(context) ? context : null;
+    }
+}

--- a/tools/csharp-roslyn-host/Rules/CodeQuality/StaticHolderTypeNotSealed.cs
+++ b/tools/csharp-roslyn-host/Rules/CodeQuality/StaticHolderTypeNotSealed.cs
@@ -37,6 +37,18 @@ internal sealed class StaticHolderTypeNotSealed : ISemanticRule
             // An empty type is a marker, not a static holder.
             if (members.Count == 0) continue;
 
+            // A `protected` member (protected, protected internal, or private
+            // protected) is only meaningful on a type meant to be inherited. A
+            // `static` class is sealed+abstract and cannot be subclassed — C# even
+            // forbids protected members on it — and marking the type `sealed` would
+            // likewise break its subclasses. So a class exposing protected members
+            // is an inheritance base (a `…Base` type handing `protected static`
+            // helpers to its subclasses), not a pointless static holder.
+            if (members.Any(m => m.DeclaredAccessibility
+                is Accessibility.Protected
+                or Accessibility.ProtectedOrInternal
+                or Accessibility.ProtectedAndInternal)) continue;
+
             var allStatic = members.All(m => m switch
             {
                 // The implicit parameterless ctor is filtered above; an EXPLICIT instance


### PR DESCRIPTION
## Human review required

These fixes ship in a **human-review** batch: the entire pickable `cs-fp-fix` queue carried `cs-fp-human-review-needed`, so there was no normal-phase queue this session. `fp-next-fix-review` will review but **not** auto-merge — a human must review and merge.

Non-rule modules touched (over the in-bounds boundary):
- **Roslyn semantic host** (`tools/csharp-roslyn-host/Rules/CodeQuality/StaticHolderTypeNotSealed.cs`) — for #782.

#777 and #781 are **in-bounds** (rule visitors + fixtures only) but ship in this human-review batch because there was no normal queue to route them to.

Closes #777
Closes #781
Closes #782

## Fixes

| rule_key | issue | positive-fixture | negative-fixture |
|---|---|---|---|
| architecture/deterministic/uri-property-as-string | #777 | `sample-csharp-project-positive/services/ArchitectureSamples/BookmarkFieldSafe.cs`, `BookmarkIndexSafe.cs` | `sample-csharp-project-negative/services/UserService/Violations/Architecture/FeedSubscription.cs` |
| code-quality/deterministic/no-extraneous-class | #781 | `sample-csharp-project-positive/services/CodeQualitySamples1/ProtectedHelperBaseSafe.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/GeometryHelpers.cs` |
| code-quality/deterministic/static-holder-type-not-sealed | #782 | `sample-csharp-project-positive/services/CodeQualitySamples1/ProtectedHelperBaseSafe.cs` | `sample-csharp-project-negative/services/UserService/Violations/CodeQuality/GeometryHelpers.cs` |

## architecture/deterministic/uri-property-as-string (#777)

OSS sources (OrchardCMS/OrchardCore):
- https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.ContentFields.Core/Fields/LinkField.cs#L7
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.ContentFields.Core/Settings/LinkFieldSettings.cs#L20``
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Indexes/OpenIdApplicationIndex.cs#L14``
- https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.Navigation.Core/MenuItem.cs#L51
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/PreviewAspect.cs#L5``

Exempt a URI-named string property whose **declaring type derives from a framework model base**: a persistence-index row (base simple-name ending in `Index` — YesSql `MapIndex`/`ReduceIndex` — where each property maps to a DB column and must stay a string) or a CMS content-model base (`ContentField`/`ContentPart`/`ContentElement`/`FieldSettings`, which hold user-entered links that are routinely relative `~/…`, an anchor `#…`, or `mailto:` — invalid as an absolute `System.Uri`). Added `enclosingTypeBaseNames` + `declaringTypeIsFrameworkModel` to `_uri-helpers.ts`; the visitor bails before flagging when the declaring type matches. Plain standalone classes (the real "should be System.Uri" case — e.g. the negative fixtures `AvatarLink.AvatarUrl` / `WebhookEndpoint.CallbackUrl`) still fire.

**Partial fix (deliberate):** this clears 3 of the 5 reported samples — `LinkField` (`ContentField`), `LinkFieldSettings` (`FieldSettings`), and the OpenId YesSql index (`ReduceIndex`). The other two — `MenuItem.Url` and `PreviewAspect.PreviewUrl` — are declared on **plain classes with no framework base**, structurally identical to the retained true-positives, so no deterministic signal separates them; they are left flagging on purpose (the genuinely ambiguous cases). In-bounds (rule visitor only).

## code-quality/deterministic/no-extraneous-class (#781)

OSS sources (OrchardCMS/OrchardCore):
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.ContentManagement.Display/Placement/ContentPartPlacementNodeFilterProvider.cs#L79``

Exempt a class that exposes a `protected` (or `protected internal` / `private protected`) member. A `static class` is sealed **and** abstract — C# forbids protected members on it and it cannot be subclassed — so a type handing `protected static` helpers to its subclasses (the reported `ContentPlacementParseFilterProviderBase`) is an inheritance base, not an extraneous static holder; suggesting `static` there would not compile. Plain all-`public static` holders still fire. In-bounds (rule visitor only).

## code-quality/deterministic/static-holder-type-not-sealed (#782)

OSS sources (OrchardCMS/OrchardCore):
- ``https://github.com/OrchardCMS/OrchardCore/blob/1d0ae14413f10e2b3c1a65927db463b30a6892fe/src/OrchardCore/OrchardCore.ContentManagement.Display/Placement/ContentPartPlacementNodeFilterProvider.cs#L79``

The Roslyn-host twin of #781, same root cause. Exempt a type with any member whose `ISymbol.DeclaredAccessibility` is `Protected` / `ProtectedOrInternal` / `ProtectedAndInternal`: a `static` (or `sealed`) type can't hand protected members to subclasses, so such a type is an inheritance base, not a pointless static holder. **Over-the-boundary:** edited `tools/csharp-roslyn-host/Rules/CodeQuality/StaticHolderTypeNotSealed.cs` (Roslyn semantic host, outside the rules directory).

## Skipped this batch

- #780 `generic-parameter-not-inferable` — **terminal-skip** (rule-contract conflict). The return-only generic converter/factory shape (`TValue DeserializeObject<TValue>(string)`) is byte-for-byte the analyzer's own asserted true-positive `JsonDeserializationConfig.Deserialize<T>` / `GenericReturnOnlyFactory.Build<T>`; any exemption that clears it breaks `csharp-negative.test.ts`. Needs a human decision on whether the converter/factory idiom is a defect. https://github.com/truecourse-ai/truecourse/issues/780
- #783 `normalize-to-lower-not-upper` — **terminal-skip**. `return shapeType.ToLowerInvariant();` (lowercase required as external index/search format) is structurally identical to the negative-fixture true-positive `return raw.ToLowerInvariant();`; no syntactic signal separates required-lowercase-output from comparison-normalization (the known CA1308 limitation). https://github.com/truecourse-ai/truecourse/issues/783
- #788 `commented-out-code` — **terminal-skip**. The flagged block genuinely contains a commented-out `foreach` loop (4 code lines vs 1 prose line); the "leading prose + code" shape is the same as the negative-fixture true-positive in `DiagnosticsToolbox.cs`. Suppressing it would break that TP or require an arbitrary natural-language special case. https://github.com/truecourse-ai/truecourse/issues/788

## FP-count delta (vs `1d0ae14413f10e2b3c1a65927db463b30a6892fe` on `OrchardCMS/OrchardCore`)

`unavailable`: the whole-target `node dist/cli.mjs analyze --no-llm --no-stash --no-skills` computes every violation (pre-crash category totals observed this run: 55,153 code-quality + 21,345 style + 12,398 C# semantic + 5,019 bugs + 1,076 architecture + 425 security + 327 performance + 227 reliability + 3 database ≈ 95,973) but then crashes while materializing the result with `RangeError: Invalid string length` — the serialized OrchardCore result JSON exceeds V8's maximum string length, so no `LATEST.json`/snapshot is written and per-rule before/after counts cannot be produced. This is a target-scale limit in the store's JSON serialization, independent of these fixes (the same crash on this exact target/ref is documented in #829); the before and after runs fail identically at the same step. A small C# project serializes fine on the same dist, confirming the crash is target-scale, not a regression.

Each fix is instead verified by targeted tests, all green: the **C# zero-FP positive project** (`csharp-positive.test.ts` — the paraphrased FP shapes now produce zero violations across all rules, tree-sitter and Roslyn-host), the **C# negative project** (`csharp-negative.test.ts` — the rules still fire on the paraphrased real bugs, with no unexpected fires), and the dedicated per-rule unit tests. Each change is a pure narrowing (adds an exemption), so it can only remove false positives, never introduce new violations.

cc @mushgev

---
_Generated by [Claude Code](https://claude.ai/code/session_01FesEHTGtM4oULLq6NWBBuw)_