### PR TITLE
assets: add docs-site logo lockups (light + dark)

### DIFF
--- a/assets/brand/docs-logo-dark.svg
+++ b/assets/brand/docs-logo-dark.svg
@@ -1,0 +1,14 @@
+<svg width="190" height="32" viewBox="0 0 190 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(2,2) scale(0.102) translate(-50,-12)">
+<polygon points="200,30 200,190 130,190" fill="#3b82f6" opacity="0.95"/>
+<line x1="200" y1="20" x2="200" y2="210" stroke="#e2e8f0" stroke-width="14" stroke-linecap="round"/>
+<rect x="185" y="20" width="30" height="16" rx="3" fill="#e2e8f0"/>
+<line x1="200" y1="20" x2="200" y2="12" stroke="#e2e8f0" stroke-width="12" stroke-linecap="round"/>
+<path d="M 100,210 L 300,210 L 280,250 L 120,250 Z" fill="#e2e8f0"/>
+<path d="M 108,225 L 292,225 L 284,245 L 116,245 Z" fill="#3b82f6" opacity="0.4"/>
+<path d="M 280,210 L 310,210 L 280,250 Z" fill="#94a3b8"/>
+<path d="M 60,260 Q 90,248 120,260 Q 150,272 180,260 Q 210,248 240,260 Q 270,272 300,260 Q 330,248 360,260" fill="none" stroke="#60a5fa" stroke-width="26" opacity="0.7" stroke-linecap="round"/>
+<path d="M 50,275 Q 80,263 110,275 Q 140,287 170,275 Q 200,263 230,275 Q 260,287 290,275 Q 320,263 350,275" fill="none" stroke="#60a5fa" stroke-width="22" opacity="0.4" stroke-linecap="round"/>
+</g>
+<text x="40" y="22" font-family="system-ui, -apple-system, sans-serif" font-size="15" font-weight="700" fill="#e2e8f0" letter-spacing="2">TRUECOURSE</text>
+</svg>

--- a/assets/brand/docs-logo-light.svg
+++ b/assets/brand/docs-logo-light.svg
@@ -1,0 +1,14 @@
+<svg width="190" height="32" viewBox="0 0 190 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(2,2) scale(0.102) translate(-50,-12)">
+<polygon points="200,30 200,190 130,190" fill="#3b82f6" opacity="0.9"/>
+<line x1="200" y1="20" x2="200" y2="210" stroke="#1e3a5f" stroke-width="14" stroke-linecap="round"/>
+<rect x="185" y="20" width="30" height="16" rx="3" fill="#1e3a5f"/>
+<line x1="200" y1="20" x2="200" y2="12" stroke="#1e3a5f" stroke-width="12" stroke-linecap="round"/>
+<path d="M 100,210 L 300,210 L 280,250 L 120,250 Z" fill="#1e3a5f"/>
+<path d="M 108,225 L 292,225 L 284,245 L 116,245 Z" fill="#2563eb" opacity="0.4"/>
+<path d="M 280,210 L 310,210 L 280,250 Z" fill="#163050"/>
+<path d="M 60,260 Q 90,248 120,260 Q 150,272 180,260 Q 210,248 240,260 Q 270,272 300,260 Q 330,248 360,260" fill="none" stroke="#3b82f6" stroke-width="26" opacity="0.6" stroke-linecap="round"/>
+<path d="M 50,275 Q 80,263 110,275 Q 140,287 170,275 Q 200,263 230,275 Q 260,287 290,275 Q 320,263 350,275" fill="none" stroke="#3b82f6" stroke-width="22" opacity="0.35" stroke-linecap="round"/>
+</g>
+<text x="40" y="22" font-family="system-ui, -apple-system, sans-serif" font-size="15" font-weight="700" fill="#1e3a5f" letter-spacing="2">TRUECOURSE</text>
+</svg>


### PR DESCRIPTION
Adds the two navbar logo SVGs the documentation site (docs.truecourse.dev) reads via jsDelivr. Mintlify's published build cannot serve data-URI logos (it prefixes them into broken S3 URLs), so the docs config points at these files instead.

Until this merges, the docs config reads them from this branch; after merging I'll flip the URLs to @main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)