### PR TITLE
fix(guard): show only flow-relevant external services

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,7 +867,9 @@ dashboard's **External APIs** tab (Spec Guard section) is the same thing as a pa
 service with its state, blocked test count and detection evidence, and an inline form that writes
 the declaration to `recipe.json` and the secret to the gitignored overlay.
 `truecourse guard externals` is the read-only view of the same data (its `--list` flag is kept for
-compatibility and is now its only behaviour).
+compatibility and is now its only behaviour). It lists the services something is actually waiting on
+— a blocked flow, a scenario that scripts faults on it, a half-configured account, or a declaration
+you touched — and counts the rest in one line; `--all` lists those too, in their own block.
 
 ### Scripted faults on a real account — `setup.externals`
 
@@ -962,6 +964,7 @@ truecourse guard run --verbose                    # List every scenario result (
 truecourse guard recipe                           # Read-only: the preparation recipe (secrets masked) + whether its inputs drifted since the last run
 truecourse guard seed                             # Read-only: the database seed (api.seed), the script it names, and the flows blocked on missing data
 truecourse guard externals                        # Read-only: each service with its state, base URL/mode, unmet requirements, blocked flows
+truecourse guard externals --all                  # …plus the detected services no flow needs, in their own block
 truecourse guard flows                            # List the synthesized flows with per-surface coverage (--show <id> for one flow's detail)
 truecourse guard flows --show <id> --story        # Read that flow's committed tests in plain words (the promise, the world, every assertion)
 truecourse guard flows dismiss <flow-id>          # Rule a flow out of testing (--note <text>); the next generate drops it and deletes its tests

--- a/apps/dashboard/client/src/components/guard/GuardExternalsPane.tsx
+++ b/apps/dashboard/client/src/components/guard/GuardExternalsPane.tsx
@@ -8,9 +8,18 @@
  * the next generate authors live-integration flows against it and the runner points
  * the app at it; unprovided ⇒ its flows stay blocked, and the card says how many.
  *
+ * What the page shows BY DEFAULT is the RELEVANT services (the engine's `relevant`
+ * flag). Detection is a fact about the code — a repo can call twenty vendors and owe
+ * the user nothing — so a service becomes the user's business only once something is
+ * waiting on it. The rest live behind one collapsed disclosure, deliberately NOT
+ * persisted: a fresh visit is always the quiet view, and expanding is the
+ * declare-ahead-of-need path (the same card, the same form).
+ *
  * A needs-setup CTA anywhere else in guard links here with `?gext=<service>`:
- * the page lands on that service's card with its account form already open, then
- * drops the param — the deep link is a one-shot jump, never a sticky selection.
+ * the page lands on that service's card with its account form already open — expanding
+ * the disclosure first when the named service lives in it, or every such CTA would
+ * land on a page that does not contain its card — then drops the param, so the deep
+ * link is a one-shot jump, never a sticky selection.
  *
  * The edit form is the SECRECY split made visible: a declaration (service,
  * `baseUrlEnv`, which variables it needs, mode, description) is committed to
