### PR TITLE
feat(ee-knowledge): source dates and Jira status history reach the corpus

### DIFF
--- a/apps/dashboard/client/package.json
+++ b/apps/dashboard/client/package.json
@@ -46,6 +46,7 @@
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-directive": "^4.0.0",
+    "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.0.6",
     "socket.io-client": "^4.8.0",

--- a/apps/dashboard/client/src/components/spec/DocMarkdown.tsx
+++ b/apps/dashboard/client/src/components/spec/DocMarkdown.tsx
@@ -194,6 +194,20 @@ function splitSections(source: string): Section[] {
   return sections;
 }
 
+/**
+ * Drop a leading YAML frontmatter block. It is metadata a doc states about
+ * itself — a synced ticket's dates and status, a repo doc's own header — and a
+ * reader wants the document, not its bookkeeping. Stripping is a rendering
+ * concern only: the block stays in the source every consumer downstream reads.
+ *
+ * Deliberately narrow. The fence must open on the very first line, and only the
+ * first block is removed, so a `---` rule inside the prose is left alone.
+ */
+function stripFrontmatter(source: string): string {
+  const m = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/.exec(source);
+  return m ? source.slice(m[0].length).replace(/^\r?\n/, '') : source;
+}
+
 export function DocMarkdown({
   source,
   highlight = [],
@@ -206,6 +220,7 @@ export function DocMarkdown({
   highlightPreamble?: boolean;
 }): ReactNode {
   const hl = new Set(highlight.map(norm));
+  source = stripFrontmatter(source);
 
   if (hl.size === 0 && !highlightPreamble) {
     return (

--- a/apps/dashboard/client/src/components/spec/DocMarkdown.tsx
+++ b/apps/dashboard/client/src/components/spec/DocMarkdown.tsx
@@ -22,6 +22,7 @@
 import type { ComponentType, ReactNode } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkDirective from 'remark-directive';
+import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
@@ -162,7 +163,7 @@ const COMPONENTS: Components = {
 function Md({ source }: { source: string }) {
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkDirective, remarkAdmonitions]}
+      remarkPlugins={[remarkGfm, remarkDirective, remarkFrontmatter, remarkAdmonitions]}
       rehypePlugins={[rehypeRaw, [rehypeSanitize, SANITIZE_SCHEMA]]}
       components={COMPONENTS}
     >
@@ -194,20 +195,6 @@ function splitSections(source: string): Section[] {
   return sections;
 }
 
-/**
- * Drop a leading YAML frontmatter block. It is metadata a doc states about
- * itself — a synced ticket's dates and status, a repo doc's own header — and a
- * reader wants the document, not its bookkeeping. Stripping is a rendering
- * concern only: the block stays in the source every consumer downstream reads.
- *
- * Deliberately narrow. The fence must open on the very first line, and only the
- * first block is removed, so a `---` rule inside the prose is left alone.
- */
-function stripFrontmatter(source: string): string {
-  const m = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/.exec(source);
-  return m ? source.slice(m[0].length).replace(/^\r?\n/, '') : source;
-}
-
 export function DocMarkdown({
   source,
   highlight = [],
@@ -220,7 +207,6 @@ export function DocMarkdown({
   highlightPreamble?: boolean;
 }): ReactNode {
   const hl = new Set(highlight.map(norm));
-  source = stripFrontmatter(source);
 
   if (hl.size === 0 && !highlightPreamble) {
     return (

--- a/ee/packages/data-store/src/knowledge-store.ts
+++ b/ee/packages/data-store/src/knowledge-store.ts
@@ -24,8 +24,8 @@ export interface KnowledgeDocRow {
   url: string | null;
   version: string | null;
   /** Creation / last-modification time in the source tool; null when it exposes none. */
-  sourceCreatedAt: string | null;
-  sourceUpdatedAt: string | null;
+  externalCreatedAt: string | null;
+  externalUpdatedAt: string | null;
   contentHash: string;
   /** sha256 of the body the last process consolidated; null until first processed. */
   processedHash: string | null;
@@ -87,8 +87,8 @@ export class PgKnowledgeStore {
         title: row.title,
         url: row.url,
         version: row.version,
-        sourceCreatedAt: row.sourceCreatedAt,
-        sourceUpdatedAt: row.sourceUpdatedAt,
+        externalCreatedAt: row.externalCreatedAt,
+        externalUpdatedAt: row.externalUpdatedAt,
         contentHash: row.contentHash,
         lastSyncedAt: now,
         createdAt: now,
@@ -104,8 +104,8 @@ export class PgKnowledgeStore {
           title: row.title,
           url: row.url,
           version: row.version,
-          sourceCreatedAt: row.sourceCreatedAt,
-          sourceUpdatedAt: row.sourceUpdatedAt,
+          externalCreatedAt: row.externalCreatedAt,
+          externalUpdatedAt: row.externalUpdatedAt,
           contentHash: row.contentHash,
           lastSyncedAt: now,
         },
@@ -153,8 +153,8 @@ export class PgKnowledgeStore {
         title: r.title,
         url: r.url,
         version: r.version,
-        sourceCreatedAt: r.sourceCreatedAt,
-        sourceUpdatedAt: r.sourceUpdatedAt,
+        externalCreatedAt: r.externalCreatedAt,
+        externalUpdatedAt: r.externalUpdatedAt,
         contentHash: r.contentHash,
         processedHash: r.processedHash,
         lastSyncedAt: r.lastSyncedAt,
@@ -204,8 +204,8 @@ export class PgKnowledgeStore {
         title: r.title,
         url: r.url,
         version: r.version,
-        sourceCreatedAt: r.sourceCreatedAt,
-        sourceUpdatedAt: r.sourceUpdatedAt,
+        externalCreatedAt: r.externalCreatedAt,
+        externalUpdatedAt: r.externalUpdatedAt,
         contentHash: r.contentHash,
         processedHash: r.processedHash,
         lastSyncedAt: r.lastSyncedAt,
@@ -236,8 +236,8 @@ export class PgKnowledgeStore {
       title: r.title,
       url: r.url,
       version: r.version,
-      sourceCreatedAt: r.sourceCreatedAt,
-      sourceUpdatedAt: r.sourceUpdatedAt,
+      externalCreatedAt: r.externalCreatedAt,
+      externalUpdatedAt: r.externalUpdatedAt,
       contentHash: r.contentHash,
       processedHash: r.processedHash,
       lastSyncedAt: r.lastSyncedAt,

--- a/ee/packages/data-store/src/knowledge-store.ts
+++ b/ee/packages/data-store/src/knowledge-store.ts
@@ -23,6 +23,9 @@ export interface KnowledgeDocRow {
   title: string;
   url: string | null;
   version: string | null;
+  /** Creation / last-modification time in the source tool; null when it exposes none. */
+  sourceCreatedAt: string | null;
+  sourceUpdatedAt: string | null;
   contentHash: string;
   /** sha256 of the body the last process consolidated; null until first processed. */
   processedHash: string | null;
@@ -84,6 +87,8 @@ export class PgKnowledgeStore {
         title: row.title,
         url: row.url,
         version: row.version,
+        sourceCreatedAt: row.sourceCreatedAt,
+        sourceUpdatedAt: row.sourceUpdatedAt,
         contentHash: row.contentHash,
         lastSyncedAt: now,
         createdAt: now,
@@ -99,6 +104,8 @@ export class PgKnowledgeStore {
           title: row.title,
           url: row.url,
           version: row.version,
+          sourceCreatedAt: row.sourceCreatedAt,
+          sourceUpdatedAt: row.sourceUpdatedAt,
           contentHash: row.contentHash,
           lastSyncedAt: now,
         },
@@ -146,6 +153,8 @@ export class PgKnowledgeStore {
         title: r.title,
         url: r.url,
         version: r.version,
+        sourceCreatedAt: r.sourceCreatedAt,
+        sourceUpdatedAt: r.sourceUpdatedAt,
         contentHash: r.contentHash,
         processedHash: r.processedHash,
         lastSyncedAt: r.lastSyncedAt,
@@ -195,6 +204,8 @@ export class PgKnowledgeStore {
         title: r.title,
         url: r.url,
         version: r.version,
+        sourceCreatedAt: r.sourceCreatedAt,
+        sourceUpdatedAt: r.sourceUpdatedAt,
         contentHash: r.contentHash,
         processedHash: r.processedHash,
         lastSyncedAt: r.lastSyncedAt,
@@ -225,6 +236,8 @@ export class PgKnowledgeStore {
       title: r.title,
       url: r.url,
       version: r.version,
+      sourceCreatedAt: r.sourceCreatedAt,
+      sourceUpdatedAt: r.sourceUpdatedAt,
       contentHash: r.contentHash,
       processedHash: r.processedHash,
       lastSyncedAt: r.lastSyncedAt,

--- a/ee/packages/db/drizzle/0010_new_lady_vermin.sql
+++ b/ee/packages/db/drizzle/0010_new_lady_vermin.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "knowledge_documents" ADD COLUMN "source_created_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "knowledge_documents" ADD COLUMN "source_updated_at" timestamp with time zone;

--- a/ee/packages/db/drizzle/0010_new_lady_vermin.sql
+++ b/ee/packages/db/drizzle/0010_new_lady_vermin.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "knowledge_documents" ADD COLUMN "source_created_at" timestamp with time zone;--> statement-breakpoint
-ALTER TABLE "knowledge_documents" ADD COLUMN "source_updated_at" timestamp with time zone;

--- a/ee/packages/db/drizzle/0010_tricky_firedrake.sql
+++ b/ee/packages/db/drizzle/0010_tricky_firedrake.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "knowledge_documents" ADD COLUMN "external_created_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "knowledge_documents" ADD COLUMN "external_updated_at" timestamp with time zone;

--- a/ee/packages/db/drizzle/meta/0010_snapshot.json
+++ b/ee/packages/db/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,2128 @@
+{
+  "id": "6bcef121-619a-4586-a7bc-3c27ab8fa77f",
+  "prevId": "3cd4f65c-b1dc-4f91-850b-299f1e21c491",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.gh_baselines": {
+      "name": "gh_baselines",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_inferred_actions": {
+      "name": "gh_inferred_actions",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gh_inferred_actions_repo_full_name_kind_identity_pk": {
+          "name": "gh_inferred_actions_repo_full_name_kind_identity_pk",
+          "columns": [
+            "repo_full_name",
+            "kind",
+            "identity"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_installations": {
+      "name": "gh_installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_prs": {
+      "name": "gh_prs",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gh_prs_repo_full_name_pr_number_pk": {
+          "name": "gh_prs_repo_full_name_pr_number_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_repos": {
+      "name": "gh_repos",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocking": {
+          "name": "blocking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "code_quality_blocking": {
+          "name": "code_quality_blocking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "code_quality_min_severity": {
+          "name": "code_quality_min_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'high'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_emails": {
+          "name": "notify_emails",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_runs": {
+      "name": "gh_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_count": {
+          "name": "added_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_count": {
+          "name": "resolved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_runs_repo_created_idx": {
+          "name": "gh_runs_repo_created_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_provider_config": {
+      "name": "llm_provider_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_model": {
+          "name": "fallback_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_enc": {
+          "name": "api_key_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_key_id": {
+          "name": "access_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content": {
+      "name": "content",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_scope_sha_pk": {
+          "name": "content_scope_sha_pk",
+          "columns": [
+            "scope",
+            "sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analyses": {
+      "name": "analyses",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "analyses_repo_analysis_idx": {
+          "name": "analyses_repo_analysis_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "analysis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "analyses_repo_key_filename_pk": {
+          "name": "analyses_repo_key_filename_pk",
+          "columns": [
+            "repo_key",
+            "filename"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_current": {
+      "name": "analysis_current",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "analysis_current_repo_key_kind_pk": {
+          "name": "analysis_current_repo_key_kind_pk",
+          "columns": [
+            "repo_key",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_history": {
+      "name": "analysis_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry": {
+          "name": "entry",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "analysis_history_repo_idx": {
+          "name": "analysis_history_repo_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decisions": {
+      "name": "decisions",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registry": {
+      "name": "registry",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_opened": {
+          "name": "last_opened",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_analyzed": {
+          "name": "last_analyzed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registry_path_unique": {
+          "name": "registry_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_config": {
+      "name": "repo_config",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_ui_state": {
+      "name": "repo_ui_state",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spec_sets": {
+      "name": "spec_sets",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha": {
+          "name": "content_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "spec_sets_repo_artifact_created_idx": {
+          "name": "spec_sets_repo_artifact_created_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "spec_sets_repo_key_commit_sha_artifact_pk": {
+          "name": "spec_sets_repo_key_commit_sha_artifact_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha",
+            "artifact"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extraction_cache": {
+      "name": "extraction_cache",
+      "schema": "",
+      "columns": {
+        "cache_name": {
+          "name": "cache_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "extraction_cache_cache_name_cache_key_pk": {
+          "name": "extraction_cache_cache_name_cache_key_pk",
+          "columns": [
+            "cache_name",
+            "cache_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_documents": {
+      "name": "knowledge_documents",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_path": {
+          "name": "doc_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_created_at": {
+          "name": "source_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_hash": {
+          "name": "processed_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "knowledge_documents_org_idx": {
+          "name": "knowledge_documents_org_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "knowledge_documents_workspace_org_id_source_kind_external_id_pk": {
+          "name": "knowledge_documents_workspace_org_id_source_kind_external_id_pk",
+          "columns": [
+            "workspace_org_id",
+            "source_kind",
+            "external_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_spec_sets": {
+      "name": "workspace_spec_sets",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha": {
+          "name": "content_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workspace_spec_sets_workspace_org_id_artifact_pk": {
+          "name": "workspace_spec_sets_workspace_org_id_artifact_pk",
+          "columns": [
+            "workspace_org_id",
+            "artifact"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_enc": {
+          "name": "token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending": {
+          "name": "pending",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "integration_connections_org_idx": {
+          "name": "integration_connections_org_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "integration_connections_workspace_org_id_provider_pk": {
+          "name": "integration_connections_workspace_org_id_provider_pk",
+          "columns": [
+            "workspace_org_id",
+            "provider"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_backfill_markers": {
+      "name": "guard_backfill_markers",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress_current": {
+          "name": "progress_current",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_total": {
+          "name": "progress_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_message": {
+          "name": "progress_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "jobs_org_idx": {
+          "name": "jobs_org_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_active_key_uniq": {
+          "name": "jobs_active_key_uniq",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status in ('queued','running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notifications_org_created_idx": {
+          "name": "notifications_org_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_baselines": {
+      "name": "pending_baselines",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiet": {
+          "name": "quiet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_guard_baselines": {
+      "name": "pending_guard_baselines",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_traces": {
+      "name": "llm_traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slice_id": {
+          "name": "slice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_sha": {
+          "name": "prompt_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_sha": {
+          "name": "output_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_sha": {
+          "name": "reasoning_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "llm_traces_org_created_idx": {
+          "name": "llm_traces_org_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_traces_trace_idx": {
+          "name": "llm_traces_trace_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_traces_org_stage_idx": {
+          "name": "llm_traces_org_stage_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_traces_org_prompt_idx": {
+          "name": "llm_traces_org_prompt_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_settings": {
+      "name": "workspace_settings",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_analysis_llm": {
+          "name": "code_analysis_llm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_results": {
+      "name": "guard_results",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guard_results_repo_key_commit_sha_pk": {
+          "name": "guard_results_repo_key_commit_sha_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_runs": {
+      "name": "guard_runs",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_baseline": {
+          "name": "is_baseline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guard_runs_repo_ran_idx": {
+          "name": "guard_runs_repo_ran_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guard_runs_baseline_idx": {
+          "name": "guard_runs_baseline_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_baseline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guard_runs_repo_run_idx": {
+          "name": "guard_runs_repo_run_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guard_runs_repo_key_commit_sha_pk": {
+          "name": "guard_runs_repo_key_commit_sha_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_scenario_sets": {
+      "name": "guard_scenario_sets",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guard_scenario_sets_repo_key_commit_sha_pk": {
+          "name": "guard_scenario_sets_repo_key_commit_sha_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/ee/packages/db/drizzle/meta/0010_snapshot.json
+++ b/ee/packages/db/drizzle/meta/0010_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "6bcef121-619a-4586-a7bc-3c27ab8fa77f",
+  "id": "4aa309e8-1c83-4304-aeee-87ff1edaefc6",
   "prevId": "3cd4f65c-b1dc-4f91-850b-299f1e21c491",
   "version": "7",
   "dialect": "postgresql",
@@ -995,14 +995,14 @@
           "primaryKey": false,
           "notNull": false
         },
-        "source_created_at": {
-          "name": "source_created_at",
+        "external_created_at": {
+          "name": "external_created_at",
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
-        "source_updated_at": {
-          "name": "source_updated_at",
+        "external_updated_at": {
+          "name": "external_updated_at",
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false

--- a/ee/packages/db/drizzle/meta/_journal.json
+++ b/ee/packages/db/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1784239769917,
       "tag": "0009_stale_mister_fear",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1787176302199,
+      "tag": "0010_new_lady_vermin",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/db/drizzle/meta/_journal.json
+++ b/ee/packages/db/drizzle/meta/_journal.json
@@ -75,8 +75,8 @@
     {
       "idx": 10,
       "version": "7",
-      "when": 1787176302199,
-      "tag": "0010_new_lady_vermin",
+      "when": 1787186776458,
+      "tag": "0010_tricky_firedrake",
       "breakpoints": true
     }
   ]

--- a/ee/packages/db/src/schema/knowledge.ts
+++ b/ee/packages/db/src/schema/knowledge.ts
@@ -61,8 +61,8 @@ export const knowledgeDocuments = pgTable(
      * put a date there because it has no version counter, Confluence puts an
      * edit counter, and nothing downstream should have to know which.
      */
-    sourceCreatedAt: ts('source_created_at'),
-    sourceUpdatedAt: ts('source_updated_at'),
+    externalCreatedAt: ts('external_created_at'),
+    externalUpdatedAt: ts('external_updated_at'),
     /** sha256 of the body at last sync — the incremental-sync diff key. */
     contentHash: text('content_hash').notNull(),
     /**

--- a/ee/packages/db/src/schema/knowledge.ts
+++ b/ee/packages/db/src/schema/knowledge.ts
@@ -54,6 +54,15 @@ export const knowledgeDocuments = pgTable(
     url: text('url'),
     /** Source version string (connector); null when only a content hash is available. */
     version: text('version'),
+    /**
+     * When the source tool says the doc was created / last modified. Nullable:
+     * rows written before these columns existed have neither, and a source may
+     * expose only one. Deliberately separate from `version` — Jira happens to
+     * put a date there because it has no version counter, Confluence puts an
+     * edit counter, and nothing downstream should have to know which.
+     */
+    sourceCreatedAt: ts('source_created_at'),
+    sourceUpdatedAt: ts('source_updated_at'),
     /** sha256 of the body at last sync — the incremental-sync diff key. */
     contentHash: text('content_hash').notNull(),
     /**

--- a/ee/packages/server/src/knowledge/connectors/confluence.ts
+++ b/ee/packages/server/src/knowledge/connectors/confluence.ts
@@ -100,19 +100,20 @@ function isoOrUndefined(value: string | undefined): string | undefined {
 }
 
 /**
- * The metadata block the consolidator reads back out of the body. Its date
- * readers scan only the first 40 lines and match `Name: value`, so these lead.
- * A page has no lifecycle status, so — unlike a Jira issue — there is no
- * `Status:` line and no history: a Confluence version is an edit counter, and
- * the API exposes no per-revision reason worth carrying.
+ * The metadata the consolidator reads back out of the doc, as YAML frontmatter —
+ * hidden from a reader by every markdown renderer, and still exactly the
+ * `name: value` shape its date reader scans the first 40 lines for.
+ *
+ * A page carries dates and nothing else: it has no lifecycle status, and its
+ * `version` is an edit counter rather than anything about the content.
  */
-function metadataBlock(page: ConfluencePage): string {
+function frontmatter(page: ConfluencePage): string {
   const lines: string[] = [];
   const created = isoOrUndefined(page.history?.createdDate);
   const updated = isoOrUndefined(page.version?.when);
-  if (created) lines.push(`Created: ${created}`);
-  if (updated) lines.push(`Updated: ${updated}`);
-  return lines.join('\n');
+  if (created) lines.push(`created: ${created}`);
+  if (updated) lines.push(`updated: ${updated}`);
+  return lines.length > 0 ? `---\n${lines.join('\n')}\n---` : '';
 }
 
 export const confluenceConnector: KnowledgeConnector<ConfluenceConfig> = {
@@ -168,8 +169,10 @@ export const confluenceConnector: KnowledgeConnector<ConfluenceConfig> = {
     );
     const title = page.title ?? `(untitled ${id})`;
     const body = storageXhtmlToMarkdown(page.body?.storage?.value ?? '');
-    const meta = metadataBlock(page);
-    // Prepend the title as an H1 so a heading-less page still has a slice anchor.
-    return { title, markdown: [`# ${title}`, meta, body].filter(Boolean).join('\n\n').trim() };
+    // The H1 anchors the slicer, so a heading-less page still has one.
+    return {
+      title,
+      markdown: [frontmatter(page), `# ${title}`, body].filter(Boolean).join('\n\n').trim(),
+    };
   },
 };

--- a/ee/packages/server/src/knowledge/connectors/confluence.ts
+++ b/ee/packages/server/src/knowledge/connectors/confluence.ts
@@ -152,7 +152,7 @@ export const confluenceConnector: KnowledgeConnector<ConfluenceConfig> = {
           title: p.title ?? `(untitled ${p.id})`,
           url: pageUrl(cfg, base, p),
           version: p.version?.number != null ? String(p.version.number) : undefined,
-          updatedAt: p.version?.when ?? '1970-01-01T00:00:00.000Z',
+          updatedAt: p.version?.when,
           createdAt: p.history?.createdDate,
         });
       }

--- a/ee/packages/server/src/knowledge/connectors/confluence.ts
+++ b/ee/packages/server/src/knowledge/connectors/confluence.ts
@@ -92,6 +92,29 @@ function pageUrl(cfg: ConfluenceConfig, base: string, p: ConfluencePage): string
   return `${siteBase(cfg)}/wiki/spaces/${cfg.spaceKey}/pages/${p.id}`;
 }
 
+/** Normalize a timestamp to real ISO-8601, or drop it when it isn't one. */
+function isoOrUndefined(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+/**
+ * The metadata block the consolidator reads back out of the body. Its date
+ * readers scan only the first 40 lines and match `Name: value`, so these lead.
+ * A page has no lifecycle status, so — unlike a Jira issue — there is no
+ * `Status:` line and no history: a Confluence version is an edit counter, and
+ * the API exposes no per-revision reason worth carrying.
+ */
+function metadataBlock(page: ConfluencePage): string {
+  const lines: string[] = [];
+  const created = isoOrUndefined(page.history?.createdDate);
+  const updated = isoOrUndefined(page.version?.when);
+  if (created) lines.push(`Created: ${created}`);
+  if (updated) lines.push(`Updated: ${updated}`);
+  return lines.join('\n');
+}
+
 export const confluenceConnector: KnowledgeConnector<ConfluenceConfig> = {
   kind: 'confluence',
   name: 'Confluence',
@@ -145,7 +168,8 @@ export const confluenceConnector: KnowledgeConnector<ConfluenceConfig> = {
     );
     const title = page.title ?? `(untitled ${id})`;
     const body = storageXhtmlToMarkdown(page.body?.storage?.value ?? '');
+    const meta = metadataBlock(page);
     // Prepend the title as an H1 so a heading-less page still has a slice anchor.
-    return { title, markdown: `# ${title}\n\n${body}`.trim() };
+    return { title, markdown: [`# ${title}`, meta, body].filter(Boolean).join('\n\n').trim() };
   },
 };

--- a/ee/packages/server/src/knowledge/connectors/confluence.ts
+++ b/ee/packages/server/src/knowledge/connectors/confluence.ts
@@ -28,6 +28,8 @@ interface ConfluencePage {
   id: string | number;
   title?: string;
   version?: { number?: number; when?: string };
+  /** Present only when the request asked for `expand=history`. */
+  history?: { createdDate?: string };
   body?: { storage?: { value?: string } };
   _links?: { webui?: string };
 }
@@ -116,7 +118,7 @@ export const confluenceConnector: KnowledgeConnector<ConfluenceConfig> = {
       const space = encodeURIComponent(cfg.spaceKey);
       const list = await getJson<ConfluenceList>(
         cfg,
-        `/content?spaceKey=${space}&type=page&status=current&expand=version&limit=${PAGE_LIMIT}&start=${start}`,
+        `/content?spaceKey=${space}&type=page&status=current&expand=version,history&limit=${PAGE_LIMIT}&start=${start}`,
       );
       const results = list.results ?? [];
       const base = list._links?.base ?? siteBase(cfg);
@@ -127,6 +129,7 @@ export const confluenceConnector: KnowledgeConnector<ConfluenceConfig> = {
           url: pageUrl(cfg, base, p),
           version: p.version?.number != null ? String(p.version.number) : undefined,
           updatedAt: p.version?.when ?? '1970-01-01T00:00:00.000Z',
+          createdAt: p.history?.createdDate,
         });
       }
       if (!list._links?.next || results.length === 0) break;
@@ -138,7 +141,7 @@ export const confluenceConnector: KnowledgeConnector<ConfluenceConfig> = {
   async fetch(cfg, id): Promise<DocContent> {
     const page = await getJson<ConfluencePage>(
       cfg,
-      `/content/${encodeURIComponent(id)}?expand=body.storage,version`,
+      `/content/${encodeURIComponent(id)}?expand=body.storage,version,history`,
     );
     const title = page.title ?? `(untitled ${id})`;
     const body = storageXhtmlToMarkdown(page.body?.storage?.value ?? '');

--- a/ee/packages/server/src/knowledge/connectors/jira.ts
+++ b/ee/packages/server/src/knowledge/connectors/jira.ts
@@ -34,15 +34,38 @@ export interface JiraConfig extends ConnectorConfig {
   // so it rides the `ConnectorConfig` string index rather than a declared field.
 }
 
+/** One field change inside a changelog entry (we only read `status`). */
+interface JiraChangelogItem {
+  field?: string;
+  fromString?: string | null;
+  toString?: string | null;
+}
+/** One changelog entry — a timestamp plus the fields that changed with it. */
+interface JiraChangelogEntry {
+  created?: string;
+  items?: JiraChangelogItem[];
+}
+
 interface JiraIssue {
   id: string | number;
   key?: string;
   fields?: {
     summary?: string;
     updated?: string;
+    created?: string;
+    /** Null when the closing transition set `status` without `resolution`. */
+    resolutiondate?: string | null;
+    status?: { name?: string; statusCategory?: { key?: string } };
     /** Rich text as an ADF node tree (Jira Cloud v3). */
     description?: unknown;
   };
+  /**
+   * Present only when the request asked for `expand=changelog`. The enhanced
+   * search endpoint returns it inline, so status history costs no extra call.
+   * `total` may exceed `histories.length` on a long history — see the truncation
+   * check at the read site.
+   */
+  changelog?: { total?: number; histories?: JiraChangelogEntry[] };
 }
 interface JiraSearchResult {
   issues?: JiraIssue[];
@@ -52,6 +75,12 @@ interface JiraSearchResult {
 
 /** Issues per search page / fetchMany batch. */
 const PAGE_LIMIT = 100;
+/**
+ * The fields a body fetch needs: the document text plus the metadata the doc
+ * header carries. `resolutiondate` is nullable even on a closed issue, so the
+ * header derives its resolved date from the changelog when it is absent.
+ */
+const ISSUE_FIELDS = 'summary,description,created,updated,resolutiondate,status';
 /** Retry a rate-limited request at most this many times before surfacing it. */
 const RETRY_LIMIT = 3;
 
@@ -142,24 +171,141 @@ async function getJson<T>(cfg: JiraConfig, path: string): Promise<T> {
   }
 }
 
-/** Build one issue's document body: `# KEY: summary` H1 + the converted description. */
-function toDocContent(issue: JiraIssue): DocContent {
+/** One status transition, flattened out of the changelog. */
+interface StatusChange {
+  at: string;
+  from: string;
+  to: string;
+}
+
+/**
+ * Normalize a Jira timestamp to real ISO-8601. Jira emits a `-0700` offset,
+ * which `parseDocDate`'s value pattern tolerates but `Date` does not reliably
+ * accept — so the header always carries a `Z` form the consolidator can parse.
+ */
+function isoOrUndefined(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+/** The status transitions in a changelog, oldest first. Other field changes are ignored. */
+function statusChanges(entries: JiraChangelogEntry[]): StatusChange[] {
+  const out: StatusChange[] = [];
+  for (const entry of entries) {
+    const at = isoOrUndefined(entry.created);
+    if (!at) continue;
+    for (const item of entry.items ?? []) {
+      if (item.field !== 'status') continue;
+      out.push({ at, from: item.fromString ?? '', to: item.toString ?? '' });
+    }
+  }
+  return out.sort((a, b) => (a.at < b.at ? -1 : a.at > b.at ? 1 : 0));
+}
+
+/**
+ * The changelog a search response embedded, and whether it was cut short. The
+ * enhanced search endpoint paginates the inline changelog, so an issue with a
+ * long history arrives partial — and its EARLIEST transitions are the ones
+ * missing, which is exactly the part the header needs.
+ */
+function inlineChangelog(issue: JiraIssue): { entries: JiraChangelogEntry[]; truncated: boolean } {
+  const entries = issue.changelog?.histories ?? [];
+  const total = issue.changelog?.total;
+  return { entries, truncated: typeof total === 'number' && total > entries.length };
+}
+
+/** One page of the per-issue changelog endpoint (`values`, not `histories`). */
+interface JiraChangelogPage {
+  values?: JiraChangelogEntry[];
+  isLast?: boolean;
+  total?: number;
+}
+
+/** Every changelog entry for one issue. Only called when the inline copy was truncated. */
+async function fetchChangelog(cfg: JiraConfig, id: string): Promise<JiraChangelogEntry[]> {
+  const entries: JiraChangelogEntry[] = [];
+  for (let startAt = 0; ; ) {
+    const page = await getJson<JiraChangelogPage>(
+      cfg,
+      `/issue/${encodeURIComponent(id)}/changelog?startAt=${startAt}&maxResults=${PAGE_LIMIT}`,
+    );
+    const values = page.values ?? [];
+    entries.push(...values);
+    if (page.isLast || values.length === 0) break;
+    startAt += values.length;
+  }
+  return entries;
+}
+
+/** An issue's status history, re-fetching the changelog only when the inline copy was short. */
+async function resolveStatusChanges(cfg: JiraConfig, issue: JiraIssue): Promise<StatusChange[]> {
+  const { entries, truncated } = inlineChangelog(issue);
+  if (!truncated) return statusChanges(entries);
+  return statusChanges(await fetchChangelog(cfg, String(issue.id)));
+}
+
+/**
+ * When the issue settled. `resolutiondate` is authoritative but nullable — a
+ * transition can set `status` without `resolution` — so an issue whose CURRENT
+ * status is in the done category falls back to when it last entered that status.
+ */
+function resolvedAt(issue: JiraIssue, changes: StatusChange[]): string | undefined {
+  const explicit = isoOrUndefined(issue.fields?.resolutiondate);
+  if (explicit) return explicit;
+  if (issue.fields?.status?.statusCategory?.key !== 'done') return undefined;
+  const current = issue.fields?.status?.name;
+  if (!current) return undefined;
+  for (let i = changes.length - 1; i >= 0; i--) {
+    if (changes[i].to === current) return changes[i].at;
+  }
+  return undefined;
+}
+
+/**
+ * The metadata block the consolidator reads back out of the body. `parseDocDate`
+ * and `parseDocStatus` scan only the first 40 lines and match `Name: value`, so
+ * the dated fields lead and the history follows. History lines deliberately open
+ * with the timestamp: a line starting with a date-field NAME would be picked up
+ * as the doc's own date, and the FIRST occurrence of a field wins.
+ */
+function metadataBlock(issue: JiraIssue, changes: StatusChange[]): string {
+  const lines: string[] = [];
+  const created = isoOrUndefined(issue.fields?.created);
+  const updated = isoOrUndefined(issue.fields?.updated);
+  const resolved = resolvedAt(issue, changes);
+  const status = issue.fields?.status?.name;
+  if (created) lines.push(`Created: ${created}`);
+  if (updated) lines.push(`Updated: ${updated}`);
+  if (resolved) lines.push(`Resolved: ${resolved}`);
+  if (status) lines.push(`Status: ${status}`);
+  if (lines.length === 0) return '';
+  const history = changes.map((c) => `- ${c.at}  ${c.from || '(none)'} -> ${c.to}`);
+  return history.length > 0
+    ? `${lines.join('\n')}\n\n## Status history\n${history.join('\n')}`
+    : lines.join('\n');
+}
+
+/** Build one issue's document body: `# KEY: summary` H1, the metadata block, the description. */
+function toDocContent(issue: JiraIssue, changes: StatusChange[] = []): DocContent {
   const key = issue.key ?? String(issue.id);
   const title = `${key}: ${issue.fields?.summary ?? ''}`;
   const body = adfToMarkdown(issue.fields?.description);
+  const meta = metadataBlock(issue, changes);
   // Prepend the title as an H1 so a heading-less description still has a slice anchor.
-  return { title, markdown: `# ${title}\n\n${body}`.trim() };
+  return { title, markdown: [`# ${title}`, meta, body].filter(Boolean).join('\n\n').trim() };
 }
 
 /** `/search/jql` query string for a JQL sweep (paginates on nextPageToken). */
 function searchPath(
   jql: string,
   fields: string,
-  opts: { maxResults?: number; pageToken?: string } = {},
+  opts: { maxResults?: number; pageToken?: string; expand?: string } = {},
 ): string {
   const max = opts.maxResults ?? PAGE_LIMIT;
   const token = opts.pageToken ? `&nextPageToken=${encodeURIComponent(opts.pageToken)}` : '';
-  return `/search/jql?jql=${encodeURIComponent(jql)}&maxResults=${max}&fields=${fields}${token}`;
+  const expand = opts.expand ? `&expand=${encodeURIComponent(opts.expand)}` : '';
+  return `/search/jql?jql=${encodeURIComponent(jql)}&maxResults=${max}&fields=${fields}${token}${expand}`;
 }
 
 export const jiraConnector: KnowledgeConnector<JiraConfig> = {
@@ -187,7 +333,10 @@ export const jiraConnector: KnowledgeConnector<JiraConfig> = {
     const jql = baseJql(cfg);
     let pageToken: string | undefined;
     for (;;) {
-      const result = await getJson<JiraSearchResult>(cfg, searchPath(jql, 'summary,updated', { pageToken }));
+      const result = await getJson<JiraSearchResult>(
+        cfg,
+        searchPath(jql, 'summary,updated,created', { pageToken }),
+      );
       const issues = result.issues ?? [];
       for (const issue of issues) {
         const key = issue.key ?? String(issue.id);
@@ -200,6 +349,7 @@ export const jiraConnector: KnowledgeConnector<JiraConfig> = {
           url: `${base}/browse/${key}`,
           version: updated,
           updatedAt: updated,
+          createdAt: issue.fields?.created,
         });
       }
       // Stop when there's no next cursor (or, defensively, an empty page).
@@ -210,8 +360,11 @@ export const jiraConnector: KnowledgeConnector<JiraConfig> = {
   },
 
   async fetch(cfg, id): Promise<DocContent> {
-    const issue = await getJson<JiraIssue>(cfg, `/issue/${encodeURIComponent(id)}?fields=summary,description`);
-    return toDocContent(issue);
+    const issue = await getJson<JiraIssue>(
+      cfg,
+      `/issue/${encodeURIComponent(id)}?fields=${ISSUE_FIELDS}&expand=changelog`,
+    );
+    return toDocContent(issue, await resolveStatusChanges(cfg, issue));
   },
 
   async fetchMany(cfg, ids) {
@@ -225,10 +378,15 @@ export const jiraConnector: KnowledgeConnector<JiraConfig> = {
     const jql = `id in (${ids.join(', ')}) ORDER BY created ASC`;
     let pageToken: string | undefined;
     for (;;) {
-      const result = await getJson<JiraSearchResult>(cfg, searchPath(jql, 'summary,description', { pageToken }));
+      const result = await getJson<JiraSearchResult>(
+        cfg,
+        searchPath(jql, ISSUE_FIELDS, { pageToken, expand: 'changelog' }),
+      );
       const issues = result.issues ?? [];
       for (const issue of issues) {
-        out.set(String(issue.id), toDocContent(issue));
+        // Sequential on purpose: the await only does I/O for the rare issue whose
+        // inline changelog was truncated; every other issue resolves in memory.
+        out.set(String(issue.id), toDocContent(issue, await resolveStatusChanges(cfg, issue)));
       }
       if (!result.nextPageToken || issues.length === 0) break;
       pageToken = result.nextPageToken;

--- a/ee/packages/server/src/knowledge/connectors/jira.ts
+++ b/ee/packages/server/src/knowledge/connectors/jira.ts
@@ -301,10 +301,15 @@ function frontmatter(issue: JiraIssue, changes: StatusChange[]): string {
   const updated = isoOrUndefined(issue.fields?.updated);
   const resolved = resolvedAt(issue, changes);
   const status = issue.fields?.status?.name;
+  // The bucket Jira files that name under. Stated beside the name, not instead
+  // of it: the reader prefers the name and falls back here, which is what keeps
+  // a workflow state we've never seen from classifying as nothing.
+  const statusCategory = issue.fields?.status?.statusCategory?.key;
   if (created) lines.push(`created: ${created}`);
   if (updated) lines.push(`updated: ${updated}`);
   if (resolved) lines.push(`resolved: ${resolved}`);
   if (status) lines.push(`status: ${yamlValue(status)}`);
+  if (statusCategory) lines.push(`status_category: ${yamlValue(statusCategory)}`);
   if (lines.length === 0) return '';
 
   if (changes.length > 0) {

--- a/ee/packages/server/src/knowledge/connectors/jira.ts
+++ b/ee/packages/server/src/knowledge/connectors/jira.ts
@@ -263,37 +263,68 @@ function resolvedAt(issue: JiraIssue, changes: StatusChange[]): string | undefin
 }
 
 /**
- * The metadata block the consolidator reads back out of the body. `parseDocDate`
- * and `parseDocStatus` scan only the first 40 lines and match `Name: value`, so
- * the dated fields lead and the history follows. History lines deliberately open
- * with the timestamp: a line starting with a date-field NAME would be picked up
- * as the doc's own date, and the FIRST occurrence of a field wins.
+ * Transitions kept in the header. The block sits ahead of the description, and
+ * the relevance classifier only reads the doc's first 60 lines — an uncapped
+ * history on a long-lived issue fills that window with a transition list and the
+ * issue reads as status tracking, so its requirements never reach extraction.
+ * The most recent are kept: they carry where the issue settled.
  */
-function metadataBlock(issue: JiraIssue, changes: StatusChange[]): string {
+const HISTORY_LIMIT = 10;
+
+/** YAML-quote a value that could otherwise parse as something else. */
+function yamlValue(raw: string): string {
+  return `"${raw.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * The metadata the consolidator reads back out of the doc, as YAML frontmatter.
+ *
+ * Frontmatter rather than visible body text for two reasons: a reader opening
+ * the doc wants the ticket, not our bookkeeping, and every markdown renderer
+ * already hides it. The consolidator's readers are unaffected — they scan the
+ * first 40 lines for `name: value`, which is exactly frontmatter's shape.
+ *
+ * Key names are the ones those readers know (`created`/`updated`/`resolved`/
+ * `status`). `status_history` deliberately is not one of them, and its entries
+ * open with a timestamp: an entry beginning with a date-field NAME would be read
+ * as the doc's own date, and the first occurrence of a field wins.
+ */
+function frontmatter(issue: JiraIssue, changes: StatusChange[]): string {
   const lines: string[] = [];
   const created = isoOrUndefined(issue.fields?.created);
   const updated = isoOrUndefined(issue.fields?.updated);
   const resolved = resolvedAt(issue, changes);
   const status = issue.fields?.status?.name;
-  if (created) lines.push(`Created: ${created}`);
-  if (updated) lines.push(`Updated: ${updated}`);
-  if (resolved) lines.push(`Resolved: ${resolved}`);
-  if (status) lines.push(`Status: ${status}`);
+  if (created) lines.push(`created: ${created}`);
+  if (updated) lines.push(`updated: ${updated}`);
+  if (resolved) lines.push(`resolved: ${resolved}`);
+  if (status) lines.push(`status: ${yamlValue(status)}`);
   if (lines.length === 0) return '';
-  const history = changes.map((c) => `- ${c.at}  ${c.from || '(none)'} -> ${c.to}`);
-  return history.length > 0
-    ? `${lines.join('\n')}\n\n## Status history\n${history.join('\n')}`
-    : lines.join('\n');
+
+  if (changes.length > 0) {
+    lines.push('status_history:');
+    const kept = changes.slice(-HISTORY_LIMIT);
+    const dropped = changes.length - kept.length;
+    // Say what was dropped rather than truncating silently — a short list would
+    // otherwise read as the issue's whole history.
+    if (dropped > 0) lines.push(`  - ${yamlValue(`… ${dropped} earlier transitions omitted`)}`);
+    for (const c of kept) {
+      lines.push(`  - ${yamlValue(`${c.at}  ${c.from || '(none)'} -> ${c.to}`)}`);
+    }
+  }
+  return `---\n${lines.join('\n')}\n---`;
 }
 
-/** Build one issue's document body: `# KEY: summary` H1, the metadata block, the description. */
+/** Build one issue's document: frontmatter, the `# KEY: summary` H1, the description. */
 function toDocContent(issue: JiraIssue, changes: StatusChange[] = []): DocContent {
   const key = issue.key ?? String(issue.id);
   const title = `${key}: ${issue.fields?.summary ?? ''}`;
   const body = adfToMarkdown(issue.fields?.description);
-  const meta = metadataBlock(issue, changes);
-  // Prepend the title as an H1 so a heading-less description still has a slice anchor.
-  return { title, markdown: [`# ${title}`, meta, body].filter(Boolean).join('\n\n').trim() };
+  // The H1 anchors the slicer, so a heading-less description still has one.
+  return {
+    title,
+    markdown: [frontmatter(issue, changes), `# ${title}`, body].filter(Boolean).join('\n\n').trim(),
+  };
 }
 
 /** `/search/jql` query string for a JQL sweep (paginates on nextPageToken). */

--- a/ee/packages/server/src/knowledge/connectors/jira.ts
+++ b/ee/packages/server/src/knowledge/connectors/jira.ts
@@ -210,9 +210,15 @@ function statusChanges(entries: JiraChangelogEntry[]): StatusChange[] {
  * missing, which is exactly the part the header needs.
  */
 function inlineChangelog(issue: JiraIssue): { entries: JiraChangelogEntry[]; truncated: boolean } {
-  const entries = issue.changelog?.histories ?? [];
-  const total = issue.changelog?.total;
-  return { entries, truncated: typeof total === 'number' && total > entries.length };
+  const changelog = issue.changelog;
+  const entries = changelog?.histories ?? [];
+  // An issue the search never carried a changelog for has nothing to be short of.
+  if (!changelog) return { entries, truncated: false };
+  // `total` is what proves the inline copy is whole. Without it we cannot tell a
+  // complete history from a clipped one, and the missing entries would be the
+  // EARLIEST — the ones the resolved-date fallback reads. Unverified means
+  // re-fetch: the call is bounded and only fires when Jira omits the count.
+  return { entries, truncated: changelog.total === undefined || changelog.total > entries.length };
 }
 
 /** One page of the per-issue changelog endpoint (`values`, not `histories`). */
@@ -373,7 +379,7 @@ export const jiraConnector: KnowledgeConnector<JiraConfig> = {
         const key = issue.key ?? String(issue.id);
         // Jira has no version counter — `updated` bumps on every edit, so it
         // serves as both the version marker and the newest-wins timestamp.
-        const updated = issue.fields?.updated ?? '1970-01-01T00:00:00.000Z';
+        const updated = issue.fields?.updated;
         refs.push({
           id: String(issue.id),
           title: `${key}: ${issue.fields?.summary ?? ''}`,

--- a/ee/packages/server/src/knowledge/connectors/types.ts
+++ b/ee/packages/server/src/knowledge/connectors/types.ts
@@ -23,8 +23,12 @@ export interface DocRef {
   url: string;
   /** Source version (e.g. Confluence version.number); undefined ⇒ hash-only diff. */
   version?: string;
-  /** ISO timestamp; feeds newest-wins (`lastTouched`). */
-  updatedAt: string;
+  /**
+   * ISO timestamp; feeds newest-wins (`lastTouched`). Absent when the source
+   * states none — say so rather than substituting a date, which would win or
+   * lose orderings on a value nobody meant.
+   */
+  updatedAt?: string;
   /** ISO timestamp of creation in the source tool, when it exposes one. */
   createdAt?: string;
 }

--- a/ee/packages/server/src/knowledge/connectors/types.ts
+++ b/ee/packages/server/src/knowledge/connectors/types.ts
@@ -25,6 +25,8 @@ export interface DocRef {
   version?: string;
   /** ISO timestamp; feeds newest-wins (`lastTouched`). */
   updatedAt: string;
+  /** ISO timestamp of creation in the source tool, when it exposes one. */
+  createdAt?: string;
 }
 
 /** One document's content, as fetched from the source. */

--- a/ee/packages/server/src/knowledge/inheritance.ts
+++ b/ee/packages/server/src/knowledge/inheritance.ts
@@ -18,6 +18,7 @@
 import type { GateStore } from '@truecourse/ee-github-app';
 import { PgKnowledgeStore } from '@truecourse/ee-data-store';
 import { getWorkspaceDecisions } from '@truecourse/core/commands/spec-in-process';
+import { lastTouchedOf } from './sync.js';
 import type {
   SpecInheritanceHook,
   WorkspaceInheritanceDoc,
@@ -53,7 +54,7 @@ export function createSpecInheritanceHook(deps: InheritanceDeps): SpecInheritanc
     for (const row of rows) {
       const markdown = await deps.knowledge.getDocBody(org, row.contentHash);
       if (markdown == null) continue; // a body somehow absent → skip it, not the whole layer
-      docs.push({ docPath: row.docPath, markdown, lastTouched: row.externalUpdatedAt ?? undefined });
+      docs.push({ docPath: row.docPath, markdown, lastTouched: lastTouchedOf(row) });
     }
     if (docs.length === 0) return null;
 

--- a/ee/packages/server/src/knowledge/inheritance.ts
+++ b/ee/packages/server/src/knowledge/inheritance.ts
@@ -53,7 +53,7 @@ export function createSpecInheritanceHook(deps: InheritanceDeps): SpecInheritanc
     for (const row of rows) {
       const markdown = await deps.knowledge.getDocBody(org, row.contentHash);
       if (markdown == null) continue; // a body somehow absent → skip it, not the whole layer
-      docs.push({ docPath: row.docPath, markdown, lastTouched: row.sourceUpdatedAt ?? undefined });
+      docs.push({ docPath: row.docPath, markdown, lastTouched: row.externalUpdatedAt ?? undefined });
     }
     if (docs.length === 0) return null;
 

--- a/ee/packages/server/src/knowledge/inheritance.ts
+++ b/ee/packages/server/src/knowledge/inheritance.ts
@@ -53,7 +53,7 @@ export function createSpecInheritanceHook(deps: InheritanceDeps): SpecInheritanc
     for (const row of rows) {
       const markdown = await deps.knowledge.getDocBody(org, row.contentHash);
       if (markdown == null) continue; // a body somehow absent → skip it, not the whole layer
-      docs.push({ docPath: row.docPath, markdown });
+      docs.push({ docPath: row.docPath, markdown, lastTouched: row.sourceUpdatedAt ?? undefined });
     }
     if (docs.length === 0) return null;
 

--- a/ee/packages/server/src/knowledge/sync.ts
+++ b/ee/packages/server/src/knowledge/sync.ts
@@ -53,6 +53,8 @@ export interface SyncDoc {
   title: string;
   url: string | null;
   version: string | null;
+  sourceCreatedAt: string | null;
+  sourceUpdatedAt: string | null;
   contentHash: string;
   doc: WorkspaceDocInput;
 }
@@ -66,6 +68,9 @@ function toSyncDoc(kind: string, ref: DocRef, content: DocContent): SyncDoc {
     title: content.title || ref.title,
     url: ref.url,
     version: ref.version ?? null,
+    // The dates in their own columns, not smuggled through `version`.
+    sourceCreatedAt: ref.createdAt ?? null,
+    sourceUpdatedAt: ref.updatedAt ?? null,
     contentHash: sha256(Buffer.from(content.markdown, 'utf-8')),
     doc: {
       docPath: connectorDocPath(kind, ref.id),
@@ -164,6 +169,8 @@ async function reconcileLedgerSlice(
       title: d.title,
       url: d.url,
       version: d.version,
+      sourceCreatedAt: d.sourceCreatedAt,
+      sourceUpdatedAt: d.sourceUpdatedAt,
       contentHash: d.contentHash,
     });
   }
@@ -229,7 +236,14 @@ export async function processWorkspaceKnowledge(
     loaded += 1;
     await progress?.(loaded, total, SYNC_MSG_FETCH);
     if (markdown == null) continue;
-    docs.push({ docPath: row.docPath, markdown, lastTouched: row.lastSyncedAt });
+    // The SOURCE's date orders the corpus. `lastSyncedAt` is the same instant for
+    // every doc in a run, so it can only be the fallback for a row that predates
+    // the source-date columns.
+    docs.push({
+      docPath: row.docPath,
+      markdown,
+      lastTouched: row.sourceUpdatedAt ?? row.lastSyncedAt,
+    });
     consolidated.push({ docPath: row.docPath, processedHash: row.contentHash });
     bySource[row.sourceKind] = (bySource[row.sourceKind] ?? 0) + 1;
   }

--- a/ee/packages/server/src/knowledge/sync.ts
+++ b/ee/packages/server/src/knowledge/sync.ts
@@ -67,8 +67,8 @@ export interface SyncDoc {
   title: string;
   url: string | null;
   version: string | null;
-  sourceCreatedAt: string | null;
-  sourceUpdatedAt: string | null;
+  externalCreatedAt: string | null;
+  externalUpdatedAt: string | null;
   contentHash: string;
   doc: WorkspaceDocInput;
 }
@@ -83,8 +83,8 @@ function toSyncDoc(kind: string, ref: DocRef, content: DocContent): SyncDoc {
     url: ref.url,
     version: ref.version ?? null,
     // The dates in their own columns, not smuggled through `version`.
-    sourceCreatedAt: isoOrNull(ref.createdAt),
-    sourceUpdatedAt: isoOrNull(ref.updatedAt),
+    externalCreatedAt: isoOrNull(ref.createdAt),
+    externalUpdatedAt: isoOrNull(ref.updatedAt),
     contentHash: sha256(Buffer.from(content.markdown, 'utf-8')),
     doc: {
       docPath: connectorDocPath(kind, ref.id),
@@ -183,8 +183,8 @@ async function reconcileLedgerSlice(
       title: d.title,
       url: d.url,
       version: d.version,
-      sourceCreatedAt: d.sourceCreatedAt,
-      sourceUpdatedAt: d.sourceUpdatedAt,
+      externalCreatedAt: d.externalCreatedAt,
+      externalUpdatedAt: d.externalUpdatedAt,
       contentHash: d.contentHash,
     });
   }
@@ -256,7 +256,7 @@ export async function processWorkspaceKnowledge(
     docs.push({
       docPath: row.docPath,
       markdown,
-      lastTouched: row.sourceUpdatedAt ?? row.lastSyncedAt,
+      lastTouched: row.externalUpdatedAt ?? row.lastSyncedAt,
     });
     consolidated.push({ docPath: row.docPath, processedHash: row.contentHash });
     bySource[row.sourceKind] = (bySource[row.sourceKind] ?? 0) + 1;

--- a/ee/packages/server/src/knowledge/sync.ts
+++ b/ee/packages/server/src/knowledge/sync.ts
@@ -62,6 +62,19 @@ function isoOrNull(value: string | undefined): string | null {
   return Number.isNaN(when.getTime()) ? null : when.toISOString();
 }
 
+/**
+ * The date that orders a ledger doc against the rest of the corpus: what the
+ * SOURCE last said, falling back to when we synced it.
+ *
+ * One function because both materialization paths need the same answer and had
+ * drifted — the workspace scan fell back, the repo inheritance path did not, so
+ * a row predating the source-date columns was stamped with the write instant
+ * there and read as newer than every doc it should have lost to.
+ */
+export function lastTouchedOf(row: { externalUpdatedAt: string | null; lastSyncedAt: string }): string {
+  return row.externalUpdatedAt ?? row.lastSyncedAt;
+}
+
 export interface SyncDoc {
   externalId: string;
   title: string;
@@ -250,14 +263,7 @@ export async function processWorkspaceKnowledge(
     loaded += 1;
     await progress?.(loaded, total, SYNC_MSG_FETCH);
     if (markdown == null) continue;
-    // The SOURCE's date orders the corpus. `lastSyncedAt` is the same instant for
-    // every doc in a run, so it can only be the fallback for a row that predates
-    // the source-date columns.
-    docs.push({
-      docPath: row.docPath,
-      markdown,
-      lastTouched: row.externalUpdatedAt ?? row.lastSyncedAt,
-    });
+    docs.push({ docPath: row.docPath, markdown, lastTouched: lastTouchedOf(row) });
     consolidated.push({ docPath: row.docPath, processedHash: row.contentHash });
     bySource[row.sourceKind] = (bySource[row.sourceKind] ?? 0) + 1;
   }

--- a/ee/packages/server/src/knowledge/sync.ts
+++ b/ee/packages/server/src/knowledge/sync.ts
@@ -48,6 +48,20 @@ export function connectorDocPath(kind: string, externalId: string): string {
   return `knowledge/${kind}/${externalId}.md`;
 }
 
+/**
+ * A source timestamp as a `timestamptz` column will accept it, or null. `DocRef`
+ * types these as strings but nothing constrains their shape — a connector may
+ * use `updatedAt` as an opaque change marker, and a source may emit a format
+ * `Date` cannot read. Either would fail the INSERT and take the whole sync with
+ * it, so an unusable value is dropped: the doc keeps its other columns and only
+ * loses its ordering hint.
+ */
+function isoOrNull(value: string | undefined): string | null {
+  if (!value) return null;
+  const when = new Date(value);
+  return Number.isNaN(when.getTime()) ? null : when.toISOString();
+}
+
 export interface SyncDoc {
   externalId: string;
   title: string;
@@ -69,8 +83,8 @@ function toSyncDoc(kind: string, ref: DocRef, content: DocContent): SyncDoc {
     url: ref.url,
     version: ref.version ?? null,
     // The dates in their own columns, not smuggled through `version`.
-    sourceCreatedAt: ref.createdAt ?? null,
-    sourceUpdatedAt: ref.updatedAt ?? null,
+    sourceCreatedAt: isoOrNull(ref.createdAt),
+    sourceUpdatedAt: isoOrNull(ref.updatedAt),
     contentHash: sha256(Buffer.from(content.markdown, 'utf-8')),
     doc: {
       docPath: connectorDocPath(kind, ref.id),

--- a/packages/core/src/commands/spec-in-process.ts
+++ b/packages/core/src/commands/spec-in-process.ts
@@ -579,13 +579,34 @@ export async function curateInProcess(
 // job); this path is corpus-only.
 // ---------------------------------------------------------------------------
 
+/**
+ * Set a materialized doc's mtime to when the SOURCE says it last changed, so
+ * discovery can order it. Best-effort: an unparseable or absent timestamp leaves
+ * the file's own mtime, which is the pre-existing behavior.
+ */
+function stampMtime(dest: string, lastTouched: string | undefined): void {
+  if (!lastTouched) return;
+  const when = new Date(lastTouched);
+  if (Number.isNaN(when.getTime())) return;
+  try {
+    fs.utimesSync(dest, when, when);
+  } catch {
+    /* a filesystem that refuses the stamp must not fail the sync */
+  }
+}
+
 /** One source document handed to the workspace corpus sync. The body is transient. */
 export interface WorkspaceDocInput {
   /** Stable, namespaced relative path, e.g. `knowledge/confluence/<externalId>.md`. */
   docPath: string;
   /** The transient markdown body. Never persisted. */
   markdown: string;
-  /** ISO timestamp (the source tool's `updatedAt`); informational. */
+  /**
+   * ISO timestamp (the source tool's `updatedAt`). Stamped onto the written
+   * file's mtime, because discovery derives a doc's date from the filesystem
+   * when it has nothing better — and every doc here is written in one loop, so
+   * without this they all share the write instant and nothing can be ordered.
+   */
   lastTouched?: string;
 }
 
@@ -626,6 +647,7 @@ export async function syncWorkspaceCorpusInProcess(options: {
       const dest = path.join(tmp, doc.docPath);
       fs.mkdirSync(path.dirname(dest), { recursive: true });
       fs.writeFileSync(dest, doc.markdown, 'utf-8');
+      stampMtime(dest, doc.lastTouched);
     }
     // Materialize the decisions BEFORE curate so it reads them from the tree, the
     // same channel a repo uses (curate reads `.truecourse/specs/decisions.json`).
@@ -695,6 +717,7 @@ export async function materializeWorkspaceInheritance(
     const dest = path.join(repoRoot, doc.docPath);
     fs.mkdirSync(path.dirname(dest), { recursive: true });
     fs.writeFileSync(dest, doc.markdown, 'utf-8');
+    stampMtime(dest, doc.lastTouched);
   }
   return { decisions: mergeInheritedDecisions(layer.decisions, repoDecisions), inherited: true };
 }

--- a/packages/core/src/lib/spec-inheritance-hook.ts
+++ b/packages/core/src/lib/spec-inheritance-hook.ts
@@ -25,6 +25,8 @@ export interface WorkspaceInheritanceDoc {
   docPath: string;
   /** The stored (content-addressed) markdown body. */
   markdown: string;
+  /** ISO timestamp the source tool reports; stamped onto the materialized file. */
+  lastTouched?: string;
 }
 
 /** The workspace layer a repo inherits: doc bodies to materialize + the workspace

--- a/packages/spec-consolidator/src/area-tagger.ts
+++ b/packages/spec-consolidator/src/area-tagger.ts
@@ -157,22 +157,41 @@ function docBody(doc: DocCandidate): string {
 
 const STATUS_VALUES = new Set(StatusSchema.options);
 
+/** `Status: shipped`. Disjoint from {@link STATUS_CATEGORY_LINE}: `status` must be
+ *  followed by the separator, so `status_category` and `status_history` miss it. */
+const STATUS_LINE = /^\s*[-*]?\s*\*{0,2}status\*{0,2}\s*[:=]\s*(.+?)\s*$/i;
+/** `Status category: done` — a tracker's coarse bucket beside its workflow name. */
+const STATUS_CATEGORY_LINE = /^\s*[-*]?\s*\*{0,2}status[ _-]?category\*{0,2}\s*[:=]\s*(.+?)\s*$/i;
+
 /**
  * Parse a lifecycle status from a doc's header. PRDs/ADRs commonly carry a
  * `Status: shipped` line (in YAML frontmatter or a header block) in the first
  * lines. Best-effort: returns undefined when nothing recognizable is found.
+ *
+ * The NAME decides whenever we understand it, and a coarse `Status category`
+ * only answers when nothing did. That order matters: a tracker files "Won't Do"
+ * under its done category, so the category alone would read a dropped ticket as
+ * shipped. Read second, it does the one thing the name cannot — keep a workflow
+ * whose vocabulary we've never seen from classifying as nothing at all.
  */
 export function parseDocStatus(body: string): Status | undefined {
   const head = body.split(/\r?\n/).slice(0, 40);
+  let category: Status | undefined;
   for (const line of head) {
-    const m = /^\s*[-*]?\s*\*{0,2}status\*{0,2}\s*[:=]\s*(.+?)\s*$/i.exec(line);
-    if (!m) continue;
-    const status = classifyStatusValue(m[1]);
-    if (status) return status;
-    // Unrecognized value on this status line (e.g. a badge image) — keep scanning
-    // for a clearer one rather than bailing on the first match.
+    const named = STATUS_LINE.exec(line);
+    if (named) {
+      const status = classifyStatusValue(named[1]);
+      if (status) return status;
+      // Unrecognized value on this status line (e.g. a badge image) — keep scanning
+      // for a clearer one rather than bailing on the first match.
+      continue;
+    }
+    if (category === undefined) {
+      const bucket = STATUS_CATEGORY_LINE.exec(line);
+      if (bucket) category = classifyStatusCategory(bucket[1]);
+    }
   }
-  return undefined;
+  return category;
 }
 
 /**
@@ -182,16 +201,42 @@ export function parseDocStatus(body: string): Status | undefined {
  * incidental keyword. Ambiguous short tokens (`ga`/`live`) only count when they
  * are the whole value.
  */
+/**
+ * Map a tracker's coarse status CATEGORY — the bucket it files a workflow state
+ * under, independent of what that state is called.
+ *
+ * A fallback only. A category cannot separate "Done" from "Won't Do" (both are
+ * done), so it answers only where the name meant nothing: an unrecognized custom
+ * state degrades to roughly right instead of to no status at all. The vocabulary
+ * is small on purpose — these are the buckets trackers actually expose, and a
+ * category we don't know stays unknown rather than being guessed at.
+ */
+function classifyStatusCategory(rawValue: string): Status | undefined {
+  const raw = rawValue.toLowerCase().replace(/[`*_"']/g, '').trim();
+  if (raw === 'done' || raw === 'complete') return 'shipped';
+  if (raw === 'new' || raw === 'to do' || raw === 'todo' || raw === 'indeterminate' || raw === 'in progress') {
+    return 'planned';
+  }
+  return undefined;
+}
+
 function classifyStatusValue(rawValue: string): Status | undefined {
-  const raw = rawValue.toLowerCase().replace(/[`*_]/g, '').trim();
+  const raw = rawValue.toLowerCase().replace(/[`*_"']/g, '').trim();
   if (!raw) return undefined;
   if (STATUS_VALUES.has(raw as Status)) return raw as Status;
-  if (/\b(out[- ]?of[- ]?scope|wont[- ]?fix|rejected|cancelled|canceled)\b/.test(raw)) return 'out-of-scope';
+  // `wont do` alongside `wont fix`: a tracker files both under its DONE category,
+  // so a name we failed to place here would fall through and read as delivered.
+  if (/\b(out[- ]?of[- ]?scope|wont[- ]?(?:fix|do)|rejected|cancelled|canceled|duplicate)\b/.test(raw)) {
+    return 'out-of-scope';
+  }
   if (/\b(deprecated|superseded|obsolete|retired)\b/.test(raw)) return 'deprecated';
   if (/\b(deferred|on[- ]?hold|paused|backlog)\b/.test(raw)) return 'deferred';
   if (/\b(in[- ]?progress|planned|draft|proposed|todo|wip|upcoming|not[- ]?started)\b/.test(raw)) return 'planned';
   // "accepted"/"approved"/"adopted" — an ADR whose decision is in force.
-  if (/\b(shipped|done|complete|completed|released|accepted|approved|adopted|active|generally[- ]?available)\b/.test(raw)) return 'shipped';
+  // `closed`/`resolved` are the default terminal states of every issue tracker,
+  // and land AFTER the negative patterns so "Closed — won't fix" still reads as
+  // out-of-scope rather than as delivered.
+  if (/\b(shipped|done|complete|completed|released|closed|resolved|accepted|approved|adopted|active|generally[- ]?available)\b/.test(raw)) return 'shipped';
   if (raw === 'ga' || raw === 'live' || raw === 'go live') return 'shipped';
   return undefined;
 }

--- a/packages/spec-consolidator/src/discovery.ts
+++ b/packages/spec-consolidator/src/discovery.ts
@@ -211,6 +211,32 @@ export function discoverDocs(rootDir: string, opts: DiscoveryOptions = {}): DocC
 }
 
 /**
+ * A YAML frontmatter block opening the document, if it has one. The fence must
+ * be the first line and must close, so a `---` used as a horizontal rule is not
+ * mistaken for one.
+ */
+const FRONTMATTER = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/;
+
+/**
+ * The document beneath any frontmatter — what the doc SAYS, separated from what
+ * it says ABOUT itself.
+ *
+ * That line matters twice. A doc's content hash keys the per-doc LLM caches, and
+ * frontmatter carries fields that move without the text moving: a synced ticket
+ * restates its `updated` on any comment or label change, so hashing it makes a
+ * sprint of comments buy a paid re-tag of every unchanged doc. And the preview
+ * is the window the relevance classifier judges a doc through — metadata spent
+ * out of that window is content the classifier never sees.
+ *
+ * The parsers that READ frontmatter keep the whole file; only identity and the
+ * preview window are taken from the document itself.
+ */
+function documentBody(content: string): string {
+  const m = FRONTMATTER.exec(content);
+  return m ? content.slice(m[0].length).replace(/^\r?\n/, '') : content;
+}
+
+/**
  * The snapshot docs of every registered web source, as ordinary candidates —
  * appended after the walk, sorted among themselves by ref.
  *
@@ -256,8 +282,11 @@ function makeCandidate(
   }
 
   const rel = ref ?? path.relative(rootDir, absPath).split(path.sep).join('/');
-  const preview = content.split(/\r?\n/).slice(0, previewLines).join('\n');
-  const contentHash = createHash('sha256').update(content).digest('hex');
+  // Identity and the preview window come from the document, not from the
+  // metadata block above it. See {@link documentBody}.
+  const body = documentBody(content);
+  const preview = body.split(/\r?\n/).slice(0, previewLines).join('\n');
+  const contentHash = createHash('sha256').update(body).digest('hex');
   const lastTouched = opts.skipGit
     ? stat.mtime.toISOString()
     : (gitLastTouched(rootDir, rel) ?? stat.mtime.toISOString());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,9 @@ importers:
       remark-directive:
         specifier: ^4.0.0
         version: 4.0.0
+      remark-frontmatter:
+        specifier: ^5.0.0
+        version: 5.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1517,11 +1520,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.24.2':
     resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
@@ -4092,6 +4095,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -4136,6 +4142,10 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -4731,6 +4741,9 @@ packages:
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
   mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
@@ -4801,6 +4814,9 @@ packages:
 
   micromark-extension-directive@4.0.0:
     resolution: {integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -5417,6 +5433,9 @@ packages:
 
   remark-directive@4.0.0:
     resolution: {integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==}
+
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -9599,6 +9618,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -9650,6 +9673,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  format@0.2.2: {}
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -10265,6 +10290,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -10436,6 +10472,13 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       parse-entities: 4.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     dependencies:
@@ -11158,6 +11201,15 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-directive: 3.1.0
       micromark-extension-directive: 4.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color

--- a/tests/dashboard-client/doc-markdown.test.tsx
+++ b/tests/dashboard-client/doc-markdown.test.tsx
@@ -123,9 +123,10 @@ describe('DocMarkdown — what the directive syntax must not touch', () => {
 
 /**
  * A synced ticket states its dates and status as YAML frontmatter, and a reader
- * opening the doc wants the ticket rather than our bookkeeping. The renderer is
- * the only place that hides it — the block stays in the source everything
- * downstream reads, so these guard the presentation contract, not the data.
+ * opening the doc wants the ticket rather than our bookkeeping. `remark-frontmatter`
+ * parses the block into a node the renderer has no handler for, so it never reaches
+ * the page. Hiding is presentation only — the block stays in the source everything
+ * downstream reads, so these guard that contract, not the data.
  */
 describe('DocMarkdown — YAML frontmatter', () => {
   const FM = [
@@ -155,6 +156,25 @@ describe('DocMarkdown — YAML frontmatter', () => {
     render(<DocMarkdown source={FM} highlight={['KAN-2: Idempotent order creation']} />);
     expect(screen.queryByText(/created:/)).toBeNull();
     expect(screen.getByText('Order creation must be idempotent.')).toBeTruthy();
+  });
+
+it('takes a block whose body would break a naive fence match', () => {
+    // A `---` inside a quoted scalar, and a key whose value is a nested block —
+    // the parser knows where the document ends; a regex over the raw text does not.
+    const tricky = [
+      '---',
+      'title: "a --- inside a value"',
+      'note: |',
+      '  a line',
+      '  --- not the end',
+      '---',
+      '',
+      '# Real heading',
+    ].join('\n');
+    render(<DocMarkdown source={tricky} />);
+    expect(screen.queryByText(/a --- inside a value/)).toBeNull();
+    expect(screen.queryByText(/not the end/)).toBeNull();
+    expect(screen.getByRole('heading', { name: 'Real heading' })).toBeTruthy();
   });
 
   it('leaves a horizontal rule inside the prose alone', () => {

--- a/tests/dashboard-client/doc-markdown.test.tsx
+++ b/tests/dashboard-client/doc-markdown.test.tsx
@@ -120,3 +120,55 @@ describe('DocMarkdown — what the directive syntax must not touch', () => {
     expect(container.querySelector('[data-admonition]')).toBeNull();
   });
 });
+
+/**
+ * A synced ticket states its dates and status as YAML frontmatter, and a reader
+ * opening the doc wants the ticket rather than our bookkeeping. The renderer is
+ * the only place that hides it — the block stays in the source everything
+ * downstream reads, so these guard the presentation contract, not the data.
+ */
+describe('DocMarkdown — YAML frontmatter', () => {
+  const FM = [
+    '---',
+    'created: 2026-07-09T20:35:49.691Z',
+    'updated: 2026-08-19T18:30:01.773Z',
+    'status: "Done"',
+    'status_history:',
+    '  - "2026-07-09T20:35:56.078Z  To Do -> Done"',
+    '---',
+    '',
+    '# KAN-2: Idempotent order creation',
+    '',
+    'Order creation must be idempotent.',
+  ].join('\n');
+
+  it('hides the block and renders the document that follows', () => {
+    render(<DocMarkdown source={FM} />);
+    expect(screen.queryByText(/created:/)).toBeNull();
+    expect(screen.queryByText(/status_history:/)).toBeNull();
+    expect(screen.queryByText(/To Do -> Done/)).toBeNull();
+    expect(screen.getByRole('heading', { name: 'KAN-2: Idempotent order creation' })).toBeTruthy();
+    expect(screen.getByText('Order creation must be idempotent.')).toBeTruthy();
+  });
+
+  it('hides it on the highlighted path too, where the doc is split by section', () => {
+    render(<DocMarkdown source={FM} highlight={['KAN-2: Idempotent order creation']} />);
+    expect(screen.queryByText(/created:/)).toBeNull();
+    expect(screen.getByText('Order creation must be idempotent.')).toBeTruthy();
+  });
+
+  it('leaves a horizontal rule inside the prose alone', () => {
+    const { container } = render(
+      <DocMarkdown source={['# Title', '', 'before', '', '---', '', 'after'].join('\n')} />,
+    );
+    expect(screen.getByText('before')).toBeTruthy();
+    expect(screen.getByText('after')).toBeTruthy();
+    expect(container.querySelector('hr')).toBeTruthy();
+  });
+
+  it('only strips a fence that opens the document', () => {
+    render(<DocMarkdown source={['intro', '', '---', 'created: 2026-01-01', '---'].join('\n')} />);
+    // Not frontmatter — it is prose that happens to look like it.
+    expect(screen.getByText(/created: 2026-01-01/)).toBeTruthy();
+  });
+});

--- a/tests/ee-server/confluence-connector.test.ts
+++ b/tests/ee-server/confluence-connector.test.ts
@@ -195,21 +195,22 @@ describe('confluenceConnector — metadata header contract', () => {
   it('emits both dates where the consolidator reads them', async () => {
     stubPage(PAGE);
     const { markdown } = await confluenceConnector.fetch(CFG, '123');
-    expect(markdown.split('\n').slice(0, 40).join('\n')).toContain('Created:');
-    expect(markdown).toContain('Created: 2026-08-19T19:08:41.489Z');
-    expect(markdown).toContain('Updated: 2026-08-19T19:09:08.426Z');
+    expect(markdown.startsWith('---\n')).toBe(true);
+    expect(markdown.split('\n').slice(0, 40).join('\n')).toContain('created:');
+    expect(markdown).toContain('created: 2026-08-19T19:08:41.489Z');
+    expect(markdown).toContain('updated: 2026-08-19T19:09:08.426Z');
     // `updated` outranks `created`, so it is the one that orders the doc.
     expect(headerDate(markdown)).toBe('2026-08-19T19:09:08.426Z');
     // The page still reads as itself — the header sits between H1 and body.
-    expect(markdown.startsWith('# Order cancellation policy')).toBe(true);
+    expect(markdown).toContain('\n# Order cancellation policy');
     expect(markdown).toContain('Users can cancel while Pending.');
   });
 
   it('carries no status — a page has no lifecycle, and version is an edit counter', async () => {
     stubPage(PAGE);
     const { markdown } = await confluenceConnector.fetch(CFG, '123');
-    expect(markdown).not.toContain('Status:');
-    expect(markdown).not.toContain('## Status history');
+    expect(markdown).not.toContain('status:');
+    expect(markdown).not.toContain('status_history:');
     // The edit counter must never surface as a date.
     expect(markdown).not.toContain('3');
   });
@@ -217,7 +218,7 @@ describe('confluenceConnector — metadata header contract', () => {
   it('omits a date the API did not return, and the block when it returned none', async () => {
     stubPage({ ...PAGE, history: undefined });
     const noCreated = await confluenceConnector.fetch(CFG, '123');
-    expect(noCreated.markdown).not.toContain('Created:');
+    expect(noCreated.markdown).not.toContain('created:');
     expect(headerDate(noCreated.markdown)).toBe('2026-08-19T19:09:08.426Z');
 
     stubPage({ ...PAGE, history: undefined, version: undefined });

--- a/tests/ee-server/confluence-connector.test.ts
+++ b/tests/ee-server/confluence-connector.test.ts
@@ -139,3 +139,101 @@ describe('confluenceConnector', () => {
     ]);
   });
 });
+
+/**
+ * The mirror of the Jira connector's header contract. This suite exists because
+ * the header was first shipped on Jira alone: Confluence fetched `history` and
+ * never wrote it into the body, so its docs hashed identically to before and a
+ * re-sync reported nothing to process. Assert the CONTRACT the consolidator's
+ * date reader imposes, not the string.
+ */
+describe('confluenceConnector — metadata header contract', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const DATE_FIELDS = ['resolved', 'resolutiondate', 'updated', 'lastmodified', 'modified', 'date', 'created'];
+  const FIELD_LINE = /^\s*[-*]?\s*\*{0,2}([a-z][a-z _-]*?)\*{0,2}\s*[:=]\s*(.+?)\s*$/i;
+
+  /** The date the consolidator would take from this body, or undefined. */
+  function headerDate(body: string): string | undefined {
+    const found = new Map<string, string>();
+    for (const line of body.split('\n').slice(0, 40)) {
+      const m = FIELD_LINE.exec(line);
+      if (!m) continue;
+      const field = m[1].toLowerCase().replace(/[\s_-]/g, '');
+      if (!DATE_FIELDS.includes(field) || found.has(field)) continue;
+      const d = new Date(m[2]);
+      if (!Number.isNaN(d.getTime())) found.set(field, d.toISOString());
+    }
+    for (const field of DATE_FIELDS) {
+      const hit = found.get(field);
+      if (hit) return hit;
+    }
+    return undefined;
+  }
+
+  function stubPage(page: Record<string, unknown>) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(page), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+      ),
+    );
+  }
+
+  const PAGE = {
+    id: '123',
+    title: 'Order cancellation policy',
+    version: { number: 3, when: '2026-08-19T19:09:08.426Z' },
+    history: { createdDate: '2026-08-19T19:08:41.489Z' },
+    body: { storage: { value: '<p>Users can cancel while Pending.</p>' } },
+  };
+
+  it('emits both dates where the consolidator reads them', async () => {
+    stubPage(PAGE);
+    const { markdown } = await confluenceConnector.fetch(CFG, '123');
+    expect(markdown.split('\n').slice(0, 40).join('\n')).toContain('Created:');
+    expect(markdown).toContain('Created: 2026-08-19T19:08:41.489Z');
+    expect(markdown).toContain('Updated: 2026-08-19T19:09:08.426Z');
+    // `updated` outranks `created`, so it is the one that orders the doc.
+    expect(headerDate(markdown)).toBe('2026-08-19T19:09:08.426Z');
+    // The page still reads as itself — the header sits between H1 and body.
+    expect(markdown.startsWith('# Order cancellation policy')).toBe(true);
+    expect(markdown).toContain('Users can cancel while Pending.');
+  });
+
+  it('carries no status — a page has no lifecycle, and version is an edit counter', async () => {
+    stubPage(PAGE);
+    const { markdown } = await confluenceConnector.fetch(CFG, '123');
+    expect(markdown).not.toContain('Status:');
+    expect(markdown).not.toContain('## Status history');
+    // The edit counter must never surface as a date.
+    expect(markdown).not.toContain('3');
+  });
+
+  it('omits a date the API did not return, and the block when it returned none', async () => {
+    stubPage({ ...PAGE, history: undefined });
+    const noCreated = await confluenceConnector.fetch(CFG, '123');
+    expect(noCreated.markdown).not.toContain('Created:');
+    expect(headerDate(noCreated.markdown)).toBe('2026-08-19T19:09:08.426Z');
+
+    stubPage({ ...PAGE, history: undefined, version: undefined });
+    const noDates = await confluenceConnector.fetch(CFG, '123');
+    expect(headerDate(noDates.markdown)).toBeUndefined();
+    // No stray blank block between the H1 and the body.
+    expect(noDates.markdown).toBe('# Order cancellation policy\n\nUsers can cancel while Pending.');
+  });
+
+  it('changes the body, so a re-sync re-processes the doc', async () => {
+    stubPage(PAGE);
+    const withDates = await confluenceConnector.fetch(CFG, '123');
+    stubPage({ ...PAGE, history: undefined, version: undefined });
+    const without = await confluenceConnector.fetch(CFG, '123');
+    // The regression this suite was written for: identical bodies hash the same,
+    // and the sync reports "nothing to process".
+    expect(withDates.markdown).not.toBe(without.markdown);
+  });
+});

--- a/tests/ee-server/confluence-connector.test.ts
+++ b/tests/ee-server/confluence-connector.test.ts
@@ -192,6 +192,15 @@ describe('confluenceConnector — metadata header contract', () => {
     body: { storage: { value: '<p>Users can cancel while Pending.</p>' } },
   };
 
+it('leaves updatedAt absent when the page states none, rather than inventing one', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ results: [{ id: '1', title: 'Undated' }], _links: {} }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )));
+    const refs = await confluenceConnector.list(CFG);
+    expect(refs[0].updatedAt).toBeUndefined();
+  });
+
   it('emits both dates where the consolidator reads them', async () => {
     stubPage(PAGE);
     const { markdown } = await confluenceConnector.fetch(CFG, '123');

--- a/tests/ee-server/jira-connector.test.ts
+++ b/tests/ee-server/jira-connector.test.ts
@@ -543,6 +543,9 @@ function headerStatusLine(body: string): string | undefined {
   return undefined;
 }
 
+/** What `relevance-filter` reads of a doc before deciding whether it is a spec. */
+const RELEVANCE_PREVIEW_LINES = 60;
+
 describe('jiraConnector — metadata header contract', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -672,8 +675,12 @@ it('caps the history and says how many it dropped, rather than truncating silent
     // The most recent survive — they carry where the issue settled.
     expect(md).toContain('S24 -> S25');
     expect(md).not.toContain('S0 -> S1');
-    // …and the block still leaves room in the 60-line relevance window.
-    expect(md.split('\n').findIndex((l) => l.startsWith('# ENG-1'))).toBeLessThan(20);
+    // …and the doc still reads as a requirement inside the window the relevance
+    // classifier sees. Uncapped, the transition list fills it and the issue
+    // classifies as status tracking.
+    const window = md.split('\n').slice(0, RELEVANCE_PREVIEW_LINES).join('\n');
+    expect(window).toContain('# ENG-1');
+    expect(window).toContain('POST /orders');
   });
 
 it('leaves updatedAt absent when the issue states none, rather than inventing one', async () => {
@@ -698,6 +705,20 @@ it('leaves updatedAt absent when the issue states none, rather than inventing on
     expect(md).not.toContain('status_history:');
     const calls = (globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
     expect(calls.some((c) => String(c[0]).includes('/changelog?'))).toBe(false);
+  });
+
+it('states the status category beside the name, for a workflow we cannot enumerate', async () => {
+    const md = await bodyOf(
+      issue({ fields: { status: { name: 'Awaiting Carrier Handoff', statusCategory: { key: 'done' } } } }),
+    );
+    expect(md).toContain('status: "Awaiting Carrier Handoff"');
+    expect(md).toContain('status_category: "done"');
+  });
+
+  it('omits the category when Jira sent none', async () => {
+    const md = await bodyOf(issue({ fields: { status: { name: 'Done' } } }));
+    expect(md).toContain('status: "Done"');
+    expect(md).not.toContain('status_category:');
   });
 
   it('omits the block entirely when an issue carries no metadata', async () => {

--- a/tests/ee-server/jira-connector.test.ts
+++ b/tests/ee-server/jira-connector.test.ts
@@ -602,23 +602,24 @@ describe('jiraConnector — metadata header contract', () => {
 
   it('emits dates in the scanned window, preferring the resolution date', async () => {
     const md = await bodyOf(issue());
-    expect(md.split('\n').slice(0, 40).join('\n')).toContain('Created:');
+    expect(md.startsWith('---\n')).toBe(true);
+    expect(md.split('\n').slice(0, 40).join('\n')).toContain('created:');
     // `resolved` outranks `updated` and `created`.
     expect(headerDate(md)).toBe('2026-03-02T17:00:00.000Z');
-    expect(headerStatusLine(md)).toBe('Done');
+    expect(headerStatusLine(md)).toBe('"Done"');
   });
 
   it('normalizes Jira offsets to a Z form, since `-0700` is not portable', async () => {
     const md = await bodyOf(issue());
     // Jira emits `2026-03-02T10:00:00.000-0700`; the header must not pass it through.
     expect(md).not.toContain('-0700');
-    expect(md).toContain('Updated: 2026-03-02T17:00:00.000Z');
+    expect(md).toContain('updated: 2026-03-02T17:00:00.000Z');
   });
 
   it('falls back to the changelog when a closed issue has no resolution date', async () => {
     const md = await bodyOf(issue({ fields: { resolutiondate: null } }));
     // Taken from the last transition INTO the current done-category status.
-    expect(md).toContain('Resolved: 2026-03-02T17:00:00.000Z');
+    expect(md).toContain('resolved: 2026-03-02T17:00:00.000Z');
     expect(headerDate(md)).toBe('2026-03-02T17:00:00.000Z');
   });
 
@@ -631,20 +632,20 @@ describe('jiraConnector — metadata header contract', () => {
         },
       }),
     );
-    expect(md).not.toContain('Resolved:');
+    expect(md).not.toContain('resolved:');
     expect(headerDate(md)).toBe('2026-03-02T17:00:00.000Z');
-    expect(headerStatusLine(md)).toBe('In Progress');
+    expect(headerStatusLine(md)).toBe('"In Progress"');
   });
 
   it('renders status history as dated lines the date reader ignores', async () => {
     const md = await bodyOf(issue());
-    expect(md).toContain('## Status history');
-    expect(md).toContain('- 2026-01-05T16:00:00.000Z  To Do -> In Progress');
+    expect(md).toContain('status_history:');
+    expect(md).toContain('- "2026-01-05T16:00:00.000Z  To Do -> In Progress"');
     // A history line opens with the timestamp, so it can never match the
     // field-name group — the January transition must not outrank March.
     expect(headerDate(md)).not.toBe('2026-01-05T16:00:00.000Z');
     // …and the heading must not read as a status line.
-    expect(headerStatusLine('## Status history\n- 2026-01-05T16:00:00.000Z  To Do -> Done')).toBeUndefined();
+    expect(headerStatusLine('status_history:\n  - "2026-01-05T16:00:00.000Z  To Do -> Done"')).toBeUndefined();
   });
 
   it('re-fetches the changelog when the search embedded only part of it', async () => {
@@ -656,12 +657,31 @@ describe('jiraConnector — metadata header contract', () => {
     expect(calls.some((c) => String(c[0]).includes('/changelog?'))).toBe(true);
   });
 
+it('caps the history and says how many it dropped, rather than truncating silently', async () => {
+    const many = Array.from({ length: 25 }, (_, i) => ({
+      created: `2026-01-${String(i + 1).padStart(2, '0')}T09:00:00.000-0700`,
+      items: [STATUS_ITEM(`S${i}`, `S${i + 1}`)],
+    }));
+    const md = await bodyOf(issue({ changelog: { total: many.length, histories: many } }));
+    // Count inside the frontmatter only — the description carries bullets too.
+    const fm = md.split('---\n')[1] ?? '';
+    const entries = fm.split('\n').filter((l) => l.trim().startsWith('- '));
+    // 10 kept + one line naming what was dropped.
+    expect(entries).toHaveLength(11);
+    expect(md).toContain('15 earlier transitions omitted');
+    // The most recent survive — they carry where the issue settled.
+    expect(md).toContain('S24 -> S25');
+    expect(md).not.toContain('S0 -> S1');
+    // …and the block still leaves room in the 60-line relevance window.
+    expect(md.split('\n').findIndex((l) => l.startsWith('# ENG-1'))).toBeLessThan(20);
+  });
+
   it('omits the block entirely when an issue carries no metadata', async () => {
     stubSearch([{ id: '10001', key: 'ENG-1', fields: { summary: 'Bare', description: description() } }]);
     const map = await jiraConnector.fetchMany!(CFG, ['10001']);
     const md = map.get('10001')!.markdown;
-    expect(md).not.toContain('Status:');
-    expect(md).not.toContain('## Status history');
+    expect(md).not.toContain('status:');
+    expect(md).not.toContain('status_history:');
     expect(headerDate(md)).toBeUndefined();
   });
 });

--- a/tests/ee-server/jira-connector.test.ts
+++ b/tests/ee-server/jira-connector.test.ts
@@ -676,6 +676,30 @@ it('caps the history and says how many it dropped, rather than truncating silent
     expect(md.split('\n').findIndex((l) => l.startsWith('# ENG-1'))).toBeLessThan(20);
   });
 
+it('leaves updatedAt absent when the issue states none, rather than inventing one', async () => {
+    stubSearch([{ id: '10001', key: 'ENG-1', fields: { summary: 'No dates' } }]);
+    const refs = await jiraConnector.list(CFG);
+    // A substituted epoch would parse as a real date, persist as one, and lose
+    // every ordering contest — a doc nobody dated must simply not be dated.
+    expect(refs[0].updatedAt).toBeUndefined();
+  });
+
+  it('re-fetches when the search gave no changelog total to verify against', async () => {
+    // Jira carried a changelog but omitted `total`: the inline copy cannot be
+    // shown whole, and what a clipped copy drops is the EARLIEST transitions.
+    const md = await bodyOf(issue({ changelog: { histories: [FULL_HISTORY[1]] } }));
+    expect(md).toContain('To Do -> In Progress');
+    const calls = (globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(calls.some((c) => String(c[0]).includes('/changelog?'))).toBe(true);
+  });
+
+  it('does not re-fetch an issue the search carried no changelog for', async () => {
+    const md = await bodyOf(issue({ changelog: undefined }));
+    expect(md).not.toContain('status_history:');
+    const calls = (globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(calls.some((c) => String(c[0]).includes('/changelog?'))).toBe(false);
+  });
+
   it('omits the block entirely when an issue carries no metadata', async () => {
     stubSearch([{ id: '10001', key: 'ENG-1', fields: { summary: 'Bare', description: description() } }]);
     const map = await jiraConnector.fetchMany!(CFG, ['10001']);

--- a/tests/ee-server/jira-connector.test.ts
+++ b/tests/ee-server/jira-connector.test.ts
@@ -496,3 +496,172 @@ describe('jiraConnector', () => {
     ]);
   });
 });
+
+/**
+ * The metadata header is a TEXT convention: a malformed one does not throw, it
+ * is simply never found, and the doc silently falls back to its file mtime. So
+ * these assert the CONTRACT the consolidator's `parseDocDate` / `parseDocStatus`
+ * impose, not the header string — a string assertion would pass while the parser
+ * rejected the shape.
+ *
+ * The readers live in `@truecourse/spec-consolidator` but are not on this base
+ * yet, so the contract is mirrored below. When they land, delete `headerDate` /
+ * `headerStatusLine` and import the real functions — the assertions stay as they
+ * are, which is the point of writing them against the contract.
+ */
+
+/** The date-field names the consolidator recognizes, MOST authoritative first. */
+const DATE_FIELDS = ['resolved', 'resolutiondate', 'updated', 'lastmodified', 'modified', 'date', 'created'];
+/** Only the first 40 lines are scanned, and only `Name: value` lines match. */
+const FIELD_LINE = /^\s*[-*]?\s*\*{0,2}([a-z][a-z _-]*?)\*{0,2}\s*[:=]\s*(.+?)\s*$/i;
+
+/** The date the consolidator would take from this body, or undefined. */
+function headerDate(body: string): string | undefined {
+  const found = new Map<string, string>();
+  for (const line of body.split('\n').slice(0, 40)) {
+    const m = FIELD_LINE.exec(line);
+    if (!m) continue;
+    const field = m[1].toLowerCase().replace(/[\s_-]/g, '');
+    // First occurrence of a field wins — a stray line above the header would shadow it.
+    if (!DATE_FIELDS.includes(field) || found.has(field)) continue;
+    const d = new Date(m[2]);
+    if (!Number.isNaN(d.getTime())) found.set(field, d.toISOString());
+  }
+  for (const field of DATE_FIELDS) {
+    const hit = found.get(field);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/** The raw value on the body's `Status:` line, or undefined. */
+function headerStatusLine(body: string): string | undefined {
+  for (const line of body.split('\n').slice(0, 40)) {
+    const m = /^\s*[-*]?\s*\*{0,2}status\*{0,2}\s*[:=]\s*(.+?)\s*$/i.exec(line);
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
+describe('jiraConnector — metadata header contract', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const STATUS_ITEM = (from: string, to: string) => ({
+    field: 'status',
+    fieldtype: 'jira',
+    fromString: from,
+    toString: to,
+  });
+
+  const FULL_HISTORY = [
+    { created: '2026-01-05T09:00:00.000-0700', items: [STATUS_ITEM('To Do', 'In Progress')] },
+    { created: '2026-03-02T10:00:00.000-0700', items: [STATUS_ITEM('In Progress', 'Done')] },
+  ];
+
+  function stubSearch(issues: unknown[]) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const body = String(input).includes('/changelog?')
+          ? { values: FULL_HISTORY, isLast: true }
+          : { issues };
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+  }
+
+  /** A closed issue carrying every field. `fields` overrides MERGE; the rest replace. */
+  function issue({ fields, ...rest }: Record<string, unknown> = {}) {
+    return {
+      id: '10001',
+      key: 'ENG-1',
+      changelog: { total: 2, histories: FULL_HISTORY },
+      ...rest,
+      fields: {
+        summary: 'Idempotent order creation',
+        created: '2026-01-04T08:00:00.000-0700',
+        updated: '2026-03-02T10:00:00.000-0700',
+        resolutiondate: '2026-03-02T10:00:00.000-0700',
+        status: { name: 'Done', statusCategory: { key: 'done' } },
+        description: description(),
+        ...(fields as object | undefined),
+      },
+    };
+  }
+
+  async function bodyOf(one: unknown): Promise<string> {
+    stubSearch([one]);
+    const map = await jiraConnector.fetchMany!(CFG, ['10001']);
+    return map.get('10001')!.markdown;
+  }
+
+  it('emits dates in the scanned window, preferring the resolution date', async () => {
+    const md = await bodyOf(issue());
+    expect(md.split('\n').slice(0, 40).join('\n')).toContain('Created:');
+    // `resolved` outranks `updated` and `created`.
+    expect(headerDate(md)).toBe('2026-03-02T17:00:00.000Z');
+    expect(headerStatusLine(md)).toBe('Done');
+  });
+
+  it('normalizes Jira offsets to a Z form, since `-0700` is not portable', async () => {
+    const md = await bodyOf(issue());
+    // Jira emits `2026-03-02T10:00:00.000-0700`; the header must not pass it through.
+    expect(md).not.toContain('-0700');
+    expect(md).toContain('Updated: 2026-03-02T17:00:00.000Z');
+  });
+
+  it('falls back to the changelog when a closed issue has no resolution date', async () => {
+    const md = await bodyOf(issue({ fields: { resolutiondate: null } }));
+    // Taken from the last transition INTO the current done-category status.
+    expect(md).toContain('Resolved: 2026-03-02T17:00:00.000Z');
+    expect(headerDate(md)).toBe('2026-03-02T17:00:00.000Z');
+  });
+
+  it('leaves Resolved absent on an unfinished issue, so `updated` orders it', async () => {
+    const md = await bodyOf(
+      issue({
+        fields: {
+          resolutiondate: null,
+          status: { name: 'In Progress', statusCategory: { key: 'indeterminate' } },
+        },
+      }),
+    );
+    expect(md).not.toContain('Resolved:');
+    expect(headerDate(md)).toBe('2026-03-02T17:00:00.000Z');
+    expect(headerStatusLine(md)).toBe('In Progress');
+  });
+
+  it('renders status history as dated lines the date reader ignores', async () => {
+    const md = await bodyOf(issue());
+    expect(md).toContain('## Status history');
+    expect(md).toContain('- 2026-01-05T16:00:00.000Z  To Do -> In Progress');
+    // A history line opens with the timestamp, so it can never match the
+    // field-name group — the January transition must not outrank March.
+    expect(headerDate(md)).not.toBe('2026-01-05T16:00:00.000Z');
+    // …and the heading must not read as a status line.
+    expect(headerStatusLine('## Status history\n- 2026-01-05T16:00:00.000Z  To Do -> Done')).toBeUndefined();
+  });
+
+  it('re-fetches the changelog when the search embedded only part of it', async () => {
+    // `total` exceeds what the search returned, and the MISSING entry is the
+    // earliest one — exactly the part the history block needs.
+    const md = await bodyOf(issue({ changelog: { total: 2, histories: [FULL_HISTORY[1]] } }));
+    expect(md).toContain('To Do -> In Progress');
+    const calls = (globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(calls.some((c) => String(c[0]).includes('/changelog?'))).toBe(true);
+  });
+
+  it('omits the block entirely when an issue carries no metadata', async () => {
+    stubSearch([{ id: '10001', key: 'ENG-1', fields: { summary: 'Bare', description: description() } }]);
+    const map = await jiraConnector.fetchMany!(CFG, ['10001']);
+    const md = map.get('10001')!.markdown;
+    expect(md).not.toContain('Status:');
+    expect(md).not.toContain('## Status history');
+    expect(headerDate(md)).toBeUndefined();
+  });
+});

--- a/tests/ee-server/knowledge-ordering-date.test.ts
+++ b/tests/ee-server/knowledge-ordering-date.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Which date orders a synced doc against the rest of the corpus.
+ *
+ * Both materialization paths ask this — the workspace scan writing a scratch
+ * tree, and the repo inheritance hook writing a checkout — and they had answered
+ * differently. The scan fell back to the sync instant; inheritance fell back to
+ * nothing, so a row predating the source-date columns was stamped with the write
+ * instant instead and read as newer than every doc it should have lost to. That
+ * inversion is what this work set out to remove, so the rule lives in one place
+ * and these pin it there.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { lastTouchedOf } from '../../ee/packages/server/src/knowledge/sync';
+
+const SYNCED = '2026-08-20T00:00:00.000Z';
+const SOURCE = '2026-01-05T00:00:00.000Z';
+
+describe('lastTouchedOf', () => {
+  it("prefers what the source said over when we happened to sync it", () => {
+    // The sync instant is the same for every doc in a run, so it can order nothing.
+    expect(lastTouchedOf({ externalUpdatedAt: SOURCE, lastSyncedAt: SYNCED })).toBe(SOURCE);
+  });
+
+  it('falls back to the sync instant for a row written before the column existed', () => {
+    expect(lastTouchedOf({ externalUpdatedAt: null, lastSyncedAt: SYNCED })).toBe(SYNCED);
+  });
+
+  it('never answers undefined — an undated doc would take the write instant instead', () => {
+    // The inheritance path used to, and a file with no stamp keeps its mtime:
+    // the moment it was written, which is newer than everything real.
+    expect(lastTouchedOf({ externalUpdatedAt: null, lastSyncedAt: SYNCED })).toBeDefined();
+  });
+});

--- a/tests/ee-server/knowledge-sync-estimate.test.ts
+++ b/tests/ee-server/knowledge-sync-estimate.test.ts
@@ -137,6 +137,9 @@ async function seedLedger(
       title: `Doc ${r.externalId}`,
       url: null,
       version: r.version ?? null,
+      // The ledger row as it stands before a sync carries source dates.
+      externalCreatedAt: null,
+      externalUpdatedAt: null,
       contentHash: hash(r.markdown),
       lastSyncedAt: '2026-01-01T00:00:00Z',
     });
@@ -164,6 +167,8 @@ async function seedStored(
       title: `Doc ${d.id}`,
       url: null,
       version: null,
+      externalCreatedAt: null,
+      externalUpdatedAt: null,
       contentHash: h,
     });
   }

--- a/tests/ee-server/knowledge-workspace-corpus.test.ts
+++ b/tests/ee-server/knowledge-workspace-corpus.test.ts
@@ -61,6 +61,10 @@ async function seedStored(
       title: d.title,
       url: null,
       version: null,
+      // No source dates: these fixtures stand in for docs whose connector
+      // reported none, which is the case the ordering fallback covers.
+      externalCreatedAt: null,
+      externalUpdatedAt: null,
       contentHash,
     });
   }

--- a/tests/spec-consolidator/area-tagger.test.ts
+++ b/tests/spec-consolidator/area-tagger.test.ts
@@ -140,3 +140,38 @@ describe('parseDocStatus', () => {
     expect(parseDocStatus('Status: ![badge](https://x/y.svg)\nStatus: shipped\n')).toBe('shipped');
   });
 });
+
+describe('parseDocStatus — the workflow name, then its category', () => {
+  it('reads the terminal states every tracker ships with', () => {
+    expect(parseDocStatus('Status: Closed')).toBe('shipped');
+    expect(parseDocStatus('Status: Resolved')).toBe('shipped');
+  });
+
+  it('sees through the quotes a YAML writer adds', () => {
+    expect(parseDocStatus('status: "Done"')).toBe('shipped');
+    expect(parseDocStatus("status: 'In Progress'")).toBe('planned');
+  });
+
+  it('falls back to the category when the workflow name means nothing to us', () => {
+    // A custom state no vocabulary could enumerate. Without the category this
+    // ticket carries no status at all.
+    const doc = ['status: "Awaiting Carrier Handoff"', 'status_category: done'].join('\n');
+    expect(parseDocStatus(doc)).toBe('shipped');
+  });
+
+  it('lets a name we DO understand overrule its own category', () => {
+    // Jira files "Won't Do" under `done`. Reading the category first would
+    // report a dropped ticket as delivered.
+    const doc = ['status: "Won\'t Do"', 'status_category: done'].join('\n');
+    expect(parseDocStatus(doc)).toBe('out-of-scope');
+  });
+
+  it('stays undefined when neither the name nor the category is known', () => {
+    expect(parseDocStatus(['status: "???"', 'status_category: mystery'].join('\n'))).toBeUndefined();
+  });
+
+  it('does not read a category line as a status line, or vice versa', () => {
+    expect(parseDocStatus('status_category: done')).toBe('shipped');
+    expect(parseDocStatus('status_history:\n  - "x -> y"')).toBeUndefined();
+  });
+});

--- a/tests/spec-consolidator/discovery.test.ts
+++ b/tests/spec-consolidator/discovery.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import {
   classifyDoc,
   discoverDocs,
@@ -401,5 +402,64 @@ describe('discoverDocs — include-scope', () => {
 
     const paths = discoverDocs(root, { skipGit: true }).map((d) => d.path);
     expect(paths).toEqual(['SPEC.md', 'docs/a.md']);
+  });
+});
+
+/**
+ * A doc's identity is what it SAYS, not what it says ABOUT itself.
+ *
+ * The content hash keys the per-doc LLM caches, and a synced ticket restates its
+ * `updated` on any comment or label change — hashing that buys a paid re-tag of
+ * text nobody touched. The preview is the window the relevance classifier judges
+ * through, so metadata spent there is content it never sees.
+ */
+describe('discoverDocs — frontmatter is metadata, not content', () => {
+  const DOC = ['# Order cancellation', '', 'Users can cancel while Pending.'].join('\n');
+  const withMeta = (updated: string) =>
+    ['---', 'created: 2026-01-01T00:00:00.000Z', `updated: ${updated}`, 'status: "Done"', '---', '', DOC].join('\n');
+
+  /** The candidate for `rel`, discovered fresh from disk. */
+  const discover = (rel: string) => {
+    const docs = discoverDocs(root, { skipGit: true });
+    return docs.find((d) => d.path === rel)!;
+  };
+
+  it('hashes the document alike however its metadata moves', () => {
+    place('a.md', withMeta('2026-01-02T00:00:00.000Z'));
+    const before = discover('a.md').contentHash;
+    place('a.md', withMeta('2026-08-20T00:00:00.000Z'));
+    const after = discover('a.md').contentHash;
+    // A comment on the ticket moved `updated` and nothing else. Were this to
+    // differ, every cache keyed on it would miss and re-pay for identical text.
+    expect(after).toBe(before);
+  });
+
+  it('still hashes a real edit differently', () => {
+    place('b.md', withMeta('2026-01-02T00:00:00.000Z'));
+    const before = discover('b.md').contentHash;
+    place('b.md', withMeta('2026-01-02T00:00:00.000Z').replace('while Pending', 'until it ships'));
+    expect(discover('b.md').contentHash).not.toBe(before);
+  });
+
+  it('gives the preview window to the document, not to the metadata', () => {
+    place('c.md', withMeta('2026-01-02T00:00:00.000Z'));
+    const preview = discover('c.md').preview;
+    expect(preview.startsWith('# Order cancellation')).toBe(true);
+    expect(preview).not.toContain('updated:');
+  });
+
+  it('leaves a doc without frontmatter exactly as it was', () => {
+    // No mass cache invalidation: a doc that never had a block hashes unchanged.
+    place('d.md', DOC);
+    expect(discover('d.md').contentHash).toBe(
+      createHash('sha256').update(DOC).digest('hex'),
+    );
+  });
+
+  it('does not take a horizontal rule for a metadata block', () => {
+    const ruled = ['---', '', '# Not frontmatter', '', 'body'].join('\n');
+    place('e.md', ruled);
+    // No closing fence, so there is no block — the doc is its whole self.
+    expect(discover('e.md').preview).toContain('---');
   });
 });


### PR DESCRIPTION
## Why

The spec scan cannot order two documents in time, so one statement superseding another reads as a live disagreement. On the plat.ai corpus that is **1,076 contradictions across 3,694 docs** — and **632 of them** (every cross-source and every Confluence↔Confluence pair) have no date signal at all.

The dates exist upstream. We were not asking for them, and the one we did ask for had nowhere to land.

## What changed

**The connectors ask for what they need.** Jira now requests `created`, `resolutiondate` and `status`, and rides `expand=changelog` on the search it already makes — status history costs no extra HTTP call. Confluence expands `history` for its creation date.

**Documents state their own dates.** Both connectors write a metadata header into the document body — the channel the consolidator's date and status readers scan. Field names and the 40-line window are theirs; history lines open with their timestamp so they cannot be mistaken for the doc's own date.

**The ledger has somewhere to put them.** `knowledge_documents` had a column for `version` and none for a date. Jira looked healthy only by accident — it has no version counter, so its `version` happens to *be* a date, while Confluence's is an edit counter and its date was dropped on write. Migration `0010` adds `source_created_at` / `source_updated_at`, nullable so existing rows are untouched.

**The pipeline stops discarding the date it is handed.** `lastTouched` was documented as `informational`, and both materialization sites wrote the body alone. Discovery then falls back to the file's mtime — and every doc is written in one loop, so the whole corpus collapsed to a single instant. Both sites now stamp the mtime from the source date: the workspace scratch tree and the repo inheritance checkout, which had the same bug for the same reason.

## Notes for review

- **`resolutiondate` is nullable on a closed issue.** A transition can set `status` without `resolution`; observed directly on a test issue that sat `Done` with `resolutiondate: null` for over a month. `Resolved:` falls back to when the issue last entered its current done-category status — free, since the changelog is already in hand.
- **The search-embedded changelog paginates.** An issue whose `total` exceeds what arrived is re-fetched whole. Its *earliest* transitions are the ones missing, which is exactly the part the header needs.
- **Jira emits a `-0700` offset** that `Date` does not reliably accept, so every timestamp is normalized to a `Z` form before it is written.
- **The tests mirror the reader contract rather than importing it.** `parseDocDate` / `parseDocStatus` are not on this base yet. The assertions are written against the rules, so when the readers land only the two mirror helpers get deleted.
- Stamping is best-effort: an unparseable timestamp, or a filesystem that refuses `utimes`, leaves the previous behavior rather than failing a sync.

## Scope

This is the producing half. The consuming half — reading the dates back out and separating supersession from disagreement — already exists on `sm/agentic-pipeline-plan`; the two meet when that merges. Until then the product scan will not show a change, and the measurement runs through the standalone harness that produced the 1,076 baseline.

## Verification

- `tests/ee-server` — 153 passing, 0 failures (7 new)
- `packages/core` typecheck: 42 errors before, 42 after — unchanged
- `tests/core`: 15 failures before, 15 after — unchanged
- Pre-existing failures on this base (`guard-store`, `journey`, `interface-mapper` load errors) were confirmed by stashing the change and re-running

🤖 Generated with [Claude Code](https://claude.com/claude-code)