### PR TITLE
fix(guard): bind known routes from opaque apps

### DIFF
--- a/packages/guard-generator/src/server-binding.ts
+++ b/packages/guard-generator/src/server-binding.ts
@@ -16,10 +16,19 @@
  * attribution: a path the manifest attributes to a known app that the
  * recipe declares no server for. Everything else — a path that matched nothing, an
  * app whose routes could not be read, a server with no `app` join key — is `unbound`,
- * which authors exactly as guard did before this module existed. A proxying
- * (`opaque`) app may serve MORE paths than the manifest names, but its positively
- * discovered routes remain safe facts. A false block is strictly worse than a
- * missed one: it silently deletes coverage.
+ * which authors exactly as guard did before this module existed. A false block is
+ * strictly worse than a missed one: it silently deletes coverage.
+ *
+ * Which makes the manifest's two uncertainty flags mean two different things here:
+ *
+ *  - `opaque` (a proxying app) — its exact route matches are still safe facts and
+ *    do bind. Its PREFIX claim does not: `apps/web` declaring `/api/version` makes
+ *    it claim all of `/api/*`, and cal.diy's documented `/api/v1/oauth/token` is a
+ *    path the web app neither declares nor rewrites. A proxy's coarse claim says
+ *    nothing about ownership, so it is skipped as if nothing matched.
+ *  - `pathsShifted` (a Next `basePath`) — the discovered paths are not the app's
+ *    real URLs, so even an exact match is a confidently-wrong positive. Such an
+ *    app contributes nothing at all: no bind, no block, no foreign-exclusion.
  */
 
 import {
@@ -117,10 +126,7 @@ export function bindFlowServer(paths: readonly string[], index: ServerRouteIndex
     const canonical = canonicalizePath(raw)
     if (canonical === null) continue
     const match = whichAppServes(index.manifest, canonical)
-    // No claim at all means nothing positive is known, so this path says nothing
-    // (R6). Opacity only means the app may serve MORE than its declared routes; a
-    // route it positively claims is still safe to bind.
-    if (!match || match.app.routes.length === 0) continue
+    if (!usableClaim(match)) continue
     const server = index.serverByApp.get(match.app.dir)
     if (server) {
       if (!boundServers.includes(server)) boundServers.push(server)
@@ -170,7 +176,7 @@ export function servedByOtherApp(index: ServerRouteIndex, boundApp: string | und
   const canonical = canonicalizePath(requestPath)
   if (canonical === null) return false
   const match = whichAppServes(index.manifest, canonical)
-  if (!match || match.app.routes.length === 0) return false
+  if (!usableClaim(match)) return false
   return match.app.dir !== normalizeDir(boundApp)
 }
 
@@ -219,6 +225,22 @@ const METHOD_PATH_RE = /\b(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(\/[A-Za-
 const CURL_URL_RE = /curl\b[^\n]*?\s(?:'|")?(https?:\/\/[^\s'"]+|\/[A-Za-z0-9{}:_\-./]*)/g
 
 // --- internals --------------------------------------------------------------
+
+/** One `whichAppServes` answer, narrowed to the claims this module may act on. */
+type AppClaim = NonNullable<ReturnType<typeof whichAppServes>>
+
+/**
+ * Is this manifest answer a fact strong enough to bind or block on (R6)? Four
+ * ways it is not, all of which mean "nothing known" rather than "not served here":
+ * nobody claimed the path, the claimant declares no routes at all, the claimant's
+ * paths are shifted (its declared URLs are wrong), or — the proxy case — an
+ * `opaque` app claimed it by prefix only, which is forwarding, not ownership.
+ */
+function usableClaim(match: AppClaim | null): match is AppClaim {
+  if (!match || match.app.routes.length === 0) return false
+  if (match.app.pathsShifted) return false
+  return !(match.app.opaque && match.match === 'prefix')
+}
 
 /** `./apps/api/v2/` → `apps/api/v2` — the manifest's own dir spelling. */
 function normalizeDir(dir: string): string {

--- a/packages/guard-generator/src/server-binding.ts
+++ b/packages/guard-generator/src/server-binding.ts
@@ -13,12 +13,13 @@
  * visible `blocked-on` gap whose fix is a recipe edit.
  *
  * **The asymmetric contract (R6).** This module may only ever block on a POSITIVE
- * attribution: a path the manifest attributes to a known, non-`opaque` app that the
+ * attribution: a path the manifest attributes to a known app that the
  * recipe declares no server for. Everything else — a path that matched nothing, an
- * app whose routes could not be read, a proxying (`opaque`) app, a server with no
- * `app` join key — is `unbound`, which authors exactly as guard did before this
- * module existed. A false block is strictly worse than a missed one: it silently
- * deletes coverage.
+ * app whose routes could not be read, a server with no `app` join key — is `unbound`,
+ * which authors exactly as guard did before this module existed. A proxying
+ * (`opaque`) app may serve MORE paths than the manifest names, but its positively
+ * discovered routes remain safe facts. A false block is strictly worse than a
+ * missed one: it silently deletes coverage.
  */
 
 import {
@@ -116,9 +117,10 @@ export function bindFlowServer(paths: readonly string[], index: ServerRouteIndex
     const canonical = canonicalizePath(raw)
     if (canonical === null) continue
     const match = whichAppServes(index.manifest, canonical)
-    // No claim at all, or a claim from an app that may forward paths it never
-    // declares: nothing positive is known, so this path says nothing (R6).
-    if (!match || match.app.opaque || match.app.routes.length === 0) continue
+    // No claim at all means nothing positive is known, so this path says nothing
+    // (R6). Opacity only means the app may serve MORE than its declared routes; a
+    // route it positively claims is still safe to bind.
+    if (!match || match.app.routes.length === 0) continue
     const server = index.serverByApp.get(match.app.dir)
     if (server) {
       if (!boundServers.includes(server)) boundServers.push(server)
@@ -168,7 +170,7 @@ export function servedByOtherApp(index: ServerRouteIndex, boundApp: string | und
   const canonical = canonicalizePath(requestPath)
   if (canonical === null) return false
   const match = whichAppServes(index.manifest, canonical)
-  if (!match || match.app.opaque || match.app.routes.length === 0) return false
+  if (!match || match.app.routes.length === 0) return false
   return match.app.dir !== normalizeDir(boundApp)
 }
 

--- a/packages/guard-runner/src/route-manifest.ts
+++ b/packages/guard-runner/src/route-manifest.ts
@@ -16,10 +16,18 @@
  *
  * **The asymmetric contract (R6).** Every heuristic here is allowed to say
  * "nothing known"; none of them is allowed to be confidently wrong. A path that
- * matches nothing, an app whose routes could not be read, an app that may forward
- * paths it does not declare (`opaque`) — all of them degrade to the behaviour
- * guard had before this module existed. The manifest may only ever *positively*
- * attribute a path to an app; callers must treat everything else as unknown.
+ * matches nothing, or an app whose routes could not be read, degrades to the
+ * behaviour guard had before this module existed. The manifest may only ever
+ * *positively* attribute a path to an app; callers must treat everything else as
+ * unknown. Uncertainty comes in two flavours a caller has to tell apart:
+ *
+ *   `opaque`       — the app may serve MORE than it declares (a proxy, an
+ *                    unreadable framework, a capped walk). What it DOES declare is
+ *                    still true, so an exact template match on it is actionable;
+ *                    its coarse {@link staticPrefixes} claim is not, since a proxy
+ *                    can hold a prefix over paths it only forwards.
+ *   `pathsShifted` — the declared paths are themselves wrong (a Next `basePath`
+ *                    remounts them all). Nothing from such an app is usable.
  */
 
 import fs from 'node:fs'
@@ -39,11 +47,25 @@ export interface RouteManifestApp {
   /** Static 1- and 2-segment prefixes covering the routes (`/v2`, `/api/v2`). Reporting only. */
   prefixes: string[]
   /**
-   * True when the app may forward paths it does not itself declare (a Next.js
-   * `rewrites()`/`proxy`/`basePath` was detected, a framework whose routes could
-   * not be read, or a tree too large to walk). Such an app NEVER produces a block.
+   * True when the app may serve MORE than it declares (a Next.js `rewrites()`/
+   * `proxy`/`basePath` was detected, a framework whose routes could not be read,
+   * or a tree too large to walk). The routes it DID declare are still facts — an
+   * exact template match on an opaque app is safe to act on; a coarse
+   * {@link staticPrefixes} claim is not, because a proxy's prefix may cover paths
+   * it merely forwards. Callers that block must degrade on the prefix case.
    */
   opaque: boolean
+  /**
+   * True when the discovered routes are not the app's real URLs — today the one
+   * cause is a Next.js `basePath`, which mounts EVERY route under a prefix this
+   * module does not read. It is a strictly stronger statement than {@link opaque}
+   * ("may serve more") and gets its own flag rather than a reason enum because
+   * that is exactly the one question a caller has to ask: an opaque app's positive
+   * routes are usable, a shifted app's are confidently wrong, so a shifted app
+   * must contribute NOTHING — no attribution, no block, no foreign-exclusion (R6).
+   * Always accompanied by `opaque: true`.
+   */
+  pathsShifted: boolean
 }
 
 export interface RouteManifest {
@@ -104,9 +126,12 @@ export function buildRouteManifest(repoRoot: string, opts: BuildRouteManifestOpt
  * within each class the most specific claim wins (most static segments / longest
  * prefix), ties broken by dir so the answer is stable.
  *
- * An `opaque` app can still be returned — it is the caller's job to degrade on
- * that flag, because "this app claims the path but may also forward others" is a
- * different fact from "nobody claims it".
+ * An `opaque` or `pathsShifted` app can still be returned — it is the caller's job
+ * to degrade on those flags, because "this app claims the path but may also
+ * forward others" and "this app's declared paths are shifted" are both different
+ * facts from "nobody claims it". The `match` kind is what makes that possible: a
+ * `route` match is an exact template the app declares, a `prefix` match is only
+ * the coarse claim derived from those templates.
  */
 export function whichAppServes(
   manifest: RouteManifest,
@@ -283,15 +308,22 @@ function readApp(repoRoot: string, dir: string): RouteManifestApp | null {
     routes: [],
     prefixes: [],
     opaque: false,
+    pathsShifted: false,
   }
 
   const budget = { files: 0 }
   if (framework === 'next') {
     // A `rewrites()`/`proxy`/`basePath` next.config means the app can answer for
     // paths it never declares — the safety valve that keeps a proxying frontend
-    // from ever being told it does not serve something.
-    if (nextConfig !== null && /\brewrites\b|\bproxy\b|\bbasePath\b/.test(readText(nextConfig))) {
+    // from ever being told it does not serve something. `basePath` says more than
+    // that: it moves every route under a prefix, so the paths read off the tree are
+    // not the app's URLs at all and must stop being facts.
+    const configText = nextConfig !== null ? readText(nextConfig) : ''
+    if (/\brewrites\b|\bproxy\b|\bbasePath\b/.test(configText)) {
       app.opaque = true
+    }
+    if (/\bbasePath\b/.test(configText)) {
+      app.pathsShifted = true
     }
     app.routes.push(...nextRoutes(abs, budget))
   } else if (framework === 'nest') {

--- a/tests/guard-generator/generate-server-binding.test.ts
+++ b/tests/guard-generator/generate-server-binding.test.ts
@@ -50,6 +50,16 @@ function monorepo(): string {
   return r
 }
 
+/** The same fixture with a proxying web app whose statically known routes stay positive facts. */
+function monorepoWithOpaqueWeb(): string {
+  const r = monorepo()
+  fs.writeFileSync(
+    path.join(r, 'apps/web/next.config.js'),
+    'module.exports = { async rewrites() { return [] } }',
+  )
+  return r
+}
+
 /** A temp repo with no workspace apps at all — the route manifest finds nothing. */
 function plainRepo(): string {
   const r = makeTempRepo()
@@ -60,6 +70,8 @@ function plainRepo(): string {
 const DOC = 'docs/api.md'
 /** One documented `/v2` endpoint — the app the fixture's Nest service serves. */
 const V2_DOC = ['## bookings', 'GET /v2/bookings returns 200 with the booking list.'].join('\n')
+/** One documented web endpoint — an exact route even when the app can also proxy. */
+const WEB_DOC = ['## version', 'GET /api/version returns 200 with the version.'].join('\n')
 /** One documented endpoint on each service — the span case. */
 const BOTH_DOC = [
   '## bookings',
@@ -71,6 +83,9 @@ const BOTH_DOC = [
 
 const v2Extract = extractBy({
   bookings: [{ driver: 'api', claim: 'GET /v2/bookings returns 200', reason: 'HTTP status + body' }],
+})
+const webExtract = extractBy({
+  version: [{ driver: 'api', claim: 'GET /api/version returns 200', reason: 'HTTP status + body' }],
 })
 const bothExtract = extractBy({
   bookings: [{ driver: 'api', claim: 'GET /v2/bookings returns 200', reason: 'HTTP status + body' }],
@@ -183,6 +198,38 @@ describe('generateGuards — the route gate', () => {
     expect(ctx?.server).toEqual({ name: 'api-v2', app: 'apps/api/v2' })
     expect(ctx?.recipeHealthPath).toBe('/v2/health')
     expect((ctx?.otherOperations ?? []).map((o) => o.path)).not.toContain('/api/version')
+  }, 60_000)
+
+  it('binds a known route of an opaque app to its declared server and stamps the YAML', async () => {
+    const r = monorepoWithOpaqueWeb()
+    writeApiRecipe(r, { entry: null, servers: TWO_SERVERS, defaultServer: 'api-v2' })
+    writeCorpus(r, [{ ref: DOC }])
+    writeDoc(r, DOC, WEB_DOC)
+
+    let ctx: AuthorUserContext | undefined
+    const res = await runGenerate({
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/api/version')),
+      extractRunner: webExtract,
+      generateRunner: authorBy(
+        {
+          version: rawApi('GET /api/version answers 200', [
+            { request: { method: 'GET', path: '/api/version' }, expect: { status: 200 } },
+          ]),
+        },
+        (c) => {
+          ctx = c
+        },
+      ),
+    })
+
+    expect(res.errors).toEqual([])
+    expect(res.written).toHaveLength(1)
+    const committed = yaml.load(fs.readFileSync(path.join(r, res.written[0].file), 'utf-8')) as {
+      server?: string
+    }
+    expect(committed.server).toBe('web')
+    expect(ctx?.server).toEqual({ name: 'web', app: 'apps/web' })
   }, 60_000)
 
   it('blocks a flow that spans two declared servers — a scenario runs against one', async () => {

--- a/tests/guard-generator/server-binding.test.ts
+++ b/tests/guard-generator/server-binding.test.ts
@@ -4,8 +4,14 @@ import {
   servedByOtherApp,
   type ServerRouteIndex,
 } from '@truecourse/guard-generator'
+import type { RouteManifestApp } from '@truecourse/guard-runner'
 
-function routeIndex(): ServerRouteIndex {
+/**
+ * The cal.com/cal.diy shape: a Nest `/v2` api whose routes are exact facts, and a
+ * proxying Next web app that declares `/api/version` — hence the coarse `/api`
+ * prefix it also claims but does not own.
+ */
+function routeIndex(webOverrides: Partial<RouteManifestApp> = {}): ServerRouteIndex {
   return {
     manifest: {
       apps: [
@@ -15,6 +21,7 @@ function routeIndex(): ServerRouteIndex {
           routes: ['/v2/bookings'],
           prefixes: ['/v2', '/v2/bookings'],
           opaque: false,
+          pathsShifted: false,
         },
         {
           dir: 'apps/web',
@@ -22,6 +29,8 @@ function routeIndex(): ServerRouteIndex {
           routes: ['/api/version'],
           prefixes: ['/api', '/api/version'],
           opaque: true,
+          pathsShifted: false,
+          ...webOverrides,
         },
       ],
     },
@@ -51,5 +60,44 @@ describe('server binding for opaque apps', () => {
   it('keeps an unmatched route unknown because an opaque app may proxy it', () => {
     expect(bindFlowServer(['/forwarded-only'], routeIndex())).toEqual({ kind: 'unbound' })
     expect(servedByOtherApp(routeIndex(), 'apps/api/v2', '/forwarded-only')).toBe(false)
+  })
+
+  it('ignores an opaque app that only claims the path by prefix — it may merely forward it', () => {
+    // `/api/v1/oauth/token` is documented, and apps/web claims `/api/*` purely
+    // because it happens to declare `/api/version`. For a proxy that says nothing.
+    expect(bindFlowServer(['/api/v1/oauth/token'], routeIndex())).toEqual({ kind: 'unbound' })
+    expect(servedByOtherApp(routeIndex(), 'apps/api/v2', '/api/v1/oauth/token')).toBe(false)
+  })
+
+  it('never blocks on an opaque app that claims the path by prefix alone', () => {
+    const index = routeIndex()
+    index.serverByApp.delete('apps/web')
+    index.appByServer.delete('web')
+    expect(bindFlowServer(['/api/v1/oauth/token'], index)).toEqual({ kind: 'unbound' })
+  })
+
+  it('still binds on a prefix claim from an app that is not a proxy', () => {
+    // `/v2/bookings/42/cancel` matches no template; the non-opaque Nest app's
+    // `/v2` prefix is a fair ownership statement, so the coarse claim still counts.
+    expect(bindFlowServer(['/v2/bookings/42/cancel'], routeIndex())).toMatchObject({
+      kind: 'bound',
+      server: 'api-v2',
+    })
+    expect(servedByOtherApp(routeIndex(), 'apps/web', '/v2/bookings/42/cancel')).toBe(true)
+  })
+})
+
+describe('server binding for apps whose discovered paths are shifted', () => {
+  it('contributes nothing even on an exact route match — the real URL carries a basePath', () => {
+    const index = routeIndex({ pathsShifted: true })
+    expect(bindFlowServer(['/api/version'], index)).toEqual({ kind: 'unbound' })
+    expect(servedByOtherApp(index, 'apps/api/v2', '/api/version')).toBe(false)
+  })
+
+  it('never blocks on a shifted app with no declared server', () => {
+    const index = routeIndex({ pathsShifted: true })
+    index.serverByApp.delete('apps/web')
+    index.appByServer.delete('web')
+    expect(bindFlowServer(['/api/version'], index)).toEqual({ kind: 'unbound' })
   })
 })

--- a/tests/guard-generator/server-binding.test.ts
+++ b/tests/guard-generator/server-binding.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  bindFlowServer,
+  servedByOtherApp,
+  type ServerRouteIndex,
+} from '@truecourse/guard-generator'
+
+function routeIndex(): ServerRouteIndex {
+  return {
+    manifest: {
+      apps: [
+        {
+          dir: 'apps/api/v2',
+          framework: 'nest',
+          routes: ['/v2/bookings'],
+          prefixes: ['/v2', '/v2/bookings'],
+          opaque: false,
+        },
+        {
+          dir: 'apps/web',
+          framework: 'next',
+          routes: ['/api/version'],
+          prefixes: ['/api', '/api/version'],
+          opaque: true,
+        },
+      ],
+    },
+    serverByApp: new Map([
+      ['apps/api/v2', 'api-v2'],
+      ['apps/web', 'web'],
+    ]),
+    appByServer: new Map([
+      ['api-v2', 'apps/api/v2'],
+      ['web', 'apps/web'],
+    ]),
+  }
+}
+
+describe('server binding for opaque apps', () => {
+  it('binds a positively matched route to its declared server', () => {
+    expect(bindFlowServer(['/api/version'], routeIndex())).toMatchObject({
+      kind: 'bound',
+      server: 'web',
+    })
+  })
+
+  it('recognizes a positively matched route as belonging to another app', () => {
+    expect(servedByOtherApp(routeIndex(), 'apps/api/v2', '/api/version')).toBe(true)
+  })
+
+  it('keeps an unmatched route unknown because an opaque app may proxy it', () => {
+    expect(bindFlowServer(['/forwarded-only'], routeIndex())).toEqual({ kind: 'unbound' })
+    expect(servedByOtherApp(routeIndex(), 'apps/api/v2', '/forwarded-only')).toBe(false)
+  })
+})

--- a/tests/guard-runner/route-manifest.test.ts
+++ b/tests/guard-runner/route-manifest.test.ts
@@ -94,6 +94,26 @@ describe('buildRouteManifest — Next.js', () => {
     expect(w.opaque).toBe(true)
     // Still a real route list — opacity is a caller-side degrade, not amnesia.
     expect(w.routes).toEqual(['/api/version'])
+    // A rewriting app may serve MORE; the paths it does declare are still its own.
+    expect(w.pathsShifted).toBe(false)
+  })
+
+  it('marks an app whose next.config sets a basePath as shifted — its declared paths are not its URLs', () => {
+    const r = repoWith({
+      'package.json': JSON.stringify({ name: 'root', workspaces: ['apps/*'] }),
+      'apps/w/package.json': JSON.stringify({ name: 'w', dependencies: { next: '14' } }),
+      'apps/w/next.config.js': "module.exports = { basePath: '/console' }",
+      'apps/w/pages/api/version.ts': '',
+    })
+    const w = app(buildRouteManifest(r), 'apps/w')
+    expect(w.opaque).toBe(true)
+    expect(w.pathsShifted).toBe(true)
+  })
+
+  it('leaves a plain Next app neither opaque nor shifted', () => {
+    const web = app(buildRouteManifest(MONOREPO), 'apps/web')
+    expect(web.opaque).toBe(false)
+    expect(web.pathsShifted).toBe(false)
   })
 })
 
@@ -113,6 +133,8 @@ describe('buildRouteManifest — NestJS', () => {
     })
     const svc = app(buildRouteManifest(r), 'apps/svc')
     expect(svc.opaque).toBe(true)
+    // Unread routes are missing, not shifted — nothing here is wrong, only absent.
+    expect(svc.pathsShifted).toBe(false)
     expect(svc.routes).toEqual([])
   })
 })


### PR DESCRIPTION
## What changed

Two commits. The first makes an opaque app's routes bind; the second narrows exactly which of its claims count.

**`fix(guard): bind known routes from opaque apps`**

- preserve positive route ownership when an app is marked `opaque`
- use the same positive-match rule when filtering another server's operation catalog
- add focused binding tests and an end-to-end generation regression that verifies `server: web` is stamped

**`fix(guard): narrow what an opaque app's claim proves`**

- an opaque app's **exact template match** binds; its **prefix claim** does not. `apps/web` declaring `/api/version` makes it claim all of `/api/*`, and for a proxy that coarse claim covers paths it merely forwards — it says nothing about ownership, so it is skipped as if nothing matched.
- split `pathsShifted` out of `opaque` on `RouteManifestApp`. A Next `basePath` remounts every route, so the paths read off the tree are not the app's URLs at all — such an app contributes nothing, exact matches included. The other opacity causes (`rewrites`, `proxy`, unreadable framework, capped walk) leave the discovered routes true and are unaffected.
- `opaque` keeps its exact prior meaning, so the run-time route triage in `guard-runner/src/run.ts` is untouched.

## Root cause

`bindFlowServer` discarded every match from an opaque app. In repositories such as cal.com, a Next.js `rewrites()` declaration marks the web app opaque even though its statically discovered `/api/*` routes are still valid positive ownership facts. Those flows became unbound, so generated scenarios omitted `server: web` and ran against the default API server.

Opacity now means only that the app may serve additional unknown paths — but only its exact routes are strong enough to bind or block on, and a `basePath` invalidates its paths outright.

## Validation

- `npx vitest run tests/guard-generator tests/guard-runner` — 1378 passed, 1 skipped (101 files)
- `pnpm build` — 21/21

Cold regenerate on the cal.diy bench (`scenarios/manifest.json` + `.cache/guard/generate` dropped, 141 calls):

- 54 api scenarios, clean split: **14 stamped `server: web`** (all pure `/api/*`, bound off exact route matches on the opaque web app), **40 unstamped** → default `api` server (all pure `/v2/*`). No scenario mixes the two.
- Zero `missing-server` / `multi-server-flow` blocks from the binding gates.
- Scenario-count churn against the prior run (58 → 55) is authoring nondeterminism — two LLM flakes and four flows judged blocked on `missing-data` fixtures — none binding-related.

Scope note: the bench exercises the opaque-exact-route binding. The prefix and `basePath` tightenings are covered by unit tests only — cal.diy has no `basePath` app, and no documented path there resolves to an opaque app by prefix alone.