@@ -78,6 +87,9 @@ export function GuardExternalsPane({ repoId, reloadKey = 0 }: GuardExternalsPane
   const [params, setParams] = useSearchParams();
   const requested = params.get('gext');
   const scrollTo = useRef<string | null>(null);
+  // Session-only, by design: persisting it would make the wall of detected services
+  // the permanent view for anyone who ever looked at it once.
+  const [showHidden, setShowHidden] = useState(false);
 
   // A needs-setup CTA elsewhere in guard named ONE service and sent the user here
   // to provide it. Land ON that card with its account form already open
@@ -85,10 +97,14 @@ export function GuardExternalsPane({ repoId, reloadKey = 0 }: GuardExternalsPane
   // param, so a later manual visit to the tab is a plain read of the page.
   useEffect(() => {
     if (!requested || !view) return;
-    if (view.services.some((s) => s.service === requested)) {
+    const target = view.services.find((s) => s.service === requested);
+    if (target) {
       setFormError(null);
       setEditing(requested);
       scrollTo.current = requested;
+      // The CTA may name a service nothing is waiting on yet (a user pre-empting a
+      // block): its card only exists inside the disclosure, so open it.
+      if (!target.relevant) setShowHidden(true);
     }
     setParams(
       (prev) => {
@@ -132,41 +148,50 @@ export function GuardExternalsPane({ repoId, reloadKey = 0 }: GuardExternalsPane
     );
   }
 
+  const relevant = view.services.filter((s) => s.relevant);
+  const hidden = view.services.filter((s) => !s.relevant);
+  const everyHiddenServiceWasDetected = hidden.every((s) => s.detected);
+  const card = (service: GuardExternalServiceView) => (
+    <ServiceCard
+      key={service.service}
+      service={service}
+      editing={editing === service.service}
+      onEdit={() => {
+        setFormError(null);
+        setEditing(editing === service.service ? null : service.service);
+      }}
+      onCancel={() => setEditing(null)}
+      onSave={onSave}
+      saving={saving}
+      error={editing === service.service ? formError : null}
+    />
+  );
+
   return (
     <div className="h-full overflow-y-auto">
       <Header view={view} />
       <div className="space-y-3 px-4 pb-8">
         <Warnings view={view} />
 
-        {view.services.length === 0 && editing !== '__new__' && (
-          <div className="rounded-lg border border-dashed border-border bg-card px-4 py-8 text-center">
-            <Plug className="mx-auto h-8 w-8 text-muted-foreground/60" />
-            <h3 className="mt-3 text-sm font-semibold text-foreground">
-              No external services {view.detectionAvailable ? 'found' : 'known yet'}
-            </h3>
-            <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">
-              {view.detectionAvailable
-                ? 'The last generate saw no third-party API in this repo. Declare one by hand if TrueCourse cannot see it (a service reached through your own wrapper, say).'
-                : 'Detection has not run — this is not a claim that the repo has none. Run `truecourse guard generate` to detect the third parties it imports, or declare one by hand.'}
-            </p>
+        {relevant.length === 0 && editing !== '__new__' && <NothingRelevant view={view} />}
+
+        {relevant.map(card)}
+
+        {hidden.length > 0 && (
+          <div>
+            <button
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => setShowHidden((v) => !v)}
+            >
+              {showHidden ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+              {hidden.length}{' '}
+              {everyHiddenServiceWasDetected
+                ? 'detected in code, not needed by any flow'
+                : `${hidden.length === 1 ? 'service' : 'services'} not needed by any flow`}
+            </button>
+            {showHidden && <div className="mt-3 space-y-3">{hidden.map(card)}</div>}
           </div>
         )}
-
-        {view.services.map((service) => (
-          <ServiceCard
-            key={service.service}
-            service={service}
-            editing={editing === service.service}
-            onEdit={() => {
-              setFormError(null);
-              setEditing(editing === service.service ? null : service.service);
-            }}
-            onCancel={() => setEditing(null)}
-            onSave={onSave}
-            saving={saving}
-            error={editing === service.service ? formError : null}
-          />
-        ))}
 
         {editing === '__new__' ? (
           <div className="rounded-lg border border-border bg-card p-3">
@@ -226,22 +251,59 @@ function Header({ view }: { view: GuardExternalsView }) {
   );
 }
 
+/**
+ * The THREE distinct answers to "why is there nothing here" — they must never share
+ * a sentence, because they ask the user for three different things (run setup, run
+ * generate, nothing at all). The middle one is the first-run state: detection has
+ * seen the third parties, but which of them MATTERS is only knowable once generate
+ * binds flows to services.
+ */
+function NothingRelevant({ view }: { view: GuardExternalsView }) {
+  const body = !view.detectionAvailable
+    ? 'Nobody has looked yet — this is not a claim that the repo has none. Run `truecourse guard setup` to find the third parties it imports, or declare one by hand.'
+    : !view.generateAvailable
+      ? 'Which services matter is not known until `truecourse guard generate` binds flows to them. Nothing detected in the code is waiting on you yet.'
+      : 'The last generate bound no flow to a third party, so nothing here needs an account. Declare one by hand if TrueCourse cannot see it (a service reached through your own wrapper, say).';
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-card px-4 py-8 text-center">
+      <Plug className="mx-auto h-8 w-8 text-muted-foreground/60" />
+      <h3 className="mt-3 text-sm font-semibold text-foreground">
+        {!view.detectionAvailable
+          ? 'No external services known yet'
+          : !view.generateAvailable
+            ? 'Nothing needs an account yet'
+            : 'No flow depends on an external service'}
+      </h3>
+      <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">{body}</p>
+      {view.recipeValid && !view.hasApiBlock && (
+        // A recipe with no `api` block is a CLI-flavored repo working as designed, so
+        // it is stated, not warned about.
+        <p className="mx-auto mt-2 max-w-md text-xs text-muted-foreground" data-tone="info">
+          This repo’s recipe has no `api` driver, so external API accounts don’t apply here.
+        </p>
+      )}
+    </div>
+  );
+}
+
 /** Everything the page must say before the cards: broken files, no detection, orphan overlay entries. */
 function Warnings({ view }: { view: GuardExternalsView }) {
   const strips: { key: string; text: string }[] = [];
   if (view.invalidReason) strips.push({ key: 'invalid', text: view.invalidReason });
-  if (!view.hasApiBlock) {
+  // Only the ABSENT-or-broken recipe is amber. "Valid recipe, no api block" is the
+  // designed shape of a CLI repo, and {@link NothingRelevant} states it neutrally.
+  if (!view.hasApiBlock && !view.recipeValid) {
     strips.push({
       key: 'no-api',
-      text: view.recipeValid
-        ? 'recipe.json has no `api` block — external services configure the api driver, so the recipe needs one before an account can be saved.'
-        : 'No usable recipe.json yet — run `truecourse guard recipe --init` before declaring external services.',
+      text: 'No usable recipe.json yet — run `truecourse guard recipe --init` before declaring external services.',
     });
   }
   if (!view.detectionAvailable) {
     strips.push({
       key: 'no-detection',
-      text: 'No generate report yet, so detection has not run: only declared services are listed. Run `truecourse guard generate` to detect the third parties this repo imports.',
+      // Detection is `guard setup`'s pass, not generate's — pointing at generate sent
+      // users to the expensive command for something the cheap one does.
+      text: 'Detection has not run, so only declared services are listed. Run `truecourse guard setup` to detect the third parties this repo imports.',
     });
   }
   if (view.unknownLocalServices.length > 0) {
@@ -256,6 +318,7 @@ function Warnings({ view }: { view: GuardExternalsView }) {
       {strips.map((s) => (
         <div
           key={s.key}
+          data-tone="warning"
           className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300"
         >
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />

--- a/apps/dashboard/client/src/types/guard-externals.ts
+++ b/apps/dashboard/client/src/types/guard-externals.ts
@@ -79,6 +79,13 @@ export interface GuardExternalServiceView {
   evidence: { filePath: string; importSource?: string; url?: string }[];
   /** Overlay env keys the recipe never declared — ignored by the engine, surfaced here. */
   undeclaredLocalEnv: string[];
+  /**
+   * Whether the page shows this row BY DEFAULT: something is waiting on the service
+   * (a blocked flow, a scenario that scripts faults on it, a half-configured account)
+   * or a human touched its declaration. Detection alone is not enough — a repo can
+   * import twenty vendors and owe the user nothing until a flow needs one.
+   */
+  relevant: boolean;
 }
 
 /** The whole externals page in one read. */
@@ -91,6 +98,13 @@ export interface GuardExternalsView {
   hasApiBlock: boolean;
   /** False means "detection has not run", NOT "this repo has no third parties". */
   detectionAvailable: boolean;
+  /**
+   * True when a `guard generate` has run (its report, or the committed manifest a
+   * clone inherits). Without it, "nothing is relevant" only means the binding of
+   * flows to services has not happened yet — a different sentence entirely.
+   */
+  generateAvailable: boolean;
+  /** EVERY known service — the page filters on `relevant`, the payload never splits. */
   services: GuardExternalServiceView[];
   unknownLocalServices: string[];
 }

--- a/docs/SPEC_GUARD_PLAN.md
+++ b/docs/SPEC_GUARD_PLAN.md
@@ -5074,3 +5074,60 @@ ports → Opus; shared-branch git surgery → inline by the coordinating session
     The dashboard route returns the abort `reason` and the generate hook toasts an ERROR for
     ANY non-`ok` status — closing the pre-existing hole where `recipe-failed` also read as
     "wrote 0 scenarios".
+
+89. **#844 external APIs — relevance, not detection (decided 2026-08-04).** A fresh repo's first
+    `guard setup` listed EVERY outbound dependency the analyzer found (22 on this repo), each
+    reading "Detected but not declared in recipe.json — nothing is configured for it yet". None of
+    them needed anything: detection is an ENGINE fact about the code, declaration is a USER decision
+    that only becomes meaningful once a flow needs the service. The first-run user read 22 warnings
+    and had zero problems. STATUS: BUILT.
+
+    THE RELEVANCE RULE — one derivation in `packages/core/src/commands/guard-externals.ts`, a
+    `relevant: boolean` on `GuardExternalServiceView`. A row is relevant when ANY of: it has
+    `blockedFlows > 0`; a COMMITTED scenario names it in `setup.externals` (a test already depends on
+    it, and it survives in git); its state is `incomplete` (a run hard-stops on one, so it can never
+    be filtered out); or it is declared AND TOUCHED. `services` stays the SINGLE COMPLETE ARRAY —
+    `externalSetupIndex`, `readGuardExternalSetupIndex`, `guardNeedsSetupServices` and the `?gext=`
+    deep link all still see every service; the RENDERERS filter.
+
+    TOUCHED = a base URL (recipe or overlay), any declared `env` var or overlay env value, a `mode`,
+    or any overlay entry at all. NOT touched = `baseUrlEnv`, `endpoints` or `description` alone,
+    because `deriveExternalsSkeleton` auto-writes exactly those three for every detected service: a
+    bare skeleton row is informationally identical to a detected-only row and belongs in the same
+    bucket. Accepted residual, documented at the predicate and not fixed: a user who hand-adds ONLY
+    an extra endpoint URL stays hidden. The test is PURELY DERIVED rather than a stored flag because
+    `hashableRecipeText` strips only literal env `value`s, so any new recipe field would enter the
+    recipe fingerprint and re-author every section the service used to block — a UI preference must
+    never cost a regenerate.
+
+    THE CLONE-SAFE TALLY — `tallyBlockedFlows` now UNIONS two sources, because neither is a
+    superset of the other. The COMMITTED `scenarios/manifest.json` is the clone-safe half (its
+    per-flow `gaps[]` carry the same `kind`/`reason` shape, keyed by `flowId`); the gitignored
+    `guard/result.json` is the ONLY place CLAIM-level `blocked-on` gaps live — they are settled at
+    claim triage, before flows are synthesized, so they carry no `flowId` and can never reach the
+    flow-keyed manifest. Reading the manifest INSTEAD of the report (the first cut of this work)
+    silently lost every claim-level tally on any repo whose manifest had a gap — a false zero,
+    which is exactly the failure this item exists to remove. Both halves are the same generate's,
+    so a flow-keyed unit present in both dedups in the per-capability set (the same mechanism that
+    keeps "a flow blocked on one service across two surfaces counts once" true) and claim-level
+    units are purely additive. Adding the manifest fixes a real bug of its own: on a fresh clone the
+    report is absent, so every needs-setup CTA read "0 blocked" and vanished. `generateAvailable`
+    rides the view for the same reason: a clone has the manifest and no report, and "no generate has
+    run" and "no flow needs a service" are different sentences.
+
+    SURFACES. `guard externals` prints the relevant rows plus ONE footer line naming the hidden
+    count and `--all`; `--all` prints the hidden ones in their own block (never interleaved — that
+    recreates the wall); `--list` is unchanged; `guard status` shares the renderer with the bare
+    count and no `--all` to offer. `guard setup`'s `provisionExternals` stays UNFILTERED — it is
+    opt-in behind a confirm that defaults to No, and filtering it would make it a permanent no-op
+    before the first generate and print the false "every declared external API has an account" line
+    — but its prompt now says up front that none of them is needed until `guard generate` binds a
+    flow to one. The dashboard renders the relevant cards, folds the rest into a collapsed
+    disclosure that is deliberately NOT persisted (a fresh visit is always the quiet view; expanding
+    is the declare-ahead-of-need path and renders the SAME card), auto-expands it when `?gext=`
+    names a hidden service, and answers "nothing here" with THREE distinct empty states (no
+    detection yet / detected but no generate / generate ran and no flow depends on one). Two copy
+    fixes rode along: the no-detection pointers said `guard generate` when detection is `guard
+    setup`'s pass, and a VALID recipe with no `api` block (a CLI-flavored repo, by design) was an
+    amber warning — it is now neutral text in the empty state, with amber kept for the absent or
+    unreadable recipe it was written for.

--- a/packages/core/src/commands/guard-externals.ts
+++ b/packages/core/src/commands/guard-externals.ts
@@ -34,11 +34,16 @@ import {
   computeRecipeFingerprint,
   readGuardResult,
   readGuardSetup,
+  readManifest,
+  manifestPath,
+  loadScenarios,
   ExternalsError,
   type ExternalRequirement,
   type ExternalState,
   type ExternalsLocalFile,
+  type MergedExternal,
   type RecipeApiExternal,
+  type ResolvedExternal,
 } from '@truecourse/guard-runner';
 import {
   parseBlockedOnCapabilities,
@@ -104,6 +109,16 @@ export interface GuardExternalServiceView {
   evidence: { filePath: string; importSource?: string; url?: string }[];
   /** Overlay env keys under this service the recipe never declared — ignored, surfaced. */
   undeclaredLocalEnv: string[];
+  /**
+   * Whether a UI shows this row BY DEFAULT. Detection is an engine fact about the
+   * code — a repo can import twenty vendors and owe the user nothing — so a service
+   * only becomes the user's business once something is waiting on it. FOUR signals,
+   * any one of which is enough: a flow is blocked on it; a committed scenario names
+   * it in `setup.externals`; its account is `incomplete` (a run hard-stops on one);
+   * or its declaration was TOUCHED by a human (see {@link isTouched} — the skeleton
+   * `guard setup` auto-writes is not a touch).
+   */
+  relevant: boolean;
 }
 
 /** The whole externals page in one read. */
@@ -125,7 +140,20 @@ export interface GuardExternalsView {
    * a UI should say so rather than claim the repo has none.
    */
   detectionAvailable: boolean;
-  /** Declared services first (declaration order), then detected-only ones. */
+  /**
+   * True when a `guard generate` has run for this repo — either its (gitignored)
+   * report or the (committed) `scenarios/manifest.json` is on disk. It is what
+   * separates "no service is relevant because nothing has bound flows to services
+   * yet" from "no flow depends on an external service": a fresh CLONE has the
+   * manifest and no report, so the report alone would tell it the wrong story.
+   */
+  generateAvailable: boolean;
+  /**
+   * EVERY service this repo knows about — declared first (declaration order), then
+   * detected-only. Deliberately NOT split by {@link GuardExternalServiceView.relevant}:
+   * the needs-setup index, the `?gext=` deep link and the CLI's `--all` all need the
+   * whole list, so the payload stays complete and each renderer filters it.
+   */
   services: GuardExternalServiceView[];
   /** Overlay entries naming a service the recipe never declares — ignored, surfaced. */
   unknownLocalServices: string[];
@@ -156,7 +184,9 @@ export function readGuardExternalsView(repoRoot: string): GuardExternalsView {
   const setup = readGuardSetup(repoRoot);
   const detected = setup?.detection?.externalServices ?? report?.externalServices ?? [];
   const detectionAvailable = setup?.detection !== undefined || report !== null;
-  const blockedFlows = tallyBlockedFlows(report);
+  const blockedFlows = tallyBlockedFlows(repoRoot, report);
+  const generateAvailable = report !== null || fs.existsSync(manifestPath(repoRoot));
+  const scenarioBound = scenarioBoundServices(repoRoot);
 
   const recipe = readRecipeForView(recipeFile);
   if ('reason' in recipe) {
@@ -166,7 +196,8 @@ export function readGuardExternalsView(repoRoot: string): GuardExternalsView {
       invalidReason: recipe.reason,
       hasApiBlock: false,
       detectionAvailable,
-      services: detectedOnlyViews(detected, blockedFlows, new Set()),
+      generateAvailable,
+      services: detectedOnlyViews(detected, blockedFlows, scenarioBound, new Set()),
     };
   }
 
@@ -186,6 +217,7 @@ export function readGuardExternalsView(repoRoot: string): GuardExternalsView {
   const services: GuardExternalServiceView[] = merged.map((m) => {
     const resolved = resolveExternal(m, process.env);
     const hit = detectedByName.get(m.service);
+    const blocked = blockedFlows.get(m.service) ?? 0;
     return {
       service: m.service,
       detected: hit !== undefined,
@@ -203,9 +235,14 @@ export function readGuardExternalsView(repoRoot: string): GuardExternalsView {
       ...(resolved.mode ? { mode: resolved.mode } : {}),
       ...(resolved.description ? { description: resolved.description } : {}),
       requirements: resolved.requirements,
-      blockedFlows: blockedFlows.get(m.service) ?? 0,
+      blockedFlows: blocked,
       evidence: hit?.evidence.map((e) => ({ ...e })) ?? [],
       undeclaredLocalEnv: m.undeclaredLocalEnv,
+      relevant:
+        blocked > 0 ||
+        scenarioBound.has(m.service) ||
+        resolved.state === 'incomplete' ||
+        isTouched(m, resolved, local[m.service] !== undefined),
     };
   });
   const declaredNames = new Set(services.map((s) => s.service));
@@ -216,7 +253,11 @@ export function readGuardExternalsView(repoRoot: string): GuardExternalsView {
     invalidReason: overlayReason,
     hasApiBlock: recipe.recipe?.api !== undefined,
     detectionAvailable,
-    services: [...services, ...detectedOnlyViews(detected, blockedFlows, declaredNames)],
+    generateAvailable,
+    services: [
+      ...services,
+      ...detectedOnlyViews(detected, blockedFlows, scenarioBound, declaredNames),
+    ],
     unknownLocalServices: Object.keys(local)
       .filter((name) => !declaredNames.has(name))
       .sort(),
@@ -315,10 +356,62 @@ export function guardNeedsSetupServices(view: GuardExternalsView): GuardNeedsSet
     );
 }
 
+// ---------------------------------------------------------------------------
+// Relevance — the one derivation every renderer filters on.
+// ---------------------------------------------------------------------------
+
+/**
+ * Has a HUMAN said anything about this declaration? `guard setup`'s
+ * `deriveExternalsSkeleton` (in `@truecourse/guard-generator`) auto-writes exactly
+ * `baseUrlEnv`, `endpoints` and `description` for every detected service, so those
+ * three carry no intent whatsoever: a bare skeleton row is
+ * informationally identical to a detected-only row and belongs in the same bucket.
+ * What a person had to type is a base URL, an env var the service needs, the kind of
+ * account it is — or anything at all in the gitignored overlay.
+ *
+ * The test is PURELY DERIVED rather than a flag on the declaration on purpose:
+ * `hashableRecipeText` strips only literal env `value`s, so any new recipe field
+ * would enter the recipe fingerprint and re-author every section the service used to
+ * block — a UI preference must never cost a regenerate.
+ *
+ * Accepted residual: a user who hand-adds ONLY an extra endpoint URL (and nothing
+ * else) reads as untouched and stays hidden. Endpoints are the skeleton's own output,
+ * so there is no signal that separates the two, and the alternative — treating every
+ * auto-written endpoint as intent — is the wall of rows this rule exists to remove.
+ */
+function isTouched(
+  merged: MergedExternal,
+  resolved: ResolvedExternal,
+  hasOverlayEntry: boolean,
+): boolean {
+  return (
+    resolved.baseUrl !== undefined ||
+    merged.env.length > 0 ||
+    resolved.mode !== undefined ||
+    hasOverlayEntry ||
+    merged.endpoints.some((e) => e.source !== 'recipe')
+  );
+}
+
+/**
+ * The services the COMMITTED scenarios name in a `setup.externals` block. A scenario
+ * scripting faults on a vendor is the strongest possible statement that the vendor
+ * matters — stronger than a declaration, since a test already depends on it — and it
+ * survives in git, so a fresh clone sees it without running anything.
+ */
+function scenarioBoundServices(repoRoot: string): Set<string> {
+  const names = new Set<string>();
+  for (const scenario of loadScenarios(repoRoot).scenarios) {
+    for (const service of Object.keys(scenario.setup?.externals ?? {})) names.add(service);
+  }
+  return names;
+}
+
 /** The detected-but-undeclared services, in detection order — pure "you could provide these". */
 function detectedOnlyViews(
   detected: readonly DetectedExternalService[],
   blockedFlows: ReadonlyMap<string, number>,
+  scenarioBound: ReadonlySet<string>,
   declaredNames: ReadonlySet<string>,
 ): GuardExternalServiceView[] {
   return detected
@@ -341,6 +434,9 @@ function detectedOnlyViews(
       blockedFlows: blockedFlows.get(d.service) ?? 0,
       evidence: d.evidence.map((e) => ({ ...e })),
       undeclaredLocalEnv: [],
+      // Nothing is declared, so nothing can be touched: a detected-only service is
+      // relevant exactly when something is already waiting on it.
+      relevant: (blockedFlows.get(d.service) ?? 0) > 0 || scenarioBound.has(d.service),
     }));
 }
 
@@ -349,20 +445,48 @@ function detectedOnlyViews(
  * is per (flow, surface) and Phase 3 stamps the SERVICE name into its capability
  * segment, so the tally is over `parseBlockedOnCapabilities` — deduped by flow, so
  * a flow blocked on one service across two surfaces counts once.
+ *
+ * BOTH SOURCES, UNIONED — neither one is a superset of the other:
+ *   - the COMMITTED `scenarios/manifest.json` is the clone-safe half. A fresh clone
+ *     inherits the scenarios and their manifest but never the gitignored report, so a
+ *     report-only tally told every cloner that nothing was blocked and silently killed
+ *     its needs-setup CTAs. Its per-flow `gaps[]` carry the same `kind`/`reason` shape,
+ *     keyed by `flowId`.
+ *   - `guard/result.json` is the ONLY place CLAIM-level `blocked-on` gaps live. They
+ *     are settled at claim triage, before flows are synthesized, so they carry no
+ *     `flowId` and can never reach the flow-keyed manifest; reading the manifest
+ *     INSTEAD of the report reports a false zero for a service blocked only there.
+ *
+ * Both halves are the same generate's, so a flow-keyed unit present in both dedups in
+ * the per-capability set — the same mechanism that makes "a flow blocked on one service
+ * across two surfaces counts once" true — and claim-level units are purely additive.
+ * A manifest written before gaps were recorded contributes nothing and the repo reads
+ * off the report alone.
  */
 function tallyBlockedFlows(
+  repoRoot: string,
   report: ReturnType<typeof readGuardResult>,
 ): Map<string, number> {
+  const gaps = [
+    ...(readManifest(repoRoot)?.flows ?? []).flatMap((flow) =>
+      flow.gaps.map((gap) => ({ unit: flow.flowId, kind: gap.kind, reason: gap.reason })),
+    ),
+    ...(report?.coverageGaps ?? []).map((gap) => ({
+      // A claim-level gap carries no flowId — key on the section it pivots on so
+      // each distinct blocked unit still counts exactly once.
+      unit: gap.flowId ?? `${gap.doc}\0${gap.anchor}`,
+      kind: gap.kind,
+      reason: gap.reason,
+    })),
+  ];
+
   const seen = new Map<string, Set<string>>();
-  for (const gap of report?.coverageGaps ?? []) {
+  for (const gap of gaps) {
     if (gap.kind !== 'blocked-on') continue;
-    // A claim-level gap carries no flowId — key on the section it pivots on so
-    // each distinct blocked unit still counts exactly once.
-    const unit = gap.flowId ?? `${gap.doc}\0${gap.anchor}`;
     for (const capability of parseBlockedOnCapabilities(gap.reason)) {
       let flows = seen.get(capability);
       if (!flows) seen.set(capability, (flows = new Set()));
-      flows.add(unit);
+      flows.add(gap.unit);
     }
   }
   return new Map([...seen].map(([capability, flows]) => [capability, flows.size]));

--- a/tests/cli/guard-externals.test.ts
+++ b/tests/cli/guard-externals.test.ts
@@ -165,6 +165,9 @@ describe('guard externals — the read-only view', () => {
 
   // Detection is SETUP's, not generate's — the whole point being that this
   // page works before a single extraction call has been paid for.
+  // …under `--all`: a detected service no flow needs is not the default view's
+  // business (see the relevance block below), but the detection SOURCE is what this
+  // asserts, and `--all` is where the whole list lives.
   it('shows a detected-but-undeclared service from the `guard setup` record alone', async () => {
     const r = repo()
     writeSetupDetection(r, {
@@ -174,7 +177,7 @@ describe('guard externals — the read-only view', () => {
       baseUrlEnv: 'FORECAST_BASE_URL',
     })
 
-    await runGuardExternals({ cwd: r, list: true })
+    await runGuardExternals({ cwd: r, all: true })
 
     expect(text()).toContain('open-meteo')
     expect(text()).toContain('not declared in recipe.json')
@@ -191,7 +194,7 @@ describe('guard externals — the read-only view', () => {
       evidence: [{ filePath: 'src/pay.ts', importSource: 'stripe' }],
     })
 
-    await runGuardExternals({ cwd: r, list: true })
+    await runGuardExternals({ cwd: r, all: true })
 
     expect(text()).toContain('stripe')
     expect(text()).not.toContain('no detection yet')
@@ -204,5 +207,97 @@ describe('guard externals — the read-only view', () => {
     await runGuardExternals({ cwd: r, list: true })
 
     expect(text()).toContain('truecourse guard setup')
+  })
+})
+
+/**
+ * The DEFAULT view is the services something is waiting on. A first `guard setup` on
+ * a real repo detects dozens of vendors and none of them owes the user anything yet,
+ * so the wall of "detected but not declared" rows is one counted line instead.
+ */
+describe('guard externals — relevance', () => {
+  /** Detection of two vendors, one of which a flow is blocked on. */
+  function twoVendors(r: string): void {
+    writeSetupDetection(
+      r,
+      { service: 'stripe', category: 'payment', evidence: [{ filePath: 'src/pay.ts', importSource: 'stripe' }] },
+      { service: 'open-meteo', source: 'http', evidence: [{ filePath: 'src/geo.ts', url: 'https://api.open-meteo.com' }] },
+    )
+    const manifest = path.join(r, '.truecourse', 'scenarios', 'manifest.json')
+    fs.mkdirSync(path.dirname(manifest), { recursive: true })
+    fs.writeFileSync(
+      manifest,
+      JSON.stringify(
+        {
+          version: 2,
+          flows: [
+            {
+              flowId: 'f1',
+              flowFingerprint: 'sha256:flow',
+              bindings: [],
+              scenarios: [],
+              journeys: [],
+              generationInputsHash: null,
+              gaps: [{ surface: 'api', kind: 'blocked-on', reason: 'blocked on stripe: pay' }],
+            },
+          ],
+        },
+        null,
+        2,
+      ) + '\n',
+    )
+  }
+
+  it('prints only the services a flow is waiting on, and counts the rest in one line', async () => {
+    const r = repo()
+    twoVendors(r)
+
+    await runGuardExternals({ cwd: r })
+
+    expect(text()).toContain('stripe')
+    expect(text()).toContain('1 blocked flow')
+    expect(text()).not.toContain('open-meteo')
+    expect(text()).toContain('1 more detected in code, not needed by any flow')
+    expect(text()).toContain('truecourse guard externals --all')
+  })
+
+  it('--all prints the hidden ones in their own block, never back among the rest', async () => {
+    const r = repo()
+    twoVendors(r)
+
+    await runGuardExternals({ cwd: r, all: true })
+
+    expect(text()).toContain('detected, not needed by any flow')
+    expect(text()).toContain('open-meteo')
+    // The hidden block replaces the count line — the same rows are not summarized twice.
+    expect(text()).not.toContain('more detected in code')
+  })
+
+  it('--list is still the default view — an old script sees no new rows', async () => {
+    const r = repo()
+    twoVendors(r)
+
+    await runGuardExternals({ cwd: r, list: true })
+
+    expect(text()).toContain('stripe')
+    expect(text()).not.toContain('open-meteo')
+    expect(text()).toContain('1 more detected in code, not needed by any flow')
+  })
+
+  it('does not claim a hidden hand declaration was detected in code', async () => {
+    const r = repo({
+      serve: ['node', 'dist/index.js'],
+      externals: {
+        manual: {
+          baseUrlEnv: 'MANUAL_BASE_URL',
+          description: 'declared ahead of detection',
+        },
+      },
+    })
+
+    await runGuardExternals({ cwd: r })
+
+    expect(text()).toContain('1 service not needed by any flow')
+    expect(text()).not.toContain('detected in code')
   })
 })

--- a/tests/cli/guard-setup.test.ts
+++ b/tests/cli/guard-setup.test.ts
@@ -282,7 +282,10 @@ describe('runGuardSetup', () => {
       }),
     });
 
-    expect(text()).toMatch(/1 external API has no account yet\. Provide one now\?/);
+    // The offer is real (declaring EARLY is the free moment, before the expensive
+    // generate) but it is not a chore: the prompt says so before it asks.
+    expect(text()).toMatch(/1 detected external API has no account\./);
+    expect(text()).toMatch(/None is needed until `guard generate` binds a flow to one/);
     const recipe = JSON.parse(fs.readFileSync(recipePath(r), 'utf-8'));
     expect(recipe.api.externals.stripe.baseUrlEnv).toBe('STRIPE_BASE_URL');
     expect(recipe.api.externals.stripe.baseUrl).toBeUndefined();

--- a/tests/core/guard-externals.test.ts
+++ b/tests/core/guard-externals.test.ts
@@ -71,6 +71,48 @@ function writeReport(r: string, report: Partial<GuardGenerateReport> = {}): void
   });
 }
 
+/** Detection as `guard setup` records it — the source that needs no generate. */
+function writeDetection(r: string, ...services: Record<string, unknown>[]): void {
+  writeJson(path.join(r, '.truecourse', 'guard', 'setup.json'), {
+    ranAt: '2026-08-04T00:00:00Z',
+    status: 'ok',
+    recipe: { status: 'ok', outcome: 'exists' },
+    detection: { externalServices: services, database: null, datastoreUrls: [] },
+  });
+}
+
+/** The COMMITTED binding record — the clone-safe source of the blocked-flow tally. */
+function writeManifest(r: string, flows: Record<string, unknown>[]): void {
+  writeJson(path.join(r, '.truecourse', 'scenarios', 'manifest.json'), { version: 2, flows });
+}
+
+/** One manifest flow with per-surface gaps and nothing else the tally reads. */
+function manifestFlow(flowId: string, gaps: { kind: string; reason: string }[]): Record<string, unknown> {
+  return {
+    flowId,
+    flowFingerprint: 'sha256:flow',
+    bindings: [],
+    scenarios: [],
+    journeys: [],
+    generationInputsHash: null,
+    gaps: gaps.map((g) => ({ surface: 'api', ...g })),
+  };
+}
+
+/** A committed api scenario whose `setup.externals` scripts faults on `service`. */
+function writeScenarioBinding(r: string, service: string): void {
+  writeJson(path.join(r, '.truecourse', 'scenarios', 'api', `${service}.yaml`), {
+    guard: 2,
+    id: `flow.${service}`,
+    title: `uses ${service}`,
+    binds: [{ doc: 'docs/a.md', section: 'x', fingerprint: 'sha256:section' }],
+    driver: 'api',
+    setup: { externals: { [service]: { calls: 1 } } },
+    steps: [{ request: { method: 'GET', path: '/x' }, expect: { status: 200 } }],
+    normalize: [],
+  });
+}
+
 describe('readGuardExternalsView', () => {
   it('is an honest empty view on a repo with no recipe and no report', () => {
     const r = repo();
@@ -226,6 +268,225 @@ describe('readGuardExternalsView', () => {
     expect(view.recipeValid).toBe(false);
     expect(view.invalidReason).toContain('recipe.json');
     expect(view.services.map((s) => s.service)).toEqual(['stripe']);
+  });
+});
+
+/**
+ * RELEVANCE — the one derivation every renderer filters on. Detection is an engine
+ * fact about the code; whether a service MATTERS is only knowable once a flow needs
+ * it, so the default view is the services something is actually waiting on.
+ */
+describe('the relevance rule', () => {
+  const relevance = (r: string): Record<string, boolean> =>
+    Object.fromEntries(readGuardExternalsView(r).services.map((s) => [s.service, s.relevant]));
+
+  it('is false for a detected service nothing needs — a first run has no chores', () => {
+    const r = repo();
+    writeJson(recipeFile(r), baseRecipe());
+    writeReport(r, {
+      externalServices: [{ service: 'stripe', category: 'payment', evidence: [] }],
+    });
+    expect(relevance(r)).toEqual({ stripe: false });
+  });
+
+  it('is true for a service a flow is blocked on', () => {
+    const r = repo();
+    writeJson(recipeFile(r), baseRecipe());
+    writeReport(r, {
+      externalServices: [
+        { service: 'stripe', evidence: [] },
+        { service: 'open-meteo', evidence: [] },
+      ],
+      coverageGaps: [
+        { doc: 'docs/a.md', anchor: 'x', kind: 'blocked-on', reason: 'blocked on stripe: pay', flowId: 'f1' },
+      ],
+    });
+    expect(relevance(r)).toEqual({ stripe: true, 'open-meteo': false });
+  });
+
+  it('is true for a service a committed scenario scripts faults on', () => {
+    const r = repo();
+    writeJson(recipeFile(r), baseRecipe());
+    writeReport(r, {
+      externalServices: [
+        { service: 'stripe', evidence: [] },
+        { service: 'open-meteo', evidence: [] },
+      ],
+    });
+    writeScenarioBinding(r, 'stripe');
+    expect(relevance(r)).toEqual({ stripe: true, 'open-meteo': false });
+  });
+
+  // The skeleton `guard setup` auto-writes is baseUrlEnv + endpoints + description
+  // for EVERY detected service, so none of those three carries user intent: a bare
+  // skeleton row says exactly what a detected-only row says.
+  it('is false for an untouched skeleton declaration — endpoints and description are auto-written', () => {
+    const r = repo();
+    writeJson(
+      recipeFile(r),
+      baseRecipe({
+        stripe: {
+          baseUrlEnv: 'STRIPE_BASE_URL',
+          endpoints: { STRIPE_FILES_BASE_URL: 'https://files.stripe.com' },
+          description: 'detected in src/pay.ts',
+        },
+      }),
+    );
+    writeReport(r, { externalServices: [{ service: 'stripe', evidence: [] }] });
+    expect(relevance(r)).toEqual({ stripe: false });
+  });
+
+  it('is true the moment the declaration is TOUCHED — a base URL, an env var, or a mode', () => {
+    const withBaseUrl = repo();
+    writeJson(recipeFile(withBaseUrl), baseRecipe({ stripe: { baseUrlEnv: 'B', baseUrl: 'https://s.test' } }));
+    expect(relevance(withBaseUrl)).toEqual({ stripe: true });
+
+    const withEnv = repo();
+    writeJson(recipeFile(withEnv), baseRecipe({ stripe: { baseUrlEnv: 'B', env: { STRIPE_KEY: {} } } }));
+    expect(relevance(withEnv)).toEqual({ stripe: true });
+
+    // `mode` says WHICH world this account is — nothing auto-writes it.
+    const withMode = repo();
+    writeJson(recipeFile(withMode), baseRecipe({ stripe: { baseUrlEnv: 'B', mode: 'sandbox' } }));
+    expect(relevance(withMode)).toEqual({ stripe: true });
+  });
+
+  it('is true when the local overlay carries anything at all for the service', () => {
+    const r = repo();
+    writeJson(recipeFile(r), baseRecipe({ stripe: { baseUrlEnv: 'STRIPE_BASE_URL' } }));
+    writeJson(localFile(r), { stripe: { endpoints: { STRIPE_BASE_URL: 'https://sandbox.stripe.test' } } });
+    expect(relevance(r)).toEqual({ stripe: true });
+  });
+
+  // `incomplete` hard-stops a guard run, so it can never be filtered out of a view —
+  // the signal is independent of the touch test that (today) also catches it.
+  it('is true for an incomplete account, whatever else is true of it', () => {
+    const r = repo();
+    writeJson(
+      recipeFile(r),
+      baseRecipe({ stripe: { baseUrlEnv: 'B', env: { STRIPE_KEY: { valueFromEnv: 'TC_UNSET_KEY_89' } } } }),
+    );
+    writeJson(localFile(r), { stripe: { baseUrl: 'https://sandbox.stripe.test' } });
+    const view = readGuardExternalsView(r);
+    expect(view.services[0].state).toBe('incomplete');
+    expect(view.services[0].relevant).toBe(true);
+  });
+
+  it('keeps `services` the COMPLETE list — the renderers filter, the payload never splits', () => {
+    const r = repo();
+    writeJson(recipeFile(r), baseRecipe({ stripe: { baseUrlEnv: 'STRIPE_BASE_URL' } }));
+    writeReport(r, {
+      externalServices: [
+        { service: 'stripe', evidence: [] },
+        { service: 'open-meteo', evidence: [] },
+      ],
+    });
+    const view = readGuardExternalsView(r);
+    expect(view.services.map((s) => s.service)).toEqual(['stripe', 'open-meteo']);
+    // …and the needs-setup index still sees every one of them.
+    expect(Object.keys(readGuardExternalSetupIndex(r))).toEqual(['stripe', 'open-meteo']);
+  });
+});
+
+/**
+ * The blocked tally reads the COMMITTED manifest first: `guard/result.json` is
+ * gitignored, so a fresh clone has the scenarios and the manifest but no report.
+ */
+describe('the clone-safe blocked-flow tally and generateAvailable', () => {
+  it('tallies blocked flows from the manifest with no generate report present', () => {
+    const r = repo();
+    writeJson(recipeFile(r), baseRecipe());
+    writeDetection(r, { service: 'stripe', evidence: [] }, { service: 'open-meteo', evidence: [] });
+    writeManifest(r, [
+      manifestFlow('f1', [{ kind: 'blocked-on', reason: 'blocked on stripe: pay' }]),
+      manifestFlow('f2', [{ kind: 'blocked-on', reason: 'blocked on stripe, open-meteo: forecast' }]),
+    ]);
+    const view = readGuardExternalsView(r);
+    expect(view.generateAvailable).toBe(true);
+    expect(view.services.map((s) => [s.service, s.blockedFlows, s.relevant])).toEqual([
+      ['stripe', 2, true],
+      ['open-meteo', 1, true],
+    ]);
+  });
+
+  it('counts a flow blocked on one service across two surfaces exactly once', () => {
+    const r = repo();
+    writeJson(recipeFile(r), baseRecipe());
+    writeDetection(r, { service: 'stripe', evidence: [] });
+    writeManifest(r, [
+      {
+        ...manifestFlow('f1', [{ kind: 'blocked-on', reason: 'blocked on stripe: pay' }]),
+        gaps: [
+          { surface: 'api', kind: 'blocked-on', reason: 'blocked on stripe: pay' },
+          { surface: 'cli', kind: 'blocked-on', reason: 'blocked on stripe: pay' },
+        ],
+      },
+    ]);
+    expect(readGuardExternalsView(r).services[0].blockedFlows).toBe(1);
+  });
+
+  // A CLAIM-level `blocked-on` gap is settled at claim triage, before flows exist, so
+  // it carries no flowId and can never reach the flow-keyed manifest. The report is
+  // the ONLY place it lives: reading the manifest INSTEAD of the report reports a
+  // false zero for a service blocked only there — no count, no needs-setup CTA, and
+  // (under the relevance rule) no row at all.
+  it('unions the report in: a claim-level gap still counts beside flow-level manifest gaps', () => {
+    const r = repo();
+    writeJson(recipeFile(r), baseRecipe());
+    writeDetection(r, { service: 'stripe', evidence: [] }, { service: 'open-meteo', evidence: [] });
+    writeManifest(r, [manifestFlow('f1', [{ kind: 'blocked-on', reason: 'blocked on stripe: pay' }])]);
+    writeReport(r, {
+      coverageGaps: [
+        { doc: 'docs/a.md', anchor: 'forecast', kind: 'blocked-on', reason: 'blocked on open-meteo: forecast' },
+      ],
+    });
+    expect(readGuardExternalsView(r).services.map((s) => [s.service, s.blockedFlows, s.relevant])).toEqual([
+      ['stripe', 1, true],
+      ['open-meteo', 1, true],
+    ]);
+  });
+
+  it('counts a flow once when the manifest and the report both name it — the union dedups', () => {
+    const r = repo();
+    writeJson(recipeFile(r), baseRecipe());
+    writeDetection(r, { service: 'stripe', evidence: [] });
+    writeManifest(r, [manifestFlow('f1', [{ kind: 'blocked-on', reason: 'blocked on stripe: pay' }])]);
+    // Both halves are the same generate's, so the flow-keyed unit is the same unit.
+    writeReport(r, {
+      coverageGaps: [
+        { doc: 'docs/a.md', anchor: 'pay', kind: 'blocked-on', reason: 'blocked on stripe: pay', flowId: 'f1' },
+      ],
+    });
+    expect(readGuardExternalsView(r).services[0].blockedFlows).toBe(1);
+  });
+
+  it('falls back to the report for a manifest written before gaps were recorded', () => {
+    const r = repo();
+    writeJson(recipeFile(r), baseRecipe());
+    writeManifest(r, [manifestFlow('f1', [])]);
+    writeReport(r, {
+      externalServices: [{ service: 'stripe', evidence: [] }],
+      coverageGaps: [
+        { doc: 'docs/a.md', anchor: 'x', kind: 'blocked-on', reason: 'blocked on stripe: pay', flowId: 'f1' },
+      ],
+    });
+    expect(readGuardExternalsView(r).services[0]).toMatchObject({ service: 'stripe', blockedFlows: 1 });
+  });
+
+  it('reads generateAvailable from either artifact — the manifest alone, or the report alone', () => {
+    const manifestOnly = repo();
+    writeJson(recipeFile(manifestOnly), baseRecipe());
+    writeManifest(manifestOnly, []);
+    expect(readGuardExternalsView(manifestOnly).generateAvailable).toBe(true);
+
+    const reportOnly = repo();
+    writeJson(recipeFile(reportOnly), baseRecipe());
+    writeReport(reportOnly);
+    expect(readGuardExternalsView(reportOnly).generateAvailable).toBe(true);
+
+    const neither = repo();
+    writeJson(recipeFile(neither), baseRecipe());
+    expect(readGuardExternalsView(neither).generateAvailable).toBe(false);
   });
 });
 

--- a/tests/dashboard-client/guard-externals.test.tsx
+++ b/tests/dashboard-client/guard-externals.test.tsx
@@ -37,6 +37,7 @@ const BASE: GuardExternalsView = {
   invalidReason: null,
   hasApiBlock: true,
   detectionAvailable: true,
+  generateAvailable: true,
   services: [],
   unknownLocalServices: [],
 };
@@ -67,6 +68,7 @@ const STRIPE: GuardExternalsView['services'][number] = {
   blockedFlows: 3,
   evidence: [{ filePath: 'src/billing/charge.ts', importSource: 'stripe' }],
   undeclaredLocalEnv: [],
+  relevant: true,
 };
 
 const OPEN_METEO: GuardExternalsView['services'][number] = {
@@ -84,6 +86,7 @@ const OPEN_METEO: GuardExternalsView['services'][number] = {
   blockedFlows: 1,
   evidence: [{ filePath: 'src/weather.ts', importSource: 'https://api.open-meteo.com' }],
   undeclaredLocalEnv: [],
+  relevant: true,
 };
 
 /**
@@ -179,8 +182,10 @@ describe('GuardExternalsPane — reading', () => {
 
     render(<GuardExternalsPane repoId="r" />);
 
-    expect(await screen.findByText(/No generate report yet/)).toBeInTheDocument();
+    // Detection is `guard setup`'s job, not generate's — the pointer must name it.
+    expect(await screen.findByText(/Detection has not run/)).toBeInTheDocument();
     expect(screen.getByText(/No external services known yet/)).toBeInTheDocument();
+    expect(screen.getAllByText(/truecourse guard setup/).length).toBeGreaterThan(0);
     // Manual declaration is still offered.
     expect(screen.getByRole('button', { name: /Add service/ })).toBeInTheDocument();
   });
@@ -199,12 +204,113 @@ describe('GuardExternalsPane — reading', () => {
     expect(screen.getByText(/STRIPE_EXTRA/)).toBeInTheDocument();
   });
 
-  it('says the recipe needs an api block before an account can be saved', async () => {
+  // A recipe with no `api` block is a CLI-flavored repo working as designed, not a
+  // problem — the amber strip is for a recipe that is ABSENT or broken.
+  it('reads a valid recipe with no api driver as neutral information, never a warning', async () => {
     stubFetch({ ...BASE, hasApiBlock: false });
 
     render(<GuardExternalsPane repoId="r" />);
 
-    expect(await screen.findByText(/no `api` block/)).toBeInTheDocument();
+    const note = await screen.findByText(/no `api` driver/);
+    expect(note.closest('[data-tone]')?.getAttribute('data-tone')).not.toBe('warning');
+  });
+
+  it('keeps the amber strip for a recipe that is absent or unreadable', async () => {
+    stubFetch({ ...BASE, hasApiBlock: false, recipeValid: false });
+
+    render(<GuardExternalsPane repoId="r" />);
+
+    const strip = await screen.findByText(/No usable recipe.json yet/);
+    expect(strip.closest('[data-tone]')?.getAttribute('data-tone')).toBe('warning');
+  });
+});
+
+/**
+ * RELEVANCE — the first-run quiet view. Detection is an engine fact about the code;
+ * a service only becomes the user's business once a flow needs it, so the page shows
+ * the relevant ones and folds the rest into one collapsed disclosure.
+ */
+describe('GuardExternalsPane — the services no flow needs', () => {
+  const HIDDEN = { ...OPEN_METEO, service: 'sendgrid', blockedFlows: 0, relevant: false };
+  const HIDDEN_DECLARATION = { ...HIDDEN, detected: false, declared: true };
+
+  it('renders only the relevant cards, with the rest behind a collapsed disclosure', async () => {
+    stubFetch({ ...BASE, services: [STRIPE, HIDDEN] });
+
+    render(<GuardExternalsPane repoId="r" />);
+
+    expect(await screen.findByText('stripe')).toBeInTheDocument();
+    expect(screen.queryByText('sendgrid')).not.toBeInTheDocument();
+    expect(screen.getByText(/1 detected in code, not needed by any flow/)).toBeInTheDocument();
+  });
+
+  it('reveals the same card — the force-declare-ahead-of-need path — when expanded', async () => {
+    stubFetch({ ...BASE, services: [STRIPE, HIDDEN] });
+    const user = userEvent.setup();
+
+    render(<GuardExternalsPane repoId="r" />);
+
+    await user.click(await screen.findByText(/1 detected in code, not needed by any flow/));
+    expect(screen.getByText('sendgrid')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Provide account' })).toBeInTheDocument();
+  });
+
+  it('does not claim a hidden hand declaration was detected in code', async () => {
+    stubFetch({ ...BASE, services: [HIDDEN_DECLARATION] });
+
+    render(<GuardExternalsPane repoId="r" />);
+
+    expect(await screen.findByText('1 service not needed by any flow')).toBeInTheDocument();
+    expect(screen.queryByText(/detected in code/)).not.toBeInTheDocument();
+  });
+
+  it('a `?gext=` CTA for a hidden service expands the disclosure and opens its form', async () => {
+    stubFetch({ ...BASE, services: [STRIPE, HIDDEN] });
+
+    render(
+      <GuardExternalsPane repoId="r" />,
+      '/repos/r?section=guard&tab=externals&gext=sendgrid',
+    );
+
+    expect(await screen.findByText('sendgrid')).toBeInTheDocument();
+    expect(screen.getByLabelText('Base URL env var')).toHaveValue('OPEN_METEO_BASE_URL');
+  });
+
+  it('does not persist the disclosure — a fresh visit is always the quiet view', async () => {
+    stubFetch({ ...BASE, services: [STRIPE, HIDDEN] });
+    const user = userEvent.setup();
+
+    const { unmount } = render(<GuardExternalsPane repoId="r" />);
+    await user.click(await screen.findByText(/1 detected in code, not needed by any flow/));
+    expect(screen.getByText('sendgrid')).toBeInTheDocument();
+    unmount();
+
+    render(<GuardExternalsPane repoId="r" />);
+    await screen.findByText('stripe');
+    expect(screen.queryByText('sendgrid')).not.toBeInTheDocument();
+  });
+
+  // The three empty states answer three different questions, so they must never
+  // share a sentence: "we have not looked", "we have not asked", "nobody needs one".
+  it('separates "no detection yet" from "no generate yet" from "no flow needs one"', async () => {
+    stubFetch({ ...BASE, detectionAvailable: false, generateAvailable: false });
+    const { unmount } = render(<GuardExternalsPane repoId="r" />);
+    expect(await screen.findByText(/No external services known yet/)).toBeInTheDocument();
+    unmount();
+
+    stubFetch({ ...BASE, generateAvailable: false, services: [HIDDEN] });
+    const second = render(<GuardExternalsPane repoId="r" />);
+    expect(await screen.findByText(/binds flows to them/)).toBeInTheDocument();
+    expect(screen.queryByText(/No external services known yet/)).not.toBeInTheDocument();
+    // The hidden ones are still one click away.
+    expect(screen.getByText(/1 detected in code, not needed by any flow/)).toBeInTheDocument();
+    second.unmount();
+
+    stubFetch({ ...BASE, generateAvailable: true, services: [HIDDEN] });
+    render(<GuardExternalsPane repoId="r" />);
+    expect(await screen.findByText(/No flow depends on an external service/)).toBeInTheDocument();
+    expect(screen.queryByText(/binds flows to them/)).not.toBeInTheDocument();
+    expect(screen.getByText(/1 detected in code, not needed by any flow/)).toBeInTheDocument();
   });
 });
 

--- a/tests/server/guard-externals-routes.test.ts
+++ b/tests/server/guard-externals-routes.test.ts
@@ -63,8 +63,34 @@ describe('Guard externals routes', () => {
       services: [],
       recipeValid: false,
       detectionAvailable: false,
+      generateAvailable: false,
       unknownLocalServices: [],
     });
+  });
+
+  // The page filters on these two, so a route that drops them renders every detected
+  // service as a chore again.
+  it('GET carries the relevance flag and generateAvailable over the wire', async () => {
+    writeJson(RECIPE, {
+      build: 'true',
+      api: {
+        serve: ['node', 'server.mjs'],
+        externals: {
+          // Touched by a human (a base URL) ⇒ relevant; skeleton-only ⇒ not.
+          'open-meteo': { baseUrlEnv: 'GEO_BASE', baseUrl: 'https://sandbox.test' },
+          stripe: { baseUrlEnv: 'STRIPE_BASE_URL', description: 'detected in src/pay.ts' },
+        },
+      },
+    });
+    writeJson('.truecourse/scenarios/manifest.json', { version: 2, flows: [] });
+
+    const res = await request(app).get(url()).expect(200);
+    expect(res.body.generateAvailable).toBe(true);
+    expect(
+      Object.fromEntries(
+        (res.body.services as { service: string; relevant: boolean }[]).map((s) => [s.service, s.relevant]),
+      ),
+    ).toEqual({ 'open-meteo': true, stripe: false });
   });
 
   it('GET joins the declaration with its resolution state', async () => {

--- a/tools/cli/src/commands/guard-externals.ts
+++ b/tools/cli/src/commands/guard-externals.ts
@@ -3,6 +3,14 @@
  *
  *   guard externals          the read-only view (what `--list` always printed)
  *   guard externals --list   the same thing, kept so existing scripts still work
+ *   guard externals --all    every detected service, hidden ones in their own block
+ *
+ * The DEFAULT is the RELEVANT services (core's `relevant` flag: blocked flows, a
+ * scenario that scripts faults on it, an incomplete account, or a declaration a human
+ * touched). Detection alone is an engine fact about the code, not a chore: a first
+ * setup on a real repo detects dozens of vendors and none of them needs anything until
+ * `guard generate` binds a flow to one, so they are counted in a single line rather
+ * than listed as a wall of warnings.
  *
  * Provisioning — picking a service and handing guard an account — moved into
  * `truecourse guard setup`. It has to: DECLARING a service is what enters the recipe
@@ -24,6 +32,8 @@ export interface RunGuardExternalsOptions {
   cwd?: string;
   /** Kept for compatibility — the view is now this command's only behaviour. */
   list?: boolean;
+  /** Print the services no flow needs too, in their own block. */
+  all?: boolean;
 }
 
 export async function runGuardExternals(opts: RunGuardExternalsOptions = {}): Promise<void> {
@@ -34,11 +44,13 @@ export async function runGuardExternals(opts: RunGuardExternalsOptions = {}): Pr
 
   if (view.invalidReason) p.log.error(view.invalidReason);
 
-  printExternalsView(view);
+  printExternalsView(view, { all: opts.all === true, offerAll: opts.all !== true });
   p.outro(
-    view.services.length > 0
+    view.services.some((s) => s.relevant)
       ? "Provide an account with `truecourse guard setup` — declaring a service there is what unblocks its flows."
-      : "Nothing to show.",
+      : view.services.length > 0
+        ? "Nothing here needs an account yet."
+        : "Nothing to show.",
   );
 }
 
@@ -46,15 +58,27 @@ export async function runGuardExternals(opts: RunGuardExternalsOptions = {}): Pr
 // The read-only rendering — shared with `guard status`.
 // ---------------------------------------------------------------------------
 
+export interface PrintExternalsOptions {
+  /** List the irrelevant services too, under their own heading. */
+  all?: boolean;
+  /** Name `--all` in the hidden-count line — only `guard externals` has that flag. */
+  offerAll?: boolean;
+}
+
 /**
- * One line per service: `<name>  <state> · <detail>`, declared services first.
- * `unprovided` is the honest default (its flows stay blocked); `incomplete` is the
- * one that needs action — a run stops on it — so its unmet requirements are named.
+ * One line per RELEVANT service: `<name>  <state> · <detail>`, declared services
+ * first. `unprovided` is the honest default (its flows stay blocked); `incomplete` is
+ * the one that needs action — a run stops on it — so its unmet requirements are named.
  *
- * `guard status` renders the same block (its externals footprint), so the two
- * surfaces can never drift.
+ * The services no flow needs are one counted line, not rows: they are the same
+ * information a `detected` list already gave, and a first run has dozens of them.
+ * Under `--all` they get their own block instead — kept SEPARATE from the rows that
+ * matter, because interleaving them back is exactly the wall this removes.
+ *
+ * `guard status` renders the same block (its externals footprint) with no `--all` to
+ * offer, so the two surfaces can never drift on what they consider worth showing.
  */
-export function printExternalsView(view: GuardExternalsView): void {
+export function printExternalsView(view: GuardExternalsView, opts: PrintExternalsOptions = {}): void {
   if (view.services.length === 0) {
     p.log.info(
       view.detectionAvailable
@@ -63,8 +87,30 @@ export function printExternalsView(view: GuardExternalsView): void {
     );
     return;
   }
-  p.log.step(`externals   ${view.services.length} service${view.services.length === 1 ? "" : "s"}`);
-  for (const s of view.services) p.log.message(`    ${serviceLine(s)}`);
+
+  const relevant = view.services.filter((s) => s.relevant);
+  const hidden = view.services.filter((s) => !s.relevant);
+  const everyHiddenServiceWasDetected = hidden.every((s) => s.detected);
+  if (relevant.length > 0) {
+    p.log.step(`externals   ${relevant.length} service${relevant.length === 1 ? "" : "s"}`);
+    for (const s of relevant) p.log.message(`    ${serviceLine(s)}`);
+  }
+  if (hidden.length > 0) {
+    if (opts.all) {
+      p.log.step(
+        `${everyHiddenServiceWasDetected ? "detected, not needed by any flow" : "not needed by any flow"}   ${hidden.length}`,
+      );
+      for (const s of hidden) p.log.message(`    ${serviceLine(s)}`);
+    } else {
+      const inventory = everyHiddenServiceWasDetected
+        ? "detected in code, not needed by any flow"
+        : `${hidden.length === 1 ? "service" : "services"} not needed by any flow`;
+      p.log.message(
+        `    ${hidden.length} ${relevant.length > 0 ? "more " : ""}${inventory}` +
+          (opts.offerAll ? " — see them with `truecourse guard externals --all`" : ""),
+      );
+    }
+  }
   if (!view.detectionAvailable) {
     p.log.message(
       "    (no detection yet — run `truecourse guard setup`; only declared services are listed)",

--- a/tools/cli/src/commands/guard-setup-externals.ts
+++ b/tools/cli/src/commands/guard-setup-externals.ts
@@ -51,9 +51,16 @@ export async function provisionExternals(repoRoot: string): Promise<void> {
       return;
     }
 
+    // The count is DELIBERATELY not filtered to the relevant services (the read
+    // surfaces' rule): before the first generate nothing is relevant yet, so filtering
+    // would make this offer a permanent no-op and print the false "every declared
+    // external API has an account" line. What the wording must not do is read as N
+    // chores — it says up front that none of them is owed anything yet, and defaults
+    // to No — because declaring EARLY is the free moment (the recipe fingerprint moves
+    // once, before the expensive generate), which is the only reason to offer it here.
     const more = bail(
       await p.confirm({
-        message: `${pending.length} external API${pending.length === 1 ? " has" : "s have"} no account yet. Provide one now?`,
+        message: `${pending.length} detected external API${pending.length === 1 ? " has" : "s have"} no account. None is needed until \`guard generate\` binds a flow to one — provide one now?`,
         initialValue: false,
       }),
     );

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -439,8 +439,9 @@ guardCmd
   .command("externals")
   .description("Show the third-party APIs this repo depends on and how each resolves (read-only)")
   .option("--list", "Kept for compatibility — the view is this command's only behaviour")
+  .option("--all", "Also list the detected services no flow needs, in their own block")
   .action(async (options) => {
-    await runGuardExternals({ list: !!options.list });
+    await runGuardExternals({ list: !!options.list, all: !!options.all });
   });
 
 const guardFlowsCmd = guardCmd


### PR DESCRIPTION
Closes #844.

## What changed

- Derive a single `relevant` flag in core from blocked flows, committed scenario bindings, incomplete accounts, and human-touched declarations while keeping the complete service inventory available to every consumer.
- Union committed manifest gaps with the gitignored generate report for clone-safe blocked-flow counts, and expose clone-safe `generateAvailable` state.
- Quiet the default CLI and dashboard views: relevant services stay visible, the rest move behind `--all` or a collapsed disclosure, and hidden deep links still auto-expand.
- Preserve opt-in setup provisioning, add distinct pre/post-generate empty states, and correct stale detection/no-API copy.
- Document the behavior in the guard plan and README.

## Root cause

Detection was presented as user work before any flow established relevance. The blocked-flow tally also depended on the gitignored report, so fresh clones lost actionable counts even when committed scenarios existed.

## Validation

- `corepack pnpm build` — 21/21 tasks passed
- `corepack pnpm vitest run tests/cli/guard-externals.test.ts tests/core/guard-externals.test.ts tests/dashboard-client/guard-externals.test.tsx tests/server/guard-externals-routes.test.ts` — 79/79 tests passed
- Two-axis review against `main` and issue #844; the incorrect hidden-inventory label found during review was fixed test-first on the CLI and dashboard seams
