### PR TITLE
feat(dashboard): the Coverage tab of a connected repository reads the stored coverage

### DIFF
--- a/apps/dashboard/client/src/preview/repo/CoverageTab.tsx
+++ b/apps/dashboard/client/src/preview/repo/CoverageTab.tsx
@@ -1,11 +1,22 @@
 /**
  * Coverage: the landing tab, the agentic coverage overview (sections, claims,
- * flows, tests and surfaces as composition bars, the freshness stamps) over fake
- * data. The corpus itself is the Corpus tab beside it.
+ * flows, tests and surfaces as composition bars, the freshness stamps). The
+ * corpus itself is the Corpus tab beside it.
+ *
+ * A CONNECTED repository reads what the server stored: the scan's corpus, the
+ * generate's claims, the status summary and the staleness signals, all over
+ * `/api/repos/<id>/…`, and re-reads them when a scan, a generate or a run of
+ * this repository lands on the socket. Before any of those exist it says so,
+ * rather than painting zeros. A fixture repository reads its fixtures.
  */
 
-import { useMemo } from 'react';
-import { SpecSourceProvider } from '@/components/spec/spec-source';
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { FolderGit2 } from 'lucide-react';
+import { EmptyState } from '@/components/ui/empty-state';
+import { createRepoSpecSource, SpecSourceProvider } from '@/components/spec/spec-source';
+import type { GuardStaleness } from '@/preview/vendor/shared';
+import * as api from '@/preview/vendor/lib/api';
 import { PageHeader } from '@/preview/ui/bits';
 import { useSpecCorpus } from '@/preview/vendor/components/spec/SpecCorpusView';
 import { GuardCoverageOverview } from '@/preview/vendor/components/guard/GuardCoverageOverview';
@@ -13,13 +24,64 @@ import { useGuardClaims } from '@/preview/vendor/hooks/useGuardClaims';
 import { createPreviewSpecSource } from '@/preview/data/fake-api';
 import { stalenessFor } from '@/preview/data/corpus-fixtures';
 import type { Repo } from '@/preview/data/types';
+import { PREVIEW_BASE } from '@/preview/shell/base';
 import { useGuardTabJump } from './tab-jump';
