### PR TITLE
feat(guard): add per-scenario pre-boot seed sidecars

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ truecourse spec scan                    # Curate docs → corpus (areas + overla
 truecourse spec conflicts list          # Review flagged overlaps (resolve with `spec conflicts resolve`)
 truecourse guard setup                  # Prepare the repo: recipe + external APIs + the data/auth seed (cheap)
 truecourse guard generate               # Author scenario tests from spec sections (classify → generate → birth-validate)
+# In CI/agent mode, generated executable sidecars require: --allow-seed-exec
 truecourse guard run                    # Run the committed scenarios; exits non-zero on any drift (CI gate)
 ```
 
@@ -224,7 +225,9 @@ Why it is a separate stage rather than something `guard generate` figures out: a
 
 It is idempotent: a bare re-run over a prepared repo reports and no-ops. `--refresh` re-derives, and replacing an existing seed script always asks first (in a non-TTY it refuses rather than clobber a hand-edited file). Output: `guard/setup.json` (the record + detection snapshot, gitignored), plus whatever it wrote to `recipe.json` and the seed script — both committable, both yours to review.
 
-**3. Guard generation** (`truecourse guard generate`) — Splits each kept doc into sections and, per section: **classifies** whether the section makes a claim a driver can assert (two drivers today — `cli` invokes your project's binary, `api` drives your HTTP service; a non-testable verdict carries a one-sentence reason and surfaces as a visible coverage gap), **authors** one or more declarative YAML scenarios from the section's claim plus the code, and **birth-validates** each one by running it immediately — the outcome becomes the test's status. Every authored test is committed, so a test that fails at birth (the spec and the code already disagree) lands as a **failing test** you can open, re-run, and resolve, not as a separate species of report entry. Output, all committable: `.truecourse/scenarios/<area>/*.yaml` (the scenarios), `scenarios/recipe.json` (how to build/prepare the repo for a run), and `scenarios/manifest.json` (section ↔ scenario bindings + section fingerprints, so re-generates only touch changed sections).
+**3. Guard generation** (`truecourse guard generate`) — Splits each kept doc into sections and, per section: **classifies** whether the section makes a claim a driver can assert (two drivers today — `cli` invokes your project's binary, `api` drives your HTTP service; a non-testable verdict carries a one-sentence reason and surfaces as a visible coverage gap), **authors** one or more declarative YAML scenarios from the section's claim plus the code, and **birth-validates** each one by running it immediately — the outcome becomes the test's status. Every authored test is committed, so a test that fails at birth (the spec and the code already disagree) lands as a **failing test** you can open, re-run, and resolve, not as a separate species of report entry. Output, all committable: `.truecourse/scenarios/<area>/*.yaml` (the scenarios), optional adjacent `*.seed.mjs` pre-boot sidecars, `scenarios/recipe.json` (how to build/prepare the repo for a run), and `scenarios/manifest.json` (section ↔ scenario bindings + section fingerprints, so re-generates only touch changed sections).
+
+Generated sidecars are executable repository code, so authority is separate from the LLM-cost prompt. Interactive generation prints one batch summary (path, declared outputs, repository-module vs direct-datastore access) and asks once before birth executes any sidecar. Non-interactive generation refuses unless `--allow-seed-exec` is present; `-y/--yes` approves only estimated LLM spend. Refusal executes and writes neither member of the pair and leaves existing scenario artifacts and generation hashes unchanged.
 
 Two authoring guarantees ride generation: a section's own **worked example** (a fenced block) is seeded into its test **byte-for-byte** — never paraphrased, the engine byte-checks the committed scenario against the doc's bytes — and a **two-sided promise** ("valid X is accepted, invalid X is rejected") gets steps for **both halves**, so exclusion logic that silently breaks can't stay green. And a last line of defense guards the whole run: when a large sample of birth steps is overwhelmingly inert — a cli entry answering everything instantly with nothing, or an api server answering every route with the same empty status — generate **aborts as a recipe failure** (nothing is written) instead of committing a green corpus that proves nothing.
 
@@ -253,7 +256,8 @@ The spec, the scenarios, and a guard baseline are committable so they travel wit
 │   ├── recipe.json           ← how to build/prepare the repo for a run
 │   ├── manifest.json         ← section ↔ scenario bindings + section fingerprints
 │   ├── externals.local.json  ← external-account base URLs + API keys (GITIGNORED)
-│   └── <area>/*.yaml         ← the scenario tests
+│   ├── <area>/*.yaml         ← the scenario tests
+│   └── <area>/*.seed.mjs     ← optional adjacent per-scenario pre-boot seed sidecars
 ├── guard/                   ← guard run store (mirrors analyze; `truecourse guard run`)
 │   ├── runs/                 ← per-run snapshots (gitignored)
 │   ├── LATEST.json           ← current run state (committable)
@@ -543,7 +547,72 @@ replaces the recipe only if the new one verifies, preserves the blocks discovery
 backup file, since `recipe.json` is committed. Whatever discovery couldn't decide (a credential's
 env var, a security scheme with no mappable header) prints as a TODO list.
 
-### Seeding — `api.seed`
+### Per-scenario pre-boot seed sidecars
+
+Use an adjacent sidecar when one API scenario needs state that must exist **before its server
+boots**, or when no safe API operation can establish it. A pair has one engine-derived basename:
+
+```text
+.truecourse/scenarios/bookings/cancelled-booking.api.1.yaml
+.truecourse/scenarios/bookings/cancelled-booking.api.1.seed.mjs
+```
+
+The API-only YAML declaration is static and secret-free:
+
+```yaml
+setup:
+  seed:
+    provides:
+      fixtures: { booking: [id] }
+      credentials:
+        owner: { header: Authorization, description: booking owner }
+```
+
+The sidecar is an ES module. Guard sets `GUARD_SEED_NAMESPACE` to a stable hash of the repository
+identity plus scenario id, and `GUARD_SEED_OUT` to the manifest path. The sidecar should reconcile
+only rows owned by that namespace to the exact desired baseline—update/reset wanted rows and delete
+stale owned rows—then emit the declared fixtures and credentials. Prefer the repository's factories
+or domain modules; direct datastore access is the reviewed fallback. Never use process-global
+truncate/reset operations or touch another namespace.
+
+Guard executes a sidecar after shared services are ready but before that scenario's server boots.
+Seedless work settles first; seeded scenarios then run one at a time in scenario-id order, including
+server shutdown, so two seeders never overlap. YAML and sidecar cross generation, local/hosted corpus
+snapshots, materialization, replacement, and deletion as one source-backed artifact; ordinary scenario
+inventory still lists YAML only. A generated pair is birth-validated from exact in-memory sources and
+persists only after success, without replacing a handwritten pair.
+
+Interactive generation asks once for each exact batch before executing it. Authority is keyed by
+sidecar path, source fingerprint, declared outputs, and access class; if an evidence retry changes
+executable source, the changed batch is shown and requires approval again. Non-interactive generation
+requires `--allow-seed-exec` (`--yes` authorizes LLM spend only).
+
+Arrangement failures (spawn, timeout, exit, malformed/missing manifest, provider collision, or failed
+convergence) are `error` results with expected value `scenario seed to materialize`. Their redacted
+diagnostic and evidence enter Guard's single existing authoring retry, which may replace both files.
+A repaired pair runs again before persistence; a second arrangement failure withholds both files and
+leaves the flow unsettled. If the retry proves there is no safe schema/repository/ownership boundary,
+the flow settles as a precise `missing-data` capability gap. By contrast, an assertion mismatch after
+successful arrangement remains an ordinary product birth finding.
+
+Credentials are header-only at runtime and are redacted from retry prompts, reports, evidence, CLI
+output, responses recorded by Guard, and dashboard data. Static output names and non-secret fixture
+values remain visible. Sidecar source itself is executable code and must be reviewed like any migration.
+
+**Acceptance/rollout benchmark (2026-08-04).** The original 27 cal.diy `missing-data` rows remain a
+benchmark population, not a release-blocking golden count. A newer local cal.diy result contains 23
+`missing-data`-named rows; it predates applying this branch and is therefore evidence about the
+remaining demand, not a claimed conversion result. The [benchmark evidence record](docs/GUARD_SEEDING_CALDIY_BENCHMARK.md)
+lists those demands and the remaining real-repository rollout gap. The repository acceptance harness covers
+the representative categories requested from that population: a lifecycle-state entity, an
+organization/team/member aggregate, recurring and past bookings, a generated verification credential,
+and exact convergence after mutation on one reusable datastore. It also proves stable distinct
+namespaces and sibling non-interference. On the local fixture it completed three seeded executions
+(two scenarios plus one mutation-repair rerun) in **669 ms**; this is a deterministic harness
+measurement, not a cal.diy production-database latency claim. Seeded concurrency remains deliberately
+deferred until real-repository telemetry justifies a safer model.
+
+### Run-level seeding — `api.seed`
 
 Some claims can't be asserted from an empty database: they need a real account, a real token, or
 a row that already exists. `api.seed` is the **authenticated one-shot** that mints them — one

--- a/docs/GUARD_SEEDING_CALDIY_BENCHMARK.md
+++ b/docs/GUARD_SEEDING_CALDIY_BENCHMARK.md
@@ -1,0 +1,44 @@
+# Guard seed-sidecar cal.diy benchmark
+
+This is an evidence record, not a golden-count test. The motivating cal.diy
+snapshot reported 44 `blocked-on` rows, 27 of which named `missing-data`. That
+historical result is the ticket's fixed benchmark population; the implementation
+does not assume that all 27 can or should become scenarios.
+
+## Evidence available on 2026-08-04
+
+The local cal.diy checkout's latest completed Guard generation result was read from
+`.truecourse/guard/result.json` (`generatedAt: 2026-08-04T17:42:26.232Z`). It was a
+successful run with 58 written scenarios, 33 `blocked-on` gaps, and 23 rows whose
+reason still named `missing-data`. This newer 23-row snapshot is not presented as a
+sidecar rollout result: it predates applying this branch to cal.diy and therefore
+cannot establish a before/after conversion rate.
+
+The 23 evidence-backed residual demands break down as follows:
+
+| Demand | Flow evidence in the current result |
+| --- | --- |
+| Team, organization, membership, or managed-event state | `create-and-book-a-managed-event-type`, `invite-view-and-remove-a-team-member`, `delete-a-team` |
+| Pending, dynamic, seated, recurring, or round-robin booking state | `confirm-a-booking`, `cancel-a-booking-with-reason-requirement-enforced`, `view-a-booking-by-seat`, `cancel-a-booking-2`, `reassign-a-booking-to-a-new-host`, `reschedule-a-booking-2`, `confirm-a-booking-2` |
+| OAuth client, managed-user token, or client-scoped webhook state | `scope-a-webhook-to-a-platform-oauth-client`, `view-oauth2-client-and-exchange-authorization-code-for-9bde4ab0`, `create-manage-and-refresh-tokens-for-a-managed-user`, `create-list-update-and-delete-oauth-client-webhooks` |
+| Calendar connection, credential, or provider-owned event state | `identify-cal-diy-created-events-in-google-calendar`, `retrieve-a-calendar-event-s-details`, `check-calendar-free-busy-times`, `create-update-and-delete-an-event-on-a-calendar-connection`, `create-update-and-delete-a-calendar-event`, `view-and-list-calendar-events`, `list-calendar-connections-and-view-connection-events` |
+| Out-of-band verification code | `request-verify-and-list-verified-phone-numbers`, `request-verify-and-list-verified-email-addresses` |
+
+The hermetic acceptance test in
+`tests/guard-runner/seeded-acceptance.test.ts` exercises the seedable shapes from
+that population: lifecycle state, organization/team/member aggregation, recurring
+and past bookings, a generated verification credential, mutation repair,
+convergence, and namespace non-interference. Three sidecar executions against one
+reusable fixture store completed in 669 ms. That is a runner acceptance measurement,
+not cal.diy production-database telemetry.
+
+## Remaining rollout evidence gap
+
+This repository does not contain a cal.diy checkout or its datastore, and this
+branch did not mutate the separate local benchmark checkout. Consequently it makes
+no claim that any of the historical 27 or current 23 rows converted to committed
+cal.diy YAML/sidecar pairs. A follow-up benchmark must run the published feature
+against a clean cal.diy worktree, review and authorize the generated executable
+sidecars, then record each selected row as either a birth-verified pair or a precise
+capability gap. Seeded concurrency remains deferred until that run supplies real
+runtime and ownership telemetry.

--- a/docs/SPEC_GUARD_PLAN.md
+++ b/docs/SPEC_GUARD_PLAN.md
@@ -4,7 +4,8 @@ STATUS: OSS v1 BUILT (Phases 0–5, 2026-07-07) — design agreed 2026-07-03; op
 follow-ups and decided-not-built items in the body (stub/http/clock capabilities, the
 generate batch-size dial, cross-area overlap dedup, section-level precedence in extraction,
 the guard-helpers-to-shared move) and Phases 6–7 (api/tui/web drivers). Phase 8 (EE
-adaptation) is IN PROGRESS on `sm/spec-guards-ee` — see its entry below. (Fidelity review
+adaptation) is IN PROGRESS on `sm/spec-guards-ee` — see its entry below. Per-scenario
+pre-boot seed sidecars are BUILT (item 89, 2026-08-04). (Fidelity review
 and the scan-staleness signal, once listed here as open, are BUILT — items 33 and 31a. The
 OSS AI-SDK transport, also once listed here, is BUILT 2026-07-27 under
 `docs/CLI_API_TRANSPORT_PLAN.md`.) This plan adds **generated, spec-section-bound
@@ -5074,3 +5075,50 @@ ports → Opus; shared-branch git surgery → inline by the coordinating session
     The dashboard route returns the abort `reason` and the generate hook toasts an ERROR for
     ANY non-`ok` status — closing the pre-existing hole where `recipe-failed` also read as
     "wrote 0 scenarios".
+
+89. **Per-scenario pre-boot seed sidecars (approved 2026-08-04).** STATUS: **BUILT
+    2026-08-04** for tickets 01–06; **TICKET 07 PARTIAL** (hermetic acceptance and benchmark
+    inventory complete; authorized real-cal.diy pair/gap rollout evidence pending). API scenarios
+    may now carry an adjacent executable `.seed.mjs` companion for state that must exist before
+    that scenario's server boots.
+    - **Source-backed artifact boundary.** `ScenarioArtifact` carries the parsed scenario,
+      exact YAML path/content and exact companions through the loader, core command,
+      `GuardExecutor`, birth validation, local store and hosted `PgGuardStore`. The YAML is
+      still the ordinary inventory item; explicit sidecar reads and corpus snapshots include
+      companion bytes. A declared missing companion and an orphan companion are load errors.
+    - **Contract and deterministic run.** Only API setup accepts `setup.seed.provides`.
+      `GUARD_SEED_NAMESPACE` is stable per repository identity + scenario id. The sidecar
+      runs after shared services and before boot, emits the existing seed manifest shape,
+      and its fixtures/credentials merge only into that scenario. Static and runtime provider
+      collisions are rejected. Seedless pools settle first; seeded scenarios then run
+      exclusively, sorted by id, through sidecar → boot → steps → shutdown.
+    - **Generation and authority.** API authoring records every precondition as bootstrap,
+      non-milestone scenario step, sidecar or unrealizable. Generated sidecar paths are
+      engine-owned; source plus access class (`repository-modules` preferred,
+      `direct-datastore` fallback) is model output. Static validation maps every declared
+      output to a sidecar precondition and rejects duplicate fixture/credential providers.
+      Interactive generation summarizes the batch and asks once before execution;
+      authority includes the exact source/outputs/access identity, so changed retry code is
+      summarized and approved again;
+      non-interactive generation requires `--allow-seed-exec` (`--yes` covers LLM spend only).
+      Refusal happens before birth/persistence. Approved pairs birth from transient sources;
+      the rollback-safe pair writer stages both before replacement, preserves handwritten ids,
+      and replacement/deletion removes only generator-owned companions.
+    - **Retry and evidence.** Spawn/timeout/exit/manifest/collision/convergence failures are
+      scenario `error`s with exact expected value `scenario seed to materialize`, a redacted
+      pre-step evidence bundle, and the existing single evidence retry. The retry may replace
+      both sources. A repaired pair reruns before persistence; a second arrangement failure
+      withholds the pair and leaves the flow unsettled; a demonstrated unsafe/insufficient
+      ownership boundary settles as an evidence-backed `missing-data` gap. Assertions that
+      fail after successful arrangement remain ordinary product findings.
+    - **Acceptance and rollout.** `tests/guard-runner/seeded-acceptance.test.ts` exercises a
+      lifecycle-state entity, organization/team/member aggregate, recurring and past booking,
+      generated verification credential, exact repair after mutation, stable distinct
+      namespaces and sibling non-interference on one reusable store. The measured local fixture
+      run was 669 ms for three seeded executions (two initial scenarios plus one repair rerun).
+      The original 27 cal.diy missing-data gaps are retained as a benchmark population rather
+      than a release-blocking golden count. A newer local result (2026-08-04T17:42:26.232Z)
+      records 23 `missing-data`-named rows; `docs/GUARD_SEEDING_CALDIY_BENCHMARK.md` groups the
+      complete current set and makes explicit that this branch does not claim a real-repository
+      conversion or production latency result. Seeded concurrency remains deferred until
+      authorized cal.diy rollout telemetry supports a safe ownership-aware model.

--- a/ee/packages/data-store/src/guard-store.ts
+++ b/ee/packages/data-store/src/guard-store.ts
@@ -455,7 +455,7 @@ export class PgGuardStore implements GuardStore {
   /** Exactly that commit's set (no latest fallback — mirrors `loadContracts`). */
   async loadScenarios(ref: RepoRef): Promise<LoadedScenarios> {
     const manifest = await this.commitManifest(ref);
-    if (!manifest) return { scenarios: [], errors: [] };
+    if (!manifest) return { artifacts: [], scenarios: [], errors: [] };
 
     const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'tc-guard-scenarios-'));
     try {

--- a/ee/packages/github-app/src/guard-baseline-runner.ts
+++ b/ee/packages/github-app/src/guard-baseline-runner.ts
@@ -125,12 +125,13 @@ export function createGuardBaselinePipeline(
         }
 
         await opts.onPhase?.('run');
-        const { recipe, scenarios } = corpus;
+        const { recipe, scenarios, artifacts } = corpus;
         const report: GuardExecReport = await deps.limiter.run(() =>
           deps.execute({
             checkoutDir: tmp,
             recipe,
             scenarios,
+            artifacts,
             branch: req.defaultBranch,
             commit: req.commitSha,
             persist: false,

--- a/ee/packages/github-app/src/guard-gate-runner.ts
+++ b/ee/packages/github-app/src/guard-gate-runner.ts
@@ -33,11 +33,14 @@ import {
   RecipeSchema,
   buildDocSectionIndex,
   loadScenarios as loadScenarioTree,
+  scenarioSeedSidecarPath,
   scenariosDir,
   type DocSectionIndex,
   type GuardExecReport,
   type GuardExecutor,
+  type LoadedScenarios,
   type Recipe,
+  type ScenarioArtifact,
 } from '@truecourse/guard-runner';
 import {
   guardGenerateInProcess,
@@ -123,6 +126,8 @@ export type GuardGateClone = (
 export interface GuardGateCorpus {
   recipe: Recipe;
   scenarios: GuardScenario[];
+  /** Exact YAML/companion sources when loaded from a source-backed store. */
+  artifacts?: ScenarioArtifact[];
 }
 
 /** A stored-but-unparseable recipe — a gate breakage (`invalid-recipe`), never an
@@ -284,10 +289,10 @@ export async function defaultLoadCorpus(
       `invalid committed recipe for ${ref.repoKey}: ${(err as Error).message}`,
     );
   }
-  let scenarios: GuardScenario[] = [];
-  if (ref.commitSha) scenarios = (await guardStore.loadScenarios(ref)).scenarios;
-  if (scenarios.length === 0) scenarios = await loadLatestScenarios(guardStore, ref.repoKey);
-  return { recipe, scenarios };
+  let loaded: LoadedScenarios = { artifacts: [], scenarios: [], errors: [] };
+  if (ref.commitSha) loaded = await guardStore.loadScenarios(ref);
+  if (loaded.scenarios.length === 0) loaded = await loadLatestScenarios(guardStore, ref.repoKey);
+  return { recipe, scenarios: loaded.scenarios, artifacts: loaded.artifacts };
 }
 
 /** The newest stored scenario set, via the commit-optional browse reads (which
@@ -295,9 +300,9 @@ export async function defaultLoadCorpus(
 async function loadLatestScenarios(
   guardStore: GuardStore,
   repoKey: string,
-): Promise<GuardScenario[]> {
+): Promise<LoadedScenarios> {
   const rels = await guardStore.listScenarioFiles(repoKey);
-  if (rels.length === 0) return [];
+  if (rels.length === 0) return { artifacts: [], scenarios: [], errors: [] };
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-guard-gate-corpus-'));
   try {
     for (const rel of rels) {
@@ -307,8 +312,11 @@ async function loadLatestScenarios(
       const dest = path.join(root, rel);
       fs.mkdirSync(path.dirname(dest), { recursive: true });
       fs.writeFileSync(dest, body);
+      const sidecarRel = scenarioSeedSidecarPath(rel);
+      const sidecarBody = await guardStore.readScenarioFile(repoKey, sidecarRel);
+      if (sidecarBody != null) fs.writeFileSync(path.join(root, sidecarRel), sidecarBody);
     }
-    return loadScenarioTree(root).scenarios;
+    return loadScenarioTree(root);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -415,7 +423,22 @@ function storedRunReport(latest: GuardLatest): GuardExecReport {
  * scenarios. Stamped onto gate-persisted head runs so the redelivery fast path
  * only reuses a stored run whose corpus matches what the gate would run now.
  */
-export function guardCorpusFingerprint(scenarios: readonly GuardScenario[]): string {
+export function guardCorpusFingerprint(
+  scenarios: readonly GuardScenario[],
+  artifacts: readonly ScenarioArtifact[] = [],
+): string {
+  if (artifacts.length > 0) {
+    const sources = artifacts
+      .map((artifact) => [
+        artifact.source.path,
+        artifact.source.content,
+        ...Object.entries(artifact.companions)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .flat(),
+      ])
+      .sort((a, b) => a[0].localeCompare(b[0]));
+    return `sha256:${createHash('sha256').update(JSON.stringify(sources)).digest('hex')}`;
+  }
   const identities = scenarios
     .map((s) => [s.id, s.title, ...s.binds.map((b) => `${b.doc}#${b.section}#${b.fingerprint}`)])
     .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
@@ -448,7 +471,7 @@ async function storedRunMatchesCommittedCorpus(
       commitSha: (await store.getBaseline(repoKey))?.commitSha ?? '',
     };
     const corpus = await defaultLoadCorpus(guardStore, ref);
-    return corpus !== null && guardCorpusFingerprint(corpus.scenarios) === fingerprint;
+    return corpus !== null && guardCorpusFingerprint(corpus.scenarios, corpus.artifacts) === fingerprint;
   } catch {
     return false;
   }
@@ -687,12 +710,13 @@ export function createGuardGatePipeline(seams: GuardGatePipelineSeams = {}): Gua
         await opts.onPhase?.('base');
         let base = opts.force ? null : await resolveStoredBase(deps.guardStore, payload);
         if (base === null && corpus !== null && corpus.scenarios.length > 0) {
-          const { recipe, scenarios } = corpus;
+          const { recipe, scenarios, artifacts } = corpus;
           const baseReport = await deps.limiter.run(() =>
             deps.execute({
               checkoutDir: tmp,
               recipe,
               scenarios,
+              artifacts,
               branch: payload.baseBranch,
               commit: baseSha,
               persist: false,
@@ -721,13 +745,14 @@ export function createGuardGatePipeline(seams: GuardGatePipelineSeams = {}): Gua
         } else if (corpus.scenarios.length === 0) {
           report = { status: 'no-scenarios', loadErrors: [] };
         } else {
-          const { recipe, scenarios } = corpus;
+          const { recipe, scenarios, artifacts } = corpus;
           await checkout(tmp, payload.headSha, opts.signal);
           report = await deps.limiter.run(() =>
             deps.execute({
               checkoutDir: tmp,
               recipe,
               scenarios,
+              artifacts,
               branch: payload.headRef,
               commit: payload.headSha,
               persist: false,
@@ -754,7 +779,10 @@ export function createGuardGatePipeline(seams: GuardGatePipelineSeams = {}): Gua
         if (report.status === 'ok' && corpus) {
           const stamped: GuardLatest = {
             ...report.latest,
-            run: { ...report.latest.run, corpusFingerprint: guardCorpusFingerprint(corpus.scenarios) },
+            run: {
+              ...report.latest.run,
+              corpusFingerprint: guardCorpusFingerprint(corpus.scenarios, corpus.artifacts),
+            },
           };
           await deps.guardStore.writeGuardRun(repoKey, stamped);
           await persistFailureEvidence(deps.guardStore, repoKey, tmp, stamped);

--- a/packages/core/src/commands/guard-in-process.ts
+++ b/packages/core/src/commands/guard-in-process.ts
@@ -20,6 +20,7 @@ import {
   validateCredentialSatisfies,
   type SatisfiesDiagnostics,
   type GuardGenerateResult,
+  type GenerateGuardsOptions,
   type GuardGenerateModels,
   type ExtractRunner,
   type GenerateRunner,
@@ -175,6 +176,10 @@ export interface GuardGenerateInProcessOptions {
    */
   llm?: 'cli' | 'agent' | 'api';
   io?: string;
+  /** Explicit non-interactive authority to execute generated pre-boot sidecars. */
+  allowSeedExec?: boolean;
+  /** Interactive batch approval seam for generated sidecar execution. */
+  approveSeedExecution?: GenerateGuardsOptions['approveSeedExecution'];
   /**
    * Pre-flight LLM cost estimate gate. Called with the token estimate before any
    * LLM work; return `false` to abort (throws {@link EstimateDeclined}). Skipped
@@ -390,6 +395,8 @@ export async function guardGenerateInProcess(
       // A hosted/EE generate works in an ephemeral checkout nobody has a terminal
       // in, so it keeps deriving its own recipe exactly as it always has.
       requireExistingRecipe: guardsMaterializeInPlace(),
+      allowSeedExec: options.allowSeedExec,
+      approveSeedExecution: options.approveSeedExecution,
       extractRunner: options.extractRunner,
       generateRunner: options.generateRunner,
       recipeRunner: options.recipeRunner,
@@ -722,13 +729,14 @@ export async function guardRunInProcess(
   // resolved recipe + selected scenarios to the executor for actual execution.
   const sourced = sourceGuardRunInputs(repoRoot, options.scenario);
   if ('early' in sourced) return sourced.early;
-  const { loaded, selected, loadErrors } = sourced;
+  const { loaded, selected, artifacts, loadErrors } = sourced;
 
   const result = mergeLoadErrors(
     await getGuardExecutor()({
       checkoutDir: repoRoot,
       recipe: loaded.recipe,
       scenarios: selected,
+      artifacts,
       branch,
       commit,
       persist: true,

--- a/packages/guard-generator/src/birth.ts
+++ b/packages/guard-generator/src/birth.ts
@@ -14,7 +14,13 @@
  * RUN level and produces no scenario verdicts at all (see {@link BirthRound}).
  */
 
-import { runFailureMessage, type GuardExecutor, type GuardRunStepStats, type Recipe } from '@truecourse/guard-runner'
+import {
+  runFailureMessage,
+  type GuardExecutor,
+  type GuardRunStepStats,
+  type Recipe,
+  type ScenarioArtifact,
+} from '@truecourse/guard-runner'
 import type {
   GuardDriverId,
   GuardFlow,
@@ -35,6 +41,18 @@ export interface BirthCandidate {
   surface: GuardDriverId
   section: SectionInput
   scenario: GuardScenario
+  /** Exact transient sources to execute before either candidate file is persisted. */
+  artifact?: ScenarioArtifact
+  /** Generator-only review metadata; never serialized into scenario YAML. */
+  seedAccess?: 'repository-modules' | 'direct-datastore'
+  /** Authored arrangement plan supplied to fidelity review with executable source. */
+  seedPreconditions?: readonly {
+    description: string
+    mechanism: 'bootstrap' | 'scenario-step' | 'sidecar' | 'unrealizable'
+    outputs?: string[]
+  }[]
+  /** Static authored YAML/sidecar identity used to key evidence retries. */
+  sourceFingerprint?: string
   /** `<flow-id>\0<surface>` — the retry/persist grouping key. */
   ref: string
 }
@@ -134,6 +152,21 @@ export async function birthValidate(
     checkoutDir: repoRoot,
     recipe: opts.recipe,
     scenarios: candidates.map((c) => c.scenario),
+    ...(candidates.some((candidate) => candidate.artifact)
+      ? {
+          artifacts: candidates.map(
+            (candidate): ScenarioArtifact =>
+              candidate.artifact ?? {
+                scenario: candidate.scenario,
+                source: {
+                  path: `.truecourse/scenarios/${candidate.scenario.id}.yaml`,
+                  content: JSON.stringify(candidate.scenario),
+                },
+                companions: {},
+              },
+          ),
+        }
+      : {}),
     persist: false,
     skipBuild: opts.skipBuild,
     noOpThresholdMs: opts.noOpThresholdMs,

--- a/packages/guard-generator/src/generate.ts
+++ b/packages/guard-generator/src/generate.ts
@@ -74,6 +74,7 @@ import {
   loadResolvedExternals,
   detectNoOpAnomaly,
   foldStepStats,
+  guardPlaceholderReferences,
   type GuardNoOpAnomaly,
   type GuardRunStepStats,
   type ResolvedExternal,
@@ -156,6 +157,7 @@ import {
   AuthoredFlowScenarioSchema,
   RawGeneratedScenarioSchema,
   FidelityReviewSchema,
+  type RawGeneratedApiScenario,
   type RawGeneratedScenario,
 } from './schemas.js'
 import {
@@ -223,6 +225,7 @@ import {
   buildFlowScenario,
   areaOrDocSlug,
   writeScenarioFile,
+  writeScenarioArtifact,
   serializeScenarioYaml,
   deleteScenarioFiles,
   existingScenarioIds,
@@ -445,6 +448,26 @@ export interface GuardGenerateModels {
   fallback?: string
 }
 
+export interface SeedExecutionSummary {
+  scenarioId: string
+  title: string
+  sidecarPath: string
+  /** Exact sidecar-source identity so changed retry code requires fresh authority. */
+  sourceFingerprint: string
+  outputs: string[]
+  access: 'repository-modules' | 'direct-datastore'
+}
+
+/** Raised before birth or persistence when generated executable setup lacks authority. */
+export class SeedExecutionNotAuthorizedError extends Error {
+  constructor(readonly sidecars: SeedExecutionSummary[]) {
+    super(
+      `generated seed sidecar execution was not authorized (${sidecars.map((sidecar) => sidecar.sidecarPath).join(', ')})`,
+    )
+    this.name = 'SeedExecutionNotAuthorizedError'
+  }
+}
+
 /**
  * Where the journey catalog comes from. Mapping needs the ANALYZER, which lives
  * above this package, so the caller injects it (core's `mapJourneys`). Omitted, the
@@ -532,6 +555,10 @@ export interface GenerateGuardsOptions {
    * is unchanged for any caller that does not opt in.
    */
   requireExistingRecipe?: boolean
+  /** Explicit non-interactive authority for executing model-authored sidecars. */
+  allowSeedExec?: boolean
+  /** Interactive authority seam: receives one stable batch summary before execution. */
+  approveSeedExecution?: (sidecars: SeedExecutionSummary[]) => boolean | Promise<boolean>
   /**
    * INTERNAL test seam: stop after flow synthesis, before journey matching and
    * authoring. Not a user-facing option and not exposed by any command — flow
@@ -616,6 +643,7 @@ export function authorCacheKey(
   sectionKeys: readonly string[],
   journeyFingerprints: readonly string[],
   recipeFingerprint: string,
+  artifactFingerprint?: string,
 ): string {
   const parts = [
     authorPromptFingerprint(surface),
@@ -626,6 +654,7 @@ export function authorCacheKey(
     [...sectionKeys].sort().join('~'),
     [...journeyFingerprints].sort().join('~'),
   ]
+  if (artifactFingerprint !== undefined) parts.push(artifactFingerprint)
   return createHash('sha256').update(parts.join('::')).digest('hex')
 }
 
@@ -638,6 +667,7 @@ export function retryCacheKey(
   journeyFingerprints: readonly string[],
   recipeFingerprint: string,
   evidence: GuardBirthFinding,
+  artifactFingerprint?: string,
 ): string {
   const evidenceHash = createHash('sha256')
     .update(
@@ -655,7 +685,7 @@ export function retryCacheKey(
   return createHash('sha256')
     .update(
       [
-        authorCacheKey(flow, surface, sectionKeys, journeyFingerprints, recipeFingerprint),
+        authorCacheKey(flow, surface, sectionKeys, journeyFingerprints, recipeFingerprint, artifactFingerprint),
         evidenceHash,
       ].join('::'),
     )
@@ -1665,6 +1695,21 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
     if (built) round1.push(built)
   }
 
+  const authorizedSidecars = new Set<string>()
+  const authorityKey = (sidecar: SeedExecutionSummary): string =>
+    JSON.stringify([sidecar.sidecarPath, sidecar.sourceFingerprint, sidecar.outputs, sidecar.access])
+  const assertSeedExecutionAuthorized = async (pool: readonly BirthCandidate[]): Promise<void> => {
+    if (options.allowSeedExec) return
+    const unauthorized = pool
+      .flatMap(seedExecutionSummary)
+      .filter((sidecar) => !authorizedSidecars.has(authorityKey(sidecar)))
+    if (unauthorized.length === 0) return
+    const approved = (await options.approveSeedExecution?.(unauthorized)) ?? false
+    if (!approved) throw new SeedExecutionNotAuthorizedError(unauthorized)
+    for (const sidecar of unauthorized) authorizedSidecars.add(authorityKey(sidecar))
+  }
+  await assertSeedExecutionAuthorized(round1)
+
   let birthTotal = 0
   let birthSettled = 0
   const bumpBirth = (): void => options.onBirthProgress?.(++birthSettled, birthTotal)
@@ -1785,6 +1830,7 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
                     outboundRequestsOverflow,
                     serverIndex,
                     retry: retryContext(entry.evidence),
+                    retrySourceFingerprint: birthCandidateSourceFingerprint(entry.outcome.candidate),
                     onAuthorFailure: options.onAuthorFailure,
                   })
                   if ('error' in attempt) {
@@ -1800,10 +1846,30 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
                     return
                   }
                   if (!attempt.scenario) {
-                    // The retry gave up on the world it needs — the round-1 candidate
-                    // is the final word, so it is committed as a failing test with
-                    // the birth result it already produced.
-                    settleFailedTest(entry.task, entry.outcome)
+                    if (isSetupDefectResult(entry.outcome.result)) {
+                      // Evidence proved arrangement could not be authored safely.
+                      // This is a capability gap, not a product assertion and never
+                      // a failing committed test.
+                      const blockedOn = enrichBlockedOn(attempt.blockedOn, externalServices)
+                      const diagnostic = oneLine(entry.outcome.result.failure?.actual ?? '')
+                      const reason = composeBlockedOnReason(
+                        [...blockedOn, ...(diagnostic ? [diagnostic] : [])],
+                        oneLine(entry.task.work.flow.title),
+                      )
+                      entry.task.work.gaps.push({ surface: entry.task.surface, kind: 'blocked-on', reason })
+                      coverageGaps.push({
+                        doc: entry.task.work.primary.doc,
+                        anchor: entry.task.work.primary.anchor,
+                        kind: 'blocked-on',
+                        flowId: entry.task.work.flow.id,
+                        surface: entry.task.surface,
+                        reason,
+                      })
+                    } else {
+                      // A behavior failure followed by an honest authoring refusal
+                      // remains the round-1 product finding.
+                      settleFailedTest(entry.task, entry.outcome)
+                    }
                     return
                   }
                   const built = safeBuild(entry.task, attempt.scenario, usedIds, errors, defaultApiServer)
@@ -1815,6 +1881,7 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
             ),
           )
           if (retryPool.length > 0) {
+            await assertSeedExecutionAuthorized(retryPool)
             birthTotal += retryPool.length
             const round2Run = await birthValidate(repoRoot, retryPool, { executor, recipe, skipBuild: true, noOpThresholdMs: options.noOpThresholdMs, onPhase: options.onBirthPhase, onScenarioSettled: bumpBirth })
             reconcileBirth()
@@ -2024,6 +2091,7 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
         ),
       )
       if (replacements.length > 0) {
+        await assertSeedExecutionAuthorized(replacements)
         birthTotal += replacements.length
         const healRun = await birthValidate(repoRoot, replacements, { executor, recipe, skipBuild: true, noOpThresholdMs: options.noOpThresholdMs, onPhase: options.onBirthPhase, onScenarioSettled: bumpBirth })
         reconcileBirth()
@@ -2292,16 +2360,20 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
       )
       continue
     }
-    // The flow re-authored: its OWN prior files go, then its survivors land.
-    deleteScenarioFiles(repoRoot, work.prior?.scenarios.map((s) => s.id) ?? [])
+    // The flow re-authored: write each survivor over its own prior artifact first;
+    // only after every survivor lands do removed ids disappear. A failed replacement
+    // therefore leaves the prior pair intact instead of deleting it up front.
     const slug = areaOrDocSlug(work.primary)
     const scenarios: GuardManifestScenario[] = []
+    const retainedScenarioIds = new Set<string>()
     let unsettledFlow = false
     for (const [surface] of work.plans) {
       const ref = `${work.flow.id}\0${surface}`
       const task = taskByKey.get(ref)
       const commit = (c: BirthCandidate, status: GuardTestStatus, finding?: GuardBirthFinding): string => {
-        const file = writeScenarioFile(repoRoot, slug, c.scenario)
+        const file = c.artifact
+          ? writeScenarioArtifact(repoRoot, c.artifact)
+          : writeScenarioFile(repoRoot, slug, c.scenario)
         written.push({
           id: c.scenario.id,
           title: c.scenario.title,
@@ -2321,6 +2393,7 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
           status,
           ...(finding ? { diagnosis: diagnosisOf(finding, file) } : {}),
         })
+        retainedScenarioIds.add(c.scenario.id)
         return file
       }
       for (const c of persisted.get(ref) ?? []) commit(c, 'passing')
@@ -2338,6 +2411,10 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
         unsettledFlow = true
       }
     }
+    deleteScenarioFiles(
+      repoRoot,
+      (work.prior?.scenarios ?? []).map((scenario) => scenario.id).filter((id) => !retainedScenarioIds.has(id)),
+    )
     // A flow left unsettled on some surface keeps a manifest entry (its committed
     // tests are real coverage) but records NO inputs hash, so the next generate
     // re-runs it. A committed failing test is NOT such a surface — it settled.
@@ -2866,6 +2943,26 @@ const AuthoredCacheSchema = z.object({
   scenario: RawGeneratedScenarioSchema.nullable(),
   blockedOn: z.array(z.string().min(1)).default([]),
 })
+const AuthoredCachePointerSchema = z.object({ candidateCacheKey: z.string().min(1) }).strict()
+
+/** Exact static identity of model-authored scenario material (runtime manifests never appear here). */
+function generatedScenarioSourceFingerprint(scenario: RawGeneratedScenario): string {
+  return createHash('sha256').update(JSON.stringify(scenario)).digest('hex')
+}
+
+function birthCandidateSourceFingerprint(candidate: BirthCandidate): string {
+  if (candidate.sourceFingerprint) return candidate.sourceFingerprint
+  if (!candidate.artifact) return createHash('sha256').update(serializeScenarioYaml(candidate.scenario)).digest('hex')
+  return createHash('sha256')
+    .update(
+      JSON.stringify([
+        candidate.artifact.source.path,
+        candidate.artifact.source.content,
+        ...Object.entries(candidate.artifact.companions).sort(([a], [b]) => a.localeCompare(b)).flat(),
+      ]),
+    )
+    .digest('hex')
+}
 
 /**
  * Author ONE scenario for one (flow, surface): cache → call → one corrective
@@ -2901,6 +2998,8 @@ async function authorFlowScenario(opts: {
    *  BOUND server's own surface and never another service's. */
   serverIndex: ServerRouteIndex
   retry?: BirthRetryContext
+  /** Exact YAML/sidecar identity of the candidate whose evidence caused a retry. */
+  retrySourceFingerprint?: string
   /**
    * The prior-rejection evidence (a taint from an earlier generate, or
    * this run's fidelity self-heal). Its presence BYPASSES the round-1 cache read:
@@ -2931,7 +3030,7 @@ async function authorFlowScenario(opts: {
         ...emptyFinding(),
         ...retry,
         title: retry.scenarioTitle,
-      })
+      }, opts.retrySourceFingerprint)
     : authorCacheKey(work.flow, surface, work.sectionKeys, journeyFingerprints, recipeFingerprint)
 
   // D3 — the flow's doc-example blocks, mined once for the byte-fidelity
@@ -2950,7 +3049,11 @@ async function authorFlowScenario(opts: {
 
   // A prior rejection poisons the cache entry (it IS the rejected scenario) —
   // skip the read; the fresh result below overwrites it under the same key.
-  const cached = opts.priorFlag ? null : await getCacheEntry(repoRoot, GENERATE_CACHE_NAME, cacheKey)
+  const cachedHead = opts.priorFlag ? null : await getCacheEntry(repoRoot, GENERATE_CACHE_NAME, cacheKey)
+  const pointer = AuthoredCachePointerSchema.safeParse(cachedHead)
+  const cached = pointer.success
+    ? await getCacheEntry(repoRoot, GENERATE_CACHE_NAME, pointer.data.candidateCacheKey)
+    : cachedHead
   if (cached) {
     const parsed = AuthoredCacheSchema.safeParse(cached)
     if (parsed.success) {
@@ -3082,7 +3185,10 @@ async function authorFlowScenario(opts: {
       }
       continue
     }
-    await setCacheEntry(repoRoot, GENERATE_CACHE_NAME, cacheKey, { scenario, blockedOn: [] })
+    const sourceFingerprint = generatedScenarioSourceFingerprint(scenario)
+    const candidateCacheKey = createHash('sha256').update(`${cacheKey}::${sourceFingerprint}`).digest('hex')
+    await setCacheEntry(repoRoot, GENERATE_CACHE_NAME, candidateCacheKey, { scenario, blockedOn: [] })
+    await setCacheEntry(repoRoot, GENERATE_CACHE_NAME, cacheKey, { candidateCacheKey })
     return { scenario, blockedOn: [] }
   }
   failed('authoring exhausted its attempts', 2, false)
@@ -3108,12 +3214,84 @@ function authorFailureReason(raw: string): string {
  * rules are self-contained (a journey has to chain with itself).
  */
 function compositionDefectOf(scenario: RawGeneratedScenario, recipe: Recipe): string | null {
-  return scenarioCompositionDefect(
+  const ordinary = scenarioCompositionDefect(
     scenario.driver === 'api'
       ? { driver: 'api', steps: scenario.steps, ...(scenario.setup ? { setup: scenario.setup } : {}) }
       : { driver: 'cli', steps: scenario.steps, ...(scenario.setup ? { setup: scenario.setup } : {}) },
     recipe.entry,
   )
+  if (ordinary || scenario.driver !== 'api') return ordinary
+
+  const local = scenario.setup?.seed?.provides
+  if (local) {
+    for (const name of Object.keys(local.fixtures ?? {})) {
+      if (recipe.api?.seed?.provides.fixtures?.[name] !== undefined) {
+        return (
+          `fixture "${name}" has more than one declared source: recipe api.seed and scenario setup.seed. ` +
+          'Every fixture reference must resolve to exactly one provider; rename or remove one declaration.'
+        )
+      }
+    }
+    for (const name of Object.keys(local.credentials ?? {})) {
+      const sources = [
+        recipe.api?.credentials?.[name] !== undefined,
+        recipe.api?.seed?.provides.credentials?.[name] !== undefined,
+      ].filter(Boolean).length
+      if (sources > 0) {
+        return (
+          `credential "${name}" has more than one declared source: the recipe and scenario setup.seed. ` +
+          'Every credential reference must resolve to exactly one provider; rename or remove one declaration.'
+        )
+      }
+    }
+  }
+  return providerReferenceDefect(scenario, recipe)
+}
+
+/**
+ * Generated placeholders are a static contract: birth must never be the first
+ * place we discover that a fixture/credential has zero (or ambiguous) providers.
+ * Scan the authored steps as data so nested JSON leaves and expectation values are
+ * covered without coupling this check to individual step shapes.
+ */
+function providerReferenceDefect(scenario: RawGeneratedApiScenario, recipe: Recipe): string | null {
+  const local = scenario.setup?.seed?.provides
+  const runSeed = recipe.api?.seed?.provides
+
+  for (const reference of guardPlaceholderReferences(scenario.steps)) {
+    const { name } = reference
+    if (reference.kind === 'credential') {
+      const sourceCount = [
+        local?.credentials?.[name] !== undefined,
+        runSeed?.credentials?.[name] !== undefined,
+        recipe.api?.credentials?.[name] !== undefined,
+      ].filter(Boolean).length
+      if (sourceCount === 0) {
+        return `credential "${name}" has no declared source; every credential reference must resolve to exactly one provider.`
+      }
+      if (sourceCount > 1) {
+        return `credential "${name}" has more than one declared source; every credential reference must resolve to exactly one provider.`
+      }
+      continue
+    }
+    const { field } = reference
+    if (field === null) {
+      return `fixture "${name}" must name a field as {{fixture:${name}.<field>}}.`
+    }
+    const sources = [local?.fixtures?.[name], runSeed?.fixtures?.[name]].filter(
+      (fields): fields is string[] => fields !== undefined,
+    )
+    if (sources.length === 0) {
+      return `fixture "${name}" has no declared source for {{fixture:${name}.${field}}}; every fixture reference must resolve to exactly one provider.`
+    }
+    if (sources.length > 1) {
+      return `fixture "${name}" has more than one declared source; every fixture reference must resolve to exactly one provider.`
+    }
+    if (!sources[0].includes(field)) {
+      return `fixture "${name}" does not declare field "${field}" required by {{fixture:${name}.${field}}}.`
+    }
+  }
+  return null
 }
 
 /** The flow milestones no step of the scenario realizes. */
@@ -3415,7 +3593,27 @@ function safeBuild(
       ...(task.server ? { server: task.server } : {}),
       defaultServer,
     })
-    return { flow: task.work.flow, surface: task.surface, section: task.work.primary, scenario, ref: taskKey(task) }
+    const candidate: BirthCandidate = {
+      flow: task.work.flow,
+      surface: task.surface,
+      section: task.work.primary,
+      scenario,
+      ref: taskKey(task),
+      sourceFingerprint: generatedScenarioSourceFingerprint(raw),
+    }
+    if (raw.driver === 'api' && raw.seedSidecar) {
+      const slug = areaOrDocSlug(task.work.primary)
+      const scenarioPath = `.truecourse/scenarios/${slug}/${scenario.id}.yaml`
+      const sidecarPath = scenarioPath.replace(/\.yaml$/, '.seed.mjs')
+      candidate.artifact = {
+        scenario,
+        source: { path: scenarioPath, content: serializeScenarioYaml(scenario) },
+        companions: { [sidecarPath]: raw.seedSidecar.source },
+      }
+      candidate.seedAccess = raw.seedSidecar.access
+      candidate.seedPreconditions = raw.preconditions
+    }
+    return candidate
   } catch (e) {
     usedIds.delete(id)
     task.errored = true
@@ -3426,6 +3624,21 @@ function safeBuild(
     })
     return null
   }
+}
+
+function seedExecutionSummary(candidate: BirthCandidate): SeedExecutionSummary[] {
+  if (!candidate.artifact || candidate.scenario.driver !== 'api') return []
+  const setup = candidate.scenario.setup
+  const rawOutputs = [
+    ...Object.keys(setup?.seed?.provides.fixtures ?? {}).map((name) => `fixture:${name}`),
+    ...Object.keys(setup?.seed?.provides.credentials ?? {}).map((name) => `credential:${name}`),
+  ].sort()
+  const sidecarPath = Object.keys(candidate.artifact.companions)[0]
+  const sourceFingerprint = `sha256:${createHash('sha256')
+    .update(candidate.artifact.companions[sidecarPath])
+    .digest('hex')}`
+  const access = candidate.seedAccess ?? 'direct-datastore'
+  return [{ scenarioId: candidate.scenario.id, title: candidate.scenario.title, sidecarPath, sourceFingerprint, outputs: rawOutputs, access }]
 }
 
 // --- Findings + errors -------------------------------------------------------
@@ -3608,7 +3821,10 @@ async function reviewFidelity(
   runner: FidelityRunner,
 ): Promise<FidelityResult> {
   const work = task.work
-  const cacheKey = fidelityCacheKey(scenarioBehavior(candidate.scenario), work)
+  const cacheKey = fidelityCacheKey(
+    [scenarioBehavior(candidate.scenario), candidate.sourceFingerprint ?? ''].join('::'),
+    work,
+  )
 
   const cached = await getCacheEntry(repoRoot, FIDELITY_CACHE_NAME, cacheKey)
   if (cached) {
@@ -3629,8 +3845,14 @@ async function reviewFidelity(
           sectionHeading: section?.headingText ?? m.anchor,
           sectionText: section?.fullText || section?.ownText || '',
         }
-      }),
+    }),
     scenarioYaml: serializeScenarioYaml(candidate.scenario),
+    ...(candidate.artifact
+      ? {
+          seedSidecarSource: Object.values(candidate.artifact.companions)[0],
+          seedPreconditions: candidate.seedPreconditions ?? [],
+        }
+      : {}),
   }
   const attempt = await callFidelityWithReask(ctx, runner)
   if ('error' in attempt) return { error: attempt.error }

--- a/packages/guard-generator/src/index.ts
+++ b/packages/guard-generator/src/index.ts
@@ -21,6 +21,8 @@ export {
   type GuardGenerateError,
   type GuardExtractionFailure,
   type AuthorFailure,
+  SeedExecutionNotAuthorizedError,
+  type SeedExecutionSummary,
   type JourneyProvider,
 } from './generate.js'
 
@@ -320,6 +322,9 @@ export {
   UntestableNoteSchema,
   DocExtractionSchema,
   RawGeneratedScenarioSchema,
+  RawGeneratedApiScenarioSchema,
+  GeneratedPreconditionSchema,
+  GeneratedSeedSidecarSchema,
   AuthoredFlowScenarioSchema,
   RealizationMatchSchema,
   FidelityReviewSchema,
@@ -339,6 +344,7 @@ export {
   type UntestableNote,
   type DocExtraction,
   type RawGeneratedScenario,
+  type RawGeneratedApiScenario,
   type AuthoredFlowScenario,
   type RealizationMatch,
   type RealizationStep,

--- a/packages/guard-generator/src/prompts.ts
+++ b/packages/guard-generator/src/prompts.ts
@@ -41,7 +41,7 @@ import type { MinedExampleBlock } from './examples.js'
  *  without the parse-side unknown-key tolerance, so the hints stay closed). One
  *  per runnable driver: each authoring prompt embeds its own. */
 const SCENARIO_JSON_SCHEMA = jsonSchemaHint(RawGeneratedCliScenarioSchema.strip())
-const API_SCENARIO_JSON_SCHEMA = jsonSchemaHint(RawGeneratedApiScenarioSchema.strip())
+const API_SCENARIO_JSON_SCHEMA = jsonSchemaHint(RawGeneratedApiScenarioSchema.innerType().strip())
 /** The extraction + recipe-proposal JSON Schemas, from the runner's Zod source. */
 const EXTRACTION_JSON_SCHEMA = jsonSchemaHint(DocExtractionSchema)
 const RECIPE_JSON_SCHEMA = jsonSchemaHint(RecipeProposalSchema)
@@ -612,16 +612,34 @@ can: when it is a third party this repo depends on, write the SERVICE (\`"stripe
 \`"sendgrid"\`) rather than a generic noun — the user prompt lists the ones detected
 in this repo. A named blocker is triaged per service; \`"external-service"\` is not.
 
-A THIRD class of blocker, distinct from both: pre-existing DATA. When the flow needs
-a record the API cannot create through its OWN endpoints — an already-cancelled
-booking, a user with a past subscription, a row in a state no request produces — and
-no fixture listed in the user prompt provides it, that flow is blocked on data, not
-on a service and not on credentials. Use the noun \`"missing-data"\` and add a SECOND
-entry naming the entity:
-  \`"blockedOn": ["missing-data", "an already-cancelled booking"]\`
-The noun makes it countable across flows; the entity names what a seed would have to
-create. Data the flow can create for itself through the API's own endpoints is NOT
-this — author those steps.
+# Plan every precondition; use a sidecar only for pre-boot data
+Record every world-state precondition in \`preconditions\`, choosing exactly one
+\`mechanism\`: \`bootstrap\` (the recipe already supplies it), \`scenario-step\`
+(an ordinary API request can create it), \`sidecar\` (it must exist before boot or no
+suitable operation exists), or \`unrealizable\`. A scenario-step used only for
+arrangement carries NO \`milestone\`; milestone behavior remains in the assertion
+steps that verify the documented promise.
+
+For a safe, deterministic pre-boot arrangement, author \`setup.seed.provides\` and
+\`seedSidecar\` together. The sidecar is an exact ES-module source string; the engine
+owns its adjacent basename, sets \`GUARD_SEED_NAMESPACE\` to a stable
+repo+scenario namespace and \`GUARD_SEED_OUT\` to the manifest path, and executes it
+before server boot. Reconcile that namespace to the exact desired state on every
+run: update/reset scenario-owned rows and delete stale scenario-owned rows rather
+than appending. Prefer repository-native factories or domain modules and set
+\`access: "repository-modules"\`; use \`"direct-datastore"\` only when no safe native
+boundary exists. The manifest must contain exactly the declared fixture fields and
+credential values. Map each declared output in a \`sidecar\` precondition as
+\`fixture:<name>\` or \`credential:<name>\`. Never duplicate a fixture or credential
+the recipe already provides.
+
+When schema knowledge, repository modules/dependencies, or safe ownership are
+insufficient, author NOTHING. Return \`blockedOn: ["missing-data", "<precise
+precondition>"]\`. The noun makes the gap countable; the second entry makes it
+actionable. Data the flow can establish through a listed API operation is not a
+sidecar or a gap—author a non-milestone plumbing request step. For example, if the
+flow requires an already-cancelled booking and no safe source can materialize one,
+name that exact precondition rather than weakening the scenario.
 
 # Ground every request in the app's own surface, never in a guess
 The user prompt states, from the app's OWN source, which operations exist, what each
@@ -690,9 +708,8 @@ or, when the flow needs world-state the sandbox cannot provide:
 Exactly one of the two. No prose, no fences — only the JSON object.`
 
 /**
- * PIN 2026-08-01 (Wave 5): rolled once for this wave's authored-vocabulary rules —
- * the doc's own examples run verbatim, and a two-sided promise gets a two-sided test
- * (the accepted input AND the rejected one). The author cache re-keys once.
+ * PIN 2026-08-04: rolled for the exact generated-sidecar namespace contract after
+ * the 2026-08-01 authored-vocabulary rules. The author cache re-keys once.
  */
 export const GENERATE_API_PROMPT_FINGERPRINT = fingerprint(GENERATE_API_SYSTEM_PROMPT)
 
@@ -1963,6 +1980,12 @@ scenario that does not assert that exact message/value is flagged (weak), no mat
 how much else it checks. Judge only what the milestones claim — a scenario is not
 flagged for failing to test something no milestone states.
 
+When a pre-boot seed sidecar is included, audit it as arrangement code too. Every
+seeded fixture/entity must correspond to a listed sidecar precondition, and the
+sidecar must only establish those preconditions. Flag a scenario if its sidecar
+performs the milestone behavior itself, makes the later assertion vacuous, or
+creates state outside the documented arrangement plan.
+
 # Two-sided claims — both halves must be asserted
 When a claim asserts BOTH what the program DOES and what it does NOT do — a set of
 inputs accepted/matched/included AND a set rejected/excluded/left out ("accepts A
@@ -1989,9 +2012,8 @@ claim quotes a value no assertion mentions); a high-confidence flag is acted on
 without a human. Omit both when faithful.`
 
 /**
- * PIN 2026-08-01 (Wave 5): rolled once — the reviewer now flags a
- * one-sided scenario `weak` on the same two-sided criterion the authoring prompts
- * teach, so the author and the auditor can never disagree on what "verifies" means.
+ * PIN 2026-08-04: rolled so the reviewer audits executable sidecar source against
+ * its declared arrangement plan and rejects milestone behavior hidden in setup.
  */
 export const FIDELITY_PROMPT_FINGERPRINT = fingerprint(FIDELITY_SYSTEM_PROMPT)
 
@@ -2011,6 +2033,14 @@ export interface FidelityUserContext {
   milestones: FidelityMilestone[]
   /** The committed YAML of the green scenario under review. */
   scenarioYaml: string
+  /** Exact generated pre-boot code, present only for a seeded API candidate. */
+  seedSidecarSource?: string
+  /** The author-declared plan against which sidecar mutations are reviewed. */
+  seedPreconditions?: readonly {
+    description: string
+    mechanism: 'bootstrap' | 'scenario-step' | 'sidecar' | 'unrealizable'
+    outputs?: string[]
+  }[]
   /** On a re-ask after invalid output, the prior output quoted back. */
   correction?: OutputCorrection
 }
@@ -2041,6 +2071,20 @@ export function buildFidelityUserPrompt(ctx: FidelityUserContext): string {
     '"""',
     ctx.scenarioYaml,
     '"""',
+  )
+  if (ctx.seedSidecarSource !== undefined) {
+    lines.push(
+      '',
+      'DECLARED PRE-BOOT PRECONDITIONS:',
+      JSON.stringify(ctx.seedPreconditions ?? [], null, 2),
+      '',
+      'SEED SIDECAR UNDER REVIEW (arrangement only; must not perform milestone behavior):',
+      '"""',
+      ctx.seedSidecarSource,
+      '"""',
+    )
+  }
+  lines.push(
     '',
     'Return exactly one JSON object: { "verdict": "faithful" } or',
     '{ "verdict": "flagged", "mismatch": "<one sentence>" }.',

--- a/packages/guard-generator/src/schemas.ts
+++ b/packages/guard-generator/src/schemas.ts
@@ -18,6 +18,7 @@
 
 import { z } from 'zod'
 import {
+  GuardApiSetupSchema,
   GuardSetupSchema,
   GuardStepSchema,
   GuardApiStepSchema,
@@ -263,18 +264,84 @@ export const RawGeneratedCliScenarioSchema = z
   .passthrough()
 export type RawGeneratedCliScenario = z.infer<typeof RawGeneratedCliScenarioSchema>
 
+export const GeneratedPreconditionSchema = z
+  .object({
+    description: z.string().min(1),
+    mechanism: z.enum(['bootstrap', 'scenario-step', 'sidecar', 'unrealizable']),
+    /** Static names produced for this precondition (`fixture:name` / `credential:name`). */
+    outputs: z.array(z.string().regex(/^(fixture|credential):[^:]+$/)).optional(),
+  })
+  .strict()
+
+export const GeneratedSeedSidecarSchema = z
+  .object({
+    source: z.string().min(1),
+    access: z.enum(['repository-modules', 'direct-datastore']),
+  })
+  .strict()
+
 export const RawGeneratedApiScenarioSchema = z
   .object({
     title: z.string().min(1),
     driver: z.literal('api'),
-    setup: GuardSetupSchema.optional(),
+    setup: GuardApiSetupSchema.optional(),
     steps: z.array(GuardApiStepSchema).min(1),
     normalize: z.array(GuardNormalizerSchema).optional(),
+    /** Engine-auditable arrangement plan; omitted for legacy, seedless model output. */
+    preconditions: z.array(GeneratedPreconditionSchema).optional(),
+    /** Exact adjacent `.seed.mjs` source. Its path is engine-owned and derived from the YAML basename. */
+    seedSidecar: GeneratedSeedSidecarSchema.optional(),
   })
   .passthrough()
+  .superRefine((scenario, ctx) => {
+    const seed = scenario.setup?.seed
+    if ((seed !== undefined) !== (scenario.seedSidecar !== undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['seedSidecar'],
+        message: 'setup.seed and seedSidecar must be authored together',
+      })
+      return
+    }
+    if (!seed) return
+    const documented = new Set(
+      (scenario.preconditions ?? [])
+        .filter((precondition) => precondition.mechanism === 'sidecar')
+        .flatMap((precondition) => precondition.outputs ?? []),
+    )
+    const declared = [
+      ...Object.keys(seed.provides.fixtures ?? {}).map((name) => `fixture:${name}`),
+      ...Object.keys(seed.provides.credentials ?? {}).map((name) => `credential:${name}`),
+    ]
+    for (const output of declared) {
+      if (documented.has(output)) continue
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['preconditions'],
+        message: `${output} must map to a documented sidecar precondition`,
+      })
+    }
+    for (const envName of ['GUARD_SEED_NAMESPACE', 'GUARD_SEED_OUT']) {
+      if (scenario.seedSidecar?.source.includes(envName)) continue
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['seedSidecar', 'source'],
+        message: `seedSidecar source must use ${envName}`,
+      })
+    }
+    for (const output of declared) {
+      const name = output.slice(output.indexOf(':') + 1)
+      if (scenario.seedSidecar?.source.includes(name)) continue
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['seedSidecar', 'source'],
+        message: `seedSidecar source must materialize its declared ${output} output`,
+      })
+    }
+  })
 export type RawGeneratedApiScenario = z.infer<typeof RawGeneratedApiScenarioSchema>
 
-export const RawGeneratedScenarioSchema = z.discriminatedUnion('driver', [
+export const RawGeneratedScenarioSchema = z.union([
   RawGeneratedCliScenarioSchema,
   RawGeneratedApiScenarioSchema,
 ])
@@ -321,7 +388,7 @@ function authoredResponse(scenario: z.ZodTypeAny) {
  * parses every reply with the driver-union above.
  */
 export const AuthoredCliResponseSchema = authoredResponse(RawGeneratedCliScenarioSchema.strip())
-export const AuthoredApiResponseSchema = authoredResponse(RawGeneratedApiScenarioSchema.strip())
+export const AuthoredApiResponseSchema = authoredResponse(RawGeneratedApiScenarioSchema.innerType().strip())
 
 // ---------------------------------------------------------------------------
 // Fidelity review (one call per green scenario, after birth passes)

--- a/packages/guard-generator/src/serialize.ts
+++ b/packages/guard-generator/src/serialize.ts
@@ -8,6 +8,7 @@
  */
 
 import fs from 'node:fs'
+import { randomUUID } from 'node:crypto'
 import path from 'node:path'
 import yaml from 'js-yaml'
 import {
@@ -20,7 +21,13 @@ import {
   type GuardScenario,
   type Journey,
 } from '@truecourse/shared'
-import { slugifyHeading, scenariosDir, loadScenarios } from '@truecourse/guard-runner'
+import {
+  slugifyHeading,
+  scenariosDir,
+  loadScenarios,
+  scenarioSeedSidecarPath,
+  type ScenarioArtifact,
+} from '@truecourse/guard-runner'
 import type { RawGeneratedScenario } from './schemas.js'
 import type { SectionInput } from './section-plan.js'
 
@@ -138,13 +145,92 @@ export function serializeScenarioYaml(scenario: GuardScenario): string {
   return yaml.dump(scenario, { lineWidth: -1, noRefs: true })
 }
 
+interface ScenarioPairSnapshot {
+  yaml: Buffer | null
+  sidecar: Buffer | null
+}
+
+function snapshotScenarioPair(yamlFile: string, sidecarFile: string): ScenarioPairSnapshot {
+  return {
+    yaml: fs.existsSync(yamlFile) ? fs.readFileSync(yamlFile) : null,
+    sidecar: fs.existsSync(sidecarFile) ? fs.readFileSync(sidecarFile) : null,
+  }
+}
+
+function restoreFile(file: string, prior: Buffer | null): void {
+  if (prior === null) {
+    if (fs.existsSync(file)) fs.rmSync(file)
+    return
+  }
+  fs.writeFileSync(file, prior)
+}
+
+/** Restore both members to their exact prior bytes when a pair mutation fails. */
+function updateScenarioPair<T>(yamlFile: string, sidecarFile: string, mutate: () => T): T {
+  const prior = snapshotScenarioPair(yamlFile, sidecarFile)
+  try {
+    return mutate()
+  } catch (error) {
+    restoreFile(yamlFile, prior.yaml)
+    restoreFile(sidecarFile, prior.sidecar)
+    throw error
+  }
+}
+
 /** Write a scenario to `<scenarios>/<slug>/<id>.yaml`, returning its repo-relative path. */
 export function writeScenarioFile(repoRoot: string, slug: string, scenario: GuardScenario): string {
   const dir = path.join(scenariosDir(repoRoot), slug)
   fs.mkdirSync(dir, { recursive: true })
   const file = path.join(dir, `${scenario.id}.yaml`)
-  fs.writeFileSync(file, serializeScenarioYaml(scenario))
+  const sidecar = scenarioSeedSidecarPath(file)
+  const staged = `${file}.${randomUUID()}.tmp`
+  try {
+    updateScenarioPair(file, sidecar, () => {
+      fs.writeFileSync(staged, serializeScenarioYaml(scenario))
+      fs.renameSync(staged, file)
+      if (fs.existsSync(sidecar)) fs.rmSync(sidecar)
+    })
+  } finally {
+    if (fs.existsSync(staged)) fs.rmSync(staged)
+  }
   return path.relative(repoRoot, file)
+}
+
+/**
+ * Commit one generated YAML/sidecar pair as a unit. Both new files are fully
+ * staged in the destination directory before either target moves. If a rename
+ * fails, the exact prior bytes are restored so callers never observe a mixed
+ * old/new pair after this operation returns an error.
+ */
+export function writeScenarioArtifact(repoRoot: string, artifact: ScenarioArtifact): string {
+  const yamlFile = path.resolve(repoRoot, artifact.source.path)
+  const expectedRoot = path.resolve(scenariosDir(repoRoot))
+  if (yamlFile !== expectedRoot && !yamlFile.startsWith(`${expectedRoot}${path.sep}`)) {
+    throw new Error(`generated scenario path escapes the scenario tree: ${artifact.source.path}`)
+  }
+  const seedRel = scenarioSeedSidecarPath(artifact.source.path)
+  const sidecarFile = path.resolve(repoRoot, seedRel)
+  const companions = Object.entries(artifact.companions)
+  if (companions.length !== 1 || companions[0][0] !== seedRel) {
+    throw new Error(`generated seed companion must be exactly ${seedRel}`)
+  }
+
+  fs.mkdirSync(path.dirname(yamlFile), { recursive: true })
+  const token = randomUUID()
+  const stagedYaml = `${yamlFile}.${token}.tmp`
+  const stagedSidecar = `${sidecarFile}.${token}.tmp`
+  try {
+    updateScenarioPair(yamlFile, sidecarFile, () => {
+      fs.writeFileSync(stagedYaml, artifact.source.content)
+      fs.writeFileSync(stagedSidecar, companions[0][1])
+      fs.renameSync(stagedSidecar, sidecarFile)
+      fs.renameSync(stagedYaml, yamlFile)
+    })
+  } finally {
+    if (fs.existsSync(stagedYaml)) fs.rmSync(stagedYaml)
+    if (fs.existsSync(stagedSidecar)) fs.rmSync(stagedSidecar)
+  }
+  return path.relative(repoRoot, yamlFile)
 }
 
 /** Delete the given ids' committed files (used to replace a section's OWN prior scenarios). */
@@ -152,6 +238,12 @@ export function deleteScenarioFiles(repoRoot: string, ids: Iterable<string>): vo
   const index = scenarioFileIndex(repoRoot)
   for (const id of ids) {
     const file = index.get(id)
-    if (file && fs.existsSync(file)) fs.rmSync(file)
+    if (file && fs.existsSync(file)) {
+      const sidecar = scenarioSeedSidecarPath(file)
+      updateScenarioPair(file, sidecar, () => {
+        if (fs.existsSync(sidecar)) fs.rmSync(sidecar)
+        fs.rmSync(file)
+      })
+    }
   }
 }

--- a/packages/guard-runner/src/api/evidence.ts
+++ b/packages/guard-runner/src/api/evidence.ts
@@ -44,6 +44,13 @@ export interface ApiEvidenceStep {
   captured?: Record<string, string>
 }
 
+/** Successful scenario-local pre-boot arrangement recorded with API evidence. */
+export interface ScenarioSetupEvidence {
+  durationMs: number
+  fixtureNames: string[]
+  output: string
+}
+
 export interface WriteApiEvidenceParams {
   repoRoot: string
   runId: string
@@ -53,6 +60,8 @@ export interface WriteApiEvidenceParams {
   binds: readonly GuardBinds[]
   /** The flow the scenario realizes; absent for a hand-written scenario. */
   flowId?: string
+  /** Successful scenario-local pre-boot arrangement summary. */
+  setup?: ScenarioSetupEvidence
   outcome: 'pass' | 'fail' | 'error'
   steps: ApiEvidenceStep[]
   /** 1-based index of the failing step; omitted on a `pass` (nothing failed). */
@@ -69,6 +78,58 @@ export interface WriteApiEvidenceParams {
    * request), so it is applied at the single write boundary. Defaults to identity.
    */
   redact?: (text: string) => string
+}
+
+/** Evidence for an arrangement failure that occurs before an API sandbox/server exists. */
+export function writeApiSetupFailureEvidence(params: {
+  repoRoot: string
+  runId: string
+  scenarioId: string
+  title: string
+  binds: readonly GuardBinds[]
+  flowId?: string
+  expected: string
+  actual: string
+  durationMs: number
+}): string {
+  const dir = evidenceScenarioDir(params.repoRoot, params.runId, params.scenarioId)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(
+    path.join(dir, 'invocation.json'),
+    JSON.stringify(
+      {
+        scenarioId: params.scenarioId,
+        title: params.title,
+        ...(params.flowId ? { flowId: params.flowId } : {}),
+        binds: params.binds,
+        outcome: 'error',
+        setupDurationMs: params.durationMs,
+        steps: [],
+      },
+      null,
+      2,
+    ),
+  )
+  fs.writeFileSync(path.join(dir, 'server.stdout.txt'), '')
+  fs.writeFileSync(path.join(dir, 'server.stderr.txt'), '')
+  fs.writeFileSync(path.join(dir, 'files.txt'), '')
+  fs.writeFileSync(path.join(dir, 'diff.txt'), `${params.expected}\n\n${params.actual}\n`)
+  fs.writeFileSync(
+    path.join(dir, 'transcript.txt'),
+    [
+      `scenario: ${params.scenarioId}`,
+      `title:    ${params.title}`,
+      ...(params.flowId ? [`flow:     ${params.flowId}`] : []),
+      ...params.binds.map((bind, index) => `${index === 0 ? 'binds:   ' : '         '} ${bind.doc} #${bind.section}`),
+      'outcome:  error',
+      `setup:    ${params.durationMs}ms`,
+      '',
+      `expected: ${params.expected}`,
+      `actual:   ${params.actual}`,
+      '',
+    ].join('\n'),
+  )
+  return evidenceRelPath(params.runId, params.scenarioId)
 }
 
 /** Write the transcript and return the repo-relative evidence directory. */
@@ -145,6 +206,15 @@ function renderTranscript(params: WriteApiEvidenceParams): string {
     lines.push(`${i === 0 ? 'binds:   ' : '         '} ${b.doc} #${b.section}`)
   }
   lines.push(`outcome:  ${params.outcome}`)
+  if (params.setup) {
+    lines.push('setup:')
+    lines.push(`   duration: ${params.setup.durationMs}ms`)
+    lines.push(`   fixtures: ${params.setup.fixtureNames.join(', ') || '(none)'}`)
+    if (params.setup.output.trim()) {
+      lines.push('   output:')
+      lines.push(indent(params.setup.output.trimEnd()))
+    }
+  }
   lines.push('')
   for (const s of params.steps) {
     lines.push(`── step ${s.index} ${s.index === params.failingStep ? '(failing)' : ''}`.trimEnd())

--- a/packages/guard-runner/src/api/run-api-scenario.ts
+++ b/packages/guard-runner/src/api/run-api-scenario.ts
@@ -62,7 +62,7 @@ import {
   UnknownFixtureError,
   JSON_PATH_MISS,
 } from './vars.js'
-import { writeApiEvidence, type ApiEvidenceStep } from './evidence.js'
+import { writeApiEvidence, type ApiEvidenceStep, type ScenarioSetupEvidence } from './evidence.js'
 import { buildCredentialRedactor } from './redact.js'
 
 const ENV_PINS = DETERMINISM_PINS
@@ -152,6 +152,8 @@ export interface RunApiScenarioContext {
    * See {@link runSeed}.
    */
   fixtures?: ReadonlyMap<string, Record<string, unknown>>
+  /** Successful pre-boot scenario arrangement, already credential-redacted. */
+  setupEvidence?: ScenarioSetupEvidence
   /**
    * This scenario's `${unique}` token — seeded into the step-vars map before the
    * first step so `${unique}` interpolates anywhere `${var}` does (path, header
@@ -311,6 +313,7 @@ export async function runApiScenario(
   const evidenceRefs = {
     binds: scenario.binds,
     ...(scenario.flow ? { flowId: scenario.flow.id } : {}),
+    ...(ctx.setupEvidence ? { setup: ctx.setupEvidence } : {}),
   }
   const credentials = ctx.credentials ?? new Map<string, string>()
   const fixtures = ctx.fixtures ?? new Map<string, Record<string, unknown>>()
@@ -1070,6 +1073,7 @@ function failResult(
     title: scenario.title,
     binds: scenario.binds,
     ...(scenario.flow ? { flowId: scenario.flow.id } : {}),
+    ...(ctx.setupEvidence ? { setup: ctx.setupEvidence } : {}),
     outcome: 'fail',
     steps: records,
     failingStep: stepIndex,

--- a/packages/guard-runner/src/api/seed.ts
+++ b/packages/guard-runner/src/api/seed.ts
@@ -28,9 +28,12 @@ import { armChildKill } from '../child-kill.js'
 import { DEFAULT_BUILD_TIMEOUT_MS } from '../build.js'
 import { warnCredentialShapes, type RecipeApiSeed, type ResolvedCredential } from '../recipe.js'
 import { buildCredentialRedactor } from './redact.js'
+import type { GuardScenarioSeed } from '@truecourse/shared'
 
 /** The env var naming the file the seed command writes its manifest JSON to. */
 export const SEED_OUT_ENV = 'GUARD_SEED_OUT'
+/** Opaque stable namespace supplied only to scenario-local seed sidecars. */
+export const SEED_NAMESPACE_ENV = 'GUARD_SEED_NAMESPACE'
 
 /** How much of the seed's combined output rides a failure message (the tail is the useful part). */
 const OUTPUT_TAIL = 2_000
@@ -54,6 +57,9 @@ export interface SeedResult {
   credentials: Map<string, ResolvedCredential>
   /** Declared fixtures, name → { field → native JSON value }; only DECLARED fields. */
   fixtures: Map<string, Record<string, unknown>>
+  /** Child-process duration and output, used by scenario setup evidence. */
+  durationMs: number
+  output: string
 }
 
 export interface RunSeedOptions {
@@ -94,13 +100,87 @@ export interface RunSeedOptions {
  * seed echoed into its output never rides the tail unmasked.
  */
 export async function runSeed(opts: RunSeedOptions): Promise<SeedResult> {
+  return executeSeed(opts, opts.seed.command)
+}
+
+export interface RunScenarioSeedOptions extends Omit<RunSeedOptions, 'seed'> {
+  seed: GuardScenarioSeed
+  /** Exact source identity/content carried by the ScenarioArtifact. */
+  sidecar: { path: string; content: string }
+  namespace: string
+}
+
+/** Execute a source-backed scenario sidecar without writing it into the corpus tree. */
+export async function runScenarioSeed(opts: RunScenarioSeedOptions): Promise<SeedResult> {
+  const repoRoot = path.resolve(opts.repoRoot)
+  const intendedPath = path.resolve(repoRoot, opts.sidecar.path)
+  const relativePath = path.relative(repoRoot, intendedPath)
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new SeedError(`scenario seed sidecar path escapes the repository: ${opts.sidecar.path}`)
+  }
+  // Recreate the sidecar's repo-relative location in an external mirror. Sibling
+  // entries are symlinked back to the checkout so native ESM `./`/`../` imports
+  // resolve exactly as they will after commit, while neither candidate source is
+  // ever placed in the committed scenario tree during birth validation.
+  const mirrorRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-guard-scenario-source-'))
+  try {
+    const parts = relativePath.split(path.sep)
+    let sourceDir = repoRoot
+    let mirrorDir = mirrorRoot
+    for (const segment of parts.slice(0, -1)) {
+      fs.mkdirSync(mirrorDir, { recursive: true })
+      if (fs.existsSync(sourceDir)) {
+        for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+          if (entry.name === segment) continue
+          fs.symlinkSync(
+            path.join(sourceDir, entry.name),
+            path.join(mirrorDir, entry.name),
+            entry.isDirectory() ? 'junction' : 'file',
+          )
+        }
+      }
+      sourceDir = path.join(sourceDir, segment)
+      mirrorDir = path.join(mirrorDir, segment)
+    }
+    fs.mkdirSync(mirrorDir, { recursive: true })
+    if (fs.existsSync(sourceDir)) {
+      for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+        if (entry.name === parts.at(-1)) continue
+        fs.symlinkSync(
+          path.join(sourceDir, entry.name),
+          path.join(mirrorDir, entry.name),
+          entry.isDirectory() ? 'junction' : 'file',
+        )
+      }
+    }
+    const tempFile = path.join(mirrorDir, parts.at(-1)!)
+    fs.writeFileSync(tempFile, opts.sidecar.content, { flag: 'wx' })
+    const declaration: RecipeApiSeed = {
+      command: `node ${opts.sidecar.path}`,
+      provides: opts.seed.provides,
+    }
+    return await executeSeed(
+      {
+        ...opts,
+        seed: declaration,
+        env: { ...(opts.env ?? {}), [SEED_NAMESPACE_ENV]: opts.namespace },
+      },
+      [process.execPath, tempFile],
+    )
+  } finally {
+    fs.rmSync(mirrorRoot, { recursive: true, force: true })
+  }
+}
+
+async function executeSeed(opts: RunSeedOptions, invocation: string | string[]): Promise<SeedResult> {
   const { repoRoot, seed } = opts
   const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-guard-seed-'))
   const outFile = path.join(outDir, 'manifest.json')
+  const startedAt = Date.now()
   try {
     const run = await spawnSeed(
       repoRoot,
-      seed.command,
+      invocation,
       { ...(opts.env ?? {}), [SEED_OUT_ENV]: outFile },
       opts.timeoutMs ?? DEFAULT_BUILD_TIMEOUT_MS,
       opts.signal,
@@ -121,7 +201,11 @@ export async function runSeed(opts: RunSeedOptions): Promise<SeedResult> {
       )
     }
     try {
-      return resolveManifest(seed, readManifest(seed.command, outFile))
+      return {
+        ...resolveManifest(seed, readManifest(seed.command, outFile)),
+        durationMs: Date.now() - startedAt,
+        output: redact(run.output),
+      }
     } catch (e) {
       // Validation/parse messages carry names, not secrets — but redact uniformly so a
       // fixture value that happens to equal a secret can never slip through either.
@@ -179,7 +263,10 @@ interface SeedManifest {
 }
 
 /** Validate the manifest against `provides` and project it to the resolved result. */
-function resolveManifest(seed: RecipeApiSeed, manifest: SeedManifest): SeedResult {
+function resolveManifest(
+  seed: RecipeApiSeed,
+  manifest: SeedManifest,
+): Pick<SeedResult, 'credentials' | 'fixtures'> {
   const credentials = new Map<string, ResolvedCredential>()
   const emittedCreds = manifest.credentials ?? {}
   for (const [name, decl] of Object.entries(seed.provides.credentials ?? {})) {
@@ -256,20 +343,28 @@ interface SeedRun {
  */
 function spawnSeed(
   repoRoot: string,
-  command: string,
+  command: string | string[],
   env: Record<string, string>,
   timeoutMs: number,
   signal?: AbortSignal,
 ): Promise<SeedRun> {
   if (signal?.aborted) return Promise.resolve({ exitCode: null, timedOut: false, output: '' })
   return new Promise<SeedRun>((resolve) => {
-    const child = spawn(command, {
+    const child = Array.isArray(command)
+      ? spawn(command[0], command.slice(1), {
+          cwd: repoRoot,
+          env: constructChildEnv({ recipeEnv: env, passthrough: BUILD_PASSTHROUGH }),
+          shell: false,
+          detached: process.platform !== 'win32',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        })
+      : spawn(command, {
       cwd: repoRoot,
       env: constructChildEnv({ recipeEnv: env, passthrough: BUILD_PASSTHROUGH }),
       shell: true,
       detached: process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'pipe'],
-    })
+        })
     let output = ''
     let settled = false
     const kill = armChildKill(child, timeoutMs, signal, { processGroup: true })

--- a/packages/guard-runner/src/api/vars.ts
+++ b/packages/guard-runner/src/api/vars.ts
@@ -37,6 +37,44 @@ const NO_FIXTURES: ReadonlyMap<string, Record<string, unknown>> = new Map()
 /** Shared empty native-capture set — no `${var}` captured a non-string value. */
 const NO_NATIVE_VARS: ReadonlyMap<string, unknown> = new Map()
 
+export type GuardPlaceholderReference =
+  | { kind: 'credential'; name: string }
+  | { kind: 'fixture'; name: string; field: string | null }
+
+/**
+ * Find authored Guard fixture/credential references in an arbitrary typed value.
+ * This is the shared syntax boundary used by static generation checks; runtime
+ * interpolation remains responsible for resolving the returned names to values.
+ */
+export function guardPlaceholderReferences(value: unknown): GuardPlaceholderReference[] {
+  const references: GuardPlaceholderReference[] = []
+  const visit = (current: unknown): void => {
+    if (typeof current === 'string') {
+      for (const [, kind, ident] of current.matchAll(/\{\{(cred|fixture):([^{}]+)\}\}/g)) {
+        if (kind === 'cred') references.push({ kind: 'credential', name: ident })
+        else {
+          const dot = ident.indexOf('.')
+          references.push({
+            kind: 'fixture',
+            name: dot < 0 ? ident : ident.slice(0, dot),
+            field: dot < 0 ? null : ident.slice(dot + 1),
+          })
+        }
+      }
+      return
+    }
+    if (Array.isArray(current)) {
+      for (const item of current) visit(item)
+      return
+    }
+    if (current && typeof current === 'object') {
+      for (const item of Object.values(current)) visit(item)
+    }
+  }
+  visit(value)
+  return references
+}
+
 /**
  * Interpolate a request's path, header values, and string bodies in one pass.
  * `{{cred:<name>}}` placeholders resolve against `credentials` in HEADER values ONLY

--- a/packages/guard-runner/src/guard-executor.ts
+++ b/packages/guard-runner/src/guard-executor.ts
@@ -13,6 +13,7 @@
 import type { GuardScenario, GuardScenarioResult } from '@truecourse/shared'
 import type { Recipe } from './recipe.js'
 import { runGuard, type RunGuardResult } from './run.js'
+import type { ScenarioArtifact } from './scenario-loader.js'
 
 export interface GuardExecInput {
   /** The checkout to build + run against (working-tree root). */
@@ -25,6 +26,12 @@ export interface GuardExecInput {
    * restriction is applied before the seam, so the executor carries no filter.
    */
   scenarios: GuardScenario[]
+  /**
+   * Source-backed form of `scenarios`. When supplied it is authoritative; the
+   * compatibility array remains required so existing hosted executors and test
+   * doubles keep their current contract while they adopt artifact sources.
+   */
+  artifacts?: ScenarioArtifact[]
   branch?: string | null
   commit?: string | null
   /** true = real run (persist LATEST/run/history), false = birth-validation (in-memory only). REQUIRED. */
@@ -66,6 +73,7 @@ export const defaultGuardExecutor: GuardExecutor = (input) =>
     repoRoot: input.checkoutDir,
     recipe: input.recipe,
     scenarios: input.scenarios,
+    artifacts: input.artifacts,
     branch: input.branch,
     commit: input.commit,
     persist: input.persist,

--- a/packages/guard-runner/src/index.ts
+++ b/packages/guard-runner/src/index.ts
@@ -4,7 +4,15 @@
  * result mapping. Zero LLM dependencies; fully exercisable with hand-written scenarios.
  */
 
-export { runGuard, sourceGuardRunInputs, defaultRunConcurrency, apiBootConcurrency, runFailureMessage, orderReadBeforeWrite } from './run.js'
+export {
+  runGuard,
+  sourceGuardRunInputs,
+  defaultRunConcurrency,
+  apiBootConcurrency,
+  runFailureMessage,
+  orderReadBeforeWrite,
+  scenarioSeedNamespace,
+} from './run.js'
 export type { RunGuardOptions, RunGuardResult, GuardRunInputs } from './run.js'
 
 export { newRunNonce, scenarioUnique, applyUnique, applyUniqueEnv, applyUniqueSetup } from './unique.js'
@@ -36,8 +44,18 @@ export type {
 export { defaultGuardExecutor } from './guard-executor.js'
 export type { GuardExecutor, GuardExecInput, GuardExecReport } from './guard-executor.js'
 
-export { loadScenarios, walkScenarioRelFiles, outdatedFormatMessage } from './scenario-loader.js'
-export type { LoadedScenarios, ScenarioLoadError } from './scenario-loader.js'
+export {
+  loadScenarios,
+  walkScenarioRelFiles,
+  outdatedFormatMessage,
+  scenarioSeedSidecarPath,
+} from './scenario-loader.js'
+export type {
+  LoadedScenarios,
+  ScenarioLoadError,
+  ScenarioArtifact,
+  ScenarioArtifactSource,
+} from './scenario-loader.js'
 
 export {
   loadRecipe,
@@ -151,20 +169,29 @@ export {
   UnknownVariableError,
   UnknownCredentialError,
   UnknownFixtureError,
+  guardPlaceholderReferences,
 } from './api/vars.js'
+export type { GuardPlaceholderReference } from './api/vars.js'
 export { preflightApiServer } from './api/preflight.js'
 export type { ApiPreflightOptions } from './api/preflight.js'
-export { writeApiEvidence } from './api/evidence.js'
-export type { ApiEvidenceStep, WriteApiEvidenceParams } from './api/evidence.js'
+export { writeApiEvidence, writeApiSetupFailureEvidence } from './api/evidence.js'
+export type { ApiEvidenceStep, ScenarioSetupEvidence, WriteApiEvidenceParams } from './api/evidence.js'
 export { buildCredentialRedactor } from './api/redact.js'
-export { runSeed, SeedError, SEED_OUT_ENV } from './api/seed.js'
-export type { SeedResult, RunSeedOptions } from './api/seed.js'
+export {
+  runSeed,
+  runScenarioSeed,
+  SeedError,
+  SEED_OUT_ENV,
+  SEED_NAMESPACE_ENV,
+} from './api/seed.js'
+export type { SeedResult, RunSeedOptions, RunScenarioSeedOptions } from './api/seed.js'
 
 export {
   runScenario,
   isSetupDefectResult,
   SANDBOX_SETUP_EXPECTED,
   CAPABILITY_SETUP_EXPECTED,
+  SCENARIO_SEED_SETUP_EXPECTED,
 } from './run-scenario.js'
 export type { RunScenarioContext } from './run-scenario.js'
 

--- a/packages/guard-runner/src/run-scenario.ts
+++ b/packages/guard-runner/src/run-scenario.ts
@@ -102,6 +102,7 @@ function observeStep(capture: StepCapture): StepObservation {
  */
 export const SANDBOX_SETUP_EXPECTED = 'sandbox setup to succeed'
 export const CAPABILITY_SETUP_EXPECTED = 'setup capabilities to materialize'
+export const SCENARIO_SEED_SETUP_EXPECTED = 'scenario seed to materialize'
 
 /**
  * True when an `error` outcome is a setup-declaration defect (a bad `setup.files`
@@ -113,6 +114,7 @@ export function isSetupDefectResult(result: GuardScenarioResult): boolean {
   if (result.outcome !== 'error') return false
   const expected = result.failure?.expected
   return expected === SANDBOX_SETUP_EXPECTED || expected === CAPABILITY_SETUP_EXPECTED
+    || expected === SCENARIO_SEED_SETUP_EXPECTED
 }
 
 /**

--- a/packages/guard-runner/src/run.ts
+++ b/packages/guard-runner/src/run.ts
@@ -48,7 +48,12 @@ import {
   ExternalsError,
   type ResolvedExternal,
 } from './externals.js'
-import { loadScenarios, type ScenarioLoadError } from './scenario-loader.js'
+import {
+  loadScenarios,
+  scenarioSeedSidecarPath,
+  type ScenarioArtifact,
+  type ScenarioLoadError,
+} from './scenario-loader.js'
 import { runBuild, runInstall, DEFAULT_BUILD_TIMEOUT_MS, DEFAULT_INSTALL_TIMEOUT_MS, type BuildResult } from './build.js'
 import { preflightEntry, formatEntryPreflightError, type EntryPreflightResult } from './preflight.js'
 import { runScenario } from './run-scenario.js'
@@ -61,7 +66,9 @@ import {
 import { runApiScenario, type RunApiScenarioContext, type ServesPathVerdict } from './api/run-api-scenario.js'
 import { buildRouteManifest, whichAppServes, type RouteManifest } from './route-manifest.js'
 import { preflightApiServer } from './api/preflight.js'
-import { runSeed, SeedError } from './api/seed.js'
+import { runSeed, runScenarioSeed, SeedError } from './api/seed.js'
+import { writeApiSetupFailureEvidence } from './api/evidence.js'
+import { SCENARIO_SEED_SETUP_EXPECTED } from './run-scenario.js'
 import { runCredentialRequests, CredentialRequestError } from './api/credential-request.js'
 import { appendGuardHistory, readJourneyCatalog, recipePath, writeGuardLatest, writeGuardRun } from './store.js'
 import { DEFAULT_STEP_TIMEOUT_MS } from './executor.js'
@@ -89,6 +96,8 @@ export interface RunGuardOptions {
    * anything to the corpus. Omitted → the committed scenarios are loaded.
    */
   scenarios?: GuardScenario[]
+  /** Source-backed scenarios; authoritative over `scenarios` when supplied. */
+  artifacts?: ScenarioArtifact[]
   /**
    * Run against this recipe instead of loading `scenarios/recipe.json` from disk.
    * The executor seam supplies it (a hosted store per-commit; birth validation the
@@ -281,7 +290,12 @@ export function runFailureMessage(result: RunGuardResult): string | null {
 /** Recipe + scenario sourcing outcome: an early result, or the inputs to execute. */
 export type GuardRunInputs =
   | { early: RunGuardResult }
-  | { loaded: LoadedRecipe; selected: GuardScenario[]; loadErrors: ScenarioLoadError[] }
+  | {
+      loaded: LoadedRecipe
+      selected: GuardScenario[]
+      artifacts: ScenarioArtifact[]
+      loadErrors: ScenarioLoadError[]
+    }
 
 /** Load the committed recipe, mapping load failures to their early results. */
 function sourceRecipe(repoRoot: string): { early: RunGuardResult } | { loaded: LoadedRecipe } {
@@ -319,10 +333,16 @@ function selectScenarios(
 export function sourceGuardRunInputs(repoRoot: string, scenarioId?: string): GuardRunInputs {
   const recipe = sourceRecipe(repoRoot)
   if ('early' in recipe) return recipe
-  const { scenarios, errors: loadErrors } = loadScenarios(repoRoot)
+  const { scenarios, artifacts, errors: loadErrors } = loadScenarios(repoRoot)
   const sel = selectScenarios(scenarios, loadErrors, scenarioId)
   if ('early' in sel) return sel
-  return { loaded: recipe.loaded, selected: sel.selected, loadErrors }
+  const selectedIds = new Set(sel.selected.map((scenario) => scenario.id))
+  return {
+    loaded: recipe.loaded,
+    selected: sel.selected,
+    artifacts: artifacts.filter((artifact) => selectedIds.has(artifact.scenario.id)),
+    loadErrors,
+  }
 }
 
 export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
@@ -343,12 +363,22 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
     loaded = disk.loaded
   }
 
-  const { scenarios, errors: loadErrors } = opts.scenarios
-    ? { scenarios: opts.scenarios, errors: [] as ScenarioLoadError[] }
-    : loadScenarios(repoRoot)
+  const loadedCorpus =
+    opts.artifacts !== undefined
+      ? { scenarios: opts.artifacts.map((artifact) => artifact.scenario), artifacts: opts.artifacts, errors: [] as ScenarioLoadError[] }
+      : opts.scenarios !== undefined
+        ? { scenarios: opts.scenarios, artifacts: [] as ScenarioArtifact[], errors: [] as ScenarioLoadError[] }
+        : loadScenarios(repoRoot)
+  const { scenarios, artifacts, errors: loadErrors } = loadedCorpus
   const sel = selectScenarios(scenarios, loadErrors, opts.scenarioId)
   if ('early' in sel) return sel.early
   const selected = sel.selected
+  const selectedIds = new Set(selected.map((scenario) => scenario.id))
+  const artifactById = new Map(
+    artifacts
+      .filter((artifact) => selectedIds.has(artifact.scenario.id))
+      .map((artifact) => [artifact.scenario.id, artifact]),
+  )
 
   // Check EVERY binding against the live section index before running anything: a
   // scenario realizes a flow, so it binds one section per milestone. A section that
@@ -862,20 +892,101 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
       // Once cancelled, no new child spawns; a post-cancel settlement doesn't count
       // either — a run ending `aborted`/`run-timed-out` discards these results.
       if (cancel.signal.aborted) return null
-      const outcome =
-        scenario.driver === 'api'
-          ? await runApiScenario(scenario, {
+      let outcome: GuardScenarioResult | undefined
+      if (scenario.driver === 'api') {
+        const serverName = boundServerById.get(scenario.id)!.name
+        const baseCredentialView = credentialsFor(serverName)
+        let scenarioCredentials = baseCredentialView.credentials
+        let scenarioForeignCredentials = baseCredentialView.foreign
+        let scenarioFixtures = apiFixtures
+        let setupEvidence: RunApiScenarioContext['setupEvidence']
+
+        if (scenario.setup?.seed) {
+          const setupStartedAt = Date.now()
+          try {
+            const fixtureCollision = Object.keys(scenario.setup.seed.provides.fixtures ?? {}).find((name) => apiFixtures?.has(name))
+            if (fixtureCollision) {
+              throw new SeedError(`scenario fixture "${fixtureCollision}" collides with a run-level fixture`)
+            }
+            const credentialCollision = Object.keys(scenario.setup.seed.provides.credentials ?? {}).find((name) => apiCredentials?.has(name))
+            if (credentialCollision) {
+              throw new SeedError(`scenario credential "${credentialCollision}" collides with a run-level credential`)
+            }
+            const artifact = artifactById.get(scenario.id)
+            if (!artifact) throw new SeedError('source-backed scenario artifact is missing')
+            const sidecarPath = scenarioSeedSidecarPath(artifact.source.path)
+            const sidecarSource = artifact.companions[sidecarPath]
+            if (sidecarSource === undefined) {
+              throw new SeedError(`adjacent sidecar "${sidecarPath}" is missing from the scenario artifact`)
+            }
+            const seeded = await runScenarioSeed({
+              repoRoot,
+              seed: scenario.setup.seed,
+              sidecar: { path: sidecarPath, content: sidecarSource },
+              namespace: scenarioSeedNamespace(repoRoot, scenario.id),
+              env: serverBoot.get(serverName)!.env,
+              knownCredentials: apiCredentials,
+              externalSecrets,
+              timeoutMs: opts.buildTimeoutMs ?? DEFAULT_BUILD_TIMEOUT_MS,
+              signal: cancel.signal,
+            })
+            scenarioFixtures = new Map(apiFixtures ?? [])
+            for (const entry of seeded.fixtures) scenarioFixtures.set(...entry)
+            scenarioCredentials = new Map(baseCredentialView.credentials)
+            scenarioForeignCredentials = new Map(baseCredentialView.foreign)
+            for (const [name, credential] of seeded.credentials) {
+              const declaration = scenario.setup.seed.provides.credentials?.[name]
+              if (declaration?.servers && !declaration.servers.includes(serverName)) {
+                scenarioForeignCredentials.set(name, declaration.servers)
+              } else {
+                scenarioCredentials.set(name, credential.value)
+              }
+            }
+            setupEvidence = {
+              durationMs: seeded.durationMs,
+              fixtureNames: [...seeded.fixtures.keys()].sort(),
+              output: seeded.output,
+            }
+          } catch (error) {
+            const actual = error instanceof Error ? error.message : String(error)
+            const durationMs = Date.now() - setupStartedAt
+            const evidencePath = writeApiSetupFailureEvidence({
+              repoRoot,
+              runId,
+              scenarioId: scenario.id,
+              title: scenario.title,
+              binds: scenario.binds,
+              ...(scenario.flow ? { flowId: scenario.flow.id } : {}),
+              expected: SCENARIO_SEED_SETUP_EXPECTED,
+              actual,
+              durationMs,
+            })
+            outcome = {
+              id: scenario.id,
+              title: scenario.title,
+              binds: scenario.binds[0],
+              ...(scenario.flow ? { flowId: scenario.flow.id } : {}),
+              outcome: 'error',
+              durationMs,
+              failure: { step: 1, expected: SCENARIO_SEED_SETUP_EXPECTED, actual },
+              evidencePath,
+            }
+          }
+        }
+
+        outcome ??= await runApiScenario(scenario, {
               repoRoot,
               runId,
               unique: scenarioUnique(runNonce, scenario.id),
               server: boundServer(scenario.id),
               recipeEnv: serverBoot.get(boundServerById.get(scenario.id)!.name)!.env,
-              credentials: credentialsFor(boundServerById.get(scenario.id)!.name).credentials,
-              foreignCredentials: credentialsFor(boundServerById.get(scenario.id)!.name).foreign,
+              credentials: scenarioCredentials,
+              foreignCredentials: scenarioForeignCredentials,
               servesPath: servesPathFor(boundServerById.get(scenario.id)!),
               externalSecrets,
               externalTargets,
-              fixtures: apiFixtures,
+              fixtures: scenarioFixtures,
+              setupEvidence,
               responseSchemas: resolveScenarioResponseSchemas(
                 operationSchemaIndex,
                 scenario as GuardApiScenario,
@@ -886,7 +997,8 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
               signal: cancel.signal,
               onStep: (o) => stepStats.onApiStep(o),
             })
-          : await runScenario(scenario, {
+      } else {
+        outcome = await runScenario(scenario, {
               repoRoot,
               runId,
               unique: scenarioUnique(runNonce, scenario.id),
@@ -897,6 +1009,8 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
               signal: cancel.signal,
               onStep: (o) => stepStats.onCliStep(o),
             })
+      }
+      if (!outcome) throw new Error(`scenario "${scenario.id}" produced no result`)
       if (cancel.signal.aborted) return null
       const result: GuardScenarioResult = {
         ...outcome,
@@ -908,6 +1022,16 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
       return result
     }
 
+    // PHASE 1: seedless scenarios use the existing two pools. A scenario-local
+    // sidecar owns mutable reusable state, so seeded scenarios are excluded from
+    // both pools and cannot overlap any seedless server lifetime.
+    const isScenarioSeeded = (item: (typeof runnable)[number]): boolean =>
+      item.scenario.driver === 'api' && item.scenario.setup?.seed !== undefined
+    const seedlessRunnable = runnable.filter((item) => !isScenarioSeeded(item))
+    const seededRunnable = runnable
+      .filter((item) => isScenarioSeeded(item) && !externalBlockedIds.has(item.scenario.id))
+      .sort((a, b) => a.scenario.id.localeCompare(b.scenario.id))
+
     // TWO POOLS, run concurrently. An api scenario boots a whole target server that
     // lives for the scenario's duration, so a shared pool at the CLI sandbox width lets
     // heavyweight servers pile up (the diagnosed cal.com starvation). The api pool caps
@@ -916,9 +1040,9 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
     // of mutating ones WITHIN the api pool (its ordering only ever mattered for the api
     // set — cli sandboxes are isolated).
     const apiRunnable = orderReadBeforeWrite(
-      runnable.filter((x) => x.scenario.driver === 'api' && !externalBlockedIds.has(x.scenario.id)),
+      seedlessRunnable.filter((x) => x.scenario.driver === 'api' && !externalBlockedIds.has(x.scenario.id)),
     )
-    const cliRunnable = runnable.filter((x) => x.scenario.driver !== 'api')
+    const cliRunnable = seedlessRunnable.filter((x) => x.scenario.driver !== 'api')
     // The two pools share ONE budget so their combined in-flight count never exceeds
     // `concurrency` — the host-load knob whose violation caused the incident. When both
     // drivers run, the api pool draws from that budget (capped so it can't starve cli of
@@ -934,9 +1058,19 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
       mapWithConcurrency(cliRunnable, cliWidth, runOne),
     ])
     const executed = [...apiResults, ...cliResults].filter((r): r is GuardScenarioResult => r !== null)
-    const stop = cancelled('run')
+    let stop = cancelled('run')
     if (stop) return stop
     results.push(...executed)
+
+    // PHASE 2: one seeded scenario at a time, in stable id order. `runOne` covers
+    // the complete exclusive interval: sidecar -> validation -> server -> steps ->
+    // shutdown. Awaiting each result before dispatching the next is the lock.
+    for (const item of seededRunnable) {
+      const result = await runOne(item)
+      stop = cancelled('run')
+      if (stop) return stop
+      if (result) results.push(result)
+    }
     results.sort((a, b) => a.id.localeCompare(b.id))
 
     const latest: GuardLatest = {
@@ -985,6 +1119,37 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
     if (servicesUp && api?.services?.down) {
       await runBuild(repoRoot, api.services.down, loaded.recipe.env, DEFAULT_BUILD_TIMEOUT_MS)
     }
+  }
+}
+
+/**
+ * Stable, opaque ownership namespace for one scenario. A Git remote is stable
+ * across local and hosted checkouts; repositories without one fall back to their
+ * absolute root, which remains stable for repeated runs against the same world.
+ */
+export function scenarioSeedNamespace(repoRoot: string, scenarioId: string): string {
+  const identity = readRepositoryIdentity(repoRoot) ?? path.resolve(repoRoot)
+  return `guard_${crypto.createHash('sha256').update(identity).update('\0').update(scenarioId).digest('hex').slice(0, 24)}`
+}
+
+function readRepositoryIdentity(repoRoot: string): string | null {
+  try {
+    const dotGit = path.join(repoRoot, '.git')
+    let gitDir = dotGit
+    if (fs.statSync(dotGit).isFile()) {
+      const match = /^gitdir:\s*(.+)$/m.exec(fs.readFileSync(dotGit, 'utf-8'))
+      if (!match) return null
+      gitDir = path.resolve(repoRoot, match[1].trim())
+      const commonDirFile = path.join(gitDir, 'commondir')
+      if (fs.existsSync(commonDirFile)) {
+        gitDir = path.resolve(gitDir, fs.readFileSync(commonDirFile, 'utf-8').trim())
+      }
+    }
+    const config = fs.readFileSync(path.join(gitDir, 'config'), 'utf-8')
+    const origin = /\[remote\s+"origin"\]([\s\S]*?)(?=\n\[|$)/.exec(config)?.[1]
+    return /^\s*url\s*=\s*(.+)$/m.exec(origin ?? '')?.[1]?.trim() ?? null
+  } catch {
+    return null
   }
 }
 

--- a/packages/guard-runner/src/scenario-loader.ts
+++ b/packages/guard-runner/src/scenario-loader.ts
@@ -28,21 +28,59 @@ export interface ScenarioLoadError {
   message: string
 }
 
+/** One source file that belongs to a scenario artifact. */
+export interface ScenarioArtifactSource {
+  /** Repo-relative POSIX path, used as the source identity across local and hosted execution. */
+  path: string
+  /** Exact source bytes decoded as UTF-8. */
+  content: string
+}
+
+/**
+ * A parsed scenario together with the sources required to execute it. Keeping the
+ * source identity beside the parsed value lets generated candidates cross the
+ * executor seam without first being written into the committed corpus.
+ */
+export interface ScenarioArtifact {
+  scenario: GuardScenario
+  source: ScenarioArtifactSource
+  /** Repo-relative path -> exact companion source. Empty for every seedless scenario. */
+  companions: Record<string, string>
+}
+
 export interface LoadedScenarios {
+  /** Source-backed artifacts for execution/storage boundaries. */
+  artifacts: ScenarioArtifact[]
+  /** Parsed-scenario compatibility view retained for existing inventory callers. */
   scenarios: GuardScenario[]
   errors: ScenarioLoadError[]
 }
 
-/** Recursively collect `*.yaml` / `*.yml` files under the scenarios dir. */
-function collectScenarioFiles(dir: string): string[] {
+/** Adjacent sidecar path derived only from the YAML source identity. */
+export function scenarioSeedSidecarPath(scenarioFile: string): string {
+  return scenarioFile.replace(/\.ya?ml$/i, '.seed.mjs')
+}
+
+/** Recursively collect files matching `accept` under the scenarios dir. */
+function collectFiles(dir: string, accept: (name: string) => boolean): string[] {
   if (!fs.existsSync(dir)) return []
   const out: string[] = []
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name)
-    if (entry.isDirectory()) out.push(...collectScenarioFiles(full))
-    else if (entry.isFile() && /\.ya?ml$/i.test(entry.name)) out.push(full)
+    if (entry.isDirectory()) out.push(...collectFiles(full, accept))
+    else if (entry.isFile() && accept(entry.name)) out.push(full)
   }
   return out.sort()
+}
+
+/** Recursively collect `*.yaml` / `*.yml` files under the scenarios dir. */
+function collectScenarioFiles(dir: string): string[] {
+  return collectFiles(dir, (name) => /\.ya?ml$/i.test(name))
+}
+
+/** Recursively collect adjacent executable scenario seed sidecars. */
+function collectScenarioSeedFiles(dir: string): string[] {
+  return collectFiles(dir, (name) => name.endsWith('.seed.mjs'))
 }
 
 /**
@@ -66,7 +104,7 @@ export function walkScenarioRelFiles(root: string): string[] {
       const childRel = rel ? `${rel}/${e.name}` : e.name
       if (e.isDirectory()) walk(childRel)
       else if (e.isFile()) {
-        if (/\.ya?ml$/i.test(e.name)) out.push(childRel)
+        if (/\.ya?ml$/i.test(e.name) || e.name.endsWith('.seed.mjs')) out.push(childRel)
         else if (rel === '' && (e.name === 'recipe.json' || e.name === 'manifest.json')) {
           out.push(childRel)
         }
@@ -94,14 +132,17 @@ export function outdatedFormatMessage(version: number): string {
 
 export function loadScenarios(repoRoot: string): LoadedScenarios {
   const root = scenariosDir(repoRoot)
-  const scenarios: GuardScenario[] = []
+  const artifacts: ScenarioArtifact[] = []
   const errors: ScenarioLoadError[] = []
+  const claimedSidecars = new Set<string>()
 
   for (const file of collectScenarioFiles(root)) {
-    const rel = path.relative(repoRoot, file)
+    const rel = path.relative(repoRoot, file).split(path.sep).join('/')
+    let content: string
     let doc: unknown
     try {
-      doc = yaml.load(fs.readFileSync(file, 'utf-8'))
+      content = fs.readFileSync(file, 'utf-8')
+      doc = yaml.load(content)
     } catch (e) {
       errors.push({ file: rel, message: `YAML parse error: ${e instanceof Error ? e.message : e}` })
       continue
@@ -130,21 +171,57 @@ export function loadScenarios(repoRoot: string): LoadedScenarios {
       })
       continue
     }
-    scenarios.push(parsed.data)
+    const companions: Record<string, string> = {}
+    if (parsed.data.driver === 'api' && parsed.data.setup?.seed) {
+      const sidecar = scenarioSeedSidecarPath(file)
+      const sidecarRel = path.relative(root, sidecar).split(path.sep).join('/')
+      try {
+        if (!fs.existsSync(sidecar) || !fs.statSync(sidecar).isFile()) {
+          errors.push({
+            file: rel,
+            message: `scenario declares setup.seed but adjacent sidecar "${sidecarRel}" is missing`,
+          })
+          continue
+        }
+        const companionRel = path.relative(repoRoot, sidecar).split(path.sep).join('/')
+        companions[companionRel] = fs.readFileSync(sidecar, 'utf-8')
+        claimedSidecars.add(path.resolve(sidecar))
+      } catch (error) {
+        errors.push({
+          file: rel,
+          message: `could not load adjacent seed sidecar "${sidecarRel}": ${error instanceof Error ? error.message : error}`,
+        })
+        continue
+      }
+    }
+    artifacts.push({
+      scenario: parsed.data,
+      source: { path: rel, content },
+      companions,
+    })
+  }
+
+  for (const sidecar of collectScenarioSeedFiles(root)) {
+    if (claimedSidecars.has(path.resolve(sidecar))) continue
+    errors.push({
+      file: path.relative(repoRoot, sidecar).split(path.sep).join('/'),
+      message: 'orphan scenario seed sidecar has no adjacent YAML declaring setup.seed',
+    })
   }
 
   // Detect duplicate ids — they would collide in the section rollup and evidence dirs.
   const seen = new Map<string, string>()
-  const deduped: GuardScenario[] = []
-  for (const s of scenarios) {
+  const deduped: ScenarioArtifact[] = []
+  for (const artifact of artifacts) {
+    const s = artifact.scenario
     const prior = seen.get(s.id)
     if (prior) {
       errors.push({ file: prior, message: `duplicate scenario id "${s.id}"` })
       continue
     }
     seen.set(s.id, s.id)
-    deduped.push(s)
+    deduped.push(artifact)
   }
 
-  return { scenarios: deduped, errors }
+  return { artifacts: deduped, scenarios: deduped.map((artifact) => artifact.scenario), errors }
 }

--- a/packages/shared/src/guard/scenario.ts
+++ b/packages/shared/src/guard/scenario.ts
@@ -656,6 +656,39 @@ export const GuardSetupSchema = z
   })
   .strict()
 
+/** Static declaration of one credential emitted by a scenario seed sidecar. */
+export const GuardScenarioSeedCredentialSchema = z
+  .object({
+    header: z.string().min(1),
+    description: z.string().min(1).optional(),
+    satisfies: z.string().min(1).optional(),
+    servers: z.array(z.string().min(1)).min(1).optional(),
+  })
+  .strict()
+
+/** The outputs an adjacent scenario seed sidecar promises to emit. */
+export const GuardScenarioSeedProvidesSchema = z
+  .object({
+    fixtures: z.record(z.string().min(1), z.array(z.string().min(1)).min(1)).optional(),
+    credentials: z.record(z.string().min(1), GuardScenarioSeedCredentialSchema).optional(),
+  })
+  .strict()
+  .refine(
+    (provides) =>
+      Object.keys(provides.fixtures ?? {}).length > 0 ||
+      Object.keys(provides.credentials ?? {}).length > 0,
+    { message: 'scenario seed provides at least one fixture or credential' },
+  )
+
+export const GuardScenarioSeedSchema = z
+  .object({ provides: GuardScenarioSeedProvidesSchema })
+  .strict()
+
+/** API setup extends the shared declarative setup with a pre-boot seed declaration. */
+export const GuardApiSetupSchema = GuardSetupSchema.extend({
+  seed: GuardScenarioSeedSchema.optional(),
+}).strict()
+
 export const GuardBindsSchema = z
   .object({
     /** Repo-relative path of the spec document. */
@@ -717,7 +750,6 @@ const envelope = {
   journey: GuardScenarioJourneyRefSchema.optional(),
   /** Every section the flow's milestones come from — denormalized at write time. */
   binds: z.array(GuardBindsSchema).min(1),
-  setup: GuardSetupSchema.optional(),
   normalize: z.array(GuardNormalizerSchema).default([]),
 }
 
@@ -725,6 +757,7 @@ export const GuardCliScenarioSchema = z
   .object({
     ...envelope,
     driver: z.literal('cli'),
+    setup: GuardSetupSchema.optional(),
     steps: z.array(GuardStepSchema).min(1),
   })
   .strict()
@@ -733,6 +766,7 @@ export const GuardApiScenarioSchema = z
   .object({
     ...envelope,
     driver: z.literal('api'),
+    setup: GuardApiSetupSchema.optional(),
     /**
      * The recipe server this scenario runs against (an `api.servers` key).
      * ENGINE-ASSIGNED at authoring from the app that serves the flow's operations;
@@ -783,6 +817,10 @@ export type GuardExternalFault = z.infer<typeof GuardExternalFaultSchema>
 export type GuardExternal = z.infer<typeof GuardExternalSchema>
 export type GuardExternals = z.infer<typeof GuardExternalsSchema>
 export type GuardSetup = z.infer<typeof GuardSetupSchema>
+export type GuardApiSetup = z.infer<typeof GuardApiSetupSchema>
+export type GuardScenarioSeed = z.infer<typeof GuardScenarioSeedSchema>
+export type GuardScenarioSeedProvides = z.infer<typeof GuardScenarioSeedProvidesSchema>
+export type GuardScenarioSeedCredential = z.infer<typeof GuardScenarioSeedCredentialSchema>
 export type GuardBinds = z.infer<typeof GuardBindsSchema>
 export type GuardScenarioFlowRef = z.infer<typeof GuardScenarioFlowRefSchema>
 export type GuardScenarioJourneyRef = z.infer<typeof GuardScenarioJourneyRefSchema>

--- a/tests/cli/estimate-presentation.test.ts
+++ b/tests/cli/estimate-presentation.test.ts
@@ -65,6 +65,7 @@ interface Driven {
   onEstimatePhase?: EstimatePhase;
   onLlmEstimate?: (e: LlmEstimate) => Promise<boolean>;
   tracker?: StepTracker;
+  allowSeedExec?: boolean;
 }
 
 /**
@@ -219,6 +220,18 @@ describe('spec scan — estimate presentation', () => {
 });
 
 describe('guard generate — estimate presentation', () => {
+  it('forwards explicit non-interactive sidecar execution authority independently of --yes', async () => {
+    let driven: Driven | undefined;
+    vi.mocked(guardGenerateInProcess).mockImplementation((async (_root: string, opts: Driven) => {
+      driven = opts;
+      return { guard: { status: 'ok', noChanges: true, written: [], birthFindings: [], errors: [], llmFailures: [], extractionFailures: [] } };
+    }) as never);
+
+    await capture(() => runGuardGenerate({ cwd: repo, yes: true, allowSeedExec: true }));
+
+    expect(driven?.allowSeedExec).toBe(true);
+  });
+
   it('resolves the estimate line before the panel, then paints the checklist once', async () => {
     vi.mocked(guardGenerateInProcess).mockImplementation((async (_root: string, opts: Driven) => {
       opts.onEstimatePhase?.start();

--- a/tests/core/guard-store.test.ts
+++ b/tests/core/guard-store.test.ts
@@ -270,6 +270,17 @@ describe('FileGuardStore — evidence', () => {
 // ---------------------------------------------------------------------------
 
 describe('FileGuardStore — scenario corpus', () => {
+  it('snapshots sidecars as corpus members while the scenario inventory stays YAML-only', async () => {
+    const r = repo();
+    seedCorpus(r);
+    fs.writeFileSync(path.join(r, SCENARIOS_REL, 'cli', 'version.1.seed.mjs'), 'export default true\n');
+
+    const { fileCount } = await saveScenarios(refFor(r), path.join(r, SCENARIOS_REL));
+
+    expect(fileCount).toBe(4);
+    expect(await listScenarioFiles(r)).toEqual(['.truecourse/scenarios/cli/version.1.yaml']);
+  });
+
   it('saveScenarios reports the scenario-set file count (decisions.json excluded)', async () => {
     const r = repo();
     seedCorpus(r);

--- a/tests/ee-data-store/guard-store.test.ts
+++ b/tests/ee-data-store/guard-store.test.ts
@@ -121,6 +121,27 @@ const MANIFEST_JSON = JSON.stringify({
 
 const RECIPE_JSON = JSON.stringify({ build: 'pnpm build', entry: ['node', 'cli.js'] });
 
+const SEEDED_SCENARIO_YAML = `guard: 2
+id: s1
+title: shows a seeded booking
+binds:
+  - doc: README.md
+    section: intro
+    fingerprint: sha256:abc
+driver: api
+setup:
+  seed:
+    provides:
+      fixtures:
+        booking: [id]
+steps:
+  - request:
+      method: GET
+      path: /bookings/{{fixture:booking.id}}
+    expect:
+      status: 200
+`;
+
 /** Seed a `.truecourse/scenarios/` tree under `srcDir`; returns the scenarios dir. */
 function seedScenarios(srcDir: string): string {
   const dir = path.join(srcDir, '.truecourse', 'scenarios');
@@ -498,6 +519,27 @@ describe('PgGuardStore — scenario corpus (pglite + Postgres content)', () => {
     expect(await scopeCount(db, contentScope.guard(REPO))).toBe(3);
   });
 
+  it('round-trips a YAML-sidecar pair byte-for-byte while inventory remains YAML-only', async () => {
+    const dir = seedScenarios(srcDir);
+    const sidecar = `import fs from 'node:fs'\nfs.writeFileSync(process.env.GUARD_SEED_OUT, '{}')\n`;
+    writeFile(dir, 'core/help.yaml', SEEDED_SCENARIO_YAML);
+    writeFile(dir, 'core/help.seed.mjs', sidecar);
+
+    const saved = await store.saveScenarios(refAt('paired'), dir);
+    const loaded = await store.loadScenarios(refAt('paired'));
+
+    expect(saved.fileCount).toBe(4);
+    expect(loaded.errors).toEqual([]);
+    expect(loaded.artifacts[0].source.content).toBe(SEEDED_SCENARIO_YAML);
+    expect(loaded.artifacts[0].companions).toEqual({
+      '.truecourse/scenarios/core/help.seed.mjs': sidecar,
+    });
+    expect(await store.listScenarioFiles(REPO, 'paired')).toEqual([
+      '.truecourse/scenarios/core/help.yaml',
+    ]);
+    expect(await store.readScenarioFile(REPO, '.truecourse/scenarios/core/help.seed.mjs', 'paired')).toBe(sidecar);
+  });
+
   it('rejects an empty commit SHA on saveScenarios', async () => {
     await expect(store.saveScenarios(refAt(''), seedScenarios(srcDir))).rejects.toThrow(/commit SHA/i);
   });
@@ -509,13 +551,13 @@ describe('PgGuardStore — scenario corpus (pglite + Postgres content)', () => {
     expect(loaded.scenarios.map((s) => s.id)).toEqual(['s1']);
     expect(loaded.scenarios[0]!.binds[0].doc).toBe('README.md');
     // an unknown commit is empty — exact-commit semantics, no latest fallback
-    expect(await store.loadScenarios(refAt('nope'))).toEqual({ scenarios: [], errors: [] });
+    expect(await store.loadScenarios(refAt('nope'))).toEqual({ artifacts: [], scenarios: [], errors: [] });
     // leaves no temp dir behind
     expect(fs.readdirSync(os.tmpdir()).filter((n) => n.startsWith('tc-guard-scenarios-'))).toEqual([]);
   });
 
   it('empty repo: load/list/read are empty, manifest/recipe null', async () => {
-    expect(await store.loadScenarios(refAt('c1'))).toEqual({ scenarios: [], errors: [] });
+    expect(await store.loadScenarios(refAt('c1'))).toEqual({ artifacts: [], scenarios: [], errors: [] });
     expect(await store.listScenarioFiles(REPO)).toEqual([]);
     expect(await store.readManifest(REPO)).toBeNull();
     expect(await store.readRecipeRaw(REPO)).toBeNull();

--- a/tests/github-app/guard-gate-runner.test.ts
+++ b/tests/github-app/guard-gate-runner.test.ts
@@ -37,6 +37,8 @@ import { OpenConflictsError } from '@truecourse/core/commands/guard-in-process';
 import {
   createGuardGatePipeline,
   cloneAbortSignal,
+  defaultLoadCorpus,
+  guardCorpusFingerprint,
   InvalidGuardRecipeError,
   GUARD_GATE_RUN_TIMEOUT_MS,
   GUARD_GATE_BUILD_TIMEOUT_MS,
@@ -628,6 +630,83 @@ describe('guard-gate pipeline — default corpus load (store-backed)', () => {
       fs.rmSync(src, { recursive: true, force: true });
     }
   }
+
+  it('preserves stored sidecar artifacts through hosted execution and fingerprints both sources', async () => {
+    const commitSha = 'seededcorpus123';
+    const seededYaml = [
+      'guard: 2',
+      'id: seeded.api.1',
+      'title: seeded',
+      'binds:',
+      '  - doc: README.md',
+      '    section: intro',
+      '    fingerprint: "sha256:f"',
+      'driver: api',
+      'setup:',
+      '  seed:',
+      '    provides:',
+      '      fixtures:',
+      '        account: [id]',
+      'steps:',
+      '  - request:',
+      '      method: GET',
+      '      path: "/accounts/{{fixture:account.id}}"',
+      '    expect:',
+      '      status: 200',
+      '',
+    ].join('\n');
+    const sidecar = '// exact hosted sidecar\n';
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-guard-gate-seeded-src-'));
+    try {
+      writeFile(src, 'recipe.json', JSON.stringify(RECIPE));
+      writeFile(src, 'api/seeded.api.1.yaml', seededYaml);
+      writeFile(src, 'api/seeded.api.1.seed.mjs', sidecar);
+      await guardStore.saveScenarios({ repoKey: REPO, commitSha }, src);
+    } finally {
+      fs.rmSync(src, { recursive: true, force: true });
+    }
+
+    const stored = await guardStore.loadScenarios({ repoKey: REPO, commitSha });
+    expect(stored.errors).toEqual([]);
+    const loaded = await defaultLoadCorpus(guardStore, { repoKey: REPO, commitSha });
+    expect(loaded?.artifacts?.[0].companions).toEqual({
+      '.truecourse/scenarios/api/seeded.api.1.seed.mjs': sidecar,
+    });
+    const latestFallback = await defaultLoadCorpus(guardStore, {
+      repoKey: REPO,
+      commitSha: 'baseline-without-a-corpus',
+    });
+    expect(latestFallback?.artifacts?.[0].companions).toEqual({
+      '.truecourse/scenarios/api/seeded.api.1.seed.mjs': sidecar,
+    });
+    const first = guardCorpusFingerprint(loaded!.scenarios, loaded!.artifacts);
+    const changed = loaded!.artifacts!.map((artifact) => ({
+      ...artifact,
+      companions: Object.fromEntries(
+        Object.entries(artifact.companions).map(([name, source]) => [name, `${source}// changed\n`]),
+      ),
+    }));
+    expect(guardCorpusFingerprint(loaded!.scenarios, changed)).not.toBe(first);
+
+    await gateStore.saveBaseline({
+      repoFullName: REPO,
+      commitSha,
+      drifts: [],
+      capturedAt: '2026-07-01T00:00:00.000Z',
+    });
+    await guardStore.writeGuardLatest(REPO, latestOf([result('seeded.api.1', 'pass')], BASE_SHA));
+    const execCalls: GuardExecInput[] = [];
+    const { clone } = fakeClone();
+    const { checkout } = fakeCheckout();
+    const { deps } = makeDeps(async (input) => {
+      execCalls.push(input);
+      return okReport(latestOf([result('seeded.api.1', 'pass')], input.commit ?? ''));
+    });
+    await createGuardGatePipeline({ clone, checkout }).run(deps, payload());
+    expect(execCalls[0].artifacts?.[0].companions).toEqual({
+      '.truecourse/scenarios/api/seeded.api.1.seed.mjs': sidecar,
+    });
+  });
 
   it('loads the stored recipe + scenarios keyed by the repo baseline commit', async () => {
     await saveCorpus('corpussha123', JSON.stringify(RECIPE));

--- a/tests/guard-generator/guard-executor.test.ts
+++ b/tests/guard-generator/guard-executor.test.ts
@@ -88,6 +88,16 @@ describe('birthValidate through the executor seam', () => {
   it('passes candidates + persist:false + skipBuild + recipe through, and maps the report back', async () => {
     const sink: { input?: GuardExecInput } = {}
     const candidates = [candidate('version.1'), candidate('version.2')]
+    candidates[0].artifact = {
+      scenario: candidates[0].scenario,
+      source: {
+        path: '.truecourse/scenarios/cli/version.1.yaml',
+        content: 'guard: 2\nid: version.1\n',
+      },
+      companions: {
+        '.truecourse/scenarios/cli/version.1.seed.mjs': 'export default true\n',
+      },
+    }
 
     const { outcomes } = await birthValidate('/repo', candidates, {
       executor: passingExecutor(sink),
@@ -102,6 +112,7 @@ describe('birthValidate through the executor seam', () => {
     expect(sink.input!.skipBuild).toBe(true)
     expect(sink.input!.recipe).toBe(RECIPE)
     expect(sink.input!.scenarios.map((s) => s.id)).toEqual(['version.1', 'version.2'])
+    expect(sink.input!.artifacts?.[0]).toEqual(candidates[0].artifact)
 
     // The report is mapped back onto each candidate.
     expect(outcomes).toHaveLength(2)

--- a/tests/guard-generator/prompts.test.ts
+++ b/tests/guard-generator/prompts.test.ts
@@ -507,8 +507,10 @@ describe('guard-generator prompts', () => {
     // `weak` on the same two-sided criterion the authoring prompts teach — a claim
     // stating a positive AND a negative half is verified only when the exclusion
     // half is asserted observably too.
-    expect(FIDELITY_PROMPT_FINGERPRINT).toBe('a4c250b19c101083')
-    expect(fingerprint(FIDELITY_SYSTEM_PROMPT)).toBe('a4c250b19c101083')
+    // Moved 2026-08-04: seeded candidates now include their executable arrangement
+    // source and declared preconditions, so milestone behavior hidden in setup is flagged.
+    expect(FIDELITY_PROMPT_FINGERPRINT).toBe('b66bb229e98c417b')
+    expect(fingerprint(FIDELITY_SYSTEM_PROMPT)).toBe('b66bb229e98c417b')
   })
 
   it('buildFidelityUserPrompt carries the flow, every milestone with its section text, and the YAML', () => {
@@ -853,8 +855,10 @@ describe('guard-generator prompts', () => {
     // accepted, invalid X rejected" gets a step for EACH half — the documented
     // success AND the documented rejection — so validation that silently stopped
     // rejecting can never stay green.
-    expect(fingerprint(GENERATE_API_SYSTEM_PROMPT)).toBe('05b921e5bee78edb')
-    expect(GENERATE_API_PROMPT_FINGERPRINT).toBe('05b921e5bee78edb')
+    // Rolled 2026-08-04 to publish the exact deterministic namespace environment
+    // contract used by the runner to generated sidecars.
+    expect(fingerprint(GENERATE_API_SYSTEM_PROMPT)).toBe('6b4a1e8148400cc9')
+    expect(GENERATE_API_PROMPT_FINGERPRINT).toBe('6b4a1e8148400cc9')
   })
 
   it('the api authoring prompt teaches the cookie jar and captureHeaders', () => {

--- a/tests/guard-generator/sidecar-generation.test.ts
+++ b/tests/guard-generator/sidecar-generation.test.ts
@@ -1,0 +1,520 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  authorCacheKey,
+  RawGeneratedApiScenarioSchema,
+  SeedExecutionNotAuthorizedError,
+  type RawGeneratedScenario,
+} from '@truecourse/guard-generator'
+import type { GuardExecInput, GuardExecReport } from '@truecourse/guard-runner'
+import { GUARD_FORMAT_VERSION, type GuardLatest, type GuardScenarioResult } from '@truecourse/shared'
+import {
+  apiJourney,
+  authorBy,
+  extractBy,
+  journeysOf,
+  makeTempRepo,
+  PASSING_API_STEPS,
+  rawApi,
+  rmrf,
+  runGenerate,
+  stampMilestones,
+  writeApiRecipe,
+  writeCorpus,
+  writeDoc,
+} from './helpers.js'
+
+const repos: string[] = []
+afterEach(() => {
+  while (repos.length) rmrf(repos.pop()!)
+})
+
+function repo(): string {
+  const value = makeTempRepo()
+  repos.push(value)
+  return value
+}
+
+const DOC = 'docs/api.md'
+const SIDE_EFFECT_FREE_SEED = [
+  "import fs from 'node:fs'",
+  "const namespace = process.env.GUARD_SEED_NAMESPACE",
+  "fs.writeFileSync(process.env.GUARD_SEED_OUT, JSON.stringify({ fixtures: { account: { id: `${namespace}-a-1` } } }))",
+  '',
+].join('\n')
+
+function seededScenario(source = SIDE_EFFECT_FREE_SEED): RawGeneratedScenario {
+  return rawApi('reads the arranged account', PASSING_API_STEPS, {
+    setup: { seed: { provides: { fixtures: { account: ['id'] } } } },
+    preconditions: [
+      {
+        description: 'an account exists before the server boots',
+        mechanism: 'sidecar',
+        outputs: ['fixture:account'],
+      },
+    ],
+    seedSidecar: { source, access: 'repository-modules' },
+  } as Partial<RawGeneratedScenario>)
+}
+
+function prepare(r: string): void {
+  writeApiRecipe(r, { entry: null })
+  writeCorpus(r, [{ ref: DOC }])
+  writeDoc(r, DOC, '## list\nGET /todos returns 200 with the todo list.\n')
+}
+
+function passingExecutor(inputs: GuardExecInput[]): (input: GuardExecInput) => Promise<GuardExecReport> {
+  return async (input) => {
+    inputs.push(input)
+    const scenarios: GuardScenarioResult[] = input.scenarios.map((scenario) => ({
+      id: scenario.id,
+      title: scenario.title,
+      binds: scenario.binds,
+      ...(scenario.flow ? { flowId: scenario.flow.id } : {}),
+      outcome: 'pass',
+      durationMs: 1,
+    }))
+    const latest: GuardLatest = {
+      run: {
+        runId: 'birth',
+        ranAt: '2026-08-04T00:00:00.000Z',
+        branch: null,
+        commit: null,
+        recipeFingerprint: 'sha256:recipe',
+        scenarioFormat: GUARD_FORMAT_VERSION,
+      },
+      summary: { total: scenarios.length, pass: scenarios.length, fail: 0, stale: 0, orphaned: 0, error: 0 },
+      scenarios,
+      sections: [],
+    }
+    return { status: 'ok', latest, latestPath: '', loadErrors: [], manifest: null }
+  }
+}
+
+function outcomeExecutor(
+  inputs: GuardExecInput[],
+  decide: (input: GuardExecInput) => GuardScenarioResult['outcome'],
+): (input: GuardExecInput) => Promise<GuardExecReport> {
+  return async (input) => {
+    inputs.push(input)
+    const scenarios: GuardScenarioResult[] = input.scenarios.map((scenario) => {
+      const outcome = decide(input)
+      return {
+        id: scenario.id,
+        title: scenario.title,
+        binds: scenario.binds,
+        ...(scenario.flow ? { flowId: scenario.flow.id } : {}),
+        outcome,
+        durationMs: 1,
+        ...(outcome === 'pass'
+          ? {}
+          : {
+              failure: {
+                step: 1,
+                expected: outcome === 'error' ? 'scenario seed to materialize' : 'status 200',
+                actual: outcome === 'error' ? 'sidecar exited 7: redacted diagnostic' : 'status 500',
+              },
+            }),
+      }
+    })
+    const count = (outcome: GuardScenarioResult['outcome']): number => scenarios.filter((s) => s.outcome === outcome).length
+    const latest: GuardLatest = {
+      run: {
+        runId: 'birth',
+        ranAt: '2026-08-04T00:00:00.000Z',
+        branch: null,
+        commit: null,
+        recipeFingerprint: 'sha256:recipe',
+        scenarioFormat: GUARD_FORMAT_VERSION,
+      },
+      summary: {
+        total: scenarios.length,
+        pass: count('pass'),
+        fail: count('fail'),
+        stale: 0,
+        orphaned: 0,
+        error: count('error'),
+      },
+      scenarios,
+      sections: [],
+    }
+    return { status: 'ok', latest, latestPath: '', loadErrors: [], manifest: null }
+  }
+}
+
+describe('generated per-scenario seed sidecars', () => {
+  it('moves generation cache identity when static YAML/sidecar material changes', () => {
+    const common = [{ fingerprint: 'sha256:flow' }, 'api' as const, ['sha256:section'], ['sha256:journey'], 'sha256:recipe'] as const
+    const first = authorCacheKey(...common, 'sha256:yaml-sidecar-a')
+    const second = authorCacheKey(...common, 'sha256:yaml-sidecar-b')
+
+    expect(first).not.toBe(second)
+  })
+
+  it('requires a documented sidecar precondition for every declared seed output', () => {
+    const candidate = seededScenario() as Record<string, unknown>
+    candidate.preconditions = []
+
+    const parsed = RawGeneratedApiScenarioSchema.safeParse(candidate)
+
+    expect(parsed.success).toBe(false)
+    expect(parsed.error?.message).toContain('fixture:account')
+  })
+
+  it('rejects sidecar source that cannot participate in deterministic namespaced materialization', () => {
+    const parsed = RawGeneratedApiScenarioSchema.safeParse(seededScenario('export default async function seed() {}'))
+
+    expect(parsed.success).toBe(false)
+    expect(parsed.error?.message).toContain('GUARD_SEED_NAMESPACE')
+    expect(parsed.error?.message).toContain('GUARD_SEED_OUT')
+  })
+
+  it('includes the sidecar source and precondition plan in fidelity review', async () => {
+    const r = repo()
+    prepare(r)
+    const reviewed: Array<{ seedSidecarSource?: string; seedPreconditions?: unknown[] }> = []
+
+    const result = await runGenerate({
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+      generateRunner: authorBy({ list: seededScenario() }),
+      executor: passingExecutor([]),
+      fidelityRunner: async (ctx) => {
+        reviewed.push(ctx)
+        return { verdict: 'faithful' }
+      },
+      allowSeedExec: true,
+    })
+
+    expect(result.status).toBe('ok')
+    expect(reviewed).toEqual([
+      expect.objectContaining({
+        seedSidecarSource: SIDE_EFFECT_FREE_SEED,
+        seedPreconditions: [expect.objectContaining({ mechanism: 'sidecar', outputs: ['fixture:account'] })],
+      }),
+    ])
+  })
+
+  it('rejects a generated fixture that has both run-level and scenario-local sources before birth', async () => {
+    const r = repo()
+    prepare(r)
+    const recipePath = path.join(r, '.truecourse', 'scenarios', 'recipe.json')
+    const recipe = JSON.parse(fs.readFileSync(recipePath, 'utf8'))
+    recipe.api.seed = {
+      command: 'node seed.mjs',
+      provides: { fixtures: { account: ['id'] } },
+    }
+    fs.writeFileSync(recipePath, JSON.stringify(recipe))
+    const executorInputs: GuardExecInput[] = []
+
+    const result = await runGenerate({
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+      generateRunner: authorBy({ list: seededScenario() }),
+      executor: passingExecutor(executorInputs),
+      allowSeedExec: true,
+    })
+
+    expect(result.status).toBe('llm-failed')
+    expect(result.reason).toContain('fixture "account" has more than one declared source')
+    expect(executorInputs).toEqual([])
+  })
+
+  it('rejects a fixture reference without exactly one declared provider before birth', async () => {
+    const r = repo()
+    prepare(r)
+    const executorInputs: GuardExecInput[] = []
+    const candidate = seededScenario() as Record<string, unknown>
+    candidate.steps = [
+      {
+        request: { method: 'GET', path: '/todos/{{fixture:missing.id}}' },
+        expect: { status: 200 },
+      },
+    ]
+
+    const result = await runGenerate({
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+      generateRunner: authorBy({ list: candidate as RawGeneratedScenario }),
+      executor: passingExecutor(executorInputs),
+      allowSeedExec: true,
+    })
+
+    expect(result.status).toBe('llm-failed')
+    expect(result.reason).toContain('fixture "missing" has no declared source')
+    expect(executorInputs).toEqual([])
+  })
+
+  it('refuses before execution or persistence when sidecar authority is absent', async () => {
+    const r = repo()
+    prepare(r)
+    const executorInputs: GuardExecInput[] = []
+
+    await expect(
+      runGenerate({
+        repoRoot: r,
+        journeys: journeysOf(r, apiJourney('GET', '/todos')),
+        extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+        generateRunner: authorBy({ list: seededScenario() }),
+        executor: passingExecutor(executorInputs),
+      }),
+    ).rejects.toBeInstanceOf(SeedExecutionNotAuthorizedError)
+
+    expect(executorInputs).toEqual([])
+    expect(fs.existsSync(path.join(r, '.truecourse', 'scenarios', 'api', 'list.api.1.yaml'))).toBe(false)
+    expect(fs.existsSync(path.join(r, '.truecourse', 'scenarios', 'api', 'list.api.1.seed.mjs'))).toBe(false)
+  })
+
+  it('rechecks authority when an evidence retry introduces the first sidecar', async () => {
+    const r = repo()
+    prepare(r)
+    const executorInputs: GuardExecInput[] = []
+
+    await expect(
+      runGenerate({
+        repoRoot: r,
+        journeys: journeysOf(r, apiJourney('GET', '/todos')),
+        extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+        generateRunner: async (ctx) => ({
+          scenario: stampMilestones(ctx.retry ? seededScenario() : rawApi('reads todos', PASSING_API_STEPS), ctx.milestones.length),
+        }),
+        executor: outcomeExecutor(executorInputs, (input) => (input.artifacts?.[0].companions && Object.keys(input.artifacts[0].companions).length > 0 ? 'pass' : 'fail')),
+      }),
+    ).rejects.toBeInstanceOf(SeedExecutionNotAuthorizedError)
+
+    expect(executorInputs).toHaveLength(1)
+    expect(fs.existsSync(path.join(r, '.truecourse', 'scenarios', 'api', 'list.api.1.seed.mjs'))).toBe(false)
+  })
+
+  it('asks again before an evidence retry executes changed sidecar source', async () => {
+    const r = repo()
+    prepare(r)
+    const executorInputs: GuardExecInput[] = []
+    const approvals: Array<Array<{ sourceFingerprint: string }>> = []
+    const repairedSeed = `${SIDE_EFFECT_FREE_SEED}// repaired arrangement\n`
+
+    const result = await runGenerate({
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+      generateRunner: async (ctx) => ({
+        scenario: stampMilestones(seededScenario(ctx.retry ? repairedSeed : SIDE_EFFECT_FREE_SEED), ctx.milestones.length),
+      }),
+      executor: outcomeExecutor(executorInputs, () => (executorInputs.length === 1 ? 'error' : 'pass')),
+      approveSeedExecution: async (summary) => {
+        approvals.push(summary)
+        return true
+      },
+    })
+
+    expect(result.status).toBe('ok')
+    expect(approvals).toHaveLength(2)
+    expect(approvals[0][0].sourceFingerprint).not.toBe(approvals[1][0].sourceFingerprint)
+    expect(executorInputs).toHaveLength(2)
+  })
+
+  it('summarizes once, birth-validates exact transient sources, and persists the approved pair', async () => {
+    const r = repo()
+    prepare(r)
+    const executorInputs: GuardExecInput[] = []
+    const approvals: unknown[] = []
+
+    const result = await runGenerate({
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+      generateRunner: authorBy({ list: seededScenario() }),
+      executor: passingExecutor(executorInputs),
+      approveSeedExecution: async (summary) => {
+        approvals.push(summary)
+        return true
+      },
+    })
+
+    expect(approvals).toEqual([
+      [
+        expect.objectContaining({
+          scenarioId: 'list.api.1',
+          outputs: ['fixture:account'],
+          access: 'repository-modules',
+        }),
+      ],
+    ])
+    expect(executorInputs).toHaveLength(1)
+    expect(executorInputs[0].artifacts).toEqual([
+      expect.objectContaining({
+        source: expect.objectContaining({ path: '.truecourse/scenarios/api/list.api.1.yaml' }),
+        companions: { '.truecourse/scenarios/api/list.api.1.seed.mjs': SIDE_EFFECT_FREE_SEED },
+      }),
+    ])
+
+    const yamlPath = path.join(r, result.written[0].file)
+    const sidecarPath = yamlPath.replace(/\.yaml$/, '.seed.mjs')
+    expect(fs.readFileSync(sidecarPath, 'utf8')).toBe(SIDE_EFFECT_FREE_SEED)
+    expect(fs.readFileSync(yamlPath, 'utf8')).toBe(executorInputs[0].artifacts![0].source.content)
+  })
+
+  it('never replaces a handwritten pair when allocating a generated id', async () => {
+    const r = repo()
+    prepare(r)
+    const manualDir = path.join(r, '.truecourse', 'scenarios', 'api')
+    fs.mkdirSync(manualDir, { recursive: true })
+    const manualYaml = JSON.stringify({
+      guard: GUARD_FORMAT_VERSION,
+      id: 'list.api.1',
+      title: 'handwritten baseline',
+      binds: [{ doc: DOC, section: 'list', fingerprint: 'sha256:manual' }],
+      driver: 'api',
+      setup: { seed: { provides: { fixtures: { manual: ['id'] } } } },
+      steps: [{ request: { method: 'GET', path: '/todos' }, expect: { status: 200 } }],
+      normalize: [],
+    })
+    const manualSidecar = '// handwritten and owned by the user\n'
+    fs.writeFileSync(path.join(manualDir, 'list.api.1.yaml'), manualYaml)
+    fs.writeFileSync(path.join(manualDir, 'list.api.1.seed.mjs'), manualSidecar)
+
+    const result = await runGenerate({
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+      generateRunner: authorBy({ list: seededScenario() }),
+      executor: passingExecutor([]),
+      allowSeedExec: true,
+    })
+
+    expect(result.written).toMatchObject([{ id: 'list.api.2' }])
+    expect(fs.readFileSync(path.join(manualDir, 'list.api.1.yaml'), 'utf8')).toBe(manualYaml)
+    expect(fs.readFileSync(path.join(manualDir, 'list.api.1.seed.mjs'), 'utf8')).toBe(manualSidecar)
+  })
+
+  it('replaces a generated pair with seedless YAML and removes the owned stale sidecar', async () => {
+    const r = repo()
+    prepare(r)
+    const base = {
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      extractRunner: extractBy({ list: [{ driver: 'api' as const, claim: 'GET /todos returns 200', reason: 'status' }] }),
+      executor: passingExecutor([]),
+    }
+    const first = await runGenerate({
+      ...base,
+      generateRunner: authorBy({ list: seededScenario() }),
+      allowSeedExec: true,
+    })
+    const yamlPath = path.join(r, first.written[0].file)
+    const sidecarPath = yamlPath.replace(/\.yaml$/, '.seed.mjs')
+    expect(fs.existsSync(sidecarPath)).toBe(true)
+
+    writeDoc(r, DOC, '## list\nGET /todos returns 200 with the complete todo list.\n')
+    const second = await runGenerate({
+      ...base,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      generateRunner: authorBy({ list: rawApi('reads the todo list', PASSING_API_STEPS) }),
+    })
+
+    expect(second.written).toMatchObject([{ id: 'list.api.1' }])
+    expect(fs.existsSync(yamlPath)).toBe(true)
+    expect(fs.existsSync(sidecarPath)).toBe(false)
+  })
+
+  it('re-authors both transient members once after an arrangement error and persists only the repaired pair', async () => {
+    const r = repo()
+    prepare(r)
+    const executorInputs: GuardExecInput[] = []
+    const bad = `${SIDE_EFFECT_FREE_SEED}// BAD arrangement\n`
+    const repaired = SIDE_EFFECT_FREE_SEED
+
+    const result = await runGenerate({
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+      generateRunner: authorBy({ list: { first: seededScenario(bad), retry: seededScenario(repaired) } }),
+      executor: outcomeExecutor(executorInputs, (input) =>
+        Object.values(input.artifacts![0].companions)[0].includes('BAD') ? 'error' : 'pass',
+      ),
+      allowSeedExec: true,
+    })
+
+    expect(executorInputs).toHaveLength(2)
+    expect(Object.values(executorInputs[0].artifacts![0].companions)[0]).toBe(bad)
+    expect(Object.values(executorInputs[1].artifacts![0].companions)[0]).toBe(repaired)
+    expect(result.written).toMatchObject([{ id: 'list.api.1', status: 'passing' }])
+    expect(fs.readFileSync(path.join(r, result.written[0].file.replace(/\.yaml$/, '.seed.mjs')), 'utf8')).toBe(repaired)
+  })
+
+  it('turns a demonstrated retry limitation into a missing-data gap and withholds both files', async () => {
+    const r = repo()
+    prepare(r)
+    const executorInputs: GuardExecInput[] = []
+
+    const result = await runGenerate({
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+      generateRunner: async (ctx) =>
+        ctx.retry
+          ? { blockedOn: ['missing-data', 'no safe repository ownership boundary for an account'] }
+          : { scenario: stampMilestones(seededScenario(), ctx.milestones.length) },
+      executor: outcomeExecutor(executorInputs, () => 'error'),
+      allowSeedExec: true,
+    })
+
+    expect(executorInputs).toHaveLength(1)
+    expect(result.coverageGaps).toEqual([
+      expect.objectContaining({ kind: 'blocked-on', reason: expect.stringContaining('missing-data') }),
+    ])
+    expect(result.written).toEqual([])
+    expect(fs.existsSync(path.join(r, '.truecourse', 'scenarios', 'api', 'list.api.1.yaml'))).toBe(false)
+    expect(fs.existsSync(path.join(r, '.truecourse', 'scenarios', 'api', 'list.api.1.seed.mjs'))).toBe(false)
+  })
+
+  it('withholds both files and leaves an authoring error after the single repair also fails arrangement', async () => {
+    const r = repo()
+    prepare(r)
+    const executorInputs: GuardExecInput[] = []
+
+    const result = await runGenerate({
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+      generateRunner: authorBy({ list: seededScenario() }),
+      executor: outcomeExecutor(executorInputs, () => 'error'),
+      allowSeedExec: true,
+    })
+
+    expect(executorInputs).toHaveLength(2)
+    expect(result.written).toEqual([])
+    expect(result.birthFindings).toEqual([])
+    expect(result.errors).toEqual([
+      expect.objectContaining({ kind: 'birth', message: expect.stringContaining('sidecar exited 7') }),
+    ])
+    expect(result.flows.unsettled).toBe(1)
+    expect(fs.existsSync(path.join(r, '.truecourse', 'scenarios', 'api', 'list.api.1.yaml'))).toBe(false)
+    expect(fs.existsSync(path.join(r, '.truecourse', 'scenarios', 'api', 'list.api.1.seed.mjs'))).toBe(false)
+  })
+
+  it('keeps an assertion failure after successful arrangement as an ordinary product finding', async () => {
+    const r = repo()
+    prepare(r)
+    const executorInputs: GuardExecInput[] = []
+
+    const result = await runGenerate({
+      repoRoot: r,
+      journeys: journeysOf(r, apiJourney('GET', '/todos')),
+      extractRunner: extractBy({ list: [{ driver: 'api', claim: 'GET /todos returns 200', reason: 'status' }] }),
+      generateRunner: authorBy({ list: seededScenario() }),
+      executor: outcomeExecutor(executorInputs, () => 'fail'),
+      allowSeedExec: true,
+    })
+
+    expect(result.written).toMatchObject([{ id: 'list.api.1', status: 'failing' }])
+    expect(result.birthFindings).toEqual([
+      expect.objectContaining({ expected: 'status 200', actual: 'status 500', committed: true }),
+    ])
+    expect(result.errors).toEqual([])
+  })
+})

--- a/tests/guard-runner/api-seed.test.ts
+++ b/tests/guard-runner/api-seed.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, afterEach, beforeEach, vi, type MockInstance } from 'vitest'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
-import { runGuard, runSeed, SeedError } from '@truecourse/guard-runner'
+import { runGuard, runScenarioSeed, runSeed, SeedError, isSetupDefectResult } from '@truecourse/guard-runner'
 import type { RecipeApiSeed } from '@truecourse/guard-runner'
 import {
   makeTempRepo,
   rmrf,
   writeApiRecipe,
   writeScenario,
+  writeScenarioFile,
   apiScenario,
   specBinds,
   FIXTURE_API_SERVER,
@@ -16,6 +18,7 @@ import {
 
 const repos: string[] = []
 afterEach(() => {
+  vi.restoreAllMocks()
   while (repos.length) rmrf(repos.pop()!)
 })
 function repo(): string {
@@ -229,6 +232,193 @@ describe('runSeed', () => {
       expect(e).toBeInstanceOf(SeedError)
       expect((e as Error).message).toContain('toString')
     }
+  })
+})
+
+describe('runScenarioSeed', () => {
+  it('removes its external source mirror when mirror construction fails', async () => {
+    const r = repo()
+    fs.writeFileSync(path.join(r, 'sibling.mjs'), 'export {}\n')
+    const before = new Set(fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('tc-guard-scenario-source-')))
+    vi.spyOn(fs, 'symlinkSync').mockImplementation(() => {
+      throw new Error('mirror link failed')
+    })
+
+    await expect(
+      runScenarioSeed({
+        repoRoot: r,
+        seed: { provides: { fixtures: { account: ['id'] } } },
+        sidecar: {
+          path: '.truecourse/scenarios/api/account.seed.mjs',
+          content: "process.env.GUARD_SEED_NAMESPACE; process.env.GUARD_SEED_OUT\n",
+        },
+        namespace: 'repo:account',
+      }),
+    ).rejects.toThrow('mirror link failed')
+
+    const after = fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('tc-guard-scenario-source-'))
+    expect(after.filter((name) => !before.has(name))).toEqual([])
+  })
+
+  it('resolves repository-relative imports from the sidecar intended directory without writing the corpus path', async () => {
+    const r = repo()
+    const scenarioDir = path.join(r, '.truecourse', 'scenarios', 'api')
+    fs.mkdirSync(scenarioDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(scenarioDir, 'seed-factory.mjs'),
+      "export const account = { id: 'account-from-repository-module' }\n",
+    )
+    const sidecarPath = '.truecourse/scenarios/api/account.seed.mjs'
+    const source = [
+      "import fs from 'node:fs'",
+      "import { account } from './seed-factory.mjs'",
+      "fs.writeFileSync(process.env.GUARD_SEED_OUT, JSON.stringify({ fixtures: { account } }))",
+      '',
+    ].join('\n')
+
+    const result = await runScenarioSeed({
+      repoRoot: r,
+      seed: { provides: { fixtures: { account: ['id'] } } },
+      sidecar: { path: sidecarPath, content: source },
+      namespace: 'repo:account',
+    })
+
+    expect(result.fixtures.get('account')).toEqual({ id: 'account-from-repository-module' })
+    expect(fs.existsSync(path.join(r, sidecarPath))).toBe(false)
+  })
+})
+
+describe('scenario-local pre-boot seed sidecars', () => {
+  it('classifies a redacted sidecar failure as a setup defect and persists its evidence', async () => {
+    const r = repo()
+    writeApiRecipe(r)
+    const secret = 'Bearer never-persist-this-secret'
+    const seeded = apiScenario({
+      id: 'scenario-seed-failure',
+      setup: {
+        seed: { provides: { credentials: { owner: { header: 'Authorization' } } } },
+      },
+      steps: [{ request: { method: 'GET', path: '/todos' }, expect: { status: 200 } }],
+    })
+    writeScenario(r, 'bookings/scenario-seed-failure.yaml', seeded)
+    writeScenarioFile(
+      r,
+      'bookings/scenario-seed-failure.seed.mjs',
+      `import fs from 'node:fs'\n` +
+        `fs.writeFileSync(process.env.GUARD_SEED_OUT, JSON.stringify({ credentials: { owner: { value: ${JSON.stringify(secret)} } } }))\n` +
+        `console.error(${JSON.stringify(secret)})\n` +
+        `process.exit(7)\n`,
+    )
+
+    const res = await runGuard({ repoRoot: r, skipBuild: true })
+
+    expect(res.status).toBe('ok')
+    if (res.status !== 'ok') return
+    const result = res.latest.scenarios[0]
+    expect(result).toMatchObject({
+      outcome: 'error',
+      failure: { expected: 'scenario seed to materialize' },
+    })
+    expect(isSetupDefectResult(result)).toBe(true)
+    expect(result.failure?.actual).not.toContain(secret)
+    expect(result.failure?.actual).toContain('«cred:owner»')
+    expect(result.evidencePath).toBeDefined()
+    const transcript = fs.readFileSync(path.join(r, result.evidencePath!, 'transcript.txt'), 'utf-8')
+    expect(transcript).toContain('scenario seed to materialize')
+    expect(transcript).toContain('«cred:owner»')
+    expect(transcript).not.toContain(secret)
+  })
+
+  it('executes a transient sidecar and preserves native fixture values through interpolation', async () => {
+    const r = repo()
+    writeApiRecipe(r)
+    const seeded = apiScenario({
+      id: 'scenario-seeded',
+      setup: { seed: { provides: { fixtures: { booking: ['id'] } } } },
+      steps: [
+        {
+          request: { method: 'GET', path: '/echo/{{fixture:booking.id}}' },
+          expect: { status: 200, json: { path: { equals: '/echo/42' } } },
+        },
+      ],
+    })
+    const yamlPath = '.truecourse/scenarios/bookings/scenario-seeded.yaml'
+    const sidecarPath = '.truecourse/scenarios/bookings/scenario-seeded.seed.mjs'
+    const sidecar = emit({ fixtures: { booking: { id: 42 } } })
+
+    const res = await runGuard({
+      repoRoot: r,
+      artifacts: [
+        {
+          scenario: seeded,
+          source: { path: yamlPath, content: JSON.stringify(seeded) },
+          companions: { [sidecarPath]: sidecar },
+        },
+      ],
+      skipBuild: true,
+      persist: false,
+    })
+
+    expect(res.status).toBe('ok')
+    if (res.status !== 'ok') return
+    expect(res.latest.scenarios[0].outcome).toBe('pass')
+    expect(fs.existsSync(path.join(r, sidecarPath))).toBe(false)
+  })
+
+  it('adds redacted setup evidence with duration and declared non-secret fixture names', async () => {
+    const r = repo()
+    writeApiRecipe(r)
+    const secret = 'Bearer scenario-local-secret'
+    const seeded = apiScenario({
+      id: 'scenario-evidence',
+      setup: {
+        seed: {
+          provides: {
+            fixtures: { booking: ['id'] },
+            credentials: { owner: { header: 'Authorization' } },
+          },
+        },
+      },
+      steps: [
+        {
+          request: {
+            method: 'GET',
+            path: '/echo/{{fixture:booking.id}}',
+            headers: { Authorization: '{{cred:owner}}' },
+          },
+          expect: {
+            status: 200,
+            json: {
+              path: { equals: '/echo/42' },
+              authorization: { equals: secret },
+            },
+          },
+        },
+      ],
+    })
+    writeScenario(r, 'bookings/scenario-evidence.yaml', seeded)
+    writeScenarioFile(
+      r,
+      'bookings/scenario-evidence.seed.mjs',
+      `import fs from 'node:fs'\n` +
+        `console.log(${JSON.stringify(`arranged booking with ${secret}`)})\n` +
+        `fs.writeFileSync(process.env.GUARD_SEED_OUT, JSON.stringify(${JSON.stringify({
+          fixtures: { booking: { id: 42 } },
+          credentials: { owner: { value: secret } },
+        })}))\n`,
+    )
+
+    const res = await runGuard({ repoRoot: r, skipBuild: true })
+
+    expect(res.status).toBe('ok')
+    if (res.status !== 'ok') return
+    const result = res.latest.scenarios[0]
+    expect(result.outcome).toBe('pass')
+    const transcript = fs.readFileSync(path.join(r, result.evidencePath!, 'transcript.txt'), 'utf-8')
+    expect(transcript).toContain('setup:')
+    expect(transcript).toContain('fixtures: booking')
+    expect(transcript).toContain('«cred:owner»')
+    expect(transcript).not.toContain(secret)
   })
 })
 

--- a/tests/guard-runner/guard-executor.test.ts
+++ b/tests/guard-runner/guard-executor.test.ts
@@ -71,6 +71,39 @@ describe('defaultGuardExecutor', () => {
     expect(fs.existsSync(guardLatestPath(r))).toBe(false)
   })
 
+  it('runs a transient source-backed artifact without writing it to the corpus first', async () => {
+    const r = repo()
+    writeRecipe(r)
+    const sc = scenario({
+      id: 'transient',
+      binds: specBinds('cli/version'),
+      steps: [{ run: ['--version'], expect: { exit: 0 } }],
+    })
+
+    const report = await defaultGuardExecutor({
+      checkoutDir: r,
+      recipe: recipeOf(r),
+      scenarios: [],
+      artifacts: [
+        {
+          scenario: sc,
+          source: {
+            path: '.truecourse/scenarios/cli/transient.yaml',
+            content: JSON.stringify(sc),
+          },
+          companions: { '.truecourse/scenarios/cli/transient.helper.mjs': 'export default true\n' },
+        },
+      ],
+      persist: false,
+      skipBuild: true,
+    })
+
+    expect(report.status).toBe('ok')
+    if (report.status !== 'ok') return
+    expect(report.latest.scenarios.map((result) => result.id)).toEqual(['transient'])
+    expect(fs.existsSync(`${r}/.truecourse/scenarios/cli/transient.yaml`)).toBe(false)
+  })
+
   it('forwards runTimeoutMs — a hanging scenario surfaces as run-timed-out', async () => {
     const r = repo()
     writeRecipe(r)

--- a/tests/guard-runner/scenario-loader.test.ts
+++ b/tests/guard-runner/scenario-loader.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
 import { loadScenarios } from '@truecourse/guard-runner'
 import { makeTempRepo, rmrf, writeScenario, writeScenarioFile, writeRecipe, scenario, apiScenario } from './helpers.js'
 
 const repos: string[] = []
 afterEach(() => {
+  vi.restoreAllMocks()
   while (repos.length) rmrf(repos.pop()!)
 })
 function repo(): string {
@@ -13,6 +16,118 @@ function repo(): string {
 }
 
 describe('loadScenarios', () => {
+  it('loads an adjacent seed sidecar as a companion of a seeded API scenario', () => {
+    const r = repo()
+    const seeded = apiScenario({
+      id: 'seeded-api',
+      setup: { seed: { provides: { fixtures: { booking: ['id'] } } } },
+      steps: [{ request: { method: 'GET', path: '/bookings/{{fixture:booking.id}}' }, expect: { status: 200 } }],
+    })
+    writeScenario(r, 'bookings/seeded-api.yaml', seeded)
+    writeScenarioFile(r, 'bookings/seeded-api.seed.mjs', 'await Promise.resolve()\n')
+
+    const loaded = loadScenarios(r)
+
+    expect(loaded.errors).toEqual([])
+    expect(loaded.artifacts).toHaveLength(1)
+    expect(loaded.artifacts[0].companions).toEqual({
+      '.truecourse/scenarios/bookings/seeded-api.seed.mjs': 'await Promise.resolve()\n',
+    })
+  })
+
+  it('reports a seeded scenario whose derived adjacent sidecar is missing', () => {
+    const r = repo()
+    writeScenario(
+      r,
+      'bookings/missing.yaml',
+      apiScenario({
+        id: 'missing-seed',
+        setup: { seed: { provides: { fixtures: { booking: ['id'] } } } },
+        steps: [{ request: { method: 'GET', path: '/bookings' }, expect: { status: 200 } }],
+      }),
+    )
+
+    const loaded = loadScenarios(r)
+
+    expect(loaded.scenarios).toEqual([])
+    expect(loaded.errors).toEqual([
+      {
+        file: '.truecourse/scenarios/bookings/missing.yaml',
+        message: 'scenario declares setup.seed but adjacent sidecar "bookings/missing.seed.mjs" is missing',
+      },
+    ])
+  })
+
+  it('records a sidecar filesystem race without crashing or hiding other scenarios', () => {
+    const r = repo()
+    writeScenario(
+      r,
+      'bookings/racy.yaml',
+      apiScenario({
+        id: 'racy-seed',
+        setup: { seed: { provides: { fixtures: { booking: ['id'] } } } },
+        steps: [{ request: { method: 'GET', path: '/bookings' }, expect: { status: 200 } }],
+      }),
+    )
+    const sidecar = path.join(r, '.truecourse', 'scenarios', 'bookings', 'racy.seed.mjs')
+    writeScenarioFile(r, 'bookings/racy.seed.mjs', 'await Promise.resolve()\n')
+    writeScenario(r, 'cli/good.yaml', scenario({ id: 'good', steps: [{ run: [], expect: { exit: 0 } }] }))
+    const realStat = fs.statSync
+    vi.spyOn(fs, 'statSync').mockImplementation(((file: fs.PathLike, ...args: unknown[]) => {
+      if (String(file) === sidecar) {
+        fs.rmSync(sidecar)
+        throw Object.assign(new Error('sidecar disappeared'), { code: 'ENOENT' })
+      }
+      return realStat(file, ...(args as []))
+    }) as typeof fs.statSync)
+
+    const loaded = loadScenarios(r)
+
+    expect(loaded.scenarios.map((item) => item.id)).toEqual(['good'])
+    expect(loaded.errors).toEqual([
+      expect.objectContaining({
+        file: '.truecourse/scenarios/bookings/racy.yaml',
+        message: expect.stringContaining('sidecar disappeared'),
+      }),
+    ])
+  })
+
+  it('reports an orphan seed sidecar with no declaring YAML scenario', () => {
+    const r = repo()
+    writeScenarioFile(r, 'bookings/orphan.seed.mjs', 'await Promise.resolve()\n')
+
+    const loaded = loadScenarios(r)
+
+    expect(loaded.scenarios).toEqual([])
+    expect(loaded.errors).toEqual([
+      {
+        file: '.truecourse/scenarios/bookings/orphan.seed.mjs',
+        message: 'orphan scenario seed sidecar has no adjacent YAML declaring setup.seed',
+      },
+    ])
+  })
+
+  it('returns each parsed scenario with its YAML source identity and source bytes', () => {
+    const r = repo()
+    const source = JSON.stringify(
+      scenario({ id: 'source-backed', steps: [{ run: ['--version'], expect: { exit: 0 } }] }),
+    )
+    writeScenarioFile(r, 'cli/source-backed.yaml', source)
+
+    const loaded = loadScenarios(r)
+
+    expect(loaded.errors).toEqual([])
+    expect(loaded.artifacts).toHaveLength(1)
+    expect(loaded.artifacts[0]).toMatchObject({
+      scenario: { id: 'source-backed' },
+      source: {
+        path: '.truecourse/scenarios/cli/source-backed.yaml',
+        content: source,
+      },
+      companions: {},
+    })
+  })
+
   it('loads valid scenarios and skips recipe.json', () => {
     const r = repo()
     writeRecipe(r)

--- a/tests/guard-runner/seeded-acceptance.test.ts
+++ b/tests/guard-runner/seeded-acceptance.test.ts
@@ -1,0 +1,144 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { runGuard, scenarioSeedNamespace, type ScenarioArtifact } from '@truecourse/guard-runner'
+import { apiScenario, makeTempRepo, rmrf, writeSpecDoc } from './helpers.js'
+
+const repos: string[] = []
+afterEach(() => {
+  while (repos.length) rmrf(repos.pop()!)
+})
+
+const SERVER = `
+import fs from 'node:fs'
+import http from 'node:http'
+import path from 'node:path'
+const file = process.env.ACCEPTANCE_STATE_PATH
+const server = http.createServer((req, res) => {
+  if (req.url === '/health') { res.writeHead(200); res.end('ok'); return }
+  const url = new URL(req.url, 'http://guard.local')
+  if (url.pathname !== '/snapshot') { res.writeHead(404); res.end(); return }
+  const namespace = url.searchParams.get('namespace')
+  const state = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : {}
+  const record = state[namespace]
+  const authorized = req.headers.authorization === 'Bearer ' + namespace + '-verification'
+  res.writeHead(record ? 200 : 404, { 'content-type': 'application/json' })
+  res.end(JSON.stringify(record ? { ...record, authorized } : { missing: true }))
+})
+server.listen(Number(process.env.PORT), '127.0.0.1')
+`
+
+const SIDECAR = `
+import fs from 'node:fs'
+import path from 'node:path'
+const namespace = process.env.GUARD_SEED_NAMESPACE
+const file = process.env.ACCEPTANCE_STATE_PATH
+const state = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : {}
+state[namespace] = {
+  lifecycle: { entity: 'booking', status: 'cancelled' },
+  aggregate: { organization: 'acme', team: 'support', member: 'owner' },
+  recurring: { count: 3, cadence: 'weekly' },
+  pastBooking: { status: 'completed' },
+  verification: { issued: true }
+}
+const staged = file + '.tmp'
+fs.writeFileSync(staged, JSON.stringify(state, null, 2))
+fs.renameSync(staged, file)
+fs.writeFileSync(process.env.GUARD_SEED_OUT, JSON.stringify({
+  fixtures: { world: { namespace } },
+  credentials: { verifier: { value: 'Bearer ' + namespace + '-verification' } }
+}))
+`
+
+function artifact(id: string): ScenarioArtifact {
+  const scenario = apiScenario({
+    id,
+    setup: {
+      seed: {
+        provides: {
+          fixtures: { world: ['namespace'] },
+          credentials: { verifier: { header: 'Authorization' } },
+        },
+      },
+    },
+    steps: [
+      {
+        request: {
+          method: 'GET',
+          path: '/snapshot?namespace={{fixture:world.namespace}}',
+          headers: { Authorization: '{{cred:verifier}}' },
+        },
+        expect: {
+          status: 200,
+          json: {
+            'lifecycle.entity': { equals: 'booking' },
+            'lifecycle.status': { equals: 'cancelled' },
+            'aggregate.organization': { equals: 'acme' },
+            'aggregate.team': { equals: 'support' },
+            'aggregate.member': { equals: 'owner' },
+            'recurring.count': { equals: 3 },
+            'recurring.cadence': { equals: 'weekly' },
+            'pastBooking.status': { equals: 'completed' },
+            'verification.issued': { equals: true },
+            authorized: { equals: true },
+          },
+        },
+      },
+    ],
+  })
+  const yamlPath = `.truecourse/scenarios/acceptance/${id}.yaml`
+  return {
+    scenario,
+    source: { path: yamlPath, content: JSON.stringify(scenario) },
+    companions: { [yamlPath.replace(/\.yaml$/, '.seed.mjs')]: SIDECAR },
+  }
+}
+
+describe('seeded acceptance — reusable datastore convergence', () => {
+  it('repairs exact owned state without accumulation and preserves sibling namespaces', async () => {
+    const repoRoot = makeTempRepo()
+    repos.push(repoRoot)
+    writeSpecDoc(repoRoot)
+    fs.writeFileSync(path.join(repoRoot, 'server.mjs'), SERVER)
+    const recipe = {
+      build: 'true',
+      api: {
+        serve: ['node', path.join(repoRoot, 'server.mjs')],
+        healthPath: '/health',
+        env: { ACCEPTANCE_STATE_PATH: path.join(repoRoot, 'acceptance-state.json') },
+      },
+    }
+    const artifacts = [artifact('cal-lifecycle'), artifact('cal-recurring')]
+
+    const first = await runGuard({ repoRoot, recipe, artifacts, skipBuild: true, persist: false })
+    expect(first.status).toBe('ok')
+    if (first.status !== 'ok') return
+    expect(first.latest.scenarios).toMatchObject([{ outcome: 'pass' }, { outcome: 'pass' }])
+
+    const statePath = path.join(repoRoot, 'acceptance-state.json')
+    const initial = JSON.parse(fs.readFileSync(statePath, 'utf8')) as Record<string, unknown>
+    const namespaces = Object.keys(initial).sort()
+    expect(namespaces).toHaveLength(2)
+    expect(namespaces[0]).not.toBe(namespaces[1])
+    const targetNamespace = scenarioSeedNamespace(repoRoot, artifacts[0].scenario.id)
+    const siblingNamespace = namespaces.find((namespace) => namespace !== targetNamespace)!
+    const siblingBefore = JSON.stringify(initial[siblingNamespace])
+
+    const mutated = structuredClone(initial) as Record<string, any>
+    mutated[targetNamespace].lifecycle.status = 'active'
+    mutated[targetNamespace].recurring.count = 99
+    mutated[targetNamespace].staleOwnedRow = { id: 'must-disappear' }
+    fs.writeFileSync(statePath, JSON.stringify(mutated, null, 2))
+
+    const second = await runGuard({ repoRoot, recipe, artifacts: [artifacts[0]], skipBuild: true, persist: false })
+    expect(second.status).toBe('ok')
+    if (second.status !== 'ok') return
+    expect(second.latest.scenarios[0].outcome).toBe('pass')
+
+    const repaired = JSON.parse(fs.readFileSync(statePath, 'utf8')) as Record<string, any>
+    expect(repaired[targetNamespace]).toEqual(initial[targetNamespace])
+    expect(repaired[targetNamespace]).not.toHaveProperty('staleOwnedRow')
+    expect(JSON.stringify(repaired[siblingNamespace])).toBe(siblingBefore)
+    expect(JSON.stringify(repaired)).not.toContain('-verification')
+  })
+})

--- a/tests/guard-runner/seeded-scheduling.test.ts
+++ b/tests/guard-runner/seeded-scheduling.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { runGuard } from '@truecourse/guard-runner'
+import {
+  apiScenario,
+  makeTempRepo,
+  rmrf,
+  writeApiRecipe,
+  writeScenario,
+  writeScenarioFile,
+} from './helpers.js'
+
+const repos: string[] = []
+afterEach(() => {
+  while (repos.length) rmrf(repos.pop()!)
+})
+
+describe('runGuard — seeded scenario scheduling', () => {
+  it('settles seedless work first, then runs seeded scenarios one at a time in deterministic order', async () => {
+    const repo = makeTempRepo()
+    repos.push(repo)
+    const eventFile = path.join(repo, 'events.txt')
+    const holdDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-seed-schedule-'))
+    writeApiRecipe(repo, {
+      env: {
+        TC_EVENT_FILE: eventFile,
+        TC_HOLD_DIR: holdDir,
+        TC_HOLD_MS: '300',
+      },
+    })
+
+    for (const id of ['seedless-a', 'seedless-b']) {
+      writeScenario(
+        repo,
+        `api/${id}.yaml`,
+        apiScenario({
+          id,
+          steps: [{ request: { method: 'GET', path: '/hold' }, expect: { status: 200 } }],
+        }),
+      )
+    }
+    for (const id of ['seeded-a', 'seeded-b']) {
+      writeScenario(
+        repo,
+        `api/${id}.yaml`,
+        apiScenario({
+          id,
+          setup: { seed: { provides: { fixtures: { marker: ['id'] } } } },
+          steps: [{ request: { method: 'GET', path: '/health' }, expect: { status: 200 } }],
+        }),
+      )
+      writeScenarioFile(
+        repo,
+        `api/${id}.seed.mjs`,
+        `import fs from 'node:fs'\n` +
+          `fs.appendFileSync(process.env.TC_EVENT_FILE, ${JSON.stringify(`seed:${id}\n`)})\n` +
+          `fs.writeFileSync(process.env.GUARD_SEED_OUT, JSON.stringify({fixtures:{marker:{id:${JSON.stringify(id)}}}}))\n`,
+      )
+    }
+
+    const res = await runGuard({
+      repoRoot: repo,
+      skipBuild: true,
+      concurrency: 4,
+      onScenarioSettled: (_done, _total, result) => {
+        fs.appendFileSync(eventFile, `settled:${result.id}\n`)
+      },
+    })
+
+    expect(res.status).toBe('ok')
+    if (res.status !== 'ok') return
+    expect(res.latest.summary).toMatchObject({ total: 4, pass: 4 })
+    const events = fs.readFileSync(eventFile, 'utf-8').trim().split('\n')
+    const firstSeed = events.findIndex((event) => event.startsWith('seed:'))
+    expect(events.slice(0, firstSeed).sort()).toEqual(['settled:seedless-a', 'settled:seedless-b'])
+    expect(events.slice(firstSeed)).toEqual([
+      'seed:seeded-a',
+      'settled:seeded-a',
+      'seed:seeded-b',
+      'settled:seeded-b',
+    ])
+    fs.rmSync(holdDir, { recursive: true, force: true })
+  })
+})

--- a/tests/shared/guard-scenario-api.test.ts
+++ b/tests/shared/guard-scenario-api.test.ts
@@ -30,6 +30,25 @@ const API_SCENARIO = {
 }
 
 describe('guard scenario schema — api driver', () => {
+  it('accepts an API scenario that declares non-empty scenario-local seed outputs', () => {
+    const parsed = GuardScenarioSchema.parse({
+      ...API_SCENARIO,
+      setup: {
+        seed: {
+          provides: {
+            fixtures: { booking: ['id', 'status'] },
+            credentials: {
+              owner: { header: 'Authorization', description: 'booking owner' },
+            },
+          },
+        },
+      },
+    })
+
+    expect(parsed.driver).toBe('api')
+    expect(parsed.setup?.seed?.provides.fixtures).toEqual({ booking: ['id', 'status'] })
+  })
+
   it('carries an optional `server` the cli driver has no counterpart for', () => {
     expect(GuardScenarioSchema.safeParse({ ...API_SCENARIO, server: 'api-v2' }).success).toBe(true)
     // Absent is the pre-multi-server meaning: the recipe's default server.

--- a/tools/cli/src/commands/guard.ts
+++ b/tools/cli/src/commands/guard.ts
@@ -12,7 +12,7 @@
 import path from "node:path";
 import * as p from "@clack/prompts";
 import { guardResultPath, runFailureMessage } from "@truecourse/guard-runner";
-import { readFlowsFile } from "@truecourse/guard-generator";
+import { readFlowsFile, SeedExecutionNotAuthorizedError } from "@truecourse/guard-generator";
 import { readManifest, readGuardLatest, readGuardResult } from "@truecourse/core/lib/guard-store";
 import { readGuardSetup } from "@truecourse/core/commands/guard-setup";
 import {
@@ -235,6 +235,8 @@ export interface RunGuardGenerateOptions {
   cwd?: string;
   /** Skip the pre-flight cost-estimate confirm (`-y` / `--yes`). */
   yes?: boolean;
+  /** Explicit authority for non-interactive generated sidecar execution. */
+  allowSeedExec?: boolean;
   /** LLM transport for this run: `cli` (spawn `claude -p`), `agent` (mailbox under `io`), or `api`. */
   llmTransport?: "cli" | "agent" | "api";
   /** I/O dir for the `agent` transport's request/response mailbox. */
@@ -277,6 +279,24 @@ export async function runGuardGenerate(opts: RunGuardGenerateOptions = {}): Prom
       tracker,
       llm: opts.llmTransport,
       io: opts.io,
+      allowSeedExec: opts.allowSeedExec,
+      approveSeedExecution: opts.allowSeedExec
+        ? undefined
+        : async (sidecars) => {
+            p.log.warn(`Generation produced ${sidecars.length} executable pre-boot seed sidecar${sidecars.length === 1 ? "" : "s"}:`);
+            for (const sidecar of sidecars) {
+              p.log.message(`  • ${sidecar.sidecarPath} · ${sidecar.access} · ${sidecar.outputs.join(", ")}`);
+            }
+            if (!process.stdin.isTTY || opts.llmTransport === "agent") {
+              p.log.error("Generated seed sidecars require explicit authority in non-interactive mode. Pass --allow-seed-exec.");
+              return false;
+            }
+            const answer = await p.confirm({
+              message: "Execute these sidecars for birth validation?",
+              initialValue: false,
+            });
+            return !p.isCancel(answer) && answer === true;
+          },
       onEstimatePhase: estimateSpinnerPhase(),
       onLlmEstimate: (est) => {
         estimatedCostUsd = est.estimatedCostUsd;
@@ -292,6 +312,10 @@ export async function runGuardGenerate(opts: RunGuardGenerateOptions = {}): Prom
     if (e instanceof EstimateDeclined) {
       p.cancel("Generate cancelled.");
       process.exit(0);
+    }
+    if (e instanceof SeedExecutionNotAuthorizedError) {
+      p.cancel("Generate cancelled before any sidecar executed or scenario pair was written.");
+      process.exit(1);
     }
     // Open spec conflicts block generate before any spend — print the FULL list
     // (area, both repo-relative paths, note) and the resolution pointers, exit 1.

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -387,11 +387,13 @@ guardCmd
   .command("generate")
   .description("Author spec-section-bound scenarios (classify → generate → birth-validate)")
   .option("-y, --yes", "Skip the pre-flight cost-estimate confirmation")
+  .option("--allow-seed-exec", "Allow non-interactive execution of generated pre-boot seed sidecars")
   .addOption(llmTransportOption())
   .option("--io <dir>", "Request/response mailbox dir for --llm-transport agent")
   .action(async (options) => {
     await runGuardGenerate({
       yes: options.yes,
+      allowSeedExec: options.allowSeedExec,
       llmTransport: options.llmTransport,
       io: options.io,
     });


### PR DESCRIPTION
## Summary

Implements Guard's per-scenario pre-boot seed sidecars as source-backed YAML + `.seed.mjs` pairs.

- loads exact scenario and sidecar bytes through a shared artifact boundary
- executes approved API seed modules before server boot with deterministic namespaces
- merges declared fixtures and credentials while redacting setup evidence
- runs seedless scenarios first, then seeded scenarios exclusively in deterministic order
- preserves pairs across local and hosted Guard stores/materialization
- adds generator/CLI approval and non-interactive authority boundaries
- re-approves changed retry code and classifies arrangement failures separately from product findings
- keeps generated pairs atomic and rollback-safe

## Ticket coverage

- 01 Source-backed scenario artifacts: complete
- 02 Handwritten pre-boot seed sidecar: complete
- 03 Exclusive seeded scheduling: complete
- 04 Atomic YAML-sidecar corpus: complete
- 05 Generate approved sidecar pairs: complete
- 06 Arrangement retry classification: complete
- 07 cal.diy acceptance and rollout: partial by evidence

Ticket 07 includes a hermetic reusable-datastore acceptance test covering lifecycle state, organizations/teams/members, recurring and past bookings, generated credentials, exact convergence/mutation repair, stable namespaces, and sibling non-interference. A real local cal.diy inventory is documented, but this branch did not authorize and execute newly generated pairs in that external checkout, so it does not claim a completed production rollout or production latency.

See `docs/GUARD_SEEDING_CALDIY_BENCHMARK.md` for the evidence and remaining gap.

## Validation

- `pnpm lint`: 16/16 tasks
- `pnpm build`: 21/21 tasks
- `pnpm test`: 495/495 files, 10,396 passed, 1 skipped
- seeded acceptance: 669 ms for three local seeded executions
- `git diff --check`: clean

One earlier full-suite run had a single unrelated endpoint-probe 404 flake. The exact test then passed under 16 and 32 concurrent independent Vitest processes, the complete endpoint-probe file passed in 16 concurrent processes, and the final full suite passed. No speculative infrastructure change was made without a reproducible product failure.

## Review rounds

1. Standards + spec: fixed hosted artifact/fingerprint propagation, transient mirror placement, rollback-safe pair updates, shared placeholder extraction, and source-inclusive cache identities.
2. Standards + spec: fixed namespace guidance, hosted fallback materialization, changed-retry reapproval, static source/output checks, fidelity context, and benchmark evidence.
3. Standards + spec: fixed sidecar stat/read race handling and transient-mirror cleanup on construction failure; no remaining implementation defects found for tickets 01–06.

## Impact

Seeded Guard scenarios can now establish scenario-owned datastore state before boot without leaking credentials or weakening deterministic execution. Hosted and local execution use the same exact source artifacts, and generation cannot introduce executable seed code without explicit authority.
