### PR TITLE
fix(guard-runner): wait for real stderr inactivity

### DIFF
--- a/packages/guard-runner/src/api/server.ts
+++ b/packages/guard-runner/src/api/server.ts
@@ -31,14 +31,13 @@ const HEALTH_ATTEMPT_TIMEOUT_MS = 2_000
 /** Grace between the stop SIGKILL and giving up on the close event. */
 const STOP_WAIT_MS = 5_000
 /**
- * Consecutive event-loop turns delivering NO child output that end a {@link
- * ApiServerHandle.drain}. Not a delay: a turn costs microseconds when the pipes
- * are quiet, and each one is a full loop iteration in which a readable pipe IS
- * read. The count only has to exceed the longest gap a child that is still
- * flushing can leave between chunks — measured at 7 turns with the host at 3×
- * CPU oversubscription, so 32 keeps a wide margin.
+ * Wall-clock inactivity that ends a {@link ApiServerHandle.drain}. Counting
+ * event-loop turns is not a flush barrier: the parent can race through dozens of
+ * `setImmediate` callbacks while the child is descheduled with accepted writes
+ * still waiting to reach its pipe. A real quiet window spans that scheduler gap
+ * and resets whenever either captured stream grows.
  */
-const DRAIN_QUIET_TURNS = 32
+const DRAIN_QUIET_MS = 25
 /**
  * Safety valve, never the mechanism: a server that writes to stderr without ever
  * pausing would otherwise keep a drain spinning. The barrier normally settles in
@@ -68,7 +67,7 @@ export interface ApiServerHandle {
    * The guarantee is over bytes the child has handed to the OS — a burst larger
    * than the pipe holds is still queued in the CHILD and is drained on a
    * best-effort basis (the barrier keeps reading while chunks keep arriving).
-   * Bounded by {@link DRAIN_QUIET_TURNS} / {@link DRAIN_CEILING_MS}; a closed
+   * Bounded by {@link DRAIN_QUIET_MS} / {@link DRAIN_CEILING_MS}; a closed
    * process returns immediately, its output already complete by construction.
    */
   drain(): Promise<void>
@@ -254,18 +253,14 @@ export async function spawnApiProcess(opts: StartApiServerOptions): Promise<Spaw
     if (exit) return
     const deadline = Date.now() + DRAIN_CEILING_MS
     let seen = stdout.length + stderr.length
-    let quiet = 0
-    do {
-      await new Promise((r) => setImmediate(r))
+    while (Date.now() < deadline) {
+      const remaining = deadline - Date.now()
+      await new Promise((r) => setTimeout(r, Math.min(DRAIN_QUIET_MS, remaining)))
       const now = stdout.length + stderr.length
-      if (now === seen) {
-        quiet += 1
-      } else {
-        seen = now
-        quiet = 0
-      }
       if (exit) return
-    } while (quiet < DRAIN_QUIET_TURNS && Date.now() < deadline)
+      if (now === seen) return
+      seen = now
+    }
   }
 
   const stop = async (): Promise<void> => {

--- a/tests/fixtures/guard-fixture-api/server.mjs
+++ b/tests/fixtures/guard-fixture-api/server.mjs
@@ -84,12 +84,15 @@ if (process.env.TC_HEALTH_FAIL) {
 }
 
 // TC_LOG_THEN_MARK=<file> (test control): write ONE stderr line and only then create
-// the marker file. A parent that observes the marker knows the line is already in the
-// pipe, so the runner's stdio flush barrier can be tested on a guaranteed state
-// rather than on a timing guess.
+// the marker file. A parent that observes the marker knows the write was accepted.
+// TC_LOG_RELEASE_MS optionally corks stderr for that long after the marker, modelling
+// a child that was descheduled while its accepted write was still being flushed.
 if (process.env.TC_LOG_THEN_MARK) {
+  const releaseMs = Number(process.env.TC_LOG_RELEASE_MS ?? 0)
+  if (releaseMs > 0) process.stderr.cork()
   console.error('drain-probe: stderr written before the marker file')
   fs.writeFileSync(process.env.TC_LOG_THEN_MARK, '1')
+  if (releaseMs > 0) setTimeout(() => process.stderr.uncork(), releaseMs)
 }
 
 // --- Concurrency instrumentation (test control) ------------------------------------

--- a/tests/guard-runner/api-server.test.ts
+++ b/tests/guard-runner/api-server.test.ts
@@ -157,15 +157,16 @@ describe('startApiServer', () => {
     // parent is free to run the response's continuation to completion before it ever
     // reads the pipe, and the failure is then assembled from an empty stderr.
     //
-    // The fixture writes its stderr line and only THEN the marker file, so spinning
-    // SYNCHRONOUSLY on the marker puts the parent in exactly that state with no timing
-    // assumption: the bytes are provably in the pipe and the loop provably has not run.
+    // The fixture accepts its stderr write and only THEN creates the marker file. It
+    // keeps the stream corked for 10ms after that, modelling the scheduler gap seen on
+    // the loaded Node 22 runner. A turn-count barrier races through that gap; a real
+    // inactivity window waits for the accepted write to arrive.
     const cwd = tempCwd()
     const marker = path.join(cwd, 'wrote-stderr.marker')
     const { server } = await spawnApiProcess({
       resolvedServe: [process.execPath, FIXTURE_API_SERVER],
       cwd,
-      env: { ...ENV, TC_LOG_THEN_MARK: marker },
+      env: { ...ENV, TC_LOG_THEN_MARK: marker, TC_LOG_RELEASE_MS: '10' },
       healthPath: '/health',
       readyTimeoutMs: 15_000,
     })


### PR DESCRIPTION
## Why

PR #845's Node 22 CI run exposed a scheduler-sensitive race in the API server stderr flush barrier. The barrier counted 32 quiet `setImmediate` turns, which can all complete while the child is descheduled with accepted stderr writes still pending. The failure excerpt then contains only the leading dump and misses the trailing error line.

## What

- Replace event-loop turn counting with a 25 ms wall-clock inactivity window.
- Reset the quiet window whenever captured stdout or stderr grows.
- Keep the existing 250 ms ceiling for continuously noisy servers.
- Extend the API fixture with a controlled delayed stderr flush and make the existing drain test deterministically reproduce the CI scheduling gap.

## Impact

Failed API guard steps now retain stderr that was accepted before the response even when the child is briefly descheduled. No public command, endpoint, configuration, or stored format changes.

## Validation

- `pnpm build`
- Node 22: `pnpm exec vitest run tests/guard-runner` — 696 passed
- Node 22 and Node 20: `pnpm exec vitest run tests/guard-runner/api-server.test.ts tests/guard-runner/api-run.test.ts` — 35 passed on each
- Node 22: deterministic drain regression repeated 20 times with concurrency 4

Follow-up test reliability fix for #845.
