### PR TITLE
fix(landing): let inline code wrap on mobile

### DIFF
--- a/apps/landing/src/globals.css
+++ b/apps/landing/src/globals.css
@@ -972,6 +972,7 @@ footer.site { padding-block: 64px 40px; }
   border: 1px solid var(--line);
   border-radius: 3px;
   padding: 1px 6px;
+  overflow-wrap: anywhere;
 }
 .post-body a code {
   color: var(--accent);


### PR DESCRIPTION
The blog post links source files by their full path inside `<code>`. On a phone those unbroken tokens pushed the page wider than the viewport (horizontal scroll). One line: `overflow-wrap: anywhere` on `.post-body code`. Verified at a 390px viewport: page scroll width equals the viewport and the path chips wrap onto two lines. Code blocks (`pre`) are unaffected and still scroll inside their own box.

This was meant to be part of #875 but was pushed after that PR had merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)