+import { useGuardRefresh } from './use-guard-refresh';
+
+/** The staleness signals: the server's for a connected repository, the fixture's otherwise. */
+function useStaleness(repo: Repo, reloadKey: number): GuardStaleness | null {
+  const [real, setReal] = useState<GuardStaleness | null>(null);
+  useEffect(() => {
+    if (!repo.real) return;
+    let cancelled = false;
+    api
+      .getGuardStaleness(repo.id)
+      .then((s) => !cancelled && setReal(s))
+      .catch(() => !cancelled && setReal(null));
+    return () => {
+      cancelled = true;
+    };
+  }, [repo.id, repo.real, reloadKey]);
+  const fixture = useMemo(() => (repo.real ? null : stalenessFor(repo.id)), [repo.id, repo.real]);
+  return repo.real ? real : fixture;
+}
 
 function CoverageBody({ repo }: { repo: Repo }) {
   useGuardTabJump();
+  const reloadKey = useGuardRefresh(repo, ['scan', 'guard-generate', 'guard-run']);
   const corpus = useSpecCorpus(repo.id, true);
-  const claims = useGuardClaims(repo.id, true);
-  const staleness = useMemo(() => stalenessFor(repo.id), [repo.id]);
+  const { refetch } = corpus;
+  useEffect(() => {
+    if (reloadKey > 0) void refetch();
+  }, [reloadKey, refetch]);
+  const claims = useGuardClaims(repo.id, true, reloadKey);
+  const staleness = useStaleness(repo, reloadKey);
+
+  // A connected repository that has neither a corpus nor a generate nor a run
+  // has not started: the honest page is the one that says where to start it.
+  if (repo.real && staleness && !staleness.hasCorpus && !staleness.hasGenerated && !staleness.hasRun) {
+    return (
+      <EmptyState
+        icon={FolderGit2}
+        title={repo.onboarding ? 'Onboarding has not produced anything yet' : 'Nothing has run on this repository yet'}
+        body={
+          repo.onboarding ? (
+            'The first scan, setup and generation are still running. Watch them in Activity.'
+          ) : (
+            <>
+              Start the first scan from{' '}
+              <Link to={`${PREVIEW_BASE}/repos/${repo.id}/activity`} className="text-primary hover:underline">
+                Activity
+              </Link>
+              .
+            </>
+          )
+        }
+      />
+    );
+  }
+  if (!staleness) return null;
+
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col">
       <PageHeader title="Coverage" />
@@ -29,6 +91,7 @@ function CoverageBody({ repo }: { repo: Repo }) {
           docsCount={corpus.data?.corpus.docs.length ?? 0}
           claims={claims.view}
           staleness={staleness}
+          reloadKey={reloadKey}
         />
       </div>
     </div>
@@ -36,7 +99,10 @@ function CoverageBody({ repo }: { repo: Repo }) {
 }
 
 export function CoverageTab({ repo }: { repo: Repo }) {
-  const source = useMemo(() => createPreviewSpecSource(repo.id), [repo.id]);
+  const source = useMemo(
+    () => (repo.real ? createRepoSpecSource(repo.id) : createPreviewSpecSource(repo.id)),
+    [repo.id, repo.real],
+  );
   return (
     <SpecSourceProvider source={source}>
       <CoverageBody repo={repo} />

--- a/apps/dashboard/client/src/preview/repo/RepoConsole.tsx
+++ b/apps/dashboard/client/src/preview/repo/RepoConsole.tsx
@@ -1,9 +1,10 @@
-// PREVIEW (UI mock, fake data) with four exceptions: on a REAL
-// (provider-connected) repository the Activity tab is the real thing, reading
-// and live-tailing the repository's sessions store, the Interfaces tab reads
-// the server's own interface catalog for that repository, the Dependencies
-// tab reads and registers against its stored dependency catalog, and the
-// Corpus tab reads the corpus its scan stored.
+// PREVIEW (UI mock, fake data) with exceptions: on a REAL (provider-connected)
+// repository the Activity tab is the real thing, reading and live-tailing the
+// repository's sessions store, the Interfaces tab reads the server's own
+// interface catalog for that repository, the Dependencies tab reads and
+// registers against its stored dependency catalog, the Corpus tab reads the
+// corpus its scan stored, the Coverage tab reads the stored coverage summary
+// over it, and the Tests and Runs tabs read what its generate and runs stored.
 
 /**
  * The repository console: one header, ONE menu, no toggle.
@@ -165,6 +166,13 @@ export default function RepoConsole() {
         <div className="min-h-0 min-w-0 flex-1">
           {active === 'settings' ? (
             <SettingsTab repo={repo} />
+          ) : active === 'coverage' && repo.real ? (
+            // REAL, not mock: the coverage of a connected repository is the
+            // server's summary over what its scan, generate and runs stored,
+            // read over `/api/repos/<id>/guard/*` and `/spec/corpus`. The tab
+            // owns its own empty state, so a repository nothing ran on says so
+            // here rather than through the fixture gate below.
+            <CoverageTab repo={repo} />
           ) : active === 'activity' && repo.real ? (
             // REAL, not mock: a provider-connected repository is a real registry
             // entry, so its Activity reads the real sessions store over

--- a/packages/core/src/commands/guard-read.ts
+++ b/packages/core/src/commands/guard-read.ts
@@ -42,7 +42,7 @@ import {
   GUARD_SETUP_DEPENDENCIES_FILE,
   GUARD_SETUP_INTERFACES_FILE,
 } from '../services/guard-setup/bundle.js'
-import { corpusFilePath, readCorpus } from '@truecourse/spec-consolidator'
+import { corpusFilePath, CuratedCorpusSchema, type CuratedCorpus } from '@truecourse/spec-consolidator'
 import {
   GUARD_COVERAGE_PLAIN_ORDER,
   GUARD_COVERAGE_STATUS_PRECEDENCE,
@@ -364,12 +364,24 @@ export function composeDocCoverage(
   }
 }
 
+/** The curated corpus a (possibly PR-scoped) view reads, or null when none was scanned. */
+async function readCorpusForView(repoKey: string, ref?: string): Promise<CuratedCorpus | null> {
+  return readPinnedWithBaselineFallback(repoKey, ref, async (commit) => {
+    const raw = await loadSpec({ repoKey, commitSha: commit ?? '' }, 'corpus')
+    if (raw == null) return null
+    const parsed = CuratedCorpusSchema.safeParse(raw)
+    return parsed.success ? parsed.data : null
+  })
+}
+
 /**
  * Every kept doc's sections counted under the five coverage words, through the
  * same per-section derivation the doc view renders ({@link composeDocCoverage})
  * — the constraint: no summary may classify a section differently than the doc
- * view does. The doc universe is the curated corpus; without one it falls back
- * to the docs the guard stores name, and null means nothing to count.
+ * view does. The doc universe is the curated corpus, read through the spec
+ * store at the view's commit (the file in OSS, the scan's stored artifact in a
+ * hosted repo); without one it falls back to the docs the guard stores name,
+ * and null means nothing to count.
  */
 export async function readGuardSectionTotals(
   repoKey: string,
@@ -384,7 +396,7 @@ export async function readGuardSectionTotals(
     externals: guardExternalSetupIndexForView(repoKey),
   }
 
-  const corpusDocs = readCorpus(repoKey)?.docs.map((d) => d.ref)
+  const corpusDocs = (await readCorpusForView(repoKey, ref))?.docs.map((d) => d.ref)
   const docs =
     corpusDocs && corpusDocs.length > 0
       ? corpusDocs

--- a/tests/server/guard-routes-hosted.test.ts
+++ b/tests/server/guard-routes-hosted.test.ts
@@ -60,6 +60,7 @@ const runAt = (commit: string, id: string, outcome: GuardLatest['scenarios'][num
 let client: PGlite;
 let db: Db;
 let guardStore: PgGuardStore;
+let specStore: PgSpecStore;
 let app: Express;
 let fixture: TestFixture;
 let repoKey: string;
@@ -101,7 +102,8 @@ beforeEach(async () => {
   await migrate(db, { migrationsFolder: MIGRATIONS_DIR });
   guardStore = new PgGuardStore(db);
   setGuardStore(guardStore);
-  setSpecStore(new PgSpecStore(db));
+  specStore = new PgSpecStore(db);
+  setSpecStore(specStore);
   setRepoDocReader(async (_repoKey, docPath) => (docPath === DOC ? DOC_CONTENT : null));
 });
 
@@ -206,6 +208,47 @@ describe('Guard routes — hosted, PR-scoped', () => {
     expect(res.body.coverage).toMatchObject({ totalSections: 1 });
     // No generate report exists at the baseline — the PR head's must not leak.
     expect(res.body.lastGenerate).toBeNull();
+  });
+
+  it('status counts sections of every corpus doc from the stored corpus, not only the docs with scenarios', async () => {
+    const OTHER_DOC = 'docs/other.md';
+    // The baseline generate report anchors the repo view's commit, as the hosted job writes it.
+    await guardStore.writeGuardResult(
+      { repoKey, commitSha: 'baselinesha' },
+      {
+        generatedAt: '2026-07-09T00:00:00.000Z',
+        status: 'ok',
+        sectionsTotal: 2,
+        sectionsChanged: 2,
+        skippedUnchanged: 0,
+        noChanges: false,
+        written: [],
+        coverageGaps: [],
+        birthFindings: [],
+        errors: [],
+        extractionFailures: [],
+        orphaned: [],
+      },
+      { baseline: true },
+    );
+    await saveSet('baselinesha', [['a1', 'alpha']]);
+    // The scan's corpus lives in the spec store; a hosted repo has no corpus.json.
+    await specStore.saveSpec({ repoKey, commitSha: 'baselinesha' }, 'corpus', {
+      version: 3,
+      generatedAt: '2026-01-01T00:00:00Z',
+      docs: [
+        { ref: DOC, kind: 'prd', lastTouched: '2026-01-01T00:00:00Z', areaTags: ['cli'] },
+        { ref: OTHER_DOC, kind: 'prd', lastTouched: '2026-01-01T00:00:00Z', areaTags: ['cli'] },
+      ],
+      areas: [{ id: 'cli', product: 'cli', concern: 'cli', docRefs: [DOC, OTHER_DOC], overlaps: [] }],
+    });
+    setRepoDocReader(async (_repoKey, docPath) =>
+      docPath === DOC ? DOC_CONTENT : docPath === OTHER_DOC ? '# Gamma\nbody c\n' : null,
+    );
+    const res = await request(app).get(url('status')).expect(200);
+    // Alpha (proven) + Beta from the doc the scenarios bind, Gamma from the doc
+    // nothing binds yet; the two without a scenario read as blocked.
+    expect(res.body.sections).toMatchObject({ total: 3, byStatus: { succeeded: 1, blocked: 2 } });
   });
 
   it('coverage?ref= paints sections from the PR head run (not the baseline)', async () => {


### PR DESCRIPTION
A connected repository's Coverage tab always showed "Nothing has run on this repository yet", even after its scan, generate and baseline run had all stored their results. The console only routed a real repository's Coverage tab through the fixture gate, so the stored state was never read.

The tab now reads the server for a connected repository, the same way Tests, Runs and Corpus do: the scan's corpus, the generate's claims, the status summary and the staleness signals. It re-reads when a scan, generate or run of that repository lands on the socket, and keeps the empty state only while nothing is stored at all. Fixture repositories keep their fixtures.

One server fix came out of it: the section tally behind `/guard/status` read the corpus with a file-only reader, so a hosted repository counted only the docs that already had scenarios. It now reads the corpus through the spec store at the view's commit, with the same baseline fallback the other inputs use. A hosted-route test covers a corpus doc with no scenario bound to it.

Changes by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
