### PR TITLE
feat(activity): stream dashboard runs and persist history in Postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ assets/generate-deck.js
 assets/*.pptx
 assets/*.pdf
 .claude/
+.codex/
 
 # .NET build artifacts (fixture projects)
 tests/fixtures/**/bin/

--- a/apps/dashboard/client/package.json
+++ b/apps/dashboard/client/package.json
@@ -52,7 +52,8 @@
     "socket.io-client": "^4.8.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "ai": "^6.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.0",

--- a/apps/dashboard/client/src/components/sessions/RunConversation.tsx
+++ b/apps/dashboard/client/src/components/sessions/RunConversation.tsx
@@ -46,6 +46,7 @@ export function RunConversation({
   repoId,
   run,
   liveEvents,
+  connectionError,
   openSessionId,
   onOpenSession,
   onBack,
@@ -55,6 +56,7 @@ export function RunConversation({
   run: PublicSessionRun;
   /** Socket-pushed events per session for THIS run. */
   liveEvents: ReadonlyMap<string, readonly SessionEvent[]>;
+  connectionError?: string | null;
   /** The session whose thread is open (`?ses=`), or null. */
   openSessionId: string | null;
   onOpenSession: (sessionId: string | null) => void;
@@ -92,6 +94,11 @@ export function RunConversation({
 
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col">
+      {connectionError && (
+        <div role="status" className="shrink-0 border-b border-border px-6 py-2 text-xs text-muted-foreground">
+          {connectionError}
+        </div>
+      )}
       <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-6 text-xs">
         <button
           type="button"

--- a/apps/dashboard/client/src/components/sessions/SessionThread.tsx
+++ b/apps/dashboard/client/src/components/sessions/SessionThread.tsx
@@ -18,6 +18,9 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowUpRight, Bot, Check, ChevronDown, ChevronRight } from 'lucide-react';
 import type { SessionEvent, SessionIndexEntry } from '@truecourse/agent-loop';
+import type { ActivityProgress } from '@truecourse/shared/activity-stream';
+
+export const SessionProgressContext = createContext<Readonly<ActivityProgress>>({});
 import { buildCorpusConflicts, resolutionForConflict } from '@truecourse/shared';
 import * as api from '@/lib/api';
 import type { SpecConflictResolution } from '@/lib/api';
@@ -417,6 +420,7 @@ export function SessionThread({ repoId, session, events, loading, error }: {
   loading: boolean;
   error: string | null;
 }) {
+  const progress = useContext(SessionProgressContext)[session.sessionId];
   const rows = toChatRows(events);
   const running = session.status === 'running' || session.status === 'waiting';
 
@@ -488,7 +492,9 @@ export function SessionThread({ repoId, session, events, loading, error }: {
   // plain "Working") stands as the newest message.
   const lastRow = rows[rows.length - 1];
   const workingText =
-    running && !(lastRow?.kind === 'action' && lastRow.inFlight)
+    running && progress
+      ? progress.kind === 'text' ? progress.text : `${progress.toolName} · ${Math.floor(progress.elapsedSeconds)}s`
+      : running && !(lastRow?.kind === 'action' && lastRow.inFlight)
       ? session.status === 'waiting'
         ? "I'm waiting on an answer to my question above."
         : "Still working. I'll post updates here as I go …"

--- a/apps/dashboard/client/src/components/sessions/SessionsActivityView.tsx
+++ b/apps/dashboard/client/src/components/sessions/SessionsActivityView.tsx
@@ -23,6 +23,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useSessionRuns } from '@/hooks/useSessionRuns';
 import { useRunStream } from '@/hooks/useRunStream';
 import { RunConversation } from './RunConversation';
+import { SessionProgressContext } from './SessionThread';
 import { RunsIndex } from './RunsIndex';
 import type { RunStarter } from './run-model';
 
@@ -79,11 +80,13 @@ export function SessionsActivityView({
 
   // The live tail of the open run, while its process is alive. Joined BEFORE
   // the transcript snapshots resolve; overlap dedups by seq.
-  const { liveEvents, liveRun } = useRunStream(
+  const usesActivityStream = listedRun?.activityStream === 'ai-sdk-v1';
+  const { liveEvents, liveRun, connectionError, progress } = useRunStream(
     repoId,
     listedRun?.command ?? null,
     listedRun?.runId ?? null,
-    listedRun?.status === 'running',
+    listedRun?.status === 'running' || usesActivityStream,
+    usesActivityStream,
   );
   // The pushed record is always fresher than the listing's.
   const run = liveRun && liveRun.runId === listedRun?.runId ? liveRun : listedRun;
@@ -96,16 +99,19 @@ export function SessionsActivityView({
 
   if (run) {
     return (
+      <SessionProgressContext.Provider value={progress}>
       <RunConversation
         key={run.runId}
         repoId={repoId}
         run={run}
         liveEvents={liveEvents}
+        connectionError={connectionError}
         openSessionId={sesParam}
         onOpenSession={openSession}
         onBack={() => openRun(null)}
         {...(starter ? { starter } : {})}
       />
+      </SessionProgressContext.Provider>
     );
   }
 

--- a/apps/dashboard/client/src/hooks/useRunStream.ts
+++ b/apps/dashboard/client/src/hooks/useRunStream.ts
@@ -1,8 +1,7 @@
 /**
- * The live tail of one agent-sessions run: joins the run's socket room
- * (`joinRun` → the server starts tailing the transcript files) and accumulates
- * the pushed `session:event`s per session plus the latest `session:run-updated`
- * record.
+ * One run's history and live updates. Dashboard Spec scans use the AI SDK
+ * stream with cursor replay; older runs and other commands join the existing
+ * socket room. The returned shapes keep the current Activity components intact.
  *
  * Deliberately NOT routed through `useSocket`'s handler map — transcripts are a
  * high-frequency stream, and this hook lets only the Activity view re-render.
@@ -15,27 +14,82 @@ import { useEffect, useState } from 'react';
 import type { SessionCommand, SessionEvent } from '@truecourse/agent-loop';
 import type { PublicSessionRun } from '@/lib/api';
 import { connectSocket } from '@/lib/socket';
+import { followActivity } from '@/lib/activity-stream';
+import { getServerUrl } from '@/lib/server-url';
+import type { ActivityEvent, ActivityProgress } from '@truecourse/shared/activity-stream';
 
 export interface RunStreamState {
   /** Events pushed since mount, per sessionId, in arrival order. */
   liveEvents: ReadonlyMap<string, readonly SessionEvent[]>;
   /** The latest pushed run record — fresher than any list read while live. */
   liveRun: PublicSessionRun | null;
+  connectionError: string | null;
+  progress: ActivityProgress;
 }
 
-const EMPTY: RunStreamState = { liveEvents: new Map(), liveRun: null };
+const EMPTY: RunStreamState = { liveEvents: new Map(), liveRun: null, connectionError: null, progress: {} };
 
 export function useRunStream(
   repoId: string,
   command: SessionCommand | null,
   runId: string | null,
   enabled: boolean,
+  activityStream = false,
 ): RunStreamState {
   const [state, setState] = useState<RunStreamState>(EMPTY);
 
   useEffect(() => {
     setState(EMPTY);
     if (!enabled || !command || !runId) return;
+
+    if (activityStream) {
+      const controller = new AbortController();
+      let frame: number | undefined;
+      let pending: Array<ActivityEvent | { kind: 'progress'; progress: ActivityProgress }> = [];
+      const flush = () => {
+        frame = undefined;
+        const events = pending;
+        pending = [];
+        if (controller.signal.aborted) return;
+        setState(prev => {
+          const liveEvents = new Map(prev.liveEvents);
+          let liveRun = prev.liveRun;
+          let progress = prev.progress;
+          const additions = new Map<string, SessionEvent[]>();
+          for (const event of events) {
+            if (event.kind === 'progress') progress = event.progress;
+            else if (event.kind === 'run') {
+              liveRun = event.run;
+              if (liveRun.status !== 'running') progress = {};
+            }
+            else {
+              if (['assistant-turn', 'tool-result', 'outcome', 'failure'].includes(event.event.type)) {
+                progress = { ...progress }; delete progress[event.sessionId];
+              }
+              const batch = additions.get(event.sessionId) ?? [];
+              batch.push(event.event);
+              additions.set(event.sessionId, batch);
+            }
+          }
+          for (const [sessionId, batch] of additions) {
+            const merged = new Map((liveEvents.get(sessionId) ?? []).map(event => [event.seq, event]));
+            for (const event of batch) merged.set(event.seq, event);
+            liveEvents.set(sessionId, [...merged.values()].sort((a, b) => a.seq - b.seq));
+          }
+          return { ...prev, liveRun, liveEvents, progress };
+        });
+      };
+      void followActivity({
+        url: `${getServerUrl()}/api/repos/${encodeURIComponent(repoId)}/sessions/runs/${command}/${encodeURIComponent(runId)}/stream`,
+        runId, signal: controller.signal,
+        onEvent: event => { pending.push(event); frame ??= requestAnimationFrame(flush); },
+        onProgress: progress => { pending.push({ kind: 'progress', progress }); frame ??= requestAnimationFrame(flush); },
+        onConnection: connectionError => {
+          if (!controller.signal.aborted) setState(prev => prev.connectionError === connectionError ? prev : { ...prev, connectionError });
+        },
+      });
+      return () => { controller.abort(); if (frame !== undefined) cancelAnimationFrame(frame); };
+    }
 
     const socket = connectSocket();
     const join = (): void => {
@@ -47,12 +101,12 @@ export function useRunStream(
       setState((prev) => {
         const next = new Map(prev.liveEvents);
         next.set(payload.sessionId, [...(next.get(payload.sessionId) ?? []), payload.event]);
-        return { liveEvents: next, liveRun: prev.liveRun };
+        return { ...prev, liveEvents: next };
       });
     };
     const onRunUpdated = (payload: { repoId: string; runId: string; run: PublicSessionRun }): void => {
       if (payload.repoId !== repoId || payload.runId !== runId) return;
-      setState((prev) => ({ liveEvents: prev.liveEvents, liveRun: payload.run }));
+      setState((prev) => ({ ...prev, liveRun: payload.run }));
     };
 
     socket.on('session:event', onEvent);
@@ -68,7 +122,7 @@ export function useRunStream(
       socket.off('connect', join);
       if (socket.connected) socket.emit('leaveRun', { repoId, runId });
     };
-  }, [repoId, command, runId, enabled]);
+  }, [repoId, command, runId, enabled, activityStream]);
 
   return state;
 }

--- a/apps/dashboard/client/src/lib/activity-stream.ts
+++ b/apps/dashboard/client/src/lib/activity-stream.ts
@@ -1,0 +1,73 @@
+import { DefaultChatTransport } from 'ai';
+import { ActivityEventSchema, ActivityProgressSchema, type ActivityEvent, type ActivityMessage, type ActivityProgress } from '@truecourse/shared/activity-stream';
+
+class ActivityAccessError extends Error {}
+
+/** SDK owns SSE decoding. This adapter only owns the run cursor and connection lifetime. */
+export async function followActivity({
+  url, runId, signal, onEvent, onProgress, onConnection, fetcher = fetch,
+}: {
+  url: string;
+  runId: string;
+  signal: AbortSignal;
+  onEvent: (event: ActivityEvent) => void;
+  onProgress?: (progress: ActivityProgress) => void;
+  onConnection: (error: string | null) => void;
+  fetcher?: typeof fetch;
+}): Promise<void> {
+  let after = -1;
+  let retry = 0;
+  while (!signal.aborted) {
+    let reader: ReadableStreamDefaultReader<import('ai').UIMessageChunk> | undefined;
+    try {
+      const transport = new DefaultChatTransport<ActivityMessage>({
+        credentials: 'include',
+        // SDK reconnect requests do not expose a signal; scope their fetch to this viewer.
+        fetch: async (input, init) => {
+          const response = await fetcher(input, { ...init, signal });
+          if (response.status >= 400 && response.status < 500 && ![408, 429].includes(response.status)) {
+            await response.body?.cancel();
+            throw new ActivityAccessError(response.status === 401 || response.status === 403
+              ? 'Activity access was denied. Sign in again or check repository access.'
+              : 'Activity could not be reopened. Refresh the page to reload this run.');
+          }
+          return response;
+        },
+        prepareReconnectToStreamRequest: () => ({ api: `${url}?after=${after}` }),
+      });
+      const stream = await transport.reconnectToStream({ chatId: runId });
+      if (!stream) throw new Error('The activity stream is unavailable');
+      reader = stream.getReader();
+      let finished = false;
+      while (!signal.aborted) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value.type === 'error') throw new Error(value.errorText);
+        if (value.type === 'data-activity') {
+          const event = ActivityEventSchema.parse(value.data);
+          if (event.cursor > after) { onEvent(event); after = event.cursor; }
+          retry = 0;
+          onConnection(null);
+        } else if (value.type === 'data-progress') {
+          onProgress?.(ActivityProgressSchema.parse(value.data));
+        } else if (value.type === 'data-heartbeat') {
+          retry = 0; onConnection(null);
+        } else if (value.type === 'finish') finished = true;
+      }
+      if (finished) { onConnection(null); return; }
+      if (!signal.aborted) throw new Error('Connection interrupted');
+    } catch (error) {
+      if (signal.aborted) return;
+      if (error instanceof ActivityAccessError) { onConnection(error.message); return; }
+      onConnection('Activity connection interrupted. Reconnecting and catching up…');
+    } finally { await reader?.cancel().catch(() => {}); reader?.releaseLock(); }
+    if (signal.aborted) return;
+    const delay = Math.min(1000 * 2 ** Math.min(retry++, 4), 15_000);
+    await new Promise<void>(resolve => {
+      const abort = () => { clearTimeout(timer); resolve(); };
+      const timer = setTimeout(() => { signal.removeEventListener('abort', abort); resolve(); }, delay);
+      signal.addEventListener('abort', abort, { once: true });
+      if (signal.aborted) { signal.removeEventListener('abort', abort); abort(); }
+    });
+  }
+}

--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -23,7 +23,8 @@
     "chokidar": "^4.0.0",
     "cors": "^2.8.5",
     "express": "^4.21.0",
-    "socket.io": "^4.8.0"
+    "socket.io": "^4.8.0",
+    "ai": "^6.0.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/apps/dashboard/server/src/jobs/index.ts
+++ b/apps/dashboard/server/src/jobs/index.ts
@@ -21,7 +21,7 @@ import {
   type JobTask,
   type StartWorker,
 } from '@truecourse/jobs';
-import { listSessionRuns } from '@truecourse/core/lib/sessions-store';
+import { listStoredSessionRuns } from '@truecourse/core/lib/sessions-store';
 import { log } from '@truecourse/core/lib/logger';
 import type { Db } from '@truecourse/db';
 import {
@@ -92,7 +92,7 @@ export function createServerJobs(opts: CreateServerJobsOptions): JobsMount {
     request: OnboardingJobRequest,
     payload: Record<string, unknown>,
   ): Promise<EnqueueResult> => {
-    if (repoIsWorking(request.repoFullName, command)) return { status: 'busy' };
+    if (await repoIsWorking(request.repoFullName, command)) return { status: 'busy' };
     const jobId = await jobs.singleFlightEnqueue(
       task,
       request.workspaceOrgId,
@@ -191,11 +191,7 @@ const jobKey = (task: string, repoFullName: string): string => `${task}:${repoFu
  * session-run store is the one place a run of a repo is visible whoever started
  * it (it sweeps dead-pid runs as it reads, so `running` means a live process).
  */
-function repoIsWorking(repoFullName: string, command: RepoCommand): boolean {
+async function repoIsWorking(repoFullName: string, command: RepoCommand): Promise<boolean> {
   if (command === 'guard-run') return false;
-  try {
-    return listSessionRuns(repoFullName, command).some((run) => run.status === 'running');
-  } catch {
-    return false; // no store yet — nothing is running
-  }
+  return (await listStoredSessionRuns(repoFullName, command)).some((run) => run.status === 'running');
 }

--- a/apps/dashboard/server/src/jobs/tasks/repo-guard-generate.ts
+++ b/apps/dashboard/server/src/jobs/tasks/repo-guard-generate.ts
@@ -1,3 +1,4 @@
+import { dashboardActivity } from '../../services/dashboard-activity.service.js';
 /**
  * `repo.guard-generate` — `truecourse guard generate` over an ephemeral clone.
  *
@@ -43,7 +44,7 @@ import {
   persistGeneratedGuard,
   readGeneratedReport,
 } from '../materialize-guard.js';
-import { firstLine, mirrorTracker, type OnboardingJobRequest } from './onboarding.js';
+import { firstLine, type OnboardingJobRequest } from './onboarding.js';
 
 export const REPO_GUARD_GENERATE_TASK = 'repo.guard-generate';
 
@@ -85,118 +86,124 @@ export function createRepoGuardGenerateTask(
     traceMeta: (payload) => ({ repoFullName: payload.repoFullName }),
 
     async run(ctx) {
-      const { repoFullName } = ctx.payload;
-      const llm = await startLlm(ctx.payload.workspaceOrgId);
+      return dashboardActivity(ctx, 'guard-generate', GUARD_GENERATE_STEPS, async (activityRun, activityTracker) => {
+        const { repoFullName } = ctx.payload;
+        const llm = await startLlm(ctx.payload.workspaceOrgId);
 
-      await ctx.phase('clone');
-      const tree = await acquireWorkTree(repoFullName);
-      try {
-        const commitSha = await resolveCommitSha(tree.dir);
-        const ref = { repoKey: repoFullName, commitSha };
-        if (!(await materializeStoredSpec(ref, tree.dir))) {
-          throw new Error(
-            `${repoFullName} has no scanned spec yet — run the spec scan before generating scenarios.`,
-          );
-        }
-        await materializeStoredGuardState(repoFullName, tree.dir);
-        // Setup's bundle goes in LAST: its recipe and catalogs are the current
-        // truth, whatever the scenario set was generated against.
-        const bundle = await loadGuardSetupBundle(repoFullName);
-        if (!bundle) {
-          throw new Error(
-            `${repoFullName} has not been set up yet — run guard setup before generating scenarios.`,
-          );
-        }
-        materializeGuardSetupBundle(tree.dir, bundle);
-        // The registered instances beside it: what a supplied dependency is
-        // provided with decides which sections generate can author.
-        await materializeGuardOverlays(repoFullName, tree.dir);
-
-        let guard;
+        await ctx.phase('clone');
+        const tree = await acquireWorkTree(repoFullName);
         try {
-          ({ guard } = await runGenerate(tree.dir, {
-            transport: llm.transport(),
-            transportMode: llm.mode,
-            attribution: llm.driver().attribution,
-            sessionsKey: repoFullName,
-            tracker: mirrorTracker(ctx, GUARD_GENERATE_STEPS),
-            requireExistingRecipe: true,
-            ...(ctx.signal ? { signal: ctx.signal } : {}),
-          }));
-        } catch (err) {
-          if (ctx.signal?.aborted) throw err;
-          if (err instanceof OpenConflictsError) {
-            await writeGuardResult(ref, buildOpenConflictsReport(err, new Date().toISOString()), {
-              baseline: true,
-            });
-            const result: GuardGenerateJobResult = {
-              repoFullName,
-              status: 'open-conflicts',
-              written: 0,
-              birthFindings: 0,
-              noChanges: false,
-              openConflicts: err.conflicts.length,
-            };
-            return {
-              result,
-              notification: {
-                level: 'warning',
-                title: 'Scenario generation blocked',
-                body: `${repoFullName} — ${firstLine(err.message)}`,
-                data: { repoFullName, openConflicts: err.conflicts.length },
-              },
-            };
+          const commitSha = await resolveCommitSha(tree.dir);
+          activityRun.setGitRef?.(commitSha);
+          activityTracker.done('clone');
+          const ref = { repoKey: repoFullName, commitSha };
+          if (!(await materializeStoredSpec(ref, tree.dir))) {
+            throw new Error(
+              `${repoFullName} has no scanned spec yet — run the spec scan before generating scenarios.`,
+            );
           }
-          throw err;
-        }
-        // A stop the user asked for: the harness settles the row cancelled, and
-        // a store that never saw this run is exactly what a cancel means.
-        if (ctx.signal?.aborted) return { notification: null };
-        if (guard.status !== 'ok') {
-          throw new Error(guard.reason ?? `guard generate ended ${guard.status}.`);
-        }
+          await materializeStoredGuardState(repoFullName, tree.dir);
+          // Setup's bundle goes in LAST: its recipe and catalogs are the current
+          // truth, whatever the scenario set was generated against.
+          const bundle = await loadGuardSetupBundle(repoFullName);
+          if (!bundle) {
+            throw new Error(
+              `${repoFullName} has not been set up yet — run guard setup before generating scenarios.`,
+            );
+          }
+          materializeGuardSetupBundle(tree.dir, bundle);
+          // The registered instances beside it: what a supplied dependency is
+          // provided with decides which sections generate can author.
+          await materializeGuardOverlays(repoFullName, tree.dir);
 
-        // The report the engine left in the tree is what gets stored, so the
-        // row's counts come from it too — never from a result it could differ from.
-        const report = readGeneratedReport(tree.dir) ?? buildGuardReport(guard, new Date().toISOString());
-        await persistGeneratedGuard(ref, tree.dir, report);
-
-        const written = report.written.length;
-        const findings = report.birthFindings.length;
-        const result: GuardGenerateJobResult = {
-          repoFullName,
-          status: 'ok',
-          written,
-          birthFindings: findings,
-          noChanges: report.noChanges,
-          openConflicts: 0,
-        };
-        return {
-          result,
-          notification: report.noChanges
-            ? {
-                level: 'success',
-                title: 'Scenarios up to date',
-                body: `${repoFullName} — nothing changed since the last generate.`,
-                data: { repoFullName },
-              }
-            : findings > 0
-              ? {
+          let guard;
+          try {
+            ({ guard } = await runGenerate(tree.dir, {
+              transport: llm.transport(),
+              transportMode: llm.mode,
+              attribution: llm.driver().attribution,
+              sessionsKey: repoFullName,
+              sessionRun: activityRun,
+              tracker: activityTracker,
+              requireExistingRecipe: true,
+              ...(ctx.signal ? { signal: ctx.signal } : {}),
+            }));
+          } catch (err) {
+            if (ctx.signal?.aborted) throw err;
+            if (err instanceof OpenConflictsError) {
+              activityRun.setError({ message: err.message, kind: 'open-conflicts' });
+              await writeGuardResult(ref, buildOpenConflictsReport(err, new Date().toISOString()), {
+                baseline: true,
+              });
+              const result: GuardGenerateJobResult = {
+                repoFullName,
+                status: 'open-conflicts',
+                written: 0,
+                birthFindings: 0,
+                noChanges: false,
+                openConflicts: err.conflicts.length,
+              };
+              return {
+                result,
+                notification: {
                   level: 'warning',
-                  title: 'Scenarios generated — findings to review',
-                  body: `${repoFullName} — ${written} scenario${written === 1 ? '' : 's'} written, ${findings} birth finding${findings === 1 ? '' : 's'}.`,
-                  data: { repoFullName, written, birthFindings: findings },
-                }
-              : {
-                  level: 'success',
-                  title: 'Scenarios generated',
-                  body: `${repoFullName} — ${written} scenario${written === 1 ? '' : 's'} written.`,
-                  data: { repoFullName, written },
+                  title: 'Scenario generation blocked',
+                  body: `${repoFullName} — ${firstLine(err.message)}`,
+                  data: { repoFullName, openConflicts: err.conflicts.length },
                 },
-        };
-      } finally {
-        tree.dispose();
-      }
+              };
+            }
+            throw err;
+          }
+          // A stop the user asked for: the harness settles the row cancelled, and
+          // a store that never saw this run is exactly what a cancel means.
+          if (ctx.signal?.aborted) return { notification: null };
+          if (guard.status !== 'ok') {
+            throw new Error(guard.reason ?? `guard generate ended ${guard.status}.`);
+          }
+
+          // The report the engine left in the tree is what gets stored, so the
+          // row's counts come from it too — never from a result it could differ from.
+          const report = readGeneratedReport(tree.dir) ?? buildGuardReport(guard, new Date().toISOString());
+          await persistGeneratedGuard(ref, tree.dir, report);
+
+          const written = report.written.length;
+          const findings = report.birthFindings.length;
+          const result: GuardGenerateJobResult = {
+            repoFullName,
+            status: 'ok',
+            written,
+            birthFindings: findings,
+            noChanges: report.noChanges,
+            openConflicts: 0,
+          };
+          return {
+            result,
+            notification: report.noChanges
+              ? {
+                  level: 'success',
+                  title: 'Scenarios up to date',
+                  body: `${repoFullName} — nothing changed since the last generate.`,
+                  data: { repoFullName },
+                }
+              : findings > 0
+                ? {
+                    level: 'warning',
+                    title: 'Scenarios generated — findings to review',
+                    body: `${repoFullName} — ${written} scenario${written === 1 ? '' : 's'} written, ${findings} birth finding${findings === 1 ? '' : 's'}.`,
+                    data: { repoFullName, written, birthFindings: findings },
+                  }
+                : {
+                    level: 'success',
+                    title: 'Scenarios generated',
+                    body: `${repoFullName} — ${written} scenario${written === 1 ? '' : 's'} written.`,
+                    data: { repoFullName, written },
+                  },
+          };
+        } finally {
+          tree.dispose();
+        }
+      });
     },
 
     onError: (err, payload) => ({

--- a/apps/dashboard/server/src/jobs/tasks/repo-guard-setup.ts
+++ b/apps/dashboard/server/src/jobs/tasks/repo-guard-setup.ts
@@ -1,3 +1,4 @@
+import { dashboardActivity } from '../../services/dashboard-activity.service.js';
 /**
  * `repo.guard-setup` — `truecourse guard setup` over an ephemeral clone.
  *
@@ -35,7 +36,7 @@ import type { JobDefinition, JobPayload } from '@truecourse/jobs';
 import { startWorkspaceLlm, type WorkspaceLlm } from '../../services/workspace-llm.service.js';
 import { acquireWorkTree } from '../../services/work-tree.service.js';
 import { materializeStoredSpec } from '../materialize-spec.js';
-import { firstLine, mirrorTracker, type OnboardingJobRequest } from './onboarding.js';
+import { firstLine, type OnboardingJobRequest } from './onboarding.js';
 
 export const REPO_GUARD_SETUP_TASK = 'repo.guard-setup';
 
@@ -71,66 +72,72 @@ export function createRepoGuardSetupTask(
     traceMeta: (payload) => ({ repoFullName: payload.repoFullName }),
 
     async run(ctx) {
-      const { repoFullName, only, refresh } = ctx.payload;
-      const llm = await startLlm(ctx.payload.workspaceOrgId);
+      return dashboardActivity(ctx, 'guard-setup', GUARD_SETUP_STEPS, async (activityRun, activityTracker) => {
+        const { repoFullName, only, refresh } = ctx.payload;
+        const llm = await startLlm(ctx.payload.workspaceOrgId);
 
-      await ctx.phase('clone');
-      const tree = await acquireWorkTree(repoFullName);
-      try {
-        const commitSha = await resolveCommitSha(tree.dir);
-        const ref = { repoKey: repoFullName, commitSha };
-        if (!(await materializeStoredSpec(ref, tree.dir))) {
-          throw new Error(
-            `${repoFullName} has no scanned spec yet — run the spec scan before guard setup.`,
-          );
+        await ctx.phase('clone');
+        const tree = await acquireWorkTree(repoFullName);
+        try {
+          const commitSha = await resolveCommitSha(tree.dir);
+          activityRun.setGitRef?.(commitSha);
+          activityTracker.done('clone');
+          const ref = { repoKey: repoFullName, commitSha };
+          if (!(await materializeStoredSpec(ref, tree.dir))) {
+            throw new Error(
+              `${repoFullName} has no scanned spec yet — run the spec scan before guard setup.`,
+            );
+          }
+          // The NEWEST bundle, not this commit's: what carries the settle spine
+          // forward is the last setup that ran, whatever commit it ran on.
+          const stored = await loadGuardSetupBundle(repoFullName);
+          if (stored) materializeGuardSetupBundle(tree.dir, stored);
+          // The registered instances go in beside it, as the two gitignored files
+          // the engine reads them from. The bundle collected below never carries
+          // them: a secret enters only through the dashboard, never out of a clone.
+          await materializeGuardOverlays(repoFullName, tree.dir);
+
+          const { report } = await runSetup(tree.dir, {
+            driver: llm.driver(),
+            transport: llm.transport(),
+            transportMode: llm.mode,
+            sessionsKey: repoFullName,
+            sessionRun: activityRun,
+            eagerRun: true,
+            tracker: activityTracker,
+            ...(ctx.signal ? { signal: ctx.signal } : {}),
+            ...(only ? { only } : {}),
+            // A hosted refresh IS the consent to replace the seed: the script lives
+            // in the bundle, never in a hand-edited tree, and the request said so.
+            ...(refresh ? { refresh: true, confirmSeedReplace: async () => true } : {}),
+          });
+
+          const files = collectGuardSetupBundle(tree.dir);
+          if (Object.keys(files).length > 0) await saveGuardSetupBundle(ref, files);
+
+          const reason = firstLine(report.reason);
+          if (report.status !== 'ok') activityRun.setError({ message: reason || 'Setup did not complete' });
+          return {
+            result: { repoFullName, status: report.status, ...(reason ? { reason } : {}) },
+            notification:
+              report.status === 'ok'
+                ? {
+                    level: 'success',
+                    title: 'Guard setup complete',
+                    body: `${repoFullName} — the recipe and its dependencies are ready.`,
+                    data: { repoFullName },
+                  }
+                : {
+                    level: 'error',
+                    title: 'Guard setup did not complete',
+                    body: `${repoFullName} — ${reason || 'setup was refused.'}`,
+                    data: { repoFullName },
+                  },
+          };
+        } finally {
+          tree.dispose();
         }
-        // The NEWEST bundle, not this commit's: what carries the settle spine
-        // forward is the last setup that ran, whatever commit it ran on.
-        const stored = await loadGuardSetupBundle(repoFullName);
-        if (stored) materializeGuardSetupBundle(tree.dir, stored);
-        // The registered instances go in beside it, as the two gitignored files
-        // the engine reads them from. The bundle collected below never carries
-        // them: a secret enters only through the dashboard, never out of a clone.
-        await materializeGuardOverlays(repoFullName, tree.dir);
-
-        const { report } = await runSetup(tree.dir, {
-          driver: llm.driver(),
-          transport: llm.transport(),
-          transportMode: llm.mode,
-          sessionsKey: repoFullName,
-          eagerRun: true,
-          tracker: mirrorTracker(ctx, GUARD_SETUP_STEPS),
-          ...(ctx.signal ? { signal: ctx.signal } : {}),
-          ...(only ? { only } : {}),
-          // A hosted refresh IS the consent to replace the seed: the script lives
-          // in the bundle, never in a hand-edited tree, and the request said so.
-          ...(refresh ? { refresh: true, confirmSeedReplace: async () => true } : {}),
-        });
-
-        const files = collectGuardSetupBundle(tree.dir);
-        if (Object.keys(files).length > 0) await saveGuardSetupBundle(ref, files);
-
-        const reason = firstLine(report.reason);
-        return {
-          result: { repoFullName, status: report.status, ...(reason ? { reason } : {}) },
-          notification:
-            report.status === 'ok'
-              ? {
-                  level: 'success',
-                  title: 'Guard setup complete',
-                  body: `${repoFullName} — the recipe and its dependencies are ready.`,
-                  data: { repoFullName },
-                }
-              : {
-                  level: 'error',
-                  title: 'Guard setup did not complete',
-                  body: `${repoFullName} — ${reason || 'setup was refused.'}`,
-                  data: { repoFullName },
-                },
-        };
-      } finally {
-        tree.dispose();
-      }
+      });
     },
 
     onError: (err, payload) => ({

--- a/apps/dashboard/server/src/jobs/tasks/repo-scan.ts
+++ b/apps/dashboard/server/src/jobs/tasks/repo-scan.ts
@@ -65,7 +65,7 @@ export function createRepoScanTask(
         // The probe died before curate could open a run — create one carrying
         // the reason, so Activity shows a failed scan instead of nothing at all.
         if (err instanceof LlmProbeFailedError) {
-          recordFailedScanRun(repoFullName, { message: err.message, kind: 'llm-probe' });
+          await recordFailedScanRun(repoFullName, { message: err.message, kind: 'llm-probe' });
         }
         throw err;
       }

--- a/apps/dashboard/server/src/routes/sessions.ts
+++ b/apps/dashboard/server/src/routes/sessions.ts
@@ -1,11 +1,12 @@
 /**
  * Agent-sessions routes — the dashboard read surface over the sessions store
- * (`.truecourse/sessions/<command>/<runId>/`).
- * Read-only; the live tail rides the socket (`joinRun` → `session:*` events,
- * see ../services/session-tailer.service.ts).
+ * (Postgres for dashboard repositories, local files for file-mode callers).
+ * Read-only. Dashboard activity runs expose a replayable AI SDK SSE stream;
+ * legacy runs use the socket tail (`joinRun` → `session:*` events).
  *
  *   GET /:id/sessions/runs                                    every run record, newest first
  *   GET /:id/sessions/runs/:command/:runId                    one run record (404 if absent)
+ *   GET /:id/sessions/runs/:command/:runId/stream             replay + live, ?after=<cursor>
  *   GET /:id/sessions/runs/:command/:runId/transcript/:sessionId
  *       one session's transcript events; ?since=<seq> returns only events past
  *       that cursor (the client's catch-up read after a socket subscribe)
@@ -15,15 +16,68 @@
  */
 
 import { Router, type Request, type Response, type NextFunction } from 'express';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { createUIMessageStreamResponse } from 'ai';
+import { createActivityStream } from '../services/activity-stream.service.js';
 import { SessionCommandSchema } from '@truecourse/agent-loop';
 import { resolveProjectForRequest } from '@truecourse/core/config/current-project';
 import {
-  listSessionRuns,
-  openSessionRun,
+  SessionRunNotFoundError,
+  listStoredSessionRuns,
+  openStoredSessionRun,
   toPublicRunRecord,
+  validateStoredActivityCursor,
+  readStoredTranscript,
+  recoverSessionActivity,
 } from '@truecourse/core/lib/sessions-store';
 
 const router: Router = Router();
+
+/** The browser attaches to a job; ending this request never cancels that job. */
+router.get('/:id/sessions/runs/:command/:runId/stream', async (req, res, next) => {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(req.params.runId)) {
+    res.status(400).json({ error: 'Invalid run ID' }); return;
+  }
+  const after = req.query.after === undefined ? -1 : Number(req.query.after);
+  if (!Number.isSafeInteger(after) || after < -1 || (req.query.after !== undefined && !/^-?\d+$/.test(String(req.query.after)))) {
+    res.status(400).json({ error: 'after must be a journal cursor' }); return;
+  }
+  const command = parseCommand(req.params.command);
+  if (!command) { res.status(400).json({ error: 'Unknown session command' }); return; }
+  const controller = new AbortController();
+  const detach = () => controller.abort();
+  res.once('close', detach);
+  try {
+    const repo = await resolveProjectForRequest(req.params.id);
+    let run;
+    try { run = await openStoredSessionRun(repo.path, command, req.params.runId); }
+    catch (error) {
+      if (!(error instanceof SessionRunNotFoundError)) throw error;
+      res.status(404).json({ error: 'Session run not found.' }); return;
+    }
+    if (run.record().activityStream !== 'ai-sdk-v1') {
+      res.status(409).json({ error: 'This run uses the legacy session transport' }); return;
+    }
+    if (!run.readActivity) recoverSessionActivity(run);
+    // Reject bad cursors before sending SSE headers.
+    try { await validateStoredActivityCursor(run, after); }
+    catch (error) {
+      if (error instanceof Error && error.message.startsWith('Activity cursor')) {
+        res.status(400).json({ error: error.message }); return;
+      }
+      throw error;
+    }
+    const response = createUIMessageStreamResponse({
+      stream: createActivityStream(run, after, controller.signal),
+      headers: { 'X-Accel-Buffering': 'no', 'Cache-Control': 'no-cache, no-transform' },
+    });
+    response.headers.forEach((value, name) => res.setHeader(name, value));
+    res.flushHeaders();
+    await pipeline(Readable.fromWeb(response.body!), res, { signal: controller.signal });
+  } catch (error) { if (!controller.signal.aborted) next(error); }
+  finally { controller.abort(); res.removeListener('close', detach); }
+});
 
 /** `:command` straight from the URL — refuse anything the store never wrote. */
 function parseCommand(raw: string): ReturnType<typeof SessionCommandSchema.parse> | null {
@@ -36,7 +90,7 @@ router.get('/:id/sessions/runs', async (req: Request, res: Response, next: NextF
     const repo = await resolveProjectForRequest(req.params.id as string);
     // listSessionRuns sweeps as a side effect: a run left `running` by a dead
     // pid reads `interrupted` here without any separate boot reconciliation.
-    res.json({ runs: listSessionRuns(repo.path).map(toPublicRunRecord) });
+    res.json({ runs: (await listStoredSessionRuns(repo.path)).map(toPublicRunRecord) });
   } catch (e) {
     next(e);
   }
@@ -53,9 +107,10 @@ router.get(
         return;
       }
       try {
-        const run = openSessionRun(repo.path, command, req.params.runId as string);
+        const run = await openStoredSessionRun(repo.path, command, req.params.runId as string);
         res.json({ run: toPublicRunRecord(run.record()) });
-      } catch {
+      } catch (error) {
+        if (!(error instanceof SessionRunNotFoundError)) throw error;
         res.status(404).json({ error: 'Session run not found.' });
       }
     } catch (e) {
@@ -80,12 +135,13 @@ router.get(
         return;
       }
       try {
-        // openSessionRun 404s a bogus runId; readEvents sanitizes the session
-        // id into the transcript filename, so the URL param never walks paths.
-        const run = openSessionRun(repo.path, command, req.params.runId as string);
-        const events = run.persistence.readEvents(req.params.sessionId as string);
-        res.json({ events: since >= 0 ? events.filter((e) => e.seq > since) : events });
-      } catch {
+        // Resolve the run before reading its session. File reads sanitize the
+        // session ID; Postgres reads filter by session and sequence in the query.
+        const run = await openStoredSessionRun(repo.path, command, req.params.runId as string);
+        const events = await readStoredTranscript(run, req.params.sessionId as string, since);
+        res.json({ events });
+      } catch (error) {
+        if (!(error instanceof SessionRunNotFoundError)) throw error;
         res.status(404).json({ error: 'Session run not found.' });
       }
     } catch (e) {

--- a/apps/dashboard/server/src/routes/spec.ts
+++ b/apps/dashboard/server/src/routes/spec.ts
@@ -308,7 +308,7 @@ router.post(
         if (e instanceof LlmProbeFailedError) {
           // The run exists only to carry the failure, so Activity shows a failed
           // scan rather than nothing at all.
-          recordFailedScanRun(repo.path, { message: e.message, kind: 'llm-probe' });
+          await recordFailedScanRun(repo.path, { message: e.message, kind: 'llm-probe' });
           res.status(502).json({ error: e.code, message: e.message });
           return;
         }

--- a/apps/dashboard/server/src/services/activity-stream.service.ts
+++ b/apps/dashboard/server/src/services/activity-stream.service.ts
@@ -1,0 +1,90 @@
+import type { UIMessageChunk } from 'ai';
+import type { ActivityEvent } from '@truecourse/shared/activity-stream';
+import { readActivityProgress, subscribeActivity } from '@truecourse/core/lib/activity-journal';
+import { readStoredActivity, type SessionRunStore } from '@truecourse/core/lib/sessions-store';
+
+/** Replay once, then deliver published events directly, independently of the job. */
+export function createActivityStream(
+  run: SessionRunStore,
+  after: number,
+  signal: AbortSignal,
+): ReadableStream<UIMessageChunk> {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  signal.addEventListener('abort', abort, { once: true });
+  if (signal.aborted) abort();
+  const iterator = chunks(run, after, controller.signal);
+  return new ReadableStream({
+    async pull(sink) {
+      try {
+        const next = await iterator.next();
+        if (next.done) { signal.removeEventListener('abort', abort); sink.close(); }
+        else sink.enqueue(next.value);
+      } catch (error) { signal.removeEventListener('abort', abort); sink.error(error); }
+    },
+    async cancel() { abort(); signal.removeEventListener('abort', abort); await iterator.return(undefined); },
+  });
+}
+
+async function* chunks(run: SessionRunStore, after: number, signal: AbortSignal): AsyncGenerator<UIMessageChunk> {
+  let changed = false;
+  let replay = true;
+  let pending: ActivityEvent[] = [];
+  let wake: (() => void) | undefined;
+  const notify = (event?: ActivityEvent) => {
+    changed = true;
+    if (event && !replay) {
+      pending.push(event);
+      // A slow viewer catches up from its cursor instead of retaining an
+      // unbounded queue. Normal live delivery never reads back from disk.
+      if (pending.length > 128) { pending = []; replay = true; }
+    }
+    wake?.();
+  };
+  const abort = () => notify();
+  // Subscribe before replay. A write during a yielded history batch wakes the next read.
+  const unsubscribe = subscribeActivity(run.dir, notify);
+  const unsubscribeRemote = run.subscribeActivity?.(() => { replay = true; notify(); });
+  signal.addEventListener('abort', abort, { once: true });
+  let heartbeatDue = false;
+  // Keep catch-up periodic even while local progress continuously wakes the stream.
+  const heartbeat = setInterval(() => {
+    if (run.readActivity) replay = true;
+    heartbeatDue = true;
+    notify();
+  }, 15_000);
+  let terminal = run.record().status !== 'running';
+  try {
+    yield { type: 'start', messageId: run.runId };
+    while (!signal.aborted) {
+      changed = false;
+      let batch: ActivityEvent[];
+      if (replay) {
+        // Enable live queuing before awaiting storage, so a commit during the
+        // history query is either replayed or queued, never dropped.
+        replay = false;
+        batch = await readStoredActivity(run, after);
+      } else { batch = pending; pending = []; }
+      for (const event of batch) {
+        if (signal.aborted) return;
+        if (event.cursor <= after) continue;
+        after = event.cursor;
+        if (event.kind === 'run') terminal = event.run.status !== 'running';
+        yield { type: 'data-activity', id: `${run.runId}:${event.cursor}`, data: event };
+      }
+      if (replay || pending.length > 0) continue;
+      yield { type: 'data-progress', data: readActivityProgress(run.dir), transient: true };
+      if (changed) continue;
+      if (terminal) { yield { type: 'finish', finishReason: 'stop' }; return; }
+      if (heartbeatDue) {
+        heartbeatDue = false;
+        yield { type: 'data-heartbeat', data: { at: new Date().toISOString() }, transient: true };
+        if (changed) continue;
+      }
+      await new Promise<void>(resolve => {
+        wake = () => { wake = undefined; resolve(); };
+        if (signal.aborted) wake();
+      });
+    }
+  } finally { clearInterval(heartbeat); unsubscribeRemote?.(); unsubscribe(); signal.removeEventListener('abort', abort); wake?.(); }
+}

--- a/apps/dashboard/server/src/services/dashboard-activity.service.ts
+++ b/apps/dashboard/server/src/services/dashboard-activity.service.ts
@@ -1,0 +1,34 @@
+import type { SessionCommand } from '@truecourse/agent-loop';
+import { createStoredSessionRun, type SessionRunStore } from '@truecourse/core/lib/sessions-store';
+import type { JobContext } from '@truecourse/jobs';
+import { mirrorTracker, type OnboardingJobPayload } from '../jobs/tasks/onboarding.js';
+import type { StepTracker } from '@truecourse/core/progress';
+
+/** The hosted job owns the run until its output has been saved. */
+export async function dashboardActivity<P extends OnboardingJobPayload, T>(
+  ctx: JobContext<P>,
+  command: SessionCommand,
+  steps: readonly { key: string; label: string }[],
+  execute: (run: SessionRunStore, tracker: StepTracker) => Promise<T>,
+): Promise<T> {
+  const run = await createStoredSessionRun(ctx.payload.repoFullName, {
+    command, gitRef: 'unknown', activityStream: true,
+  });
+  const tracker = mirrorTracker(ctx, [{ key: 'clone', label: 'Preparing repository' }, ...steps]);
+  const untap = tracker.tap(progress => {
+    if (progress.steps) run.setChecklist(progress.steps);
+  });
+  try {
+    tracker.start('clone');
+    const result = await execute(run, tracker);
+    run.finish(ctx.signal?.aborted ? 'interrupted' : run.record().error ? 'failed' : 'completed');
+    await run.flush?.();
+    return result;
+  } catch (error) {
+    run.finish(ctx.signal?.aborted ? 'interrupted' : 'failed', {
+      error: { message: error instanceof Error ? error.message : String(error) },
+    });
+    await run.flush?.();
+    throw error;
+  } finally { untap(); }
+}

--- a/apps/dashboard/server/src/services/session-tailer.service.ts
+++ b/apps/dashboard/server/src/services/session-tailer.service.ts
@@ -21,6 +21,7 @@ import { watch, type FSWatcher } from 'chokidar';
 import type { SessionCommand, SessionEvent } from '@truecourse/agent-loop';
 import { RunRecordSchema } from '@truecourse/agent-loop';
 import {
+  subscribeStoredSessionRuns,
   sessionRunDir,
   sessionsDir,
   toPublicRunRecord,
@@ -74,7 +75,7 @@ export function acquireRunTail(target: RunTailTarget, sink: RunTailSink): void {
       if (run) sink.onRunUpdated(run);
       return;
     }
-    if (!base.endsWith('.jsonl')) return;
+    if (!base.endsWith('.jsonl') || base === 'activity.jsonl') return;
     const sessionId = base.slice(0, -'.jsonl'.length);
     for (const event of consumeAppended(offsets, file)) sink.onEvent(sessionId, event);
   };
@@ -119,7 +120,7 @@ export function stopAllRunTails(): void {
 // ---------------------------------------------------------------------------
 
 interface RunsWatch {
-  watcher: FSWatcher;
+  watcher: Pick<FSWatcher, 'close'>;
   refs: number;
   pending?: ReturnType<typeof setTimeout>;
 }
@@ -133,6 +134,17 @@ export function acquireRunsWatch(repoPath: string, onChange: () => void): void {
   const existing = runsWatches.get(repoPath);
   if (existing) {
     existing.refs++;
+    return;
+  }
+  const entry: RunsWatch = { watcher: { close: async () => {} }, refs: 1 };
+  const notify = () => {
+    clearTimeout(entry.pending);
+    entry.pending = setTimeout(onChange, RUNS_DEBOUNCE_MS);
+  };
+  const unsubscribe = subscribeStoredSessionRuns(repoPath, notify);
+  if (unsubscribe) {
+    entry.watcher = { close: async () => { unsubscribe(); } };
+    runsWatches.set(repoPath, entry);
     return;
   }
   // chokidar (4.x, pinned) never attaches to a directory that does not exist:
@@ -152,7 +164,7 @@ export function acquireRunsWatch(repoPath: string, onChange: () => void): void {
   }
   // depth 2: sessions/<command>/<runId>/run.json
   const watcher = watch(sessionsDir(repoPath), { ignoreInitial: true, depth: 2 });
-  const entry: RunsWatch = { watcher, refs: 1 };
+  entry.watcher = watcher;
   const onFile = (file: string): void => {
     if (path.basename(file) !== 'run.json') return;
     clearTimeout(entry.pending);
@@ -239,7 +251,7 @@ function statSize(file: string): number {
 
 function listJsonl(dir: string): string[] {
   try {
-    return fs.readdirSync(dir).filter((name) => name.endsWith('.jsonl'));
+    return fs.readdirSync(dir).filter((name) => name.endsWith('.jsonl') && name !== 'activity.jsonl');
   } catch {
     return [];
   }

--- a/apps/dashboard/server/src/services/spec-scan.service.ts
+++ b/apps/dashboard/server/src/services/spec-scan.service.ts
@@ -11,11 +11,9 @@
  * apart. Cancellation is the job's too — the `AbortSignal` threaded in here is
  * the one the harness trips when a repository is disconnected mid-scan.
  *
- * Progress reaches the client through the two channels the manual Scan already
- * used, so no new plumbing exists for it: the socket spec tracker
- * (`spec:progress` in the repo's room) and the sessions store's own `run.json`
- * — keyed by the repo IDENTITY, not the throwaway clone, so the repo's runs
- * watcher sees every write and the transcripts outlive the clone.
+ * Activity streams directly from the sessions store's durable journal. The
+ * existing socket spec tracker still serves other progress surfaces. Records
+ * use the repository identity, so both history and transcripts outlive the clone.
  */
 
 import fs from 'node:fs';
@@ -23,7 +21,7 @@ import path from 'node:path';
 import type { RunError } from '@truecourse/agent-loop';
 import type { CuratedCorpus } from '@truecourse/spec-consolidator';
 import { log } from '@truecourse/core/lib/logger';
-import { createSessionRun, openSessionRun } from '@truecourse/core/lib/sessions-store';
+import { createStoredSessionRun, openStoredSessionRun } from '@truecourse/core/lib/sessions-store';
 import { resolveCommitSha } from '@truecourse/core/lib/repo-ref';
 import { saveSpec, saveSpecDocs, specsMaterializeInPlace } from '@truecourse/core/lib/spec-store';
 import { materializeSpecSources, specSourcesMaterializeInPlace } from '@truecourse/core/lib/spec-sources';
@@ -89,6 +87,7 @@ export async function runStoredSpecScan(
       repoIdentity,
       sessionsKey: repoKey,
       ...options,
+      deferRunCompletion: true,
       onRunStarted: (info) => {
         runId = info.runId;
         options.onRunStarted?.(info);
@@ -112,12 +111,24 @@ export async function runStoredSpecScan(
       // scope orchestrator and auto-resolved conflicts reopen.
       await saveDecisions(repoKey, result.curate.decisions);
     }
+    if (runId) {
+      const run = await openStoredSessionRun(repoKey, 'spec-scan', runId);
+      run.finish(options.signal?.aborted ? 'interrupted' : 'completed');
+      await run.flush?.();
+    }
     return result;
   } catch (err) {
     // A cancelled scan is not a failed one — it stopped because the caller said
     // so, and the record already says `interrupted`.
     if (runId && !options.signal?.aborted) {
-      stampRunError(repoKey, runId, { message: messageOf(err) });
+      const run = await openStoredSessionRun(repoKey, 'spec-scan', runId);
+      if (run.record().status === 'running' || run.record().status === 'completed') run.finish('failed', { error: { message: messageOf(err) } });
+      else if (!run.record().error) run.setError({ message: messageOf(err) });
+      await run.flush?.();
+    } else if (runId && options.signal?.aborted) {
+      const run = await openStoredSessionRun(repoKey, 'spec-scan', runId);
+      if (run.record().status === 'running') run.finish('interrupted');
+      await run.flush?.();
     }
     throw err;
   } finally {
@@ -152,20 +163,22 @@ export function snapshotDocs(treeDir: string, corpus: CuratedCorpus): Record<str
  * died before `curateInProcess` could create one. Best-effort: a store that
  * cannot be written must not turn one failure into two.
  */
-export function recordFailedScanRun(repoKey: string, error: RunError): void {
+export async function recordFailedScanRun(repoKey: string, error: RunError): Promise<void> {
   try {
-    createSessionRun(repoKey, { command: 'spec-scan', gitRef: 'unknown' }).finish('failed', {
-      error,
-    });
+    const run = await createStoredSessionRun(repoKey, { command: 'spec-scan', gitRef: 'unknown', activityStream: true });
+    run.finish('failed', { error });
+    await run.flush?.();
   } catch (err) {
     log.warn(`[spec-scan] could not record the failed scan for ${repoKey}: ${messageOf(err)}`);
   }
 }
 
 /** Stamp the reason onto a run that already exists (and already finished). */
-export function stampRunError(repoKey: string, runId: string, error: RunError): void {
+export async function stampRunError(repoKey: string, runId: string, error: RunError): Promise<void> {
   try {
-    openSessionRun(repoKey, 'spec-scan', runId).setError(error);
+    const run = await openStoredSessionRun(repoKey, 'spec-scan', runId);
+    run.setError(error);
+    await run.flush?.();
   } catch (err) {
     log.warn(`[spec-scan] could not stamp the scan failure for ${repoKey}: ${messageOf(err)}`);
   }

--- a/apps/dashboard/server/src/stores.ts
+++ b/apps/dashboard/server/src/stores.ts
@@ -25,10 +25,11 @@ import { setRepoConfigStore } from '@truecourse/core/config/project-config';
 import { setUiStateStore } from '@truecourse/core/config/ui-state';
 import { setRegistryStore } from '@truecourse/core/config/registry';
 import { setAnalyzeLock } from '@truecourse/core/lib/analyze-lock';
-import { setSessionsRootResolver } from '@truecourse/core/lib/sessions-store';
+import { setSessionsRootResolver, setSessionRunBackend } from '@truecourse/core/lib/sessions-store';
 import { getGlobalDir } from '@truecourse/core/config/paths';
 import { setKvCacheStore } from '@truecourse/llm';
 import {
+  PgSessionRunStore,
   PgAnalysisStore,
   PgSpecStore,
   PgSpecSourcesStore,
@@ -104,16 +105,15 @@ export function installDbStores(
   // pool).
   setAnalyzeLock(new PgAnalyzeLock(lockPool));
 
-  // Session transcripts are the one store still on disk (they are an append
-  // stream the run watcher tails). Key them by repo IDENTITY under the global
-  // dir so they survive the ephemeral clone; an absolute key is a real local
-  // path (tests, file-mode tools sharing the process) and keeps the in-tree
-  // default.
+  // Stable identities for stream subscriptions, provider scratch paths, and
+  // importing pre-migration file histories. New dashboard history uses Postgres.
   setSessionsRootResolver((repoDirOrKey) =>
     path.isAbsolute(repoDirOrKey)
       ? path.join(repoDirOrKey, '.truecourse', 'sessions')
       : path.join(getGlobalDir(), 'sessions', repoDirName(repoDirOrKey)),
   );
+
+  setSessionRunBackend(new PgSessionRunStore(db, lockPool));
 
   // Disconnecting a repo purges its per-repo rows (they key on the bare repo
   // key with no workspace column — left behind, the next workspace to connect

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "ai": "^6.0.0",
     "@electric-sql/pglite": "^0.2.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",

--- a/packages/agent-loop/src/agent-loop.ts
+++ b/packages/agent-loop/src/agent-loop.ts
@@ -413,6 +413,9 @@ function startSession<TOutcome>(
           ...(input.sharedPrefix ? { sharedPrefix: input.sharedPrefix } : {}),
           ...(resume ? { resume } : {}),
           onEvent: track,
+          ...(persistence.publishProgress ? {
+            onProgress: (progress: import('./session-driver.js').SessionProgress) => persistence.publishProgress!(sessionId, progress),
+          } : {}),
           signal: controller.signal,
         });
         if (pendingInterrupt) void handle.interrupt();
@@ -558,7 +561,7 @@ function startSession<TOutcome>(
   })();
 
   return {
-    outcome,
+    outcome: outcome.finally(() => persistence.flush?.()),
     steer: (message) => handle?.steer(message),
     status: () => status,
   };

--- a/packages/agent-loop/src/session-driver.ts
+++ b/packages/agent-loop/src/session-driver.ts
@@ -11,6 +11,14 @@
  */
 
 import type { SessionDef } from './session-def.js';
+import { z } from 'zod';
+
+/** Ephemeral display progress. Never enters the transcript or turn budget. */
+export const SessionProgressSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('text'), turnId: z.string(), text: z.string() }),
+  z.object({ kind: z.literal('tool'), toolCallId: z.string(), toolName: z.string(), elapsedSeconds: z.number().nonnegative() }),
+]);
+export type SessionProgress = z.infer<typeof SessionProgressSchema>;
 import type {
   RawPayload,
   SessionEvent,
@@ -75,6 +83,7 @@ export interface SessionRunInput {
    *  raw escape hatch — its native wire payload — which the shell
    *  carries onto the persisted envelope. */
   onEvent(event: SessionEventBody & { raw?: RawPayload }): void;
+  onProgress?: (progress: SessionProgress) => void;
   signal: AbortSignal;
 }
 

--- a/packages/agent-loop/src/session-store.ts
+++ b/packages/agent-loop/src/session-store.ts
@@ -62,6 +62,8 @@ const RunRecordFieldsSchema = z.object({
   startedAt: z.string(),
   finishedAt: z.string().optional(),
   status: RunStatusSchema,
+  /** Dashboard runs with direct publication and durable AI SDK stream replay. */
+  activityStream: z.literal('ai-sdk-v1').optional(),
   /**
    * How the run presents ITSELF, in the same block vocabulary its sessions'
    * outcomes use — the phase checklist is a `checklist` block, nothing more.
@@ -128,6 +130,10 @@ export type RunRecord = z.infer<typeof RunRecordFieldsSchema>;
  * a dead process's memory.
  */
 export interface SessionPersistence {
+  /** Await committed history before the session returns its outcome. */
+  flush?(): Promise<void>;
+  /** Optional live channel. CLI stores and replay transcripts do not need it. */
+  publishProgress?(sessionId: string, progress: import('./session-driver.js').SessionProgress): void;
   appendEvent(sessionId: string, event: SessionEvent): void;
   updateIndex(entry: SessionIndexEntry): void;
   /** Full transcript read-back; tolerates (drops) a crash-truncated final

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -303,6 +303,10 @@
     "./types/snapshot": {
       "types": "./dist/types/snapshot.d.ts",
       "import": "./dist/types/snapshot.js"
+    },
+    "./lib/activity-journal": {
+      "types": "./dist/lib/activity-journal.d.ts",
+      "import": "./dist/lib/activity-journal.js"
     }
   },
   "scripts": {

--- a/packages/core/src/commands/guard-in-process.ts
+++ b/packages/core/src/commands/guard-in-process.ts
@@ -57,7 +57,7 @@ import { getGit } from '../lib/git.js';
 import { getGuardExecutor } from '../lib/guard-executor.js';
 import { guardsMaterializeInPlace } from '../lib/guard-store.js';
 import { resolveCommitSha } from '../lib/repo-ref.js';
-import { createSessionRun, type SessionRunStartedInfo } from '../lib/sessions-store.js';
+import { createSessionRun, type SessionRunStartedInfo, type SessionRunStore } from '../lib/sessions-store.js';
 import {
   agentTransport,
   cliTransport,
@@ -253,6 +253,8 @@ export interface GuardGenerateInProcessOptions {
    * ephemeral clone deleted after the run (a hosted job). Defaults to `repoRoot`.
    */
   sessionsKey?: string;
+  /** Hosted lifecycle owns completion after result persistence. */
+  sessionRun?: SessionRunStore;
   /**
    * What the run record says it ran on. A caller that built the transport
    * itself knows (the workspace's provider); unset, the session driver's own
@@ -403,7 +405,7 @@ export async function guardGenerateInProcess(
   // FIRST: a generate that started and was stopped by a gate — a blocked
   // corpus, a declined estimate, an unusable provider config — is still a
   // generate that started, and Activity must say so and why.
-  const run = createSessionRun(options.sessionsKey ?? repoRoot, {
+  const run = options.sessionRun ?? createSessionRun(options.sessionsKey ?? repoRoot, {
     command: 'guard-generate',
     gitRef: await resolveCommitSha(repoRoot),
   });
@@ -418,6 +420,11 @@ export async function guardGenerateInProcess(
       }),
     );
   });
+
+  const finishRun: SessionRunStore['finish'] = (status, opts) => {
+    if (!options.sessionRun) run.finish(status, opts);
+    else if (opts?.error) run.setError(opts.error);
+  };
 
   let transport: LlmTransport | undefined;
   try {
@@ -443,11 +450,11 @@ export async function guardGenerateInProcess(
     untap?.();
     // A stop the user asked for is not a failure; a gate that refused is, and
     // the record carries its reason under the gate's own kind.
-    if (e instanceof EstimateDeclined) run.finish('interrupted');
+    if (e instanceof EstimateDeclined) finishRun('interrupted');
     else if (e instanceof OpenConflictsError) {
-      run.finish('failed', { error: { message: firstLine(e.message) ?? e.message, kind: 'open-conflicts' } });
+      finishRun('failed', { error: { message: firstLine(e.message) ?? e.message, kind: 'open-conflicts' } });
     } else {
-      run.finish('failed', { error: { message: (e as Error).message, kind: 'llm-config' } });
+      finishRun('failed', { error: { message: (e as Error).message, kind: 'llm-config' } });
     }
     throw e;
   }
@@ -714,7 +721,7 @@ export async function guardGenerateInProcess(
       // (what `guard status` and the dashboard read) with a partial abort. The
       // caller still gets the failure — loudly, and non-zero.
       if (!options.only || options.only === 'worker') persistGuardReport(repoRoot, guard);
-      run.finish('failed', {
+      finishRun('failed', {
         error: { message: firstLine(guard.reason) ?? `generate ended ${guard.status}`, kind: guard.status },
       });
       return { guard, sessionsRunDir: run.dir };
@@ -727,7 +734,7 @@ export async function guardGenerateInProcess(
     // a partial run's counts would read as a whole one's.
     if (guard.stoppedAfter) {
       tracker?.done(STEPS[cur], `stopped after ${guard.stoppedAfter}`);
-      run.finish('completed');
+      if (!options.sessionRun) finishRun('completed');
       return { guard, sessionsRunDir: run.dir };
     }
 
@@ -751,15 +758,15 @@ export async function guardGenerateInProcess(
     // on every completed generate (including the noChanges no-op); NOT on a thrown
     // error, which never reaches here — the report describes a completed generate.
     persistGuardReport(repoRoot, guard);
-    run.finish('completed');
+    if (!options.sessionRun) finishRun('completed');
 
     return { guard, sessionsRunDir: run.dir };
   } catch (e) {
     tracker?.error(STEPS[cur], (e as Error).message);
     // A stop the caller asked for is not a failure; anything else lands its
     // reason on the record, the only place a watcher can read it.
-    if (options.signal?.aborted) run.finish('interrupted');
-    else run.finish('failed', { error: { message: (e as Error).message, kind: 'generate' } });
+    if (options.signal?.aborted) finishRun('interrupted');
+    else finishRun('failed', { error: { message: (e as Error).message, kind: 'generate' } });
     throw e;
   } finally {
     untap?.();

--- a/packages/core/src/commands/guard-interfaces.ts
+++ b/packages/core/src/commands/guard-interfaces.ts
@@ -40,7 +40,7 @@ import {
 } from '@truecourse/shared/llm';
 import type { SessionDriver, SessionEvent } from '@truecourse/agent-loop';
 import path from 'node:path';
-import { createSessionRun, type SessionRunStartedInfo } from '../lib/sessions-store.js';
+import { createStoredSessionRun, type SessionRunStartedInfo } from '../lib/sessions-store.js';
 import { resolveCommitSha } from '../lib/repo-ref.js';
 import {
   createConfiguredApiTransport,
@@ -173,43 +173,43 @@ export async function runGuardInterfaceAuthoring(
 ): Promise<GuardInterfaceAuthorRun> {
   const { repoRoot } = opts;
   const gitRef = await resolveCommitSha(repoRoot);
-  const run = createSessionRun(opts.sessionsKey ?? repoRoot, { command: 'guard-interfaces', gitRef });
-  opts.onRunStarted?.({ command: 'guard-interfaces', runId: run.runId, dir: run.dir });
-  // A hosted caller hands over the workspace's own driver; a checkout resolves
-  // one from the saved config.
-  const { driver, mode, attribution } = opts.driver
-    ? {
-        driver: opts.driver,
-        mode: opts.transportMode ?? effectiveLlmMode(opts.transport),
-        attribution: opts.driver.attribution,
-      }
-    : createConfiguredSessionDriver({
-        ...(opts.transport ? { transport: opts.transport } : {}),
-        cwd: repoRoot,
-        providerStateDir: path.join(run.dir, 'provider'),
-      });
-  // Which model answered is part of what a run MEANS: a transcript read after
-  // a config change, or after a fallback swap, must not need the config of the
-  // day to be interpretable.
-  const llm = {
-    mode,
-    provider: attribution.provider,
-    model: attribution.model,
-    ...(attribution.fallbackModel ? { fallbackModel: attribution.fallbackModel } : {}),
-  };
-  run.setLlm(llm);
-
-  // The GROUNDING, once per run and amortised over every place in it:
-  // the route module of each place, the modules it renders, and the api effects
-  // its requests join to. One analyzer pass, so the sessions read instead of
-  // rediscovering. It degrades to nothing rather than failing the run.
-  opts.onStatus?.('reading the working tree');
-  const context = await deriveWebAuthoringContext(repoRoot, { catalog: readInterfaceCatalog(repoRoot) });
-  opts.onStatus?.(
-    `context: ${context.contexts.size} place(s) grounded from ${context.files} file(s) in ${context.seconds}s`,
-  );
-
+  const run = await createStoredSessionRun(opts.sessionsKey ?? repoRoot, { command: 'guard-interfaces', gitRef, activityStream: !!opts.sessionsKey });
   try {
+    opts.onRunStarted?.({ command: 'guard-interfaces', runId: run.runId, dir: run.dir });
+    // A hosted caller hands over the workspace's own driver; a checkout resolves
+    // one from the saved config.
+    const { driver, mode, attribution } = opts.driver
+      ? {
+          driver: opts.driver,
+          mode: opts.transportMode ?? effectiveLlmMode(opts.transport),
+          attribution: opts.driver.attribution,
+        }
+      : createConfiguredSessionDriver({
+          ...(opts.transport ? { transport: opts.transport } : {}),
+          cwd: repoRoot,
+          providerStateDir: path.join(run.dir, 'provider'),
+        });
+    // Which model answered is part of what a run MEANS: a transcript read after
+    // a config change, or after a fallback swap, must not need the config of the
+    // day to be interpretable.
+    const llm = {
+      mode,
+      provider: attribution.provider,
+      model: attribution.model,
+      ...(attribution.fallbackModel ? { fallbackModel: attribution.fallbackModel } : {}),
+    };
+    run.setLlm(llm);
+
+    // The GROUNDING, once per run and amortised over every place in it:
+    // the route module of each place, the modules it renders, and the api effects
+    // its requests join to. One analyzer pass, so the sessions read instead of
+    // rediscovering. It degrades to nothing rather than failing the run.
+    opts.onStatus?.('reading the working tree');
+    const context = await deriveWebAuthoringContext(repoRoot, { catalog: readInterfaceCatalog(repoRoot) });
+    opts.onStatus?.(
+      `context: ${context.contexts.size} place(s) grounded from ${context.files} file(s) in ${context.seconds}s`,
+    );
+
     const result = await authorWebInterfaces({
       repoRoot,
       driver,
@@ -259,9 +259,9 @@ export async function runGuardInterfaceAuthoring(
       ...(reconcile ? { reconcile } : {}),
     };
   } catch (error) {
-    run.finish('failed');
+    run.finish(opts.signal?.aborted ? 'interrupted' : 'failed', { error: { message: error instanceof Error ? error.message : String(error) } });
     throw error;
-  }
+  } finally { await run.flush?.(); }
 }
 
 export interface RunGuardInterfaceReconcileOptions {

--- a/packages/core/src/commands/guard-setup.ts
+++ b/packages/core/src/commands/guard-setup.ts
@@ -65,7 +65,7 @@ import { resolveFallbackModel, resolveModel } from '../config/llm-models.js';
 import { getModelPrices } from '../services/llm/model-prices.js';
 import { estimateGuardSetup } from '../services/llm/spec-estimate.js';
 import { mapInterfaces } from '../services/interface.service.js';
-import { sessionRunDir, type SessionRunStartedInfo } from '../lib/sessions-store.js';
+import { sessionRunDir, type SessionRunStartedInfo, type SessionRunStore } from '../lib/sessions-store.js';
 import {
   AUTH_PROOF_SESSION_KIND,
   buildAuthProof,
@@ -135,6 +135,8 @@ export interface GuardSetupInProcessOptions {
    * `repoRoot`.
    */
   sessionsKey?: string;
+  /** Hosted lifecycle owns this run and its final result persistence. */
+  sessionRun?: SessionRunStore;
   /**
    * Open the run record up front rather than on the first session, so a hosted
    * run is watchable from the moment it starts — including one that fails
@@ -370,6 +372,7 @@ export async function guardSetupInProcess(
   const sessionsAvailable = options.llm !== 'agent' && options.recipeRunner === undefined;
   const sessionContextOptions = {
     repoRoot,
+    ...(options.sessionRun ? { run: options.sessionRun } : {}),
     stepSessionKinds: GUARD_SETUP_STEP_SESSION_KINDS,
     ...(options.sessionsKey ? { sessionsKey: options.sessionsKey } : {}),
     ...(options.tracker ? { tracker: options.tracker } : {}),
@@ -545,7 +548,7 @@ export async function guardSetupInProcess(
     throw e;
   } finally {
     // Close the sessions-store run, when any session actually ran under it.
-    sessionContext?.finish(options.signal?.aborted === true, closingFailure ?? undefined);
+    await sessionContext?.finish(options.signal?.aborted === true, closingFailure ?? undefined);
     if (llmLog) {
       setLlmCallSink(undefined);
       llmLog.finish(Date.now() - startedAt);

--- a/packages/core/src/commands/spec-in-process.ts
+++ b/packages/core/src/commands/spec-in-process.ts
@@ -53,7 +53,7 @@ import {
 import { CURATE_DOC_SESSION_KIND } from '../services/spec-scan/curate-doc.js';
 import { SETTLE_AREAS_SESSION_KIND } from '../services/spec-scan/settle-areas.js';
 import { OVERLAP_SESSION_KIND } from '../services/spec-scan/overlap.js';
-import { createSessionRun, type SessionRunStartedInfo } from '../lib/sessions-store.js';
+import { createStoredSessionRun, type SessionRunStartedInfo } from '../lib/sessions-store.js';
 import { resolveCommitSha } from '../lib/repo-ref.js';
 import {
   createConfiguredSessionDriver,
@@ -364,6 +364,8 @@ export interface SpecCurateInProcessResult {
 }
 
 export interface CurateInProcessOptions {
+  /** The dashboard finishes only after its server-side corpus persistence succeeds. */
+  deferRunCompletion?: boolean;
   tracker?: StepTracker;
   source?: TelemetrySource;
   /**
@@ -522,13 +524,15 @@ export async function curateInProcess(
   // The sessions run + transcript store: `sessions/spec-scan/<runId>/`.
   // Created after the estimate gate, so a declined scan leaves no run record.
   const gitRef = await resolveCommitSha(repoRoot);
-  const run = createSessionRun(options.sessionsKey ?? repoRoot, { command: 'spec-scan', gitRef });
+  const run = await createStoredSessionRun(options.sessionsKey ?? repoRoot, {
+    command: 'spec-scan', gitRef, activityStream: options.source === 'dashboard',
+  });
   options.onRunStarted?.({ command: 'spec-scan', runId: run.runId, dir: run.dir });
   // Mirror the step checklist into the run record as the run's own display:
   // the CLI renders the tracker locally, but the dashboard can only see what
   // run.json carries, and the early phases (discover/tag) have no sessions to
   // show progress through.
-  tracker?.tap((p) => {
+  const untap = tracker?.tap((p) => {
     if (!p.steps) return;
     run.setChecklist(
       p.steps.map((step) => {
@@ -651,7 +655,9 @@ export async function curateInProcess(
       // A cancelled scan is not a failed one: it stopped because the caller
       // said so, which is the same word the boot sweep gives a run whose
       // process died under it.
-      run.finish(e instanceof ScanAbortedError ? 'interrupted' : 'failed');
+      run.finish(e instanceof ScanAbortedError ? 'interrupted' : 'failed', {
+        ...(e instanceof ScanAbortedError ? {} : { error: { message: e instanceof Error ? e.message : String(e) } }),
+      });
       throw e;
     }
 
@@ -672,7 +678,7 @@ export async function curateInProcess(
           : 'anchors verified',
       );
     }
-    run.finish('completed');
+    if (!options.deferRunCompletion) run.finish('completed');
 
     // A partial (single-step) run never reports telemetry — its counts would
     // read as a whole scan's.
@@ -700,9 +706,9 @@ export async function curateInProcess(
   } catch (e) {
     // The run record is closed exactly once; the inner catch handled the scan
     // path, this covers the estimate/telemetry edges around it.
-    if (run.record().status === 'running') run.finish('failed');
+    if (run.record().status === 'running') run.finish('failed', { error: { message: e instanceof Error ? e.message : String(e) } });
     throw e;
-  }
+  } finally { untap?.(); await run.flush?.(); }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/lib/activity-journal.ts
+++ b/packages/core/src/lib/activity-journal.ts
@@ -1,0 +1,106 @@
+/** Durable replay and direct publication for dashboard activity streams.
+ * The worker and HTTP server run in the same process. The journal, rather
+ * than a viewer's connection or an in-memory queue, owns event history.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { ActivityEventSchema, type ActivityEvent, type ActivityEventBody } from '@truecourse/shared/activity-stream';
+import type { SessionProgress } from '@truecourse/agent-loop';
+
+const FILE = 'activity.jsonl';
+const listeners = new Map<string, Set<(event?: ActivityEvent) => void>>();
+const progress = new Map<string, Map<string, SessionProgress>>();
+
+export function publishActivityProgress(dir: string, sessionId: string, value: SessionProgress): void {
+  let sessions = progress.get(dir);
+  if (!sessions) { sessions = new Map(); progress.set(dir, sessions); }
+  sessions.set(sessionId, value);
+  for (const notify of listeners.get(dir) ?? []) notify();
+}
+
+export function readActivityProgress(dir: string): Record<string, SessionProgress> {
+  return Object.fromEntries(progress.get(dir) ?? []);
+}
+
+/** Only incomplete final records may be discarded, never a complete corrupt record. */
+function completeSize(file: string): number {
+  let fd: number;
+  try { fd = fs.openSync(file, 'r'); }
+  catch (error) { if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 0; throw error; }
+  try {
+    let end = fs.fstatSync(fd).size;
+    const buffer = Buffer.alloc(4096);
+    while (end > 0) {
+      const start = Math.max(0, end - buffer.length);
+      const length = fs.readSync(fd, buffer, 0, end - start, start);
+      const newline = buffer.subarray(0, length).lastIndexOf(10);
+      if (newline !== -1) return start + newline + 1;
+      end = start;
+    }
+    return 0;
+  } finally { fs.closeSync(fd); }
+}
+
+export function appendActivityEvent(dir: string, body: ActivityEventBody): ActivityEvent {
+  const file = path.join(dir, FILE);
+  const cursor = completeSize(file);
+  if (fs.existsSync(file) && fs.statSync(file).size !== cursor) fs.truncateSync(file, cursor);
+  const serialized = JSON.stringify({ ...body, cursor });
+  fs.appendFileSync(file, serialized + '\n');
+  // A run's session index is mutable. Live delivery must carry the same detached
+  // snapshot as replay, not a reference that a later index update can change.
+  const event = JSON.parse(serialized) as ActivityEvent;
+  publishCommittedActivity(dir, event);
+  return event;
+}
+
+/** Publish only after the selected durable store commits. */
+export function publishCommittedActivity(dir: string, event: ActivityEvent): void {
+  if (event.kind === 'run') {
+    if (event.run.status !== 'running') progress.delete(dir);
+    else for (const session of event.run.sessions) {
+      if (session.status !== 'running') progress.get(dir)?.delete(session.sessionId);
+    }
+  } else if (['assistant-turn', 'tool-result', 'outcome', 'failure'].includes(event.event.type)) {
+    progress.get(dir)?.delete(event.sessionId);
+  }
+  if (progress.get(dir)?.size === 0) progress.delete(dir);
+  for (const notify of listeners.get(dir) ?? []) notify(event);
+}
+
+/** Check a reconnect cursor without loading or decoding the journal. */
+export function validateActivityCursor(dir: string, after: number): void {
+  if (after < 0) return;
+  const file = path.join(dir, FILE);
+  const end = completeSize(file);
+  if (after >= end) throw new Error('Activity cursor is beyond the journal');
+  if (after === 0) return;
+  const fd = fs.openSync(file, 'r');
+  try {
+    const preceding = Buffer.alloc(1);
+    fs.readSync(fd, preceding, 0, 1, after - 1);
+    if (preceding[0] !== 10) throw new Error('Activity cursor is not a record boundary');
+  } finally { fs.closeSync(fd); }
+}
+
+export function readActivityEvents(dir: string, after = -1): ActivityEvent[] {
+  validateActivityCursor(dir, after);
+  const file = path.join(dir, FILE);
+  const end = completeSize(file);
+  if (end === 0) return [];
+  const start = Math.max(0, after);
+  const fd = fs.openSync(file, 'r');
+  try {
+    const buffer = Buffer.alloc(end - start);
+    fs.readSync(fd, buffer, 0, buffer.length, start);
+    return buffer.toString('utf8').trimEnd().split('\n').map(line => ActivityEventSchema.parse(JSON.parse(line)))
+      .filter(event => event.cursor > after);
+  } finally { fs.closeSync(fd); }
+}
+
+export function subscribeActivity(dir: string, notify: (event?: ActivityEvent) => void): () => void {
+  let set = listeners.get(dir);
+  if (!set) { set = new Set(); listeners.set(dir, set); }
+  set.add(notify);
+  return () => { set.delete(notify); if (set.size === 0) listeners.delete(dir); };
+}

--- a/packages/core/src/lib/sessions-store.ts
+++ b/packages/core/src/lib/sessions-store.ts
@@ -27,6 +27,7 @@ import {
 } from '@truecourse/agent-loop';
 import { getRepoTruecourseDir } from '../config/paths.js';
 import { atomicWriteJson } from './atomic-write.js';
+import { appendActivityEvent, publishActivityProgress, readActivityEvents, validateActivityCursor } from './activity-journal.js';
 
 /**
  * Where a repo's sessions live. The default is the repo tree
@@ -63,7 +64,7 @@ export function sessionsDir(repoDir: string): string {
 export interface SessionRunStartedInfo {
   command: SessionCommand;
   runId: string;
-  /** The run directory, `<repo>/.truecourse/sessions/<command>/<runId>`. */
+  /** Stable local run path for file history or provider scratch state. Postgres history is not stored here. */
   dir: string;
 }
 
@@ -86,9 +87,17 @@ export function sessionRunDir(repoDir: string, command: SessionCommand, runId: s
 /** A live handle on one run's records — the shell writes through it. */
 export interface SessionRunStore {
   readonly runId: string;
-  /** The run directory, `<repo>/.truecourse/sessions/<command>/<runId>`. */
+  /** Stable local run path for file history or provider scratch state. Postgres history is not stored here. */
   readonly dir: string;
   record(): RunRecord;
+  /** Drain ordered async writes before the owning job settles. */
+  flush?(): Promise<void>;
+  subscribeActivity?(notify: () => void): () => void;
+  readActivity?(after: number): Promise<import('@truecourse/shared/activity-stream').ActivityEvent[]>;
+  validateActivityCursor?(after: number): Promise<void>;
+  /** Dashboard reads load only this session; synchronous persistence reads belong to live writers. */
+  readTranscript?(sessionId: string, since: number): Promise<SessionEvent[]>;
+  setGitRef?(gitRef: string): void;
   /** What `runAgentLoop` persists through. */
   readonly persistence: SessionPersistence;
   /** Advertise the live session API (URL + token, never a bare port). */
@@ -123,7 +132,7 @@ export interface SessionRunStore {
 
 export function createSessionRun(
   repoDir: string,
-  opts: { command: SessionCommand; gitRef: string; now?: () => Date },
+  opts: { command: SessionCommand; gitRef: string; now?: () => Date; activityStream?: boolean },
 ): SessionRunStore {
   // Starting a run is the boot the sweep belongs to: before this
   // process writes a new record, every run left `running` by a process that
@@ -140,10 +149,12 @@ export function createSessionRun(
     status: 'running',
     pid: process.pid,
     sessions: [],
+    ...(opts.activityStream ? { activityStream: 'ai-sdk-v1' as const } : {}),
   };
   const dir = sessionRunDir(repoDir, opts.command, runId);
   fs.mkdirSync(dir, { recursive: true });
   atomicWriteJson(path.join(dir, 'run.json'), record);
+  if (record.activityStream) appendActivityEvent(dir, { kind: 'run', run: toPublicRunRecord(record) });
   return openRun(dir, record);
 }
 
@@ -162,15 +173,25 @@ export function openSessionRun(
 
 function openRun(dir: string, record: RunRecord): SessionRunStore {
   const runJsonPath = path.join(dir, 'run.json');
-  const write = (): void => atomicWriteJson(runJsonPath, record);
+  const write = (): void => {
+    atomicWriteJson(runJsonPath, record);
+    if (record.activityStream) appendActivityEvent(dir, { kind: 'run', run: toPublicRunRecord(record) });
+  };
 
   return {
     runId: record.runId,
     dir,
     record: () => record,
+    setGitRef(gitRef) { record.gitRef = gitRef; write(); },
     persistence: {
+      ...(record.activityStream ? {
+        publishProgress: (sessionId: string, progress: import('@truecourse/agent-loop').SessionProgress) => {
+          if (record.status === 'running') publishActivityProgress(dir, sessionId, progress);
+        },
+      } : {}),
       appendEvent(sessionId, event) {
         fs.appendFileSync(transcriptPath(dir, sessionId), JSON.stringify(event) + '\n');
+        if (record.activityStream) appendActivityEvent(dir, { kind: 'session-event', sessionId, event });
       },
       updateIndex(entry: SessionIndexEntry) {
         const i = record.sessions.findIndex((s) => s.sessionId === entry.sessionId);
@@ -216,6 +237,30 @@ function openRun(dir: string, record: RunRecord): SessionRunStore {
 function transcriptPath(dir: string, sessionId: string): string {
   // Session ids are minted by us (uuids), but keep filenames safe anyway.
   return path.join(dir, `${sessionId.replace(/[^A-Za-z0-9._-]/g, '_')}.jsonl`);
+}
+
+/** Repair a crash between a transcript/snapshot write and its journal append. */
+export function recoverSessionActivity(run: SessionRunStore): void {
+  if (!run.record().activityStream) return;
+  const journal = readActivityEvents(run.dir);
+  const seen = new Map<string, Set<number>>();
+  let lastRun: PublicRunRecord | undefined;
+  for (const entry of journal) {
+    if (entry.kind === 'run') lastRun = entry.run;
+    else {
+      const seqs = seen.get(entry.sessionId) ?? new Set<number>();
+      seqs.add(entry.event.seq); seen.set(entry.sessionId, seqs);
+    }
+  }
+  for (const name of fs.readdirSync(run.dir)) {
+    if (!name.endsWith('.jsonl') || name === 'activity.jsonl') continue;
+    const sessionId = name.slice(0, -6);
+    for (const event of run.persistence.readEvents(sessionId)) {
+      if (!seen.get(sessionId)?.has(event.seq)) appendActivityEvent(run.dir, { kind: 'session-event', sessionId, event });
+    }
+  }
+  const current = toPublicRunRecord(run.record());
+  if (JSON.stringify(lastRun) !== JSON.stringify(current)) appendActivityEvent(run.dir, { kind: 'run', run: current });
 }
 
 /**
@@ -321,7 +366,9 @@ function sweepRuns(
         session.status = 'parked';
       }
     }
-    atomicWriteJson(path.join(sessionRunDir(repoDir, run.command, run.runId), 'run.json'), run);
+    const dir = sessionRunDir(repoDir, run.command, run.runId);
+    atomicWriteJson(path.join(dir, 'run.json'), run);
+    if (run.activityStream) appendActivityEvent(dir, { kind: 'run', run: toPublicRunRecord(run) });
     interrupted.push(run);
   }
   return interrupted;
@@ -334,4 +381,51 @@ function defaultIsProcessAlive(pid: number): boolean {
   } catch {
     return false;
   }
+}
+
+/** Dashboard storage boundary. File-mode callers retain the synchronous store. */
+export interface SessionRunBackend {
+  subscribeRepo(repoKey: string, notify: () => void): () => void;
+  create(repoKey: string, opts: Parameters<typeof createSessionRun>[1]): Promise<SessionRunStore>;
+  open(repoKey: string, command: SessionCommand, runId: string): Promise<SessionRunStore>;
+  list(repoKey: string, command?: SessionCommand): Promise<RunRecord[]>;
+}
+export class SessionRunNotFoundError extends Error {
+  constructor() { super('Session run not found'); }
+}
+let backend: SessionRunBackend | undefined;
+export function setSessionRunBackend(value: SessionRunBackend | undefined): void { backend = value; }
+export async function createStoredSessionRun(repoKey: string, opts: Parameters<typeof createSessionRun>[1]): Promise<SessionRunStore> {
+  return backend && !path.isAbsolute(repoKey) ? backend.create(repoKey, opts) : createSessionRun(repoKey, opts);
+}
+export async function openStoredSessionRun(repoKey: string, command: SessionCommand, runId: string): Promise<SessionRunStore> {
+  if (backend && !path.isAbsolute(repoKey)) return backend.open(repoKey, command, runId);
+  try { return openSessionRun(repoKey, command, runId); }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') throw new SessionRunNotFoundError();
+    throw error;
+  }
+}
+export async function listStoredSessionRuns(repoKey: string, command?: SessionCommand): Promise<RunRecord[]> {
+  return backend && !path.isAbsolute(repoKey) ? backend.list(repoKey, command) : listSessionRuns(repoKey, command);
+}
+export async function readStoredActivity(run: SessionRunStore, after = -1) {
+  if (run.readActivity) return run.readActivity(after);
+  return readActivityEvents(run.dir, after);
+}
+
+export async function validateStoredActivityCursor(run: SessionRunStore, after: number): Promise<void> {
+  if (run.validateActivityCursor) return run.validateActivityCursor(after);
+  validateActivityCursor(run.dir, after);
+}
+
+export async function readStoredTranscript(run: SessionRunStore, sessionId: string, since = -1): Promise<SessionEvent[]> {
+  if (run.readTranscript) return run.readTranscript(sessionId, since);
+  const events = run.persistence.readEvents(sessionId);
+  return since >= 0 ? events.filter(event => event.seq > since) : events;
+}
+
+/** undefined means the caller should watch the file store. */
+export function subscribeStoredSessionRuns(repoKey: string, notify: () => void): (() => void) | undefined {
+  return backend && !path.isAbsolute(repoKey) ? backend.subscribeRepo(repoKey, notify) : undefined;
 }

--- a/packages/core/src/services/agent/session-pool.ts
+++ b/packages/core/src/services/agent/session-pool.ts
@@ -373,6 +373,8 @@ function tee(
   observeIndex: (entry: SessionIndexEntry) => void,
 ): SessionPersistence {
   return {
+    ...(persistence.flush ? { flush: persistence.flush.bind(persistence) } : {}),
+    ...(persistence.publishProgress ? { publishProgress: persistence.publishProgress.bind(persistence) } : {}),
     appendEvent(sessionId, event) {
       persistence.appendEvent(sessionId, event)
       observe(event)

--- a/packages/core/src/services/guard-setup/interfaces-step.ts
+++ b/packages/core/src/services/guard-setup/interfaces-step.ts
@@ -190,6 +190,8 @@ async function runReconcile(
     updateIndex: (entry: Parameters<
       Awaited<ReturnType<GuardSetupSessionContext['acquire']>>['persistence']['updateIndex']
     >[0]) => acquired!.persistence.updateIndex(entry),
+    flush: async () => { await acquired?.persistence.flush?.(); },
+    publishProgress: (sessionId: string, progress: import('@truecourse/agent-loop').SessionProgress) => acquired?.persistence.publishProgress?.(sessionId, progress),
     readEvents: (sessionId: string) => acquired?.persistence.readEvents(sessionId) ?? [],
   };
 

--- a/packages/core/src/services/guard-setup/reconcile-interfaces.ts
+++ b/packages/core/src/services/guard-setup/reconcile-interfaces.ts
@@ -440,6 +440,8 @@ function teePersistence(
   observe: (event: SessionEvent) => void,
 ): SessionPersistence {
   return {
+    ...(persistence.publishProgress ? { publishProgress: persistence.publishProgress.bind(persistence) } : {}),
+    ...(persistence.flush ? { flush: persistence.flush.bind(persistence) } : {}),
     appendEvent(sessionId, event) {
       persistence.appendEvent(sessionId, event)
       observe(event)

--- a/packages/core/src/services/guard-setup/session-context.ts
+++ b/packages/core/src/services/guard-setup/session-context.ts
@@ -69,7 +69,7 @@ export interface GuardSetupSessionContext {
    * did — and lands in the record so a surface that never saw the process
    * still reads why.
    */
-  finish(aborted: boolean, failure?: RunError): void;
+  finish(aborted: boolean, failure?: RunError): void | Promise<void>;
 }
 
 /** One session failure as a reason a setup report row can carry. */
@@ -98,6 +98,7 @@ interface SessionContextBase {
    * ephemeral clone deleted the moment the run settles.
    */
   sessionsKey?: string;
+  run?: SessionRunStore;
   /** A per-run `--llm-transport` flag; the saved selection answers otherwise.
    *  Ignored when a driver is injected — that caller already chose. */
   transport?: LlmTransportFlag;
@@ -150,7 +151,7 @@ export function createGuardSetupSessionContext(
 
   const build = async (): Promise<{ run: SessionRunStore; driver: SessionDriver }> => {
     const gitRef = await resolveCommitSha(opts.repoRoot);
-    const store = createSessionRun(opts.sessionsKey ?? opts.repoRoot, {
+    const store = opts.run ?? createSessionRun(opts.sessionsKey ?? opts.repoRoot, {
       command: 'guard-setup',
       gitRef,
     });
@@ -191,7 +192,10 @@ export function createGuardSetupSessionContext(
     if (!run) return;
     untap?.();
     untap = null;
-    if (aborted) run.finish('interrupted');
+    if (opts.run) {
+      if (failure) run.setError(failure);
+      else if (failed > 0 && completed === 0) run.setError({ message: 'All setup sessions failed' });
+    } else if (aborted) run.finish('interrupted');
     else if (failure) run.finish('failed', { error: failure });
     else run.finish(failed > 0 && completed === 0 ? 'failed' : 'completed');
     run = null;
@@ -224,7 +228,7 @@ export function createGuardSetupSessionContext(
       // before its own creation settled) — close it the moment it exists. A
       // build that failed leaves nothing to close.
       const pending = acquired;
-      if (pending) void pending.then(() => close(aborted, failure)).catch(() => {});
+      if (pending) return pending.then(() => close(aborted, failure));
     },
   };
 }

--- a/packages/core/src/services/interface.service.ts
+++ b/packages/core/src/services/interface.service.ts
@@ -80,6 +80,7 @@ import type {
   InterfacesFile,
 } from '@truecourse/shared';
 import { log } from '../lib/logger.js';
+import { nextAppRoots } from './next-app-roots.js';
 
 export interface MapInterfacesOptions {
   /** Map these analyses instead of re-analyzing the tree (callers that already have them). */
@@ -402,7 +403,10 @@ async function deriveInterfaces(
   // `source.web` means what it means everywhere else: which ladder read the area.
   try {
     const appRoot = servedWebAppRoot(repoPath);
-    webPlaces.push(...deriveWebPlacesFromTree(fileAnalyses, appRoot ? { appRoot } : {}));
+    webPlaces.push(...deriveWebPlacesFromTree(fileAnalyses, {
+      ...(appRoot ? { appRoot } : {}),
+      nextAppRoots: nextAppRoots(repoPath, fileAnalyses),
+    }));
     source.web = 'tree';
   } catch (error) {
     log.warn(`interface mapping: web derivation failed, web catalog is empty (${errorText(error)})`);

--- a/packages/core/src/services/next-app-roots.ts
+++ b/packages/core/src/services/next-app-roots.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { FileAnalysis } from '@truecourse/shared';
+
+/** Read app manifests once each, bounded to the repository being mapped. */
+export function nextAppRoots(repoRoot: string, analyses: readonly FileAnalysis[]): string[] {
+  const root = path.resolve(repoRoot);
+  const visited = new Set<string>();
+  const roots: string[] = [];
+  for (const analysis of analyses) {
+    let directory = path.dirname(path.resolve(root, analysis.filePath));
+    while (directory === root || directory.startsWith(`${root}${path.sep}`)) {
+      if (visited.has(directory)) break;
+      visited.add(directory);
+      try {
+        const manifest = JSON.parse(fs.readFileSync(path.join(directory, 'package.json'), 'utf8'));
+        if (typeof manifest?.dependencies?.next === 'string'
+          || typeof manifest?.devDependencies?.next === 'string') {
+          roots.push(directory);
+        }
+      } catch {
+        // An absent or invalid manifest provides no framework evidence.
+      }
+      if (directory === root) break;
+      directory = path.dirname(directory);
+    }
+  }
+  return roots.sort();
+}

--- a/packages/core/src/services/web-context.service.ts
+++ b/packages/core/src/services/web-context.service.ts
@@ -30,6 +30,7 @@ import {
 import type { FileAnalysis, InterfacesFile } from '@truecourse/shared';
 import { log } from '../lib/logger.js';
 import { analyzeWorkingTree } from './interface.service.js';
+import { nextAppRoots } from './next-app-roots.js';
 
 export interface DeriveWebAuthoringContextOptions {
   /** Reuse analyses instead of re-reading the tree (a caller that already has them). */
@@ -71,7 +72,9 @@ export async function deriveWebAuthoringContext(
   }
 
   try {
-    const { seeds } = formWebResources(deriveWebPlacesFromTree(fileAnalyses));
+    const { seeds } = formWebResources(deriveWebPlacesFromTree(fileAnalyses, {
+      nextAppRoots: nextAppRoots(repoRoot, fileAnalyses),
+    }));
     if (seeds.size === 0) return empty(fileAnalyses.length);
     const contexts = deriveWebPlaceContexts({
       repoRoot,

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -35,3 +35,5 @@ export {
   type PendingGuardBaselineInput,
   type PendingGuardBaselineView,
 } from './jobs-store.js';
+
+export { PgSessionRunStore } from './session-run-store.js';

--- a/packages/data-store/src/repo-purge.ts
+++ b/packages/data-store/src/repo-purge.ts
@@ -13,6 +13,7 @@
 
 import { eq, inArray, or, sql } from 'drizzle-orm';
 import {
+  activityRuns,
   analyses,
   analysisCurrent,
   analysisHistory,
@@ -40,6 +41,7 @@ const likeLiteral = (s: string): string => s.replace(/[\\%_]/g, (c) => `\\${c}`)
 
 export async function purgeRepoData(db: Db, repoKey: string): Promise<void> {
   await db.transaction(async (tx) => {
+    await tx.delete(activityRuns).where(eq(activityRuns.repoKey, repoKey));
     await tx.delete(analyses).where(eq(analyses.repoKey, repoKey));
     await tx.delete(analysisCurrent).where(eq(analysisCurrent.repoKey, repoKey));
     await tx.delete(analysisHistory).where(eq(analysisHistory.repoKey, repoKey));

--- a/packages/data-store/src/session-run-store.ts
+++ b/packages/data-store/src/session-run-store.ts
@@ -1,0 +1,306 @@
+import fs from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { and, asc, eq, gt, sql, getTableColumns } from 'drizzle-orm';
+import { activityRuns, activityEvents, type Db, type Pool, type PoolClient } from '@truecourse/db';
+import {
+  SessionRunNotFoundError, createSessionRun, listSessionRuns, openSessionRun, sessionRunDir,
+  toPublicRunRecord, type SessionRunBackend, type SessionRunStore,
+} from '@truecourse/core/lib/sessions-store';
+import { publishActivityProgress, publishCommittedActivity, readActivityEvents } from '@truecourse/core/lib/activity-journal';
+import { ActivityEventSchema, type ActivityEvent, type ActivityEventBody } from '@truecourse/shared/activity-stream';
+import type { SessionRunStore as Store } from '@truecourse/core/lib/sessions-store';
+
+type Record = ReturnType<Store['record']>;
+type Command = Record['command'];
+type Event = ReturnType<Store['persistence']['readEvents']>[number];
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+/** Ordered asynchronous writes behind the pipeline's synchronous progress callbacks.
+ * A job MUST await flush before settling. Publication happens after commit.
+ */
+export class PgSessionRunStore implements SessionRunBackend {
+  private readonly owner = randomUUID();
+  private readonly live = new Map<string, SessionRunStore>();
+  private readonly imports = new Map<string, Promise<void>>();
+  private readonly watchers = new Map<string, Set<() => void>>();
+  private listener: PoolClient | undefined;
+  private connecting = false;
+  private retry: ReturnType<typeof setTimeout> | undefined;
+  constructor(private readonly db: Db, private readonly notificationPool?: Pool) {}
+
+  private async listen(): Promise<void> {
+    if (!this.notificationPool || this.listener || this.connecting || !this.watchers.size) return;
+    this.connecting = true;
+    try {
+      const client = await this.notificationPool.connect();
+      this.listener = client;
+      const lost = () => {
+        if (this.listener !== client) return;
+        this.listener = undefined;
+        client.release(true);
+        for (const callbacks of this.watchers.values()) for (const notify of callbacks) notify();
+        this.scheduleListen();
+      };
+      client.on('error', lost);
+      client.on('end', lost);
+      client.on('notification', notification => {
+        if (notification.channel !== 'truecourse_activity' || !notification.payload) return;
+        try {
+          const { repoKey, runId, owner } = JSON.parse(notification.payload) as { repoKey: string; runId: string; owner?: string };
+          if (owner !== this.owner) this.announce(repoKey, runId);
+        } catch { /* Ignore foreign payloads on this channel. */ }
+      });
+      await client.query('LISTEN truecourse_activity');
+      if (!this.watchers.size && this.listener === client) { this.listener = undefined; client.release(true); return; }
+      // Cover the gap before LISTEN and any connection recovery.
+      for (const callbacks of this.watchers.values()) for (const notify of callbacks) notify();
+    } catch {
+      if (this.listener) { this.listener.release(true); this.listener = undefined; }
+      this.scheduleListen();
+    } finally { this.connecting = false; }
+  }
+
+  private scheduleListen(): void {
+    if (this.retry || !this.watchers.size) return;
+    this.retry = setTimeout(() => { this.retry = undefined; void this.listen(); }, 1000);
+    this.retry.unref();
+  }
+
+  private announce(repoKey: string, runId: string, includeRun = true): void {
+    for (const key of [`repo:${repoKey}`, ...(includeRun ? [`run:${runId}`] : [])]) for (const notify of this.watchers.get(key) ?? []) notify();
+  }
+
+  subscribeRepo(repoKey: string, notify: () => void): () => void { return this.subscribe(`repo:${repoKey}`, notify); }
+
+  private subscribe(runId: string, notify: () => void): () => void {
+    let callbacks = this.watchers.get(runId);
+    if (!callbacks) { callbacks = new Set(); this.watchers.set(runId, callbacks); }
+    callbacks.add(notify); void this.listen();
+    return () => {
+      callbacks.delete(notify);
+      if (!callbacks.size) this.watchers.delete(runId);
+      if (!this.watchers.size) {
+        if (this.retry) { clearTimeout(this.retry); this.retry = undefined; }
+        if (this.listener) { const client = this.listener; this.listener = undefined; client.release(true); }
+      }
+    };
+  }
+
+  private prepare(repoKey: string): Promise<void> {
+    let pending = this.imports.get(repoKey);
+    if (!pending) {
+      pending = this.importLegacy(repoKey).catch(error => { this.imports.delete(repoKey); throw error; });
+      this.imports.set(repoKey, pending);
+    }
+    return pending;
+  }
+
+  /** Import old journals without changing their reconnect cursors. Files remain
+   * as a backup; conflict-safe inserts make a restart/retry idempotent. */
+  private async importLegacy(repoKey: string): Promise<void> {
+    const importedIds = new Set((await this.db.select({ id: activityRuns.runId }).from(activityRuns).where(eq(activityRuns.repoKey, repoKey))).map(row => row.id));
+    for (const record of listSessionRuns(repoKey)) {
+      if (importedIds.has(record.runId)) continue;
+      const run = openSessionRun(repoKey, record.command, record.runId);
+      const events = readActivityEvents(run.dir);
+      let cursor = events.length ? events[events.length - 1]!.cursor + 1 : 0;
+      const seen = new Set(events.filter(e => e.kind === 'session-event').map(e => `${e.sessionId}:${e.event.seq}`));
+      for (const file of fs.readdirSync(run.dir)) {
+        if (!file.endsWith('.jsonl') || file === 'activity.jsonl') continue;
+        const sessionId = file.slice(0, -6);
+        for (const event of run.persistence.readEvents(sessionId)) {
+          if (!seen.has(`${sessionId}:${event.seq}`)) events.push({ cursor: cursor++, kind: 'session-event', sessionId, event });
+        }
+      }
+      const imported = { ...toPublicRunRecord(record), activityStream: 'ai-sdk-v1' as const };
+      events.push({ cursor: cursor++, kind: 'run', run: imported });
+      await this.db.transaction(async tx => {
+        const inserted = await tx.insert(activityRuns).values({
+          runId: record.runId, repoKey, command: record.command, record: imported, nextCursor: cursor,
+          leaseUntil: record.status === 'running' ? new Date().toISOString() : null,
+        }).onConflictDoNothing().returning({ id: activityRuns.runId });
+        if (!inserted.length) return;
+        // Bounded inserts avoid PostgreSQL's parameter limit on long histories.
+        for (let i = 0; i < events.length; i += 200) {
+          await tx.insert(activityEvents).values(events.slice(i, i + 200).map(({ cursor, ...body }) => ({ runId: record.runId, cursor, body })));
+        }
+      });
+    }
+  }
+
+  async create(repoKey: string, opts: Parameters<typeof createSessionRun>[1]): Promise<SessionRunStore> {
+    await this.prepare(repoKey);
+    await this.reconcile(repoKey);
+    const record: Record = {
+      command: opts.command, runId: randomUUID(), gitRef: opts.gitRef,
+      startedAt: (opts.now?.() ?? new Date()).toISOString(), status: 'running', sessions: [], activityStream: 'ai-sdk-v1',
+    };
+    await this.db.transaction(async tx => {
+      await tx.insert(activityRuns).values({
+        runId: record.runId, repoKey, command: record.command, record, nextCursor: 1,
+        owner: this.owner, leaseUntil: sql`CURRENT_TIMESTAMP + interval '60 seconds'`,
+      });
+      await tx.insert(activityEvents).values({ runId: record.runId, cursor: 0, body: { kind: 'run', run: record } });
+      await tx.execute(sql`SELECT pg_notify('truecourse_activity', ${JSON.stringify({ repoKey, runId: record.runId, owner: this.owner })})`);
+    });
+    const run = this.handle(repoKey, record);
+    this.live.set(record.runId, run);
+    this.announce(repoKey, record.runId, false);
+    publishCommittedActivity(run.dir, { cursor: 0, kind: 'run', run: clone(record) });
+    return run;
+  }
+
+  async open(repoKey: string, command: Command, runId: string): Promise<SessionRunStore> {
+    await this.prepare(repoKey);
+    await this.reconcile(repoKey);
+    const [row] = await this.db.select().from(activityRuns).where(and(eq(activityRuns.repoKey, repoKey), eq(activityRuns.command, command), eq(activityRuns.runId, runId)));
+    if (!row) throw new SessionRunNotFoundError();
+    const live = this.live.get(runId);
+    if (live && (row.record.status === 'running' || live.record().status === row.record.status)) { await live.flush?.(); return live; }
+    if (live) this.live.delete(runId);
+    return this.handle(repoKey, clone(row.record) as Record, false);
+  }
+
+  async list(repoKey: string, command?: Command): Promise<Record[]> {
+    await this.prepare(repoKey);
+    await this.reconcile(repoKey);
+    const rows = await this.db.select().from(activityRuns).where(and(eq(activityRuns.repoKey, repoKey), command ? eq(activityRuns.command, command) : undefined));
+    return rows.map(row => clone(row.record) as Record).sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+  }
+
+  /** A lease is machine-independent; a reused PID cannot keep a dead run alive. */
+  private async reconcile(repoKey: string): Promise<void> {
+    const recovered: ActivityEvent[] = [];
+    await this.db.transaction(async tx => {
+      const rows = await tx.select().from(activityRuns).where(and(
+        eq(activityRuns.repoKey, repoKey), sql`${activityRuns.record}->>'status' = 'running'`,
+        sql`${activityRuns.leaseUntil} < CURRENT_TIMESTAMP`,
+      )).for('update');
+      for (const row of rows) {
+        const record = clone(row.record) as Record;
+        record.status = 'interrupted'; record.finishedAt = new Date().toISOString();
+        delete record.endpoint; delete record.pid;
+        for (const session of record.sessions) if (session.status === 'running' || session.status === 'waiting') session.status = 'parked';
+        await tx.update(activityRuns).set({ record, owner: null, leaseUntil: null, nextCursor: row.nextCursor + 1 }).where(eq(activityRuns.runId, row.runId));
+        await tx.insert(activityEvents).values({ runId: row.runId, cursor: row.nextCursor, body: { kind: 'run', run: record } });
+        await tx.execute(sql`SELECT pg_notify('truecourse_activity', ${JSON.stringify({ repoKey, runId: row.runId, owner: this.owner })})`);
+        recovered.push({ cursor: row.nextCursor, kind: 'run', run: record });
+      }
+    });
+    for (const event of recovered) {
+      if (event.kind !== 'run') continue;
+      publishCommittedActivity(sessionRunDir(repoKey, event.run.command, event.run.runId), event);
+      this.announce(repoKey, event.run.runId, false);
+    }
+  }
+
+  private async validateCursor(runId: string, after: number): Promise<void> {
+    if (after >= 0) {
+      const [cursor] = await this.db.select({ cursor: activityEvents.cursor }).from(activityEvents).where(and(eq(activityEvents.runId, runId), eq(activityEvents.cursor, after)));
+      if (!cursor) throw new Error('Activity cursor is not a record boundary');
+    }
+  }
+
+  private async readEvents(runId: string, after: number): Promise<ActivityEvent[]> {
+    await this.validateCursor(runId, after);
+    const rows = await this.db.select().from(activityEvents).where(and(eq(activityEvents.runId, runId), gt(activityEvents.cursor, after))).orderBy(asc(activityEvents.cursor));
+    return rows.map(row => ActivityEventSchema.parse({ ...row.body, cursor: row.cursor }));
+  }
+
+  private async readTranscript(runId: string, sessionId: string, since: number): Promise<Event[]> {
+    const rows = await this.db.select().from(activityEvents).where(and(
+      eq(activityEvents.runId, runId),
+      sql`${activityEvents.body}->>'kind' = 'session-event'`,
+      sql`${activityEvents.body}->>'sessionId' = ${sessionId}`,
+      since >= 0 ? sql`(${activityEvents.body}->'event'->>'seq')::bigint > ${since}` : undefined,
+    )).orderBy(asc(activityEvents.cursor));
+    return rows.map(row => {
+      const entry = ActivityEventSchema.parse({ ...row.body, cursor: row.cursor });
+      if (entry.kind !== 'session-event') throw new Error('Expected a session transcript event');
+      return entry.event;
+    });
+  }
+
+  private handle(repoKey: string, record: Record, owned = true): SessionRunStore {
+    const dir = sessionRunDir(repoKey, record.command, record.runId);
+    const transcripts = new Map<string, Event[]>();
+    let pending = Promise.resolve();
+    let failure: unknown;
+    const flush = async () => { await pending; if (failure) throw failure; };
+    const enqueue = (body: ActivityEventBody, snapshot?: Record) => {
+      if (failure) throw failure;
+      const value = clone(body);
+      const state = snapshot ? clone(toPublicRunRecord(snapshot)) : undefined;
+      pending = pending.then(async () => {
+        if (failure) return;
+        const event = await this.db.transaction(async tx => {
+          const [row] = await tx.select({ ...getTableColumns(activityRuns), leaseActive: sql<boolean>`${activityRuns.leaseUntil} > CURRENT_TIMESTAMP` }).from(activityRuns).where(and(eq(activityRuns.runId, record.runId), eq(activityRuns.repoKey, repoKey))).for('update');
+          if (!row) throw new Error('Session run was removed');
+          if (owned && (row.owner !== this.owner || !row.leaseActive)) throw new Error('Activity writer lost its lease');
+          if (!owned && row.record.status === 'running') throw new Error('Activity writer does not own this run');
+          if (row.record.status !== 'running' && state?.status === 'running') throw new Error('Activity run is already terminal');
+          await tx.insert(activityEvents).values({ runId: record.runId, cursor: row.nextCursor, body: value });
+          await tx.update(activityRuns).set({
+            nextCursor: row.nextCursor + 1,
+            ...(state ? { record: state } : {}),
+            ...(state && state.status !== 'running' ? { owner: null, leaseUntil: null } : {}),
+          }).where(eq(activityRuns.runId, record.runId));
+          await tx.execute(sql`SELECT pg_notify('truecourse_activity', ${JSON.stringify({ repoKey, runId: record.runId, owner: this.owner })})`);
+          return { ...value, cursor: row.nextCursor } as ActivityEvent;
+        });
+        publishCommittedActivity(dir, event);
+        this.announce(repoKey, record.runId, false);
+        if (value.kind === 'run' && value.run.status !== 'running') { clearInterval(heartbeat); this.live.delete(record.runId); }
+      }).catch(error => { failure = error; clearInterval(heartbeat); this.live.delete(record.runId); });
+    };
+    const heartbeat = setInterval(() => {
+      if (!owned || failure) return;
+      void this.db.update(activityRuns).set({ leaseUntil: sql`CURRENT_TIMESTAMP + interval '60 seconds'` }).where(and(eq(activityRuns.runId, record.runId), eq(activityRuns.owner, this.owner), sql`${activityRuns.leaseUntil} > CURRENT_TIMESTAMP`)).returning({ id: activityRuns.runId }).then(rows => {
+        if (!rows.length && record.status === 'running') throw new Error('Activity writer lost its lease');
+      }).catch(error => { failure = error; clearInterval(heartbeat); });
+    }, 20_000);
+    heartbeat.unref();
+    if (!owned) clearInterval(heartbeat);
+    const write = () => enqueue({ kind: 'run', run: toPublicRunRecord(record) }, record);
+    return {
+      runId: record.runId, dir, record: () => record, flush,
+      subscribeActivity: notify => this.subscribe(`run:${record.runId}`, notify),
+      readActivity: async after => { await flush(); await this.reconcile(repoKey); return this.readEvents(record.runId, after); },
+      validateActivityCursor: async after => { await flush(); await this.validateCursor(record.runId, after); },
+      readTranscript: async (sessionId, since) => { await flush(); return this.readTranscript(record.runId, sessionId, since); },
+      setGitRef(gitRef) { record.gitRef = gitRef; write(); },
+      setEndpoint(endpoint) { record.endpoint = endpoint; write(); },
+      setLlm(llm) { record.llm = llm; write(); },
+      setChecklist(items) {
+        const blocks = record.display?.blocks ?? [];
+        const at = blocks.findIndex(block => block.kind === 'checklist');
+        const checklist = { kind: 'checklist' as const, items };
+        record.display = { blocks: at < 0 ? [checklist, ...blocks] : blocks.map((block, i) => i === at ? checklist : block) };
+        write();
+      },
+      setError(error) { record.error = error; write(); },
+      finish(status, options) {
+        record.status = status; record.finishedAt = new Date().toISOString(); delete record.endpoint;
+        if (options?.error) record.error = options.error;
+        write();
+      },
+      persistence: {
+        flush,
+        publishProgress(sessionId, progress) { if (record.status === 'running') publishActivityProgress(dir, sessionId, progress); },
+        appendEvent(sessionId, event) {
+          const events = transcripts.get(sessionId) ?? []; events.push(clone(event)); transcripts.set(sessionId, events);
+          enqueue({ kind: 'session-event', sessionId, event });
+        },
+        updateIndex(entry) {
+          const i = record.sessions.findIndex(s => s.sessionId === entry.sessionId);
+          if (i < 0) record.sessions.push(entry); else record.sessions[i] = entry;
+          write();
+        },
+        readEvents: sessionId => {
+          if (!owned) throw new Error('Reopened Postgres runs require readStoredTranscript for asynchronous transcript reads');
+          return clone(transcripts.get(sessionId) ?? []);
+        },
+      },
+    };
+  }
+}

--- a/packages/db/drizzle/0015_activity_history.sql
+++ b/packages/db/drizzle/0015_activity_history.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "activity_events" (
+	"run_id" text NOT NULL,
+	"cursor" bigint NOT NULL,
+	"body" jsonb NOT NULL,
+	CONSTRAINT "activity_events_run_id_cursor_pk" PRIMARY KEY("run_id","cursor")
+);
+--> statement-breakpoint
+CREATE TABLE "activity_runs" (
+	"run_id" text PRIMARY KEY NOT NULL,
+	"repo_key" text NOT NULL,
+	"command" text NOT NULL,
+	"record" jsonb NOT NULL,
+	"next_cursor" bigint DEFAULT 0 NOT NULL,
+	"owner" text,
+	"lease_until" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "activity_events" ADD CONSTRAINT "activity_events_run_id_activity_runs_run_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."activity_runs"("run_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "activity_runs_repo_idx" ON "activity_runs" USING btree ("repo_key");

--- a/packages/db/drizzle/meta/0015_snapshot.json
+++ b/packages/db/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,2373 @@
+{
+  "id": "f22b7a2f-9657-44ab-8319-040f106470b0",
+  "prevId": "3202fe48-355e-4f16-ae2b-d589291d100e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_events": {
+      "name": "activity_events",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_events_run_id_activity_runs_run_id_fk": {
+          "name": "activity_events_run_id_activity_runs_run_id_fk",
+          "tableFrom": "activity_events",
+          "tableTo": "activity_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_events_run_id_cursor_pk": {
+          "name": "activity_events_run_id_cursor_pk",
+          "columns": [
+            "run_id",
+            "cursor"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_runs": {
+      "name": "activity_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record": {
+          "name": "record",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_cursor": {
+          "name": "next_cursor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "activity_runs_repo_idx": {
+          "name": "activity_runs_repo_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_baselines": {
+      "name": "gh_baselines",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_inferred_actions": {
+      "name": "gh_inferred_actions",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gh_inferred_actions_repo_full_name_kind_identity_pk": {
+          "name": "gh_inferred_actions_repo_full_name_kind_identity_pk",
+          "columns": [
+            "repo_full_name",
+            "kind",
+            "identity"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_installations": {
+      "name": "gh_installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_prs": {
+      "name": "gh_prs",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gh_prs_repo_full_name_pr_number_pk": {
+          "name": "gh_prs_repo_full_name_pr_number_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_repos": {
+      "name": "gh_repos",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocking": {
+          "name": "blocking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "code_quality_blocking": {
+          "name": "code_quality_blocking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "code_quality_min_severity": {
+          "name": "code_quality_min_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'high'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_emails": {
+          "name": "notify_emails",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_runs": {
+      "name": "gh_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_count": {
+          "name": "added_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_count": {
+          "name": "resolved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_runs_repo_created_idx": {
+          "name": "gh_runs_repo_created_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_provider_config": {
+      "name": "llm_provider_config",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_model": {
+          "name": "fallback_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_enc": {
+          "name": "api_key_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_key_id": {
+          "name": "access_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content": {
+      "name": "content",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_scope_sha_pk": {
+          "name": "content_scope_sha_pk",
+          "columns": [
+            "scope",
+            "sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analyses": {
+      "name": "analyses",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "analyses_repo_analysis_idx": {
+          "name": "analyses_repo_analysis_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "analysis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "analyses_repo_key_filename_pk": {
+          "name": "analyses_repo_key_filename_pk",
+          "columns": [
+            "repo_key",
+            "filename"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_current": {
+      "name": "analysis_current",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "analysis_current_repo_key_kind_pk": {
+          "name": "analysis_current_repo_key_kind_pk",
+          "columns": [
+            "repo_key",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_history": {
+      "name": "analysis_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry": {
+          "name": "entry",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "analysis_history_repo_idx": {
+          "name": "analysis_history_repo_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decisions": {
+      "name": "decisions",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registry": {
+      "name": "registry",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_opened": {
+          "name": "last_opened",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_analyzed": {
+          "name": "last_analyzed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registry_path_unique": {
+          "name": "registry_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_config": {
+      "name": "repo_config",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_ui_state": {
+      "name": "repo_ui_state",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spec_sets": {
+      "name": "spec_sets",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha": {
+          "name": "content_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "spec_sets_repo_artifact_created_idx": {
+          "name": "spec_sets_repo_artifact_created_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "spec_sets_repo_key_commit_sha_artifact_pk": {
+          "name": "spec_sets_repo_key_commit_sha_artifact_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha",
+            "artifact"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spec_sources": {
+      "name": "spec_sources",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "registry": {
+          "name": "registry",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extraction_cache": {
+      "name": "extraction_cache",
+      "schema": "",
+      "columns": {
+        "cache_name": {
+          "name": "cache_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "extraction_cache_cache_name_cache_key_pk": {
+          "name": "extraction_cache_cache_name_cache_key_pk",
+          "columns": [
+            "cache_name",
+            "cache_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_documents": {
+      "name": "knowledge_documents",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_path": {
+          "name": "doc_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_hash": {
+          "name": "processed_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "knowledge_documents_org_idx": {
+          "name": "knowledge_documents_org_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "knowledge_documents_workspace_org_id_source_kind_external_id_pk": {
+          "name": "knowledge_documents_workspace_org_id_source_kind_external_id_pk",
+          "columns": [
+            "workspace_org_id",
+            "source_kind",
+            "external_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_spec_sets": {
+      "name": "workspace_spec_sets",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha": {
+          "name": "content_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workspace_spec_sets_workspace_org_id_artifact_pk": {
+          "name": "workspace_spec_sets_workspace_org_id_artifact_pk",
+          "columns": [
+            "workspace_org_id",
+            "artifact"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_enc": {
+          "name": "token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending": {
+          "name": "pending",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "integration_connections_org_idx": {
+          "name": "integration_connections_org_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "integration_connections_workspace_org_id_provider_pk": {
+          "name": "integration_connections_workspace_org_id_provider_pk",
+          "columns": [
+            "workspace_org_id",
+            "provider"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_backfill_markers": {
+      "name": "guard_backfill_markers",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress_current": {
+          "name": "progress_current",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_total": {
+          "name": "progress_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_message": {
+          "name": "progress_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "jobs_org_idx": {
+          "name": "jobs_org_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_active_key_uniq": {
+          "name": "jobs_active_key_uniq",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status in ('queued','running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notifications_org_created_idx": {
+          "name": "notifications_org_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_baselines": {
+      "name": "pending_baselines",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force": {
+          "name": "force",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiet": {
+          "name": "quiet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_guard_baselines": {
+      "name": "pending_guard_baselines",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_traces": {
+      "name": "llm_traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slice_id": {
+          "name": "slice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_sha": {
+          "name": "prompt_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_sha": {
+          "name": "output_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_sha": {
+          "name": "reasoning_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "llm_traces_org_created_idx": {
+          "name": "llm_traces_org_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_traces_trace_idx": {
+          "name": "llm_traces_trace_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_traces_org_stage_idx": {
+          "name": "llm_traces_org_stage_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_traces_org_prompt_idx": {
+          "name": "llm_traces_org_prompt_idx",
+          "columns": [
+            {
+              "expression": "workspace_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_settings": {
+      "name": "workspace_settings",
+      "schema": "",
+      "columns": {
+        "workspace_org_id": {
+          "name": "workspace_org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_analysis_llm": {
+          "name": "code_analysis_llm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_dependency_overlays": {
+      "name": "guard_dependency_overlays",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "overlays_enc": {
+          "name": "overlays_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_results": {
+      "name": "guard_results",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_baseline": {
+          "name": "is_baseline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guard_results_repo_key_commit_sha_pk": {
+          "name": "guard_results_repo_key_commit_sha_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_runs": {
+      "name": "guard_runs",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_baseline": {
+          "name": "is_baseline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guard_runs_repo_ran_idx": {
+          "name": "guard_runs_repo_ran_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guard_runs_baseline_idx": {
+          "name": "guard_runs_baseline_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_baseline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guard_runs_repo_run_idx": {
+          "name": "guard_runs_repo_run_idx",
+          "columns": [
+            {
+              "expression": "repo_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guard_runs_repo_key_commit_sha_pk": {
+          "name": "guard_runs_repo_key_commit_sha_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_scenario_sets": {
+      "name": "guard_scenario_sets",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guard_scenario_sets_repo_key_commit_sha_pk": {
+          "name": "guard_scenario_sets_repo_key_commit_sha_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_setup_sets": {
+      "name": "guard_setup_sets",
+      "schema": "",
+      "columns": {
+        "repo_key": {
+          "name": "repo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guard_setup_sets_repo_key_commit_sha_pk": {
+          "name": "guard_setup_sets_repo_key_commit_sha_pk",
+          "columns": [
+            "repo_key",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1788594720526,
       "tag": "0014_spec_sources",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1788868561780,
+      "tag": "0015_activity_history",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/activity.ts
+++ b/packages/db/src/schema/activity.ts
@@ -1,0 +1,19 @@
+import { pgTable, text, bigint, jsonb, timestamp, index, primaryKey } from 'drizzle-orm/pg-core';
+
+/** Dashboard activity is repository scoped, like the corpus and guard stores. */
+export const activityRuns = pgTable('activity_runs', {
+  runId: text('run_id').primaryKey(),
+  repoKey: text('repo_key').notNull(),
+  command: text('command').notNull(),
+  record: jsonb('record').$type<Record<string, unknown>>().notNull(),
+  nextCursor: bigint('next_cursor', { mode: 'number' }).notNull().default(0),
+  owner: text('owner'),
+  leaseUntil: timestamp('lease_until', { withTimezone: true, mode: 'string' }),
+}, t => [index('activity_runs_repo_idx').on(t.repoKey)]);
+
+/** Run updates and complete transcript events share a single ordered journal. */
+export const activityEvents = pgTable('activity_events', {
+  runId: text('run_id').notNull().references(() => activityRuns.runId, { onDelete: 'cascade' }),
+  cursor: bigint('cursor', { mode: 'number' }).notNull(),
+  body: jsonb('body').$type<Record<string, unknown>>().notNull(),
+}, t => [primaryKey({ columns: [t.runId, t.cursor] })]);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,3 +1,5 @@
+export * from './activity.js';
+import { activityRuns, activityEvents } from './activity.js';
 /**
  * The full ee Postgres schema, composed from per-feature files. One schema, one
  * migration history, one `migrate()` — see `../db.ts`.
@@ -46,6 +48,8 @@ import {
 } from './guard.js';
 
 export const schema = {
+  activityRuns,
+  activityEvents,
   ghInstallations,
   ghRepos,
   ghBaselines,

--- a/packages/interface-mapper/src/web-tree.ts
+++ b/packages/interface-mapper/src/web-tree.ts
@@ -62,6 +62,8 @@ export interface WebPlaceSeed {
 export type WebPlace = WebPlaceSeed
 
 export interface DeriveWebPlacesOptions {
+  /** App roots whose package manifest declares Next.js, supplied by the caller. */
+  nextAppRoots?: readonly string[]
   /**
    * Absolute directory of the app the recipe SERVES (`recipe.web.app`, resolved
    * against the repo). A monorepo holds several routable apps and only one is
@@ -76,6 +78,7 @@ export interface DeriveWebPlacesOptions {
 export interface WebTree {
   files: readonly string[]
   analyses: readonly FileAnalysis[]
+  nextAppRoots?: readonly string[]
 }
 
 /** The idiom registry, in precedence order. */
@@ -103,6 +106,7 @@ export function deriveWebPlacesFromTree(
   const tree: WebTree = {
     files: fileAnalyses.map((analysis) => analysis.filePath),
     analyses: fileAnalyses,
+    nextAppRoots: options.nextAppRoots,
   }
 
   const analyses = new Map(fileAnalyses.map((analysis) => [analysis.filePath, analysis]))

--- a/packages/interface-mapper/src/web/next-files.ts
+++ b/packages/interface-mapper/src/web/next-files.ts
@@ -25,13 +25,13 @@ import type { WebPlaceSeed, WebTree } from '../web-tree.js'
 //    it is excluded by construction rather than by a rule — and `pages/api/**`,
 //    which is not, is excluded explicitly below.
 //
-// THE GATE is `next.config.*`. Without it this reader is a menace: `pages/` is
+// THE GATE is `next.config.*` or a manifest declaring Next.js. `pages/` is
 // one of the most common directory names in a React codebase and `page.tsx` one
 // of the most common filenames. strapi's admin panel keeps 40-odd components
 // under `admin/src/pages/`, and an ungated reader turns every one of them into a
 // screen at an address the app has never served. So a router root is only a
-// router root when a Next.js config file sits at its app root — and the NEAREST
-// such config wins, which is what makes this correct in a monorepo where several
+// router root when a config or dependency identifies its app root. The NEAREST
+// root wins, which is what makes this correct in a monorepo where several
 // apps each have their own.
 // ---------------------------------------------------------------------------
 
@@ -73,10 +73,12 @@ function readNextRoutes(
 
 /**
  * The `<app-root>/{,src/}<router>` directories of every Next.js app in the tree.
- * Longest first, so the nearest config wins for a file several apps could claim.
+ * Longest first, so the nearest app wins for a file several apps could claim.
  */
 function nextRouterRoots(tree: WebTree, router: 'app' | 'pages'): string[] {
-  const roots: string[] = []
+  const roots: string[] = (tree.nextAppRoots ?? []).flatMap((appRoot) => [
+    `${appRoot}/${router}`, `${appRoot}/src/${router}`,
+  ])
   for (const filePath of tree.files) {
     const cut = filePath.lastIndexOf('/')
     if (cut < 0 || !NEXT_CONFIG.test(filePath.slice(cut + 1))) continue

--- a/packages/llm-claude-agent/src/sdk-types.ts
+++ b/packages/llm-claude-agent/src/sdk-types.ts
@@ -96,6 +96,26 @@ export interface SdkRateLimitEvent {
   [k: string]: unknown;
 }
 
+export interface SdkPartialAssistantMessage {
+  type: 'stream_event';
+  parent_tool_use_id: string | null;
+  event: {
+    type: string;
+    index?: number;
+    message?: { id?: string };
+    content_block?: { type: string; text?: string };
+    delta?: { type: string; text?: string };
+  };
+}
+
+export interface SdkToolProgressMessage {
+  type: 'tool_progress';
+  parent_tool_use_id: string | null;
+  tool_use_id: string;
+  tool_name: string;
+  elapsed_time_seconds: number;
+}
+
 export interface SdkResultSuccess {
   type: 'result';
   subtype: 'success';
@@ -131,6 +151,8 @@ export type SdkMessage =
   | SdkSystemMessage
   | SdkResultMessage
   | SdkRateLimitEvent
+  | SdkPartialAssistantMessage
+  | SdkToolProgressMessage
   | { type: string; [k: string]: unknown };
 
 // ---------------------------------------------------------------------------

--- a/packages/llm-claude-agent/src/session-driver.ts
+++ b/packages/llm-claude-agent/src/session-driver.ts
@@ -38,6 +38,8 @@ import { loadSdk } from './sdk-import.js';
 import type {
   SdkAssistantMessage,
   SdkMcpToolResult,
+  SdkPartialAssistantMessage,
+  SdkToolProgressMessage,
   SdkMessage,
   SdkModule,
   SdkQuery,
@@ -196,6 +198,8 @@ async function runClaudeAgentSession(
     raws: SdkAssistantMessage[];
   }
   let pendingTurn: PendingTurn | undefined;
+  let progressTurnId: string | undefined;
+  const progressBlocks = new Map<number, string>();
   const flushTurn = (): void => {
     if (!pendingTurn) return;
     const text = pendingTurn.texts.join('\n');
@@ -247,6 +251,7 @@ async function runClaudeAgentSession(
   });
 
   const options: SdkQueryOptions = {
+    ...(input.onProgress ? { includePartialMessages: true } : {}),
     // -- isolation invariants, hardcoded ------------------------------
     tools: [], // no built-in tools
     disallowedTools: ['ToolSearch'], // deferred tool loading steals the first turn (spike)
@@ -320,8 +325,35 @@ async function runClaudeAgentSession(
   // wrapped, and a result we already hold wins over the trailing throw.
   try {
     for await (const message of query as AsyncIterable<SdkMessage>) {
-      if (message.type !== 'assistant') flushTurn();
+      // Partial blocks and tool heartbeats are not turn boundaries. In particular,
+      // partials may arrive BETWEEN same-message-id complete assistant blocks.
+      if (message.type !== 'assistant' && message.type !== 'stream_event' && message.type !== 'tool_progress') flushTurn();
       switch (message.type) {
+        case 'stream_event': {
+          const partial = message as SdkPartialAssistantMessage;
+          if (partial.parent_tool_use_id !== null || !input.onProgress) break;
+          const event = partial.event;
+          if (event.type === 'message_start') {
+            if (pendingTurn && pendingTurn.id !== event.message?.id) flushTurn();
+            progressTurnId = event.message?.id;
+            progressBlocks.clear();
+          } else if (progressTurnId && typeof event.index === 'number') {
+            if (event.type === 'content_block_start' && event.content_block?.type === 'text') {
+              progressBlocks.set(event.index, event.content_block.text ?? '');
+            } else if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+              progressBlocks.set(event.index, (progressBlocks.get(event.index) ?? '') + (event.delta.text ?? ''));
+            } else break;
+            input.onProgress({ kind: 'text', turnId: progressTurnId, text: [...progressBlocks].sort(([a], [b]) => a - b).map(([, text]) => text).join('\n') });
+          }
+          break;
+        }
+        case 'tool_progress': {
+          const progress = message as SdkToolProgressMessage;
+          if (progress.parent_tool_use_id === null && Number.isFinite(progress.elapsed_time_seconds)) {
+            input.onProgress?.({ kind: 'tool', toolCallId: progress.tool_use_id, toolName: bareToolName(progress.tool_name), elapsedSeconds: Math.max(0, progress.elapsed_time_seconds) });
+          }
+          break;
+        }
         case 'system': {
           const system = message as SdkSystemMessage;
           // The harness owns this retry; we own the RECORD of it (item 11).
@@ -634,8 +666,6 @@ function mapResultError(result: SdkResultMessage): SessionFailure {
  * did anything.
  */
 const IGNORED_MESSAGE_TYPES = new Set([
-  'stream_event',
-  'tool_progress',
   'thinking_tokens',
   'status',
   'auth_status',

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -21,6 +21,10 @@
     "./openapi-node": {
       "types": "./dist/openapi/node-ref-context.d.ts",
       "import": "./dist/openapi/node-ref-context.js"
+    },
+    "./activity-stream": {
+      "types": "./dist/activity-stream.d.ts",
+      "import": "./dist/activity-stream.js"
     }
   },
   "scripts": {
@@ -32,7 +36,9 @@
     "ignore": "^7.0.5",
     "js-yaml": "^4.1.0",
     "zod": "^3.23.8",
-    "zod-to-json-schema": "^3.25.1"
+    "zod-to-json-schema": "^3.25.1",
+    "ai": "^6.0.0",
+    "@truecourse/agent-loop": "workspace:*"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/packages/shared/src/activity-stream.ts
+++ b/packages/shared/src/activity-stream.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { RunRecordSchema, SessionEventSchema, SessionProgressSchema } from '@truecourse/agent-loop';
+import type { UIMessage } from 'ai';
+
+/** A public snapshot never carries the live session API's credential. */
+export const ActivityRunSchema = RunRecordSchema.transform(({ endpoint: _endpoint, pid: _pid, ...run }) => run);
+export type ActivityRun = z.infer<typeof ActivityRunSchema>;
+
+/** Opaque monotonic cursor scoped to a run: a database sequence or legacy byte offset. */
+export const ActivityEventSchema = z.discriminatedUnion('kind', [
+  z.object({ cursor: z.number().int().nonnegative(), kind: z.literal('run'), run: ActivityRunSchema }),
+  z.object({
+    cursor: z.number().int().nonnegative(), kind: z.literal('session-event'),
+    sessionId: z.string(), event: SessionEventSchema,
+  }),
+]);
+export type ActivityEvent = z.infer<typeof ActivityEventSchema>;
+export type ActivityEventBody = ActivityEvent extends infer E
+  ? E extends ActivityEvent ? Omit<E, 'cursor'> : never : never;
+
+export type ActivityMessage = UIMessage<never, {
+  activity: ActivityEvent;
+  progress: ActivityProgress;
+  heartbeat: { at: string };
+}>;
+
+export const ActivityProgressSchema = z.record(SessionProgressSchema);
+export type ActivityProgress = z.infer<typeof ActivityProgressSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      ai:
+        specifier: ^6.0.0
+        version: 6.0.196(zod@3.25.76)
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
@@ -206,6 +209,9 @@ importers:
       '@xyflow/react':
         specifier: ^12.4.0
         version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      ai:
+        specifier: ^6.0.0
+        version: 6.0.196(zod@3.25.76)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -330,6 +336,9 @@ importers:
       '@workos-inc/node':
         specifier: ^7.0.0
         version: 7.82.0(express@4.22.1)
+      ai:
+        specifier: ^6.0.0
+        version: 6.0.196(zod@3.25.76)
       chokidar:
         specifier: ^4.0.0
         version: 4.0.3
@@ -1117,6 +1126,12 @@ importers:
 
   packages/shared:
     dependencies:
+      '@truecourse/agent-loop':
+        specifier: workspace:*
+        version: link:../agent-loop
+      ai:
+        specifier: ^6.0.0
+        version: 6.0.196(zod@3.25.76)
       ignore:
         specifier: ^7.0.5
         version: 7.0.5

--- a/tests/architecture/ee-import-boundary.test.ts
+++ b/tests/architecture/ee-import-boundary.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -58,17 +59,69 @@ const STATIC_EE_IMPORT =
 
 // Vendor SDKs whose blast radius the boundary keeps contained.
 //
-// The AI SDK (`ai` / `@ai-sdk/*`) has exactly ONE sanctioned home in OSS:
-// `packages/llm-api`, the direct-API LLM transport both editions install. No
-// other OSS source may import it — everything else reaches the model through
-// the `LlmTransport` seam in `@truecourse/shared/llm`.
+// Model and provider APIs belong in `packages/llm-api`. Dashboard activity
+// streaming also uses the SDK's UI transport, with only the named imports
+// below allowed. Model access still goes through `@truecourse/shared/llm`.
 //
 // The cloud blob SDKs (`@aws-sdk/*` / `@azure/*`, used by `ee/packages/storage`)
 // stay enterprise-only: OSS uses the filesystem.
 const AI_SDK_HOME = 'packages/llm-api';
 
-const STATIC_AISDK_IMPORT =
-  /(?:^|\n)\s*import\b[^\n]*\bfrom\s*['"](?:ai|@ai-sdk\/[^'"]+)['"]|(?:^|\n)\s*import\s*['"](?:ai|@ai-sdk\/[^'"]+)['"]|require\(\s*['"](?:ai|@ai-sdk\/[^'"]+)['"]/;
+const ACTIVITY_SDK_IMPORTS: Record<string, { values: string[]; types: string[] }> = {
+  'apps/dashboard/client/src/lib/activity-stream.ts': {
+    values: ['DefaultChatTransport'], types: ['UIMessageChunk'],
+  },
+  'apps/dashboard/server/src/routes/sessions.ts': {
+    values: ['createUIMessageStreamResponse'], types: [],
+  },
+  'apps/dashboard/server/src/services/activity-stream.service.ts': {
+    values: [], types: ['UIMessageChunk'],
+  },
+  'packages/shared/src/activity-stream.ts': {
+    values: [], types: ['UIMessage'],
+  },
+};
+
+function aiSdkImportViolations(file: string, src: string): string[] {
+  // Most source files never reference the SDK. Parse only candidates, while
+  // handling multiline imports and aliases without relying on their layout.
+  if (!/['"](?:ai|@ai-sdk\/[^'"]+)['"]/.test(src)) return [];
+  const source = ts.createSourceFile(file, src, ts.ScriptTarget.Latest, true);
+  const allowed = ACTIVITY_SDK_IMPORTS[file];
+  const violations: string[] = [];
+  const isSdk = (node: ts.Node | undefined): node is ts.StringLiteral =>
+    !!node && ts.isStringLiteral(node) && (node.text === 'ai' || node.text.startsWith('@ai-sdk/'));
+  const visit = (node: ts.Node) => {
+    if (ts.isImportDeclaration(node) && isSdk(node.moduleSpecifier)) {
+      const clause = node.importClause;
+      const bindings = clause?.namedBindings;
+      const permitted = node.moduleSpecifier.text === 'ai' && allowed && clause && !clause.name
+        && bindings && ts.isNamedImports(bindings) && bindings.elements.length > 0
+        && bindings.elements.every(element => {
+          const name = (element.propertyName ?? element.name).text;
+          return allowed.values.includes(name)
+            || ((clause.isTypeOnly || element.isTypeOnly) && allowed.types.includes(name));
+        });
+      if (!permitted) violations.push(node.getText(source));
+    } else if (
+      (ts.isExportDeclaration(node) && isSdk(node.moduleSpecifier))
+      || (ts.isExternalModuleReference(node) && isSdk(node.expression))
+      || (ts.isCallExpression(node) && ts.isIdentifier(node.expression)
+        && node.expression.text === 'require' && isSdk(node.arguments[0]))
+    ) {
+      violations.push(node.getText(source));
+    } else if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)
+      && isSdk(node.argument.literal)) {
+      if (node.argument.literal.text !== 'ai' || node.isTypeOf || !node.qualifier
+        || !ts.isIdentifier(node.qualifier) || !allowed?.types.includes(node.qualifier.text)) {
+        violations.push(node.getText(source));
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return violations;
+}
 
 const STATIC_CLOUD_SDK_IMPORT =
   /(?:^|\n)\s*import\b[^\n]*\bfrom\s*['"](?:@aws-sdk\/[^'"]+|@azure\/[^'"]+)['"]|(?:^|\n)\s*import\s*['"](?:@aws-sdk\/[^'"]+|@azure\/[^'"]+)['"]|require\(\s*['"](?:@aws-sdk\/[^'"]+|@azure\/[^'"]+)['"]/;
@@ -102,7 +155,7 @@ describe('open-core import boundary', () => {
     ).toEqual([]);
   });
 
-  it('only packages/llm-api statically imports the AI SDK (ai / @ai-sdk/*)', () => {
+  it('keeps AI SDK model access in llm-api and permits only activity UI transport imports elsewhere', () => {
     const files: string[] = [];
     for (const root of OSS_ROOTS) walk(path.join(repoRoot, root), files);
 
@@ -111,12 +164,14 @@ describe('open-core import boundary', () => {
       const rel = path.relative(repoRoot, file);
       if (rel.startsWith(`${AI_SDK_HOME}${path.sep}`)) continue;
       const src = fs.readFileSync(file, 'utf8');
-      if (STATIC_AISDK_IMPORT.test(src)) offenders.push(rel);
+      for (const violation of aiSdkImportViolations(rel.split(path.sep).join('/'), src)) {
+        offenders.push(`${rel}: ${violation}`);
+      }
     }
 
     expect(
       offenders,
-      `OSS files importing the AI SDK outside ${AI_SDK_HOME} (reach the model through @truecourse/shared/llm instead):\n${offenders.join('\n')}`,
+      `Disallowed AI SDK imports outside ${AI_SDK_HOME} (only activity UI transport imports are allowed; reach models through @truecourse/shared/llm):\n${offenders.join('\n')}`,
     ).toEqual([]);
   });
 
@@ -124,9 +179,43 @@ describe('open-core import boundary', () => {
     const files: string[] = [];
     walk(path.join(repoRoot, AI_SDK_HOME), files);
     const importers = files.filter((f) =>
-      STATIC_AISDK_IMPORT.test(fs.readFileSync(f, 'utf8')),
+      aiSdkImportViolations(path.relative(repoRoot, f), fs.readFileSync(f, 'utf8')).length > 0,
     );
     expect(importers.length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    "import { DefaultChatTransport as Transport } from 'ai';",
+    "import {\n DefaultChatTransport, type UIMessageChunk,\n} from 'ai';",
+    "import type { UIMessageChunk } from 'ai';",
+    "type Chunk = import('ai').UIMessageChunk;",
+  ])('permits activity transport imports: %s', src => {
+    expect(aiSdkImportViolations('apps/dashboard/client/src/lib/activity-stream.ts', src)).toEqual([]);
+  });
+
+  it.each([
+    "import { streamText } from 'ai';",
+    "import {\n DefaultChatTransport,\n generateText as generate,\n} from 'ai';",
+    "import type { LanguageModel } from 'ai';",
+    "import { UIMessageChunk } from 'ai';",
+    "import * as sdk from 'ai';",
+    "import sdk from 'ai';",
+    "import 'ai';",
+    "import { openai } from '@ai-sdk/openai';",
+    "export { streamText } from 'ai';",
+    "export * from '@ai-sdk/openai';",
+    "const sdk = require('ai');",
+    "import sdk = require('ai');",
+    "type Model = import('ai').LanguageModel;",
+    "type SDK = typeof import('ai');",
+  ])('rejects model APIs and unrestricted SDK access inside activity files: %s', src => {
+    expect(aiSdkImportViolations('apps/dashboard/client/src/lib/activity-stream.ts', src).length).toBeGreaterThan(0);
+  });
+
+  it('keeps UI transport imports scoped to their activity adapters', () => {
+    const src = "import { DefaultChatTransport } from 'ai';";
+    expect(aiSdkImportViolations('packages/core/src/commands/spec-in-process.ts', src)).toHaveLength(1);
+    expect(aiSdkImportViolations('packages/shared/src/activity-stream.ts', src)).toHaveLength(1);
   });
 
   it('only packages/llm-claude-agent references the Claude Agent SDK', () => {

--- a/tests/core/corpus-in-process.test.ts
+++ b/tests/core/corpus-in-process.test.ts
@@ -13,6 +13,7 @@ import { StepTracker, estimateStepPhase, type AnalysisStep } from '../../package
 import { readCorpus } from '../../packages/spec-consolidator/src/index.js';
 import type { DecisionsFile } from '../../packages/spec-consolidator/src/index.js';
 import { docPathOf, outcome, stubDriver, toolResult } from './spec-scan-session-stub';
+import { readActivityEvents } from '../../packages/core/src/lib/activity-journal';
 
 let repo: string;
 beforeEach(() => {
@@ -85,6 +86,15 @@ const scanOptions = (driver = scanDriver()) => ({
   skipGit: true,
 });
 describe('curateInProcess', () => {
+  it('opts dashboard scans into direct replay and lets the hosted caller finish after saving', async () => {
+    const result = await curateInProcess(repo, { ...scanOptions(), source: 'dashboard', deferRunCompletion: true });
+    const journal = readActivityEvents(result.sessionsRunDir);
+    expect(journal[0]).toMatchObject({ kind: 'run', run: { activityStream: 'ai-sdk-v1' } });
+    expect(journal.some(e => e.kind === 'session-event' && e.event.type === 'outcome')).toBe(true);
+    const run = JSON.parse(fs.readFileSync(path.join(result.sessionsRunDir, 'run.json'), 'utf8'));
+    expect(run.status).toBe('running');
+    expect(run.finishedAt).toBeUndefined();
+  });
   it('curates the repo docs into corpus.json', async () => {
     const { curate } = await curateInProcess(repo, scanOptions());
     expect(curate.stats.docsKept).toBe(2);

--- a/tests/core/web-context.test.ts
+++ b/tests/core/web-context.test.ts
@@ -14,6 +14,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { deriveWebAuthoringContext } from '../../packages/core/src/services/web-context.service';
+import { mapInterfaces } from '../../packages/core/src/services/interface.service';
+import { planWorkItems } from '../../packages/core/src/services/interface-author/author';
 import type { InterfacesFile } from '../../packages/shared/src/index';
 
 let repo: string;
@@ -80,6 +82,35 @@ afterEach(() => {
 });
 
 describe('deriveWebAuthoringContext', () => {
+  it('maps and prepares authoring for a Next.js app with no config file', async () => {
+    writeApp();
+    fs.unlinkSync(path.join(repo, 'next.config.js'));
+    write('package.json', JSON.stringify({ dependencies: { next: '16.0.0' } }));
+
+    const { catalog } = await mapInterfaces(repo, { probeExec: null });
+    expect(catalog.resources?.web?.map((place) => place.address)).toEqual(['/tasks']);
+    expect(planWorkItems(catalog, null).map((item) => item.place.id)).toEqual(['tasks']);
+    const { contexts } = await deriveWebAuthoringContext(repo, { catalog });
+    expect(contexts.get('tasks')?.module).toBe('app/tasks/page.tsx');
+    expect(contexts.get('tasks')?.renders).toEqual(['components/task-list.tsx']);
+  });
+
+  it('recognizes only Next.js packages in a mixed monorepo without config files', async () => {
+    write('package.json', JSON.stringify({ private: true }));
+    write('apps/web/package.json', JSON.stringify({ devDependencies: { next: '16.0.0' } }));
+    write('apps/web/src/pages/index.tsx', 'export default function Home() { return <h1>Home</h1> }');
+    write('apps/web/src/pages/api/tasks.ts', 'export default function handler() {}');
+    write('apps/admin/package.json', JSON.stringify({ dependencies: { react: '19.0.0' } }));
+    write('apps/admin/src/pages/Settings.tsx', 'export default function Settings() { return <h1>Settings</h1> }');
+    write('apps/broken/package.json', '{');
+    write('apps/broken/app/page.tsx', 'export default function Home() { return <h1>Home</h1> }');
+
+    const { catalog } = await mapInterfaces(repo, { probeExec: null });
+    expect(catalog.resources?.web?.map((place) => place.address)).toEqual(['/']);
+    const { contexts } = await deriveWebAuthoringContext(repo, { catalog });
+    expect([...contexts.values()].map((context) => context.module)).toEqual(['apps/web/src/pages/index.tsx']);
+  });
+
   it('grounds each derived place in the module that renders it and the api it calls', async () => {
     writeApp();
     const { contexts, files } = await deriveWebAuthoringContext(repo, { catalog: CATALOG });

--- a/tests/dashboard-client/sessions-activity.test.tsx
+++ b/tests/dashboard-client/sessions-activity.test.tsx
@@ -18,6 +18,7 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import type { ChecklistItem, SessionEvent } from '@truecourse/agent-loop';
+import { createUIMessageStreamResponse, type UIMessageChunk } from 'ai';
 
 vi.mock('@/lib/socket', () => {
   const socket = {
@@ -205,6 +206,32 @@ function renderAt(search: string) {
 
 beforeEach(() => {
   serve([]);
+});
+
+it('shows partial progress in the existing thread, then replaces it with one completed turn', async () => {
+  const run = scan({ activityStream: 'ai-sdk-v1', sessions: [session({ status: 'running' })] });
+  serve([run]);
+  const snapshotFetch = window.fetch;
+  let sink!: ReadableStreamDefaultController<UIMessageChunk>;
+  const stream = new ReadableStream<UIMessageChunk>({ start(controller) { sink = controller; } });
+  window.fetch = vi.fn(async (input, init) => {
+    if (String(input).includes('/stream?')) return createUIMessageStreamResponse({ stream });
+    return snapshotFetch(input, init);
+  });
+  const view = renderAt(`?run=${run.runId}&ses=ses-1`);
+  await waitFor(() => expect(window.fetch).toHaveBeenCalledWith(expect.stringContaining('/stream?after=-1'), expect.objectContaining({ method: 'GET' })));
+  sink.enqueue({ type: 'start', messageId: run.runId });
+  sink.enqueue({ type: 'data-progress', transient: true, data: { 'ses-1': { kind: 'text', turnId: 'm1', text: 'Reading the specification live' } } });
+  await screen.findByText('Reading the specification live');
+  sink.enqueue({ type: 'data-activity', id: 'event-1', data: { kind: 'session-event', cursor: 100, sessionId: 'ses-1', event: {
+    type: 'assistant-turn', seq: 1, ts: at(1), text: 'Finished reading the specification.',
+    usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheCreateTokens: 0, costUsd: 0, costSource: 'unpriced' },
+  } } });
+  await screen.findByText('Finished reading the specification.');
+  expect(screen.queryByText('Reading the specification live')).not.toBeInTheDocument();
+  expect(screen.getAllByText('Finished reading the specification.')).toHaveLength(1);
+  sink.enqueue({ type: 'finish', finishReason: 'stop' }); sink.close();
+  view.unmount();
 });
 
 afterEach(() => {

--- a/tests/dashboard-server/onboarding-jobs.test.ts
+++ b/tests/dashboard-server/onboarding-jobs.test.ts
@@ -33,7 +33,7 @@ import { drizzle } from 'drizzle-orm/pglite';
 import { migrate } from 'drizzle-orm/pglite/migrator';
 import type { Runner } from 'graphile-worker';
 import { schema, MIGRATIONS_DIR, type Db } from '@truecourse/db';
-import { JobStore, NotificationStore, PgGuardStore, PgGuardOverlayStore, PgSpecStore } from '@truecourse/data-store';
+import { JobStore, NotificationStore, PgSessionRunStore, PgGuardStore, PgGuardOverlayStore, PgSpecStore } from '@truecourse/data-store';
 import { registerJob, type JobTask, type StartWorker } from '@truecourse/jobs';
 import type { JobView } from '@truecourse/shared';
 // The dist entries the server itself imports — a source-path import here would
@@ -54,6 +54,9 @@ import { setGuardOverlayStore, writeGuardOverlays } from '@truecourse/core/lib/g
 import { setSpecStore, saveSpec } from '@truecourse/core/lib/spec-store';
 import {
   listSessionRuns,
+  listStoredSessionRuns,
+  openStoredSessionRun,
+  setSessionRunBackend,
   setSessionsRootResolver,
   resetSessionsRootResolver,
 } from '@truecourse/core/lib/sessions-store';
@@ -178,6 +181,7 @@ afterEach(async () => {
   setRepoJobsCanceller(null);
   setWorkTreeProvider(null);
   await jobs.stop();
+  setSessionRunBackend(undefined);
   await client.close();
   fs.rmSync(path.join(process.env.TRUECOURSE_HOME as string, 'sessions'), {
     recursive: true,
@@ -421,7 +425,8 @@ describe('the guard setup job', () => {
     await jobs.start();
   });
 
-  it('saves the bundle under the clone’s commit and records a watchable run', async () => {
+  it.each(['file', 'postgres'])('saves the bundle and records a watchable run with %s history', async storage => {
+    if (storage === 'postgres') setSessionRunBackend(new PgSessionRunStore(db));
     const outcome = await jobs.enqueueGuardSetup(request);
     expect(outcome.status).toBe('queued');
     await Promise.all(running);
@@ -443,9 +448,10 @@ describe('the guard setup job', () => {
 
     // The run record lives under the repo IDENTITY (never the throwaway clone),
     // carries the provider it ran on, and mirrors the step checklist.
-    const [run] = listSessionRuns(REPO, 'guard-setup');
-    expect(run).toMatchObject({ status: 'completed', llm: { mode: 'api', provider: 'test' } });
+    const [run] = await listStoredSessionRuns(REPO, 'guard-setup');
+    expect(run).toMatchObject({ activityStream: 'ai-sdk-v1', status: 'completed', llm: { mode: 'api', provider: 'test' } });
     expect(checklistKeys(run)).toEqual([
+      'clone',
       'recipe',
       'detect',
       'catalog',
@@ -741,7 +747,8 @@ describe('the guard generate job', () => {
     expect(disposed).toEqual([clone]);
   });
 
-  it('materializes the stored state, then saves the set, the baseline report and the evidence', async () => {
+  it.each(['file', 'postgres'])('materializes and persists generated results with %s activity history', async storage => {
+    if (storage === 'postgres') setSessionRunBackend(new PgSessionRunStore(db));
     await saveSetupBundle();
     await writeGuardDecisions(REPO, { dismissedClaims: [DISMISSED], dismissedFlows: [] });
 
@@ -847,6 +854,29 @@ describe('the guard generate job', () => {
     const [job] = await jobsOfType('repo.guard-generate');
     expect(job).toMatchObject({ status: 'failed', error: 'every extract call failed' });
     expect(await readGuardBaselineCommit(REPO)).toBeNull();
+  });
+
+  it('keeps Postgres activity running until results save and records a persistence failure', async () => {
+    await saveSetupBundle();
+    setSessionRunBackend(new PgSessionRunStore(db));
+    let checked = false;
+    class FailingResults extends PgGuardStore {
+      override async writeGuardResult(): Promise<void> {
+        const [run] = await listStoredSessionRuns(REPO, 'guard-generate');
+        expect(run.status).toBe('running');
+        checked = true;
+        throw new Error('result persistence failed');
+      }
+    }
+    setGuardStore(new FailingResults(db));
+    await jobs.enqueueGuardGenerate(request);
+    await Promise.all(running);
+    expect(checked).toBe(true);
+    const [run] = await listStoredSessionRuns(REPO, 'guard-generate');
+    expect(run).toMatchObject({ status: 'failed', error: { message: 'result persistence failed' } });
+    const opened = await openStoredSessionRun(REPO, 'guard-generate', run.runId);
+    const events = await opened.readActivity!(-1);
+    expect(events.some(e => e.kind === 'run' && e.run.status === 'completed')).toBe(false);
   });
 
   it('a cancelled generate leaves the store exactly as it found it', async () => {
@@ -1019,11 +1049,13 @@ describe('the guard run job', () => {
   });
 
   it('runs the stored set over setup’s recipe, then saves the baseline run and its evidence', async () => {
+    setSessionRunBackend(new PgSessionRunStore(db));
     await storeGeneratedSet();
     await saveSetupBundle();
 
     await jobs.enqueueGuardRun(request);
     await Promise.all(running);
+    expect(await listStoredSessionRuns(REPO)).toEqual([]);
 
     const [job] = await jobsOfType('repo.guard-run');
     expect(job?.error).toBeNull();

--- a/tests/dashboard-server/spec-scan-snapshot.test.ts
+++ b/tests/dashboard-server/spec-scan-snapshot.test.ts
@@ -14,7 +14,7 @@ import { PGlite } from '@electric-sql/pglite';
 import { drizzle } from 'drizzle-orm/pglite';
 import { migrate } from 'drizzle-orm/pglite/migrator';
 import { schema, MIGRATIONS_DIR, type Db } from '@truecourse/db';
-import { PgSpecStore } from '@truecourse/data-store';
+import { PgSpecStore, PgSessionRunStore } from '@truecourse/data-store';
 import type { CuratedCorpus } from '../../packages/spec-consolidator/src/index.js';
 
 vi.mock('@truecourse/core/commands/spec-in-process', async (importOriginal) => ({
@@ -32,12 +32,14 @@ import { hashContent, readSourcesFile } from '../../packages/spec-consolidator/s
 import { PgSpecSourcesStore } from '@truecourse/data-store';
 import { runStoredSpecScan, snapshotDocs } from '../../apps/dashboard/server/src/services/spec-scan.service';
 import { setWorkTreeProvider } from '../../apps/dashboard/server/src/services/work-tree.service';
+import { createStoredSessionRun, openStoredSessionRun, readStoredActivity, setSessionRunBackend, setSessionsRootResolver, resetSessionsRootResolver } from '@truecourse/core/lib/sessions-store';
 
 const REPO = 'acme/widgets';
 
 let client: PGlite;
 let db: Db;
 let tree: string;
+let history: string;
 
 const git = (cwd: string, ...args: string[]): string =>
   execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
@@ -58,6 +60,8 @@ beforeEach(async () => {
   await migrate(db, { migrationsFolder: MIGRATIONS_DIR });
   setSpecStore(new PgSpecStore(db));
   setSpecSourcesStore(new PgSpecSourcesStore(db));
+  history = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-scan-history-'));
+  setSessionsRootResolver(() => history);
   setRepoDocReader((repoKey, docPath, opts) => loadSpecDoc(repoKey, docPath, opts?.commit));
 
   tree = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'tc-scan-snapshot-')));
@@ -74,6 +78,10 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
+  setSessionRunBackend(undefined);
+  resetSessionsRootResolver();
+  fs.rmSync(history, { recursive: true, force: true });
   setWorkTreeProvider(null);
   resetSpecSourcesStore();
   resetSpecStore();
@@ -90,6 +98,30 @@ describe('snapshotDocs', () => {
 });
 
 describe('the hosted scan', () => {
+  it.each([['file', false], ['file', true], ['postgres', false], ['postgres', true]] as const)('finishes after saving with %s history, persistence failure=%s', async (storage, fail) => {
+    if (storage === 'postgres') setSessionRunBackend(new PgSessionRunStore(db));
+    let runId = '';
+    vi.mocked(curateInProcess).mockImplementationOnce(async (_root, options) => {
+      expect(options?.deferRunCompletion).toBe(true);
+      const run = await createStoredSessionRun(REPO, { command: 'spec-scan', gitRef: 'abc', activityStream: true });
+      runId = run.runId;
+      options?.onRunStarted?.({ command: 'spec-scan', runId, dir: run.dir });
+      return { curate: { corpus: corpus(['docs/orders.md']), decisions: { version: 2 } } } as never;
+    });
+    const save = PgSpecStore.prototype.saveSpec;
+    vi.spyOn(PgSpecStore.prototype, 'saveSpec').mockImplementation(async function (ref, artifact, json) {
+      expect((await openStoredSessionRun(REPO, 'spec-scan', runId)).record().status).toBe('running');
+      if (fail) throw new Error('Cannot persist corpus');
+      return save.call(this, ref, artifact, json);
+    });
+    if (fail) await expect(runStoredSpecScan(REPO, { source: 'dashboard' })).rejects.toThrow('Cannot persist corpus');
+    else await runStoredSpecScan(REPO, { source: 'dashboard' });
+    const run = await openStoredSessionRun(REPO, 'spec-scan', runId);
+    expect(run.record().status).toBe(fail ? 'failed' : 'completed');
+    expect((await readStoredActivity(run)).at(-1)).toMatchObject({ kind: 'run', run: { status: fail ? 'failed' : 'completed' } });
+    if (fail) expect(run.record().error?.message).toBe('Cannot persist corpus');
+  });
+
   it('stores the documents under the scan commit, where the doc reader finds them after the clone is gone', async () => {
     vi.mocked(curateInProcess).mockResolvedValue({
       curate: { corpus: corpus(['docs/orders.md', '.truecourse/specs/sources/stripe/refunds.md']), decisions: { version: 2 } },

--- a/tests/data-store/session-run-store.test.ts
+++ b/tests/data-store/session-run-store.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import { EventEmitter } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
+import { PGlite } from '@electric-sql/pglite';
+import { drizzle } from 'drizzle-orm/pglite';
+import { migrate } from 'drizzle-orm/pglite/migrator';
+import { eq, sql } from 'drizzle-orm';
+import { schema, activityRuns, activityEvents, MIGRATIONS_DIR, type Db, type Pool } from '@truecourse/db';
+import { PgSessionRunStore } from '../../packages/data-store/src/session-run-store';
+import { purgeRepoData } from '../../packages/data-store/src/repo-purge';
+import { createSessionRun, readStoredTranscript, validateStoredActivityCursor, setSessionRunBackend, setSessionsRootResolver, resetSessionsRootResolver, type SessionRunStore } from '@truecourse/core/lib/sessions-store';
+import { subscribeActivity, readActivityEvents } from '@truecourse/core/lib/activity-journal';
+import { acquireRunsWatch, releaseRunsWatch } from '../../apps/dashboard/server/src/services/session-tailer.service';
+import { createActivityStream } from '../../apps/dashboard/server/src/services/activity-stream.service';
+
+const REPO = 'acme/widget';
+let client: PGlite;
+let db: Db;
+let store: PgSessionRunStore;
+let root: string;
+const queries: Array<{ query: string; params: unknown[] }> = [];
+const live: SessionRunStore[] = [];
+const event = (seq = 0) => ({ type: 'user-message' as const, seq, ts: new Date().toISOString(), content: `message ${seq}` });
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-pg-activity-'));
+  setSessionsRootResolver(key => path.join(root, encodeURIComponent(key)));
+  client = new PGlite();
+  const d = drizzle(client, { schema, logger: { logQuery(query, params) { queries.push({ query, params }); } } });
+  await migrate(d, { migrationsFolder: MIGRATIONS_DIR });
+  db = d as unknown as Db;
+  store = new PgSessionRunStore(db);
+});
+afterEach(async () => {
+  for (const run of live.splice(0)) {
+    try { run.finish('interrupted'); await run.flush?.(); } catch { /* failed writer already stopped */ }
+  }
+  await client.close();
+  setSessionRunBackend(undefined);
+  resetSessionsRootResolver();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+async function create(command: 'spec-scan' | 'guard-setup' | 'guard-generate' | 'guard-interfaces' = 'spec-scan') {
+  const run = await store.create(REPO, { command, gitRef: 'abc', activityStream: true });
+  live.push(run); return run;
+}
+
+describe('Postgres activity storage', () => {
+  it.each([false, true])('opens metadata without history and scopes replay/transcripts, completed=%s', async completed => {
+    const run = await create();
+    run.persistence.appendEvent('other', event(0));
+    run.persistence.appendEvent('target', event(0));
+    run.persistence.appendEvent('target', event(1));
+    if (completed) run.finish('completed');
+    await run.flush!();
+    const other = new PgSessionRunStore(db);
+    queries.length = 0;
+    const reopened = await other.open(REPO, 'spec-scan', run.runId);
+    expect(queries.filter(q => q.query.includes('"activity_events"'))).toEqual([]);
+
+    queries.length = 0;
+    await validateStoredActivityCursor(reopened, 2);
+    const validation = queries.filter(q => q.query.includes('"activity_events"'));
+    expect(validation).toHaveLength(1);
+    expect(validation[0].query).not.toContain('"body"');
+    await expect(validateStoredActivityCursor(reopened, 9999)).rejects.toThrow('boundary');
+
+    queries.length = 0;
+    const replay = await reopened.readActivity!(2);
+    expect(replay.map(e => e.cursor)).toEqual(completed ? [3, 4] : [3]);
+    const historyQuery = queries.find(q => q.query.includes('"body"'))!;
+    expect(historyQuery.query).toContain('"activity_events"."cursor" >');
+    expect(historyQuery.params).toContain(2);
+
+    queries.length = 0;
+    expect(await readStoredTranscript(reopened, 'target', 0)).toEqual(run.persistence.readEvents('target').filter(e => e.seq > 0));
+    const transcriptQueries = queries.filter(q => q.query.includes('"activity_events"'));
+    expect(transcriptQueries).toHaveLength(1);
+    expect(transcriptQueries[0].query).toContain("->>'sessionId'");
+    expect(transcriptQueries[0].query).toContain("->>'seq'");
+    expect(transcriptQueries[0].params).toEqual([run.runId, 'target', 0]);
+    expect(await readStoredTranscript(reopened, 'missing')).toEqual([]);
+
+    // A remote handle must read fresh data on each transcript request.
+    if (!completed) {
+      run.persistence.appendEvent('target', event(2));
+      await run.flush!();
+      expect((await readStoredTranscript(reopened, 'target', 1)).map(e => e.seq)).toEqual([2]);
+    }
+  });
+
+  it.each(['spec-scan', 'guard-setup', 'guard-generate', 'guard-interfaces'] as const)('stores %s history without creating files and reopens on another server', async command => {
+    const run = await create(command);
+    run.setEndpoint({ url: 'http://runner', token: 'never-persist-this' });
+    run.persistence.appendEvent('s1', event());
+    run.persistence.updateIndex({ sessionId: 's1', kind: 'test', workItem: 'doc', status: 'completed', spent: { turns: 1, tokens: 2, costUsd: 0 } });
+    run.finish('completed'); await run.flush!();
+    expect(fs.existsSync(run.dir)).toBe(false);
+    const reopened = await new PgSessionRunStore(db).open(REPO, command, run.runId);
+    expect(await readStoredTranscript(reopened, 's1')).toEqual(run.persistence.readEvents('s1'));
+    const history = await reopened.readActivity!(-1);
+    expect(history.map(e => e.cursor)).toEqual([0, 1, 2, 3, 4]);
+    expect(JSON.stringify(await db.select().from(activityRuns))).not.toContain('never-persist-this');
+    expect(JSON.stringify(history)).not.toContain('never-persist-this');
+    expect(reopened.record().status).toBe('completed');
+    const reader = createActivityStream(reopened, -1, new AbortController().signal).getReader();
+    const chunks = [];
+    for (;;) { const next = await reader.read(); if (next.done) break; chunks.push(next.value); }
+    expect(chunks.at(-1)).toMatchObject({ type: 'finish' });
+  });
+
+  it('publishes only committed immutable snapshots and resumes strictly after a cursor', async () => {
+    const run = await create();
+    const observations: Promise<void>[] = [];
+    const unsubscribe = subscribeActivity(run.dir, e => {
+      if (!e) return;
+      observations.push((async () => {
+        const rows = await db.select().from(activityEvents).where(eq(activityEvents.runId, run.runId));
+        expect(rows.some(row => row.cursor === e.cursor)).toBe(true);
+      })());
+    });
+    run.setChecklist([{ key: 'a', label: 'Read documents', status: 'active' }]);
+    run.setChecklist([{ key: 'a', label: 'Read documents', status: 'done' }]);
+    await run.flush!(); await Promise.all(observations); unsubscribe();
+    const events = await run.readActivity!(-1);
+    expect(events[1]).toMatchObject({ kind: 'run', run: { display: { blocks: [{ items: [{ status: 'active' }] }] } } });
+    expect(await run.readActivity!(1)).toEqual(events.slice(2));
+    await expect(run.readActivity!(900)).rejects.toThrow('boundary');
+  });
+
+  it('rolls back the snapshot and cursor together on write failure and rejects flush', async () => {
+    const run = await create();
+    await db.execute(sql`ALTER TABLE activity_events ADD CONSTRAINT reject_test CHECK (cursor = 0)`);
+    let published = 0;
+    const unsubscribe = subscribeActivity(run.dir, e => { if (e) published++; });
+    run.setError({ message: 'cannot commit' });
+    await expect(run.flush!()).rejects.toThrow();
+    unsubscribe();
+    expect(published).toBe(0);
+    const [row] = await db.select().from(activityRuns);
+    expect(row!.nextCursor).toBe(1);
+    expect(row!.record.error).toBeUndefined();
+  });
+
+  it('isolates repo/command reads and cascades history when disconnecting a repository', async () => {
+    const run = await create();
+    run.finish('completed'); await run.flush!();
+    await expect(store.open('other/repo', 'spec-scan', run.runId)).rejects.toThrow('not found');
+    await expect(store.open(REPO, 'guard-setup', run.runId)).rejects.toThrow('not found');
+    expect(await store.list('other/repo')).toEqual([]);
+    await purgeRepoData(db, REPO);
+    expect(await db.select().from(activityEvents)).toEqual([]);
+  });
+
+  it('interrupts expired owners, parks questions, and fences a late writer', async () => {
+    const run = await create();
+    run.persistence.updateIndex({ sessionId: 's', kind: 'test', workItem: 'doc', status: 'waiting', spent: { turns: 0, tokens: 0, costUsd: 0 } });
+    await run.flush!();
+    await db.update(activityRuns).set({ leaseUntil: '2000-01-01T00:00:00Z' }).where(eq(activityRuns.runId, run.runId));
+    const other = new PgSessionRunStore(db);
+    expect((await other.list(REPO))[0]).toMatchObject({ status: 'interrupted', sessions: [{ status: 'parked' }] });
+    run.setChecklist([]);
+    await expect(run.flush!()).rejects.toThrow('lost its lease');
+  });
+
+  it('imports old file history once with the original replay cursors and missing transcript events', async () => {
+    const old = createSessionRun(REPO, { command: 'guard-setup', gitRef: 'abc', activityStream: true });
+    old.persistence.appendEvent('s', event());
+    old.finish('completed');
+    const original = readActivityEvents(old.dir);
+    fs.appendFileSync(path.join(old.dir, 's.jsonl'), JSON.stringify(event(1)) + '\n');
+    const imported = await store.open(REPO, 'guard-setup', old.runId);
+    const events = await imported.readActivity!(-1);
+    expect(events.slice(0, original.length)).toEqual(original);
+    expect((await readStoredTranscript(imported, 's')).map(e => e.seq)).toEqual([0, 1]);
+    const again = await new PgSessionRunStore(db).open(REPO, 'guard-setup', old.runId);
+    expect(await again.readActivity!(-1)).toEqual(events);
+    expect(fs.existsSync(path.join(old.dir, 'run.json'))).toBe(true);
+  });
+});
+
+
+it('notifies another server of new runs through PostgreSQL LISTEN/NOTIFY', async () => {
+  // Exercise real database notifications; only the pg socket is represented
+  // by PGlite's in-process listener because this test starts no server.
+  const connection = new EventEmitter();
+  let unlisten: (() => Promise<void>) | undefined;
+  let ready!: () => void;
+  const listening = new Promise<void>(resolve => { ready = resolve; });
+  const pool = { connect: async () => Object.assign(connection, {
+    query: async () => {
+      unlisten = await client.listen('truecourse_activity', payload => connection.emit('notification', { channel: 'truecourse_activity', payload }));
+      ready();
+    },
+    release: () => { void unlisten?.(); },
+  }) } as unknown as Pool;
+  const other = new PgSessionRunStore(db, pool);
+  let notifications = 0;
+  const stop = other.subscribeRepo(REPO, () => { notifications++; });
+  await listening;
+  await Promise.resolve();
+  notifications = 0;
+  const run = await create();
+  expect(notifications).toBeGreaterThan(0);
+  expect((await other.list(REPO))[0]!.runId).toBe(run.runId);
+  stop();
+  await unlisten?.();
+});
+
+
+it('updates the existing run-list watch without creating a file watcher or directory', async () => {
+  setSessionRunBackend(store);
+  const changed = new Promise<void>(resolve => acquireRunsWatch(REPO, resolve));
+  try {
+    const run = await create();
+    await changed;
+    expect(fs.existsSync(run.dir)).toBe(false);
+    expect((await store.list(REPO)).map(r => r.runId)).toEqual([run.runId]);
+  } finally { releaseRunsWatch(REPO); }
+});

--- a/tests/llm-claude-agent/session-driver.test.ts
+++ b/tests/llm-claude-agent/session-driver.test.ts
@@ -160,6 +160,32 @@ function runSession(sdk: SdkModule, overrides?: Partial<SessionRunInput>) {
 // ---------------------------------------------------------------------------
 
 describe('claude agent session driver', () => {
+  it('streams text and tool progress without splitting one complete assistant turn', async () => {
+    const progress: unknown[] = [];
+    const { sdk, captured } = fakeSdk(async function* (ctx) {
+      await ctx.nextUserMessage(); yield init();
+      const partial = (event: object, parent: string | null = null): SdkMessage => ({ type: 'stream_event', parent_tool_use_id: parent, event });
+      yield partial({ type: 'message_start', message: { id: 'turn-1' } });
+      yield partial({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } });
+      yield partial({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Read ' } });
+      yield { ...assistant([{ type: 'text', text: 'Read ' }]), message: { id: 'turn-1', content: [{ type: 'text', text: 'Read ' }], usage: { input_tokens: 4, output_tokens: 2 } } };
+      yield partial({ type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'docs.' } });
+      yield partial({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'SECRET CHILD' } }, 'child');
+      yield { type: 'tool_progress', parent_tool_use_id: null, tool_use_id: 'tool-1', tool_name: 'mcp__session__probe', elapsed_time_seconds: 3 };
+      yield { ...assistant([{ type: 'text', text: 'docs.' }]), message: { id: 'turn-1', content: [{ type: 'text', text: 'docs.' }], usage: { input_tokens: 4, output_tokens: 2 } } };
+      yield success({ verdict: 'keep' });
+    });
+    const { handle, events } = runSession(sdk, { onProgress: p => progress.push(p) });
+    await handle.done;
+    expect(captured.options?.includePartialMessages).toBe(true);
+    expect(progress).toContainEqual({ kind: 'text', turnId: 'turn-1', text: 'Read \ndocs.' });
+    expect(progress).toContainEqual({ kind: 'tool', toolCallId: 'tool-1', toolName: 'probe', elapsedSeconds: 3 });
+    expect(JSON.stringify(progress)).not.toContain('SECRET CHILD');
+    const turns = events.filter(e => e.type === 'assistant-turn');
+    expect(turns).toHaveLength(1);
+    expect(turns[0]).toMatchObject({ text: 'Read \ndocs.', usage: { inputTokens: 4, outputTokens: 2 } });
+  });
+
   it('declares live steering, native structured outcome, and resume-at-message', () => {
     const { sdk } = fakeSdk(async function* () {});
     const driver = createClaudeAgentSessionDriver({ sdk });

--- a/tests/server/activity-client.test.ts
+++ b/tests/server/activity-client.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createUIMessageStreamResponse, type UIMessageChunk } from 'ai';
+import { followActivity } from '../../apps/dashboard/client/src/lib/activity-stream';
+import type { ActivityEvent } from '@truecourse/shared/activity-stream';
+
+const initial: ActivityEvent = { kind: 'run', cursor: 0, run: {
+  command: 'spec-scan', runId: 'r1', gitRef: 'abc', startedAt: '2026-09-07T10:00:00Z', status: 'running', sessions: [], activityStream: 'ai-sdk-v1',
+} };
+const next: ActivityEvent = { kind: 'session-event', cursor: 200, sessionId: 's1', event: { type: 'user-message', content: 'Read docs', seq: 0, ts: '2026-09-07T10:00:01Z' } };
+const chunk = (data: ActivityEvent): UIMessageChunk => ({ type: 'data-activity', id: `r1:${data.cursor}`, data });
+const response = (...chunks: UIMessageChunk[]) => createUIMessageStreamResponse({ stream: new ReadableStream({ start(c) { chunks.forEach(x => c.enqueue(x)); c.close(); } }) });
+
+afterEach(() => vi.useRealTimers());
+
+describe('SDK activity client', () => {
+  it('resumes an interrupted stream from the last applied cursor and ignores replay overlap', async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(response({ type: 'start', messageId: 'r1' }, chunk(initial)))
+      .mockResolvedValueOnce(response({ type: 'start', messageId: 'r1' }, chunk(initial), chunk(next), { type: 'finish', finishReason: 'stop' }));
+    const events: ActivityEvent[] = [];
+    let disconnected!: () => void;
+    const gap = new Promise<void>(resolve => { disconnected = resolve; });
+    const controller = new AbortController();
+    const done = followActivity({ url: '/stream', runId: 'r1', signal: controller.signal, fetcher,
+      onEvent: e => events.push(e), onConnection: e => { if (e) disconnected(); },
+    });
+    await gap;
+    await vi.advanceTimersByTimeAsync(1000);
+    await done;
+    expect(fetcher.mock.calls.map(([url]) => url)).toEqual(['/stream?after=-1', '/stream?after=0']);
+    expect(fetcher.mock.calls[0][1]).toMatchObject({ credentials: 'include', signal: controller.signal, method: 'GET' });
+    expect(events).toEqual([initial, next]);
+  });
+
+  it('cancels reconnect delay on viewer unmount', async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn<typeof fetch>().mockRejectedValue(new Error('offline'));
+    const controller = new AbortController();
+    let disconnected!: () => void;
+    const gap = new Promise<void>(resolve => { disconnected = resolve; });
+    const done = followActivity({ url: '/stream', runId: 'r1', signal: controller.signal, fetcher,
+      onEvent: () => {}, onConnection: error => { if (error) disconnected(); },
+    });
+    await gap; controller.abort(); await done;
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry denied access and keeps transient progress outside history', async () => {
+    const denied = vi.fn<typeof fetch>().mockResolvedValue(new Response('', { status: 403 }));
+    const errors: Array<string | null> = [];
+    await followActivity({ url: '/stream', runId: 'r1', signal: new AbortController().signal, fetcher: denied, onEvent: () => {}, onConnection: e => errors.push(e) });
+    expect(denied).toHaveBeenCalledTimes(1);
+    expect(errors.at(-1)).toContain('access was denied');
+    const progress: unknown[] = [];
+    const events: unknown[] = [];
+    await followActivity({ url: '/stream', runId: 'r1', signal: new AbortController().signal,
+      fetcher: async () => response(chunk(initial), { type: 'data-progress', data: { s1: { kind: 'text', turnId: 'm1', text: 'Reading' } }, transient: true }, { type: 'finish', finishReason: 'stop' }),
+      onEvent: e => events.push(e), onProgress: p => progress.push(p), onConnection: () => {},
+    });
+    expect(events).toEqual([initial]);
+    expect(progress).toEqual([{ s1: { kind: 'text', turnId: 'm1', text: 'Reading' } }]);
+  });
+});

--- a/tests/server/activity-stream.test.ts
+++ b/tests/server/activity-stream.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readUIMessageStream } from 'ai';
+import { createSessionRun, openSessionRun, reconcileSessionsStore, recoverSessionActivity } from '@truecourse/core/lib/sessions-store';
+import { readActivityEvents, readActivityProgress, subscribeActivity } from '@truecourse/core/lib/activity-journal';
+import { createActivityStream } from '../../apps/dashboard/server/src/services/activity-stream.service';
+import type { SessionEvent } from '@truecourse/agent-loop';
+
+const event = (seq = 0): SessionEvent => ({ type: 'user-message', seq, ts: new Date().toISOString(), content: `Read café ${seq}` });
+
+describe('dashboard activity journal and stream', () => {
+  let root: string;
+  beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-activity-')); });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+  const create = () => createSessionRun(root, { command: 'spec-scan', gitRef: 'abc', activityStream: true });
+
+  it('delivers local updates without replay and catches up periodically and on remote notification', async () => {
+    vi.useFakeTimers();
+    const run = create();
+    const history = readActivityEvents(run.dir);
+    run.readActivity = vi.fn(async after => history.filter(e => e.cursor > after));
+    let remote: (() => void) | undefined;
+    run.subscribeActivity = notify => { remote = notify; return () => { remote = undefined; }; };
+    const controller = new AbortController();
+    const reader = createActivityStream(run, -1, controller.signal).getReader();
+    const chunks: import('ai').UIMessageChunk[] = [];
+    const consume = (async () => {
+      for (;;) { const next = await reader.read(); if (next.done) break; chunks.push(next.value); }
+    })();
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      expect(run.readActivity).toHaveBeenCalledTimes(1);
+      for (let i = 0; i < 3; i++) {
+        await vi.advanceTimersByTimeAsync(4000);
+        run.persistence.publishProgress!('s', { kind: 'text', turnId: 't', text: `partial ${i}` });
+        await vi.advanceTimersByTimeAsync(0);
+      }
+      run.persistence.appendEvent('s', event());
+      await vi.advanceTimersByTimeAsync(0);
+      expect(run.readActivity).toHaveBeenCalledTimes(1);
+      expect(chunks.filter(c => c.type === 'data-activity')).toHaveLength(2);
+      expect(chunks.some(c => c.type === 'data-progress' && JSON.stringify(c.data).includes('partial 2'))).toBe(true);
+
+      // Local wakeups must neither trigger nor postpone the 15-second catch-up.
+      history.push({ cursor: 10000, kind: 'session-event', sessionId: 'remote', event: event(1) });
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(run.readActivity).toHaveBeenCalledTimes(2);
+      expect(chunks.filter(c => c.type === 'data-activity')).toHaveLength(3);
+      expect(chunks.some(c => c.type === 'data-heartbeat')).toBe(true);
+
+      history.push({ cursor: 10001, kind: 'run', run: { ...run.record(), status: 'completed' } });
+      remote!();
+      await consume;
+      expect(run.readActivity).toHaveBeenCalledTimes(3);
+      expect(chunks.at(-1)).toMatchObject({ type: 'finish' });
+      expect(remote).toBeUndefined();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally { controller.abort(); await consume; vi.useRealTimers(); }
+  });
+
+  it('publishes only persisted events, with independent session identities and byte cursors', () => {
+    const run = create();
+    let observed = 0;
+    const unsubscribe = subscribeActivity(run.dir, () => { observed = readActivityEvents(run.dir).length; });
+    run.persistence.appendEvent('a', event());
+    run.persistence.appendEvent('b', event());
+    expect(observed).toBe(3);
+    const records = readActivityEvents(run.dir);
+    expect(records.map(e => e.cursor)).toEqual([...records.map(e => e.cursor)].sort((a,b) => a-b));
+    expect(readActivityEvents(run.dir, records[1].cursor)).toEqual([records[2]]);
+    expect(readActivityEvents(run.dir, records[2].cursor)).toEqual([]);
+    expect(() => readActivityEvents(run.dir, 2)).toThrow('boundary');
+    expect(() => readActivityEvents(run.dir, 999999)).toThrow('beyond');
+    unsubscribe();
+  });
+
+  it('publishes immutable run snapshots directly and keeps slow viewers lossless', async () => {
+    const run = create();
+    const published: import('@truecourse/shared/activity-stream').ActivityEvent[] = [];
+    const unsubscribe = subscribeActivity(run.dir, event => { if (event) published.push(event); });
+    run.persistence.updateIndex({ sessionId: 'a', kind: 'scan', workItem: 'doc', status: 'running', spent: { turns: 0, tokens: 0, costUsd: 0 } });
+    const reader = createActivityStream(run, -1, new AbortController().signal).getReader();
+    await reader.read();
+    // Begin replay, then leave the viewer behind a burst that exceeds its live queue.
+    await reader.read();
+    for (let seq = 0; seq < 150; seq++) run.persistence.appendEvent('a', event(seq));
+    run.persistence.updateIndex({ sessionId: 'a', kind: 'scan', workItem: 'doc', status: 'completed', spent: { turns: 1, tokens: 2, costUsd: 0 } });
+    run.finish('completed');
+    expect(published[0]).toMatchObject({ kind: 'run', run: { sessions: [{ status: 'running' }] } });
+    const transcript = [];
+    for (;;) {
+      const next = await reader.read(); if (next.done) break;
+      if (next.value.type === 'data-activity' && (next.value.data as { kind: string }).kind === 'session-event') transcript.push(next.value.data);
+    }
+    expect(transcript).toHaveLength(150);
+    unsubscribe();
+  });
+
+  it('keeps CLI storage unchanged and does not publish credentials', () => {
+    const legacy = createSessionRun(root, { command: 'spec-scan', gitRef: 'abc' });
+    legacy.persistence.appendEvent('a', event());
+    expect(fs.existsSync(path.join(legacy.dir, 'activity.jsonl'))).toBe(false);
+    expect(legacy.persistence.publishProgress).toBeUndefined();
+    const run = create();
+    run.setEndpoint({ url: 'http://localhost:1234', token: 'NEVER-PUBLIC' });
+    const journal = fs.readFileSync(path.join(run.dir, 'activity.jsonl'), 'utf8');
+    expect(journal).not.toContain('NEVER-PUBLIC');
+    expect(journal).not.toContain('"pid"');
+    expect(journal).not.toContain('"endpoint"');
+  });
+
+  it('repairs a crash between transcript persistence and journal append, including a partial tail', () => {
+    const run = create();
+    fs.appendFileSync(path.join(run.dir, 'a.jsonl'), JSON.stringify(event())+'\n');
+    fs.appendFileSync(path.join(run.dir, 'activity.jsonl'), '{"cursor":');
+    recoverSessionActivity(run);
+    expect(readActivityEvents(run.dir).filter(e => e.kind === 'session-event')).toHaveLength(1);
+    recoverSessionActivity(run);
+    expect(readActivityEvents(run.dir).filter(e => e.kind === 'session-event')).toHaveLength(1);
+    run.finish('completed');
+    expect(readActivityEvents(run.dir).at(-1)).toMatchObject({ kind: 'run', run: { status: 'completed' } });
+  });
+
+  it('fails loudly for complete corrupt records', () => {
+    const run = create();
+    fs.appendFileSync(path.join(run.dir, 'activity.jsonl'), 'corrupt\n');
+    expect(() => readActivityEvents(run.dir)).toThrow();
+  });
+
+  it('replays a finished run as SDK data parts, even when no viewer saw it live', async () => {
+    const run = create();
+    run.persistence.appendEvent('a', event());
+    run.finish('completed');
+    const snapshots = [];
+    for await (const message of readUIMessageStream({ stream: createActivityStream(run, -1, new AbortController().signal), terminateOnError: true })) snapshots.push(message);
+    const last = snapshots.at(-1)!;
+    expect(last.id).toBe(run.runId);
+    expect(last.parts.filter(p => p.type === 'data-activity')).toHaveLength(3);
+    expect(last.parts.some(p => p.type === 'data-progress' || p.type === 'data-heartbeat')).toBe(false);
+  });
+
+  it('catches events written while replay is being consumed and isolates viewer cancellation', async () => {
+    const run = create();
+    const first = createActivityStream(run, -1, new AbortController().signal).getReader();
+    const second = createActivityStream(run, -1, new AbortController().signal).getReader();
+    expect((await first.read()).value?.type).toBe('start');
+    expect((await second.read()).value?.type).toBe('start');
+    await first.cancel();
+    expect(run.record().status).toBe('running');
+    run.persistence.appendEvent('later', event());
+    run.finish('completed');
+    const chunks = [];
+    for (;;) { const next = await second.read(); if (next.done) break; chunks.push(next.value); }
+    expect(chunks.filter(c => c.type === 'data-activity')).toHaveLength(3);
+    expect(chunks.at(-1)).toMatchObject({ type: 'finish' });
+  });
+
+  it('replays missed events from a cursor after reopening the run and records dead-process recovery', async () => {
+    const run = create();
+    const cursor = readActivityEvents(run.dir).at(-1)!.cursor;
+    run.persistence.appendEvent('a', event());
+    reconcileSessionsStore(root, { isProcessAlive: () => false });
+    const reopened = openSessionRun(root, 'spec-scan', run.runId);
+    expect(reopened.record().status).toBe('interrupted');
+    const reader = createActivityStream(reopened, cursor, new AbortController().signal).getReader();
+    const replay = [];
+    for (;;) { const next = await reader.read(); if (next.done) break; if (next.value.type === 'data-activity') replay.push(next.value.data); }
+    expect(replay).toHaveLength(2);
+    expect(replay.at(-1)).toMatchObject({ kind: 'run', run: { status: 'interrupted' } });
+  });
+
+  it('keeps partial progress transient and removes it when the complete turn lands', () => {
+    const run = create();
+    const initial = readActivityEvents(run.dir).length;
+    run.persistence.publishProgress!('a', { kind: 'text', turnId: 'turn-1', text: 'Reading…' });
+    expect(readActivityProgress(run.dir).a).toMatchObject({ text: 'Reading…' });
+    expect(readActivityEvents(run.dir)).toHaveLength(initial);
+    expect(run.persistence.readEvents('a')).toEqual([]);
+    run.persistence.appendEvent('a', { ...event(), type: 'assistant-turn', text: 'Read.', usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheCreateTokens: 0, costUsd: 0, costSource: 'unpriced' } });
+    expect(readActivityProgress(run.dir)).toEqual({});
+    run.finish('completed');
+  });
+});
+
+
+it('does not lose a commit arriving while an asynchronous replay query is in flight', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-activity-await-'));
+  const run = createSessionRun(root, { command: 'guard-generate', gitRef: 'abc', activityStream: true });
+  let resolveRead!: () => void;
+  const gate = new Promise<void>(resolve => { resolveRead = resolve; });
+  let reading!: () => void;
+  const started = new Promise<void>(resolve => { reading = resolve; });
+  let first = true;
+  run.readActivity = async after => {
+    const snapshot = readActivityEvents(run.dir, after);
+    if (first) { first = false; reading(); await gate; }
+    return snapshot;
+  };
+  const reader = createActivityStream(run, -1, new AbortController().signal).getReader();
+  await reader.read();
+  const pending = reader.read();
+  await started;
+  run.persistence.appendEvent('s', event());
+  run.finish('completed');
+  resolveRead();
+  const chunks = [(await pending).value];
+  for (;;) { const next = await reader.read(); if (next.done) break; chunks.push(next.value); }
+  expect(chunks.filter(c => c?.type === 'data-activity')).toHaveLength(3);
+  expect(chunks.at(-1)).toMatchObject({ type: 'finish' });
+  fs.rmSync(root, { recursive: true, force: true });
+});

--- a/tests/server/sessions-routes.test.ts
+++ b/tests/server/sessions-routes.test.ts
@@ -63,6 +63,40 @@ describe('Sessions routes', () => {
     return run;
   };
 
+  it.each(['spec-scan', 'guard-setup', 'guard-generate', 'guard-interfaces'] as const)('serves %s history using the AI SDK SSE protocol', async command => {
+    const run = createSessionRun(root, { command, gitRef: 'abc', activityStream: true });
+    run.setEndpoint({ url: 'http://localhost:1', token: 'DO-NOT-STREAM' });
+    run.persistence.appendEvent('a', EVENT(0) as never);
+    run.finish('completed');
+    const res = await request(app).get(url(`runs/${command}/${run.runId}/stream`));
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    expect(res.headers['x-vercel-ai-ui-message-stream']).toBe('v1');
+    expect(res.text).toContain('data-activity');
+    expect(res.text).toContain('turn 0');
+    expect(res.text).toContain('[DONE]');
+    expect(res.text).not.toContain('DO-NOT-STREAM');
+    const records = fs.readFileSync(path.join(run.dir, 'activity.jsonl'), 'utf8').trim().split('\n').map(line => JSON.parse(line));
+    const resumed = await request(app).get(url(`runs/${command}/${run.runId}/stream?after=${records.at(-1).cursor}`));
+    expect(resumed.status).toBe(200);
+    expect(resumed.text).not.toContain('data-activity');
+    expect(resumed.text).toContain('"type":"finish"');
+  });
+
+  it('rejects invalid stream cursors, unsupported runs, unsafe IDs, and missing repositories', async () => {
+    const run = createSessionRun(root, { command: 'spec-scan', gitRef: 'abc', activityStream: true });
+    run.finish('completed');
+    for (const cursor of ['NaN', '-2', '1.2', '999999999', '2']) {
+      await request(app).get(url(`runs/spec-scan/${run.runId}/stream?after=${cursor}`)).expect(400);
+    }
+    const legacy = seedRun();
+    await request(app).get(url(`runs/spec-scan/${legacy.runId}/stream`)).expect(409);
+    await request(app).get(url('runs/unknown-command/anything/stream')).expect(400);
+    await request(app).get(url('runs/spec-scan/missing/stream')).expect(404);
+    await request(app).get(url('runs/spec-scan/..%2Foutside/stream')).expect(400);
+    await request(app).get(`/api/repos/missing/sessions/runs/spec-scan/${run.runId}/stream`).expect(404);
+  });
+
   it('lists runs newest-first with endpoint and pid stripped', async () => {
     const run = seedRun();
     const res = await request(app).get(url('runs'));


### PR DESCRIPTION
Dashboard activity runs now stream progress through AI SDK data events and retain their history in Postgres. Spec scan, Guard setup, generation, and existing interface-authoring runs can replay saved events and resume streaming after reconnecting.

- Persist run snapshots and ordered transcript events with writer leases, interrupted-run recovery, and notifications after commits. Import existing file histories on first access.
- Forward Claude progress while it happens and wait for persistence before marking hosted runs complete.
- Reuse existing run types and dashboard widgets. Deterministic Guard execution does not gain a run record; CLI storage stays file-based.
- Discover Next.js application roots from package manifests so interface mapping and web context find apps in monorepos.
- Ignore local Codex workspace files.

Validation completed during implementation: 244 focused tests passed, server and dependency builds passed, and the dashboard client typecheck passed. Coverage includes Postgres persistence and migration, stream replay and reconnect handling, routes, dashboard jobs, and Claude progress. The subsequent commit rewrite removed only PLAN.md and README.md changes; all other file contents were verified unchanged.

Includes migration `0015_activity_history.sql`. Restart the dashboard server to apply the migration through its startup flow.
