### PR TITLE
fix(dashboard): constrain table columns and stabilize filter toolbars

### DIFF
--- a/apps/dashboard/client/src/preview/repo/CorpusTab.tsx
+++ b/apps/dashboard/client/src/preview/repo/CorpusTab.tsx
@@ -267,22 +267,30 @@ function CorpusBody({ repo, versions }: { repo: Repo; versions: ReturnType<typeo
         {...(repo.real ? { right: <RealScanButton repo={repo} hasCorpus={corpus.data !== null} /> } : {})}
       />
       <CoverageVersionPicker repo={repo} versions={versions.versions} version={versions.version} onSelect={versions.select} />
-      <div className="min-h-0 flex-1 overflow-auto">
-        <div className="sticky top-0 z-10 flex flex-wrap items-center gap-x-6 gap-y-1 border-b border-border bg-card px-6 py-2">
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            aria-label="Search the corpus"
-            placeholder="Search documents and conflicts"
-            className="w-64 rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
-          />
-          <div className="flex flex-wrap items-center gap-x-4 [&>div]:border-0 [&>div]:px-0 [&>div]:py-0">
-            <FilterBar label="Type" ariaLabel="Filter by type" options={typeOptions} selected={typeFilter} onChange={setTypeFilter} />
-            <FilterBar label="Status" ariaLabel="Filter documents by status" options={statusOptions} selected={statusFilter} onChange={setStatusFilter} multi />
-            <FilterBar label="Area" ariaLabel="Filter by area" options={areaOptions} selected={areaFilter} onChange={setAreaFilter} multi />
-          </div>
-        </div>
-        <table className="w-full border-collapse text-[13px]" aria-label="Spec corpus">
+      <div className="flex min-w-0 shrink-0 flex-wrap items-center gap-x-4 gap-y-2 border-b border-border bg-card px-6 py-2 [&>div]:border-0 [&>div]:p-0">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label="Search the corpus"
+          placeholder="Search documents and conflicts"
+          className="w-64 max-w-full shrink-0 rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+        <FilterBar label="Type" ariaLabel="Filter by type" options={typeOptions} selected={typeFilter} onChange={setTypeFilter} />
+        <FilterBar label="Status" ariaLabel="Filter documents by status" options={statusOptions} selected={statusFilter} onChange={setStatusFilter} multi />
+        <FilterBar label="Area" ariaLabel="Filter by area" options={areaOptions} selected={areaFilter} onChange={setAreaFilter} multi />
+      </div>
+      <div className="min-h-0 min-w-0 flex-1 overflow-auto">
+        {/* Keep long corpus notes from sizing the table and pushing metadata off screen. */}
+        <table className="w-full min-w-4xl table-fixed border-collapse text-[13px]" aria-label="Spec corpus">
+          <colgroup>
+            <col />
+            <col className="w-24" />
+            <col className="w-40" />
+            <col className="w-24" />
+            <col className="w-24" />
+            <col className="w-28" />
+            <col className="w-36" />
+          </colgroup>
           <thead className="bg-card">
             <tr className="border-b border-border text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               <th className="px-6 py-2 text-left font-semibold">Document</th>
@@ -307,16 +315,18 @@ function CorpusBody({ repo, versions }: { repo: Repo; versions: ReturnType<typeo
               >
                 <td className="px-6 py-2.5">
                   <span className="flex items-center gap-2">
-                    <span className="min-w-0 truncate text-foreground">{r.title}</span>
+                    <span className="min-w-0 truncate text-foreground" title={r.title}>{r.title}</span>
                     {r.kind === 'conflict' && <span className={CHIP_CLASS}>conflict</span>}
                     {r.kind === 'doc' && r.web && <span className={CHIP_CLASS}>site</span>}
                   </span>
                   {r.kind === 'doc' && (
-                    <span className="block truncate font-mono text-[11px] text-muted-foreground">{r.ref}</span>
+                    <span className="block truncate font-mono text-[11px] text-muted-foreground" title={r.ref}>{r.ref}</span>
                   )}
                 </td>
                 <td className="px-3 py-2.5">
-                  <span className={CHIP_CLASS}>{r.area}</span>
+                  <span className={`${CHIP_CLASS} max-w-full`} title={r.area}>
+                    <span className="truncate">{r.area}</span>
+                  </span>
                 </td>
                 <td className="px-3 py-2.5">
                   {r.kind === 'doc' ? (

--- a/apps/dashboard/client/src/preview/repo/DependenciesTab.tsx
+++ b/apps/dashboard/client/src/preview/repo/DependenciesTab.tsx
@@ -76,38 +76,43 @@ export function DependenciesTab({ repo }: { repo: Repo }) {
         title="Dependencies"
         subtitle={rows.length === all.length ? `${all.length}` : `${rows.length} of ${all.length}`}
       />
-      <div className="flex shrink-0 flex-wrap items-center gap-x-6 gap-y-1 border-b border-border px-6 py-2">
+      <div className="flex min-w-0 shrink-0 flex-wrap items-center gap-x-4 gap-y-2 border-b border-border px-6 py-2 [&>div]:border-0 [&>div]:p-0">
         <input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           aria-label="Search dependencies"
           placeholder="Search dependencies"
-          className="w-64 rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+          className="w-64 max-w-full shrink-0 rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
         />
-        <div className="flex flex-wrap items-center gap-x-4 [&>div]:border-0 [&>div]:px-0 [&>div]:py-0">
-          <FilterBar
-            label="Class"
-            ariaLabel="Filter dependencies by class"
-            options={classOptions}
-            selected={classFilter}
-            onChange={setClassFilter}
-            multi
-          />
-          <FilterBar
-            label="State"
-            ariaLabel="Filter dependencies by state"
-            options={stateOptions}
-            selected={stateFilter}
-            onChange={setStateFilter}
-            multi
-          />
-        </div>
+        <FilterBar
+          label="Class"
+          ariaLabel="Filter dependencies by class"
+          options={classOptions}
+          selected={classFilter}
+          onChange={setClassFilter}
+          multi
+        />
+        <FilterBar
+          label="State"
+          ariaLabel="Filter dependencies by state"
+          options={stateOptions}
+          selected={stateFilter}
+          onChange={setStateFilter}
+          multi
+        />
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto">
-        <table className="w-full border-collapse text-[13px]" aria-label="Dependencies">
+      <div className="min-h-0 min-w-0 flex-1 overflow-auto">
+        <table className="w-full min-w-3xl table-fixed border-collapse text-[13px]" aria-label="Dependencies">
+          <colgroup>
+            <col />
+            <col className="w-36" />
+            <col className="w-36" />
+            <col className="w-40" />
+            <col className="w-28" />
+          </colgroup>
           <thead className="sticky top-0 z-10 bg-card">
-            <tr className="border-b border-border text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            <tr className="whitespace-nowrap border-b border-border text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               <th className="px-6 py-2 text-left font-semibold">Dependency</th>
               <th className="px-3 py-2 text-left font-semibold">Class</th>
               <th className="px-3 py-2 text-left font-semibold">Type</th>
@@ -130,13 +135,13 @@ export function DependenciesTab({ repo }: { repo: Repo }) {
                   className="cursor-pointer border-b border-border/60 transition-colors hover:bg-muted/40 focus:bg-muted/40 focus:outline-none"
                 >
                   <td className="px-6 py-2.5">
-                    <span className="block truncate text-foreground">{d.name}</span>
-                    <span className="block truncate text-[11px] text-muted-foreground">{d.summary}</span>
+                    <span className="block truncate text-foreground" title={d.name}>{d.name}</span>
+                    <span className="block truncate text-[11px] text-muted-foreground" title={d.summary}>{d.summary}</span>
                   </td>
                   <td className="px-3 py-2.5">
-                    <span className={CHIP_CLASS}>{CLASS_LABEL[d.class]}</span>
+                    <span className={`${CHIP_CLASS} whitespace-nowrap`}>{CLASS_LABEL[d.class]}</span>
                   </td>
-                  <td className="px-3 py-2.5 text-muted-foreground">{type?.label ?? ''}</td>
+                  <td className="whitespace-nowrap px-3 py-2.5 text-muted-foreground">{type?.label ?? ''}</td>
                   <td className="px-3 py-2.5">
                     {state && (
                       <span className="inline-flex shrink-0 items-center gap-1.5 text-[10px] font-medium text-foreground">

--- a/apps/dashboard/client/src/preview/repo/RunsTab.tsx
+++ b/apps/dashboard/client/src/preview/repo/RunsTab.tsx
@@ -75,29 +75,36 @@ export function RunsTab({ repo }: { repo: Repo }) {
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col">
       <PageHeader title="Runs" subtitle={rows.length === history.length ? `${history.length}` : `${rows.length} of ${history.length}`} />
-      <div className="flex shrink-0 flex-wrap items-center gap-x-6 gap-y-1 border-b border-border px-6 py-2">
+      <div className="flex min-w-0 shrink-0 flex-wrap items-center gap-x-6 gap-y-2 border-b border-border px-6 py-2 [&>div]:border-0 [&>div]:p-0">
         <input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           aria-label="Search runs"
           placeholder="Search runs (PR, commit, branch)"
-          className="w-64 rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+          className="w-64 max-w-full shrink-0 rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
         />
-        <div className="flex flex-wrap items-center gap-x-4 [&>div]:border-0 [&>div]:px-0 [&>div]:py-0">
-          <FilterBar
-            label="Origin"
-            ariaLabel="Filter runs by origin"
-            options={originOptions}
-            selected={originFilter}
-            onChange={setOriginFilter}
-          />
-        </div>
+        <FilterBar
+          label="Origin"
+          ariaLabel="Filter runs by origin"
+          options={originOptions}
+          selected={originFilter}
+          onChange={setOriginFilter}
+        />
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto">
-        <table className="w-full border-collapse text-[13px]" aria-label="Runs">
+      <div className="min-h-0 min-w-0 flex-1 overflow-auto">
+        <table className={`w-full table-fixed border-collapse text-[13px] ${showCoverage ? 'min-w-6xl' : 'min-w-4xl'}`} aria-label="Runs">
+          <colgroup>
+            <col className="w-32" />
+            <col />
+            <col className="w-28" />
+            <col className="w-20" />
+            <col className="w-64" />
+            {showCoverage && <col className="w-44" />}
+            <col className="w-52" />
+          </colgroup>
           <thead className="sticky top-0 z-10 bg-card">
-            <tr className="border-b border-border text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            <tr className="whitespace-nowrap border-b border-border text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               <th className="px-6 py-2 text-left font-semibold">Commit</th>
               <th className="px-3 py-2 text-left font-semibold">Branch</th>
               <th className="px-3 py-2 text-left font-semibold">Pull request</th>
@@ -121,19 +128,23 @@ export function RunsTab({ repo }: { repo: Repo }) {
                   }}
                   className="cursor-pointer border-b border-border/60 transition-colors hover:bg-muted/40 focus:bg-muted/40 focus:outline-none"
                 >
-                  <td className="px-6 py-2.5 font-mono text-[12px] text-foreground">{h.commit ?? h.runId}</td>
-                  <td className="px-3 py-2.5 font-mono text-[12px] text-foreground">{h.branch ?? ''}</td>
+                  <td className="px-6 py-2.5 font-mono text-[12px] text-foreground">
+                    <span className="block truncate" title={h.commit ?? h.runId}>{h.commit?.slice(0, 8) ?? h.runId}</span>
+                  </td>
+                  <td className="px-3 py-2.5 font-mono text-[12px] text-foreground">
+                    <span className="block truncate" title={h.branch ?? ''}>{h.branch ?? ''}</span>
+                  </td>
                   <td className="px-3 py-2.5 text-foreground">{h.pullRequest != null ? `#${h.pullRequest}` : ''}</td>
                   <td className="px-3 py-2.5">
                     <span className={CHIP_CLASS}>{h.origin ?? 'hosted'}</span>
                   </td>
                   <td className="px-3 py-2.5">
-                    <span className="flex items-center gap-3">
+                    <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
                       <span className="inline-flex shrink-0 items-center gap-1.5 text-[10px] font-medium text-foreground">
                         <span aria-hidden className={`h-2 w-2 shrink-0 rounded-full ${guardStatusMeta(verdict).dot}`} />
                         {verdict === 'fail' ? 'Failed' : 'Passed'}
                       </span>
-                      <span className="inline-flex items-center gap-2 tabular-nums">
+                      <span className="inline-flex flex-wrap items-center gap-2 tabular-nums">
                         {GUARD_OUTCOMES.filter((o) => h.summary[o] > 0).map((o) => (
                           <HoverPopover key={o} portal width="narrow" content={`${h.summary[o]} ${guardStatusMeta(o).label}`}>
                             <span className="inline-flex items-center gap-1 text-[10px] text-foreground">
@@ -146,9 +157,13 @@ export function RunsTab({ repo }: { repo: Repo }) {
                     </span>
                   </td>
                   {showCoverage && (
-                    <td className="px-3 py-2.5 text-muted-foreground">{version ? `${version.label} · ${version.sha}` : ''}</td>
+                    <td className="px-3 py-2.5 text-muted-foreground">
+                      <span className="block truncate" title={version ? `${version.label} · ${version.sha}` : ''}>
+                        {version ? `${version.label} · ${version.sha}` : ''}
+                      </span>
+                    </td>
                   )}
-                  <td className="px-6 py-2.5 text-muted-foreground">{formatGuardTime(h.ranAt)}</td>
+                  <td className="whitespace-nowrap px-6 py-2.5 text-muted-foreground">{formatGuardTime(h.ranAt)}</td>
                 </tr>
               );
             })}
@@ -165,4 +180,3 @@ export function RunsTab({ repo }: { repo: Repo }) {
     </div>
   );
 }
-

--- a/apps/dashboard/client/src/preview/ui/filter-bar.tsx
+++ b/apps/dashboard/client/src/preview/ui/filter-bar.tsx
@@ -12,7 +12,8 @@
  * builds a second filter control.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+import { Combobox } from '@base-ui/react/combobox';
 import { Search, X } from 'lucide-react';
 
 export interface FilterOption {
@@ -89,7 +90,7 @@ function FilterChips({ label, options, selected, onChange, multi, ariaLabel }: R
     <div
       role="group"
       aria-label={ariaLabel}
-      className="flex shrink-0 flex-wrap items-center gap-1 border-b border-border px-3 py-2"
+      className="flex min-w-0 max-w-full flex-wrap items-center gap-1 border-b border-border px-3 py-2"
     >
       <span className="mr-1 shrink-0 text-[10px] uppercase tracking-wider text-muted-foreground">{label}</span>
       {options.map((o) => {
@@ -126,24 +127,13 @@ function FilterChips({ label, options, selected, onChange, multi, ariaLabel }: R
 
 /**
  * The many-options shape: the selection as removable pills plus a search input
- * that reveals a scrollable, type-narrowed list of the rest. The list expands
- * INLINE (not a floating popover) so a panel's `overflow-hidden` can't clip it.
+ * that reveals a scrollable, type-narrowed list of the rest. Portal the popup
+ * so it neither expands the toolbar nor gets clipped by a scrolling panel.
  */
 function FilterCombobox({ label, options, selected, onChange, multi, ariaLabel }: Required<Pick<FilterBarProps, 'label' | 'options' | 'selected' | 'onChange' | 'multi' | 'ariaLabel'>>) {
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  // Close the suggestion list when focus/clicks leave the widget.
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', onDown);
-    return () => document.removeEventListener('mousedown', onDown);
-  }, [open]);
 
   const q = query.trim().toLowerCase();
   const selectedList = options.filter((o) => selected.includes(o.key));
@@ -152,41 +142,63 @@ function FilterCombobox({ label, options, selected, onChange, multi, ariaLabel }
   );
 
   return (
-    <div ref={containerRef} role="group" aria-label={ariaLabel} className="shrink-0 border-b border-border">
-      <div className="flex flex-wrap items-center gap-1 px-3 py-2">
+    <Combobox.Root<FilterOption, boolean>
+      multiple={multi}
+      items={suggestions}
+      filter={null}
+      value={multi ? selectedList : selectedList[0] ?? null}
+      onValueChange={(value, details) => {
+        // Escape dismisses the search popup; selected filters have explicit removal controls.
+        if (details.reason === 'escape-key') {
+          details.cancel();
+          return;
+        }
+        onChange((Array.isArray(value) ? value : value ? [value] : []).map((o) => o.key));
+        setQuery('');
+      }}
+      isItemEqualToValue={(a, b) => a.key === b.key}
+      itemToStringLabel={(o) => o.label}
+      inputValue={query}
+      onInputValueChange={(value, details) => {
+        // The selection is shown in pills; keep the input for searching.
+        if (details.reason === 'input-change' || details.reason === 'input-clear') setQuery(value);
+      }}
+      open={open}
+      onOpenChange={(next, details) => {
+        if (multi && details.reason === 'item-press') details.cancel();
+        else setOpen(next);
+      }}
+    >
+      <div ref={containerRef} role="group" aria-label={ariaLabel} className="flex min-w-0 max-w-full flex-wrap items-center gap-1 border-b border-border px-3 py-2">
         <span className="mr-1 shrink-0 text-[10px] uppercase tracking-wider text-muted-foreground">{label}</span>
         {selectedList.map((o) => (
           <span
             key={o.key}
-            className="inline-flex items-center gap-1 rounded-full bg-primary px-2 py-0.5 text-[10px] text-primary-foreground"
+            className="inline-flex max-w-full items-center gap-1 rounded-full bg-primary px-2 py-0.5 text-[10px] text-primary-foreground"
           >
-            {o.label}
-            {o.count == null ? '' : ` ${o.count}`}
+            <span className="min-w-0 truncate" title={o.label}>
+              {o.label}
+              {o.count == null ? '' : ` ${o.count}`}
+            </span>
             <button
               type="button"
               aria-label={`Remove ${o.label}`}
               onClick={() => onChange(toggle(selected, o.key, multi))}
-              className="hover:opacity-80"
+              className="shrink-0 hover:opacity-80"
             >
               <X className="h-2.5 w-2.5" />
             </button>
           </span>
         ))}
-        <div className="flex min-w-[7rem] flex-1 items-center gap-1">
+        <div className="flex w-36 max-w-full items-center gap-1">
           <Search className="h-3 w-3 shrink-0 text-muted-foreground" />
-          <input
-            ref={inputRef}
-            value={query}
+          <Combobox.Input
             // Distinct from the GROUP's name: a screen reader announces the
             // control's own job, and a test can address either one.
             aria-label={`Type to filter ${label}`}
-            onChange={(e) => {
-              setQuery(e.target.value);
-              setOpen(true);
-            }}
             onFocus={() => setOpen(true)}
             placeholder={selectedList.length ? 'Add…' : 'Type to filter…'}
-            className="w-full bg-transparent text-[11px] text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
+            className="min-w-0 w-full bg-transparent text-[11px] text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
           />
         </div>
         {selected.length > 0 && (
@@ -199,30 +211,29 @@ function FilterCombobox({ label, options, selected, onChange, multi, ariaLabel }
           </button>
         )}
       </div>
-      {open && suggestions.length > 0 && (
-        <div className="max-h-48 overflow-y-auto border-t border-border/60 py-1">
-          {suggestions.map((o) => (
-            <button
-              key={o.key}
-              type="button"
-              onClick={() => {
-                onChange(toggle(selected, o.key, multi));
-                setQuery('');
-                inputRef.current?.focus();
-              }}
-              className="flex w-full items-center justify-between gap-2 px-3 py-1 text-left text-[11px] text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-            >
-              <span className="truncate">{o.label}</span>
-              {o.count != null && <span className="shrink-0 text-[10px]">{o.count}</span>}
-            </button>
-          ))}
-        </div>
-      )}
-      {open && suggestions.length === 0 && q !== '' && (
-        <div className="border-t border-border/60 px-3 py-2 text-[11px] text-muted-foreground/70">
-          Nothing matches “{query}”.
-        </div>
-      )}
-    </div>
+      <Combobox.Portal>
+        <Combobox.Positioner anchor={containerRef} align="start" sideOffset={4} className="z-50">
+          <Combobox.Popup className="w-64 max-w-(--available-width) overflow-hidden rounded-md border border-border bg-popover text-popover-foreground">
+            <Combobox.List aria-label={`${label} options`} className="max-h-[min(12rem,var(--available-height))] overflow-y-auto py-1">
+              {suggestions.map((o) => (
+                <Combobox.Item
+                  key={o.key}
+                  value={o}
+                  className="flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-1 text-left text-[11px] text-muted-foreground data-highlighted:bg-muted/50 data-highlighted:text-foreground"
+                >
+                  <span className="truncate">{o.label}</span>
+                  {o.count != null && <span className="shrink-0 text-[10px]">{o.count}</span>}
+                </Combobox.Item>
+              ))}
+              {suggestions.length === 0 && (
+                <div className="px-3 py-2 text-[11px] text-muted-foreground">
+                  {q ? `Nothing matches “${query}”.` : 'All options selected.'}
+                </div>
+              )}
+            </Combobox.List>
+          </Combobox.Popup>
+        </Combobox.Positioner>
+      </Combobox.Portal>
+    </Combobox.Root>
   );
 }

--- a/tests/dashboard-client/preview-filter-bar.test.tsx
+++ b/tests/dashboard-client/preview-filter-bar.test.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FilterBar } from '@/preview/ui/filter-bar';
+
+const options = Array.from({ length: 13 }, (_, i) => ({ key: `area-${i}`, label: `Area ${i}`, count: i + 1 }));
+
+function Harness({ multi = true }: { multi?: boolean }) {
+  const [selected, setSelected] = useState<string[]>([]);
+  return (
+    <>
+      <div data-testid="toolbar" style={{ overflow: 'hidden' }}>
+        <FilterBar label="Area" ariaLabel="Filter by area" options={options} selected={selected} onChange={setSelected} multi={multi} />
+      </div>
+      <button type="button">Outside</button>
+      <output aria-label="Selection">{selected.join(',')}</output>
+    </>
+  );
+}
+
+describe('preview filter dropdown', () => {
+  it('opens outside the toolbar so suggestions cannot expand or be clipped by it', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByRole('combobox', { name: 'Type to filter Area' });
+    await user.click(input);
+    const list = await screen.findByRole('listbox', { name: 'Area options' });
+    expect(screen.getByTestId('toolbar')).not.toContainElement(list);
+    expect(within(list).getAllByRole('option')).toHaveLength(13);
+    expect(input).toHaveFocus();
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('filters and selects several areas, then removes and clears selections', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'Area 12');
+    expect(screen.getAllByRole('option')).toHaveLength(1);
+    await user.click(screen.getByRole('option', { name: 'Area 12 13' }));
+    expect(screen.getByLabelText('Selection')).toHaveTextContent('area-12');
+    expect(input).toHaveValue('');
+    await user.click(screen.getByRole('option', { name: 'Area 3 4' }));
+    expect(screen.getByLabelText('Selection')).toHaveTextContent('area-3');
+    await user.click(screen.getByRole('button', { name: 'Remove Area 12' }));
+    expect(screen.getByLabelText('Selection')).toHaveTextContent(/^area-3$/);
+    await user.click(screen.getByRole('button', { name: 'clear' }));
+    expect(screen.getByLabelText('Selection')).toBeEmptyDOMElement();
+  });
+
+  it('selects with the keyboard and dismisses with Escape or an outside click', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByRole('combobox');
+    const outside = screen.getByRole('button', { name: 'Outside' });
+    await user.type(input, 'Area 12');
+    await user.keyboard('{ArrowDown}{Enter}');
+    expect(screen.getByLabelText('Selection')).toHaveTextContent('area-12');
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    expect(input).toHaveFocus();
+    await user.click(input);
+    await screen.findByRole('listbox');
+    await user.click(outside);
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    expect(outside).toHaveFocus();
+  });
+
+  it.each([true, false])('preserves selections after repeated Escape presses with multi=%s', async (multi) => {
+    const user = userEvent.setup();
+    render(<Harness multi={multi} />);
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'Area 12');
+    await user.keyboard('{ArrowDown}{Enter}');
+    if (multi) {
+      await user.click(screen.getByRole('option', { name: 'Area 3 4' }));
+    }
+    const selection = screen.getByLabelText('Selection').textContent;
+    await user.type(input, 'missing');
+    await screen.findByRole('listbox');
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    await user.keyboard('{Escape}{Escape}');
+
+    expect(input).toHaveFocus();
+    expect(screen.getByLabelText('Selection').textContent).toBe(selection);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove Area 12' })).toBeInTheDocument();
+    if (multi) expect(screen.getByRole('button', { name: 'Remove Area 3' })).toBeInTheDocument();
+  });
+
+  it('replaces a single selection and closes after choosing an option', async () => {
+    const user = userEvent.setup();
+    render(<Harness multi={false} />);
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'Area 12');
+    await user.click(screen.getByRole('option', { name: 'Area 12 13' }));
+    expect(screen.getByLabelText('Selection')).toHaveTextContent(/^area-12$/);
+    expect(input).toHaveValue('');
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    await user.type(input, 'Area 3');
+    await user.keyboard('{ArrowDown}{Enter}');
+    expect(screen.getByLabelText('Selection')).toHaveTextContent(/^area-3$/);
+  });
+
+  it('keeps the empty search result outside the toolbar', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.type(screen.getByRole('combobox'), 'missing');
+    const empty = screen.getByText('Nothing matches “missing”.');
+    expect(screen.getByTestId('toolbar')).not.toContainElement(empty);
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+  });
+});

--- a/tests/dashboard-client/preview-tests-runs-real.test.tsx
+++ b/tests/dashboard-client/preview-tests-runs-real.test.tsx
@@ -196,6 +196,21 @@ describe('the Tests tab of a connected repository', () => {
 });
 
 describe('the Runs tab of a connected repository', () => {
+  it('shows a short commit while preserving the full hash for hover and search', async () => {
+    const commit = '3ec877a68bc423373220f9ee2fda3d93ba368680';
+    serve({ history: { runs: [{ ...HISTORY.runs[0], commit }, HISTORY.runs[1]] } });
+    renderAt(`/preview/repos/${REAL.id}/runs`);
+    const user = userEvent.setup();
+    const table = await screen.findByRole('table', { name: 'Runs' });
+    const shortCommit = await within(table).findByText(commit.slice(0, 8));
+    expect(shortCommit).toHaveAttribute('title', commit);
+
+    await user.type(screen.getByRole('textbox', { name: 'Search runs' }), commit);
+    expect(within(table).getAllByRole('row')).toHaveLength(2);
+    expect(within(table).getByText(commit.slice(0, 8))).toBeInTheDocument();
+    expect(within(table).queryByText('f00d123')).not.toBeInTheDocument();
+  });
+
   it('lists every stored run, newest first, naming its pull request and origin', async () => {
     const calls = serve();
     renderAt(`/preview/repos/${REAL.id}/runs`);


### PR DESCRIPTION
Long conflict descriptions, dependency summaries, and full commit hashes expanded the first table column and squeezed metadata off screen. Corpus, Runs, and Dependencies now reserve column widths, truncate long text with full values on hover, and scroll their tables independently of wrapping toolbars. Runs display eight-character hashes while retaining full-hash search and single-line dates.

Area search now opens an anchored, portalled combobox instead of expanding the toolbar. Selected chips wrap within the available width, and keyboard selection, dismissal, and repeated Escape presses preserve the filter selection.

Validation:
- 48 tests passed across filter, Corpus, connected Tests/Runs, setup-tab, and preview smoke suites.
- Dashboard client typecheck passed.
- Visual browser verification was blocked by authentication and local-file URL policies.
