### PR TITLE
perf(dev): run workspace packages from source with tsx

### DIFF
--- a/apps/dashboard/client/vite.config.ts
+++ b/apps/dashboard/client/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defaultClientConditions, defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -8,7 +8,7 @@ const eeClientEntry = path.resolve(repoRoot, 'ee/packages/client/src/index.tsx')
 // The enterprise overlay is optional: a community checkout has no `ee/`.
 const eePresent = fs.existsSync(eeClientEntry);
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
   // Whether the enterprise client code is included in this build. Requires
   // the ee overlay to be present, and is on in dev or an explicit enterprise
   // build; a plain production (community) build leaves it off so the ee chunk
@@ -21,6 +21,9 @@ export default defineConfig(({ mode }) => {
       'import.meta.env.VITE_TC_EE': JSON.stringify(includeEe),
     },
     resolve: {
+      conditions: command === 'serve'
+        ? ['truecourse-source', ...defaultClientConditions]
+        : [...defaultClientConditions],
       alias: {
         '@': path.resolve(__dirname, './src'),
         // Resolve the enterprise client to its source (not the node_modules

--- a/apps/dashboard/server/package.json
+++ b/apps/dashboard/server/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "TRUECOURSE_DEV=1 tsx watch src/index.ts",
+    "dev": "TRUECOURSE_DEV=1 tsx watch --conditions=truecourse-source src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/agent-loop": "workspace:*",

--- a/ee/packages/client/src/knowledge-spec-source.ts
+++ b/ee/packages/client/src/knowledge-spec-source.ts
@@ -55,6 +55,6 @@ export function createWorkspaceSpecSource(): SpecSource {
       postJson<SpecConflictAck>(`${BASE}/conflict-resolution`, payload),
     deleteConflictResolution: (payload: DeleteConflictPayload) =>
       delJson<SpecConflictAck>(`${BASE}/conflict-resolution`, payload),
-    scan: async () => null,
+    scan: async () => undefined,
   };
 }

--- a/ee/packages/data-store/package.json
+++ b/ee/packages/data-store/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/core": "workspace:*",

--- a/ee/packages/github-app/package.json
+++ b/ee/packages/github-app/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@octokit/auth-app": "^7.1.3",

--- a/ee/packages/llm/package.json
+++ b/ee/packages/llm/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/llm-api": "workspace:*"

--- a/ee/packages/server/package.json
+++ b/ee/packages/server/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@sentry/node": "^10.0.0",

--- a/ee/packages/storage/package.json
+++ b/ee/packages/storage/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1059.0",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,15 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "dev": "turbo dev --concurrency=32",
+    "dev": "turbo dev",
     "build": "turbo build",
     "lint": "turbo lint",
     "clean": "turbo clean",
     "start": "turbo start",
     "build:dist": "tsx scripts/build.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "turbo typecheck --concurrency=2"
   },
   "devDependencies": {
     "ai": "^6.0.0",

--- a/packages/agent-loop/package.json
+++ b/packages/agent-loop/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "zod": "^3.23.8"

--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/shared": "workspace:*",

--- a/packages/analyzer/src/deterministic-scan/controller.ts
+++ b/packages/analyzer/src/deterministic-scan/controller.ts
@@ -52,14 +52,17 @@ export type IsolatedScanInput = Omit<DeterministicScanInput, 'startIndex'>
 
 /**
  * Locate the worker entry for the current packaging layout:
- *  - unbundled (tsc output, dev/tests): `worker.js` sits next to this module.
+ *  - source (tsx): `worker-source.mjs` registers tsx inside the worker thread.
+ *  - unbundled (tsc output): `worker.js` sits next to this module.
  *  - bundled (esbuild `cli.mjs`/`server.mjs`): this module is inlined into the
  *    entry bundle, and scripts/build.ts emits the worker as a sibling
  *    `det-scan-worker.mjs`. `import.meta.url` then points at the bundle dir.
  * Returns null when neither exists (the caller falls back to in-thread).
  */
 function resolveWorkerPath(): string | null {
-  const here = path.dirname(fileURLToPath(import.meta.url))
+  const currentFile = fileURLToPath(import.meta.url)
+  const here = path.dirname(currentFile)
+  if (currentFile.endsWith('.ts')) return path.join(here, 'worker-source.mjs')
   const candidates = [path.join(here, 'worker.js'), path.join(here, 'det-scan-worker.mjs')]
   for (const candidate of candidates) {
     if (fs.existsSync(candidate)) return candidate

--- a/packages/analyzer/src/deterministic-scan/worker-source.mjs
+++ b/packages/analyzer/src/deterministic-scan/worker-source.mjs
@@ -1,0 +1,5 @@
+// Worker threads need their own TypeScript loader. This entry is used only
+// when the controller runs from source; compiled and bundled workers use JS.
+import { tsImport } from 'tsx/esm/api'
+
+await tsImport('./worker.ts', import.meta.url)

--- a/packages/contract-extractor/package.json
+++ b/packages/contract-extractor/package.json
@@ -7,46 +7,35 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./cache": {
-      "types": "./dist/cache.d.ts",
-      "import": "./dist/cache.js"
-    },
     "./merger": {
+      "truecourse-source": "./src/merger.ts",
       "types": "./dist/merger.d.ts",
       "import": "./dist/merger.js"
     },
     "./writer": {
+      "truecourse-source": "./src/writer.ts",
       "types": "./dist/writer.d.ts",
       "import": "./dist/writer.js"
     },
     "./validator": {
+      "truecourse-source": "./src/validator.ts",
       "types": "./dist/validator.d.ts",
       "import": "./dist/validator.js"
     },
-    "./bootstrap": {
-      "types": "./dist/bootstrap.d.ts",
-      "import": "./dist/bootstrap.js"
-    },
-    "./llm-bootstrap": {
-      "types": "./dist/llm-bootstrap.d.ts",
-      "import": "./dist/llm-bootstrap.js"
-    },
     "./corpus-diff": {
+      "truecourse-source": "./src/corpus-diff.ts",
       "types": "./dist/corpus-diff.d.ts",
       "import": "./dist/corpus-diff.js"
-    },
-    "./specs-config": {
-      "types": "./dist/specs-config.d.ts",
-      "import": "./dist/specs-config.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/contract-verifier": "workspace:*",

--- a/packages/contract-verifier/package.json
+++ b/packages/contract-verifier/package.json
@@ -7,22 +7,25 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./parser": {
+      "truecourse-source": "./src/parser/index.ts",
       "types": "./dist/parser/index.d.ts",
       "import": "./dist/parser/index.js"
     },
     "./resolver": {
+      "truecourse-source": "./src/resolver/index.ts",
       "types": "./dist/resolver/index.d.ts",
       "import": "./dist/resolver/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/analyzer": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,314 +5,380 @@
   "type": "module",
   "exports": {
     "./commands/analyze-in-process": {
+      "truecourse-source": "./src/commands/analyze-in-process.ts",
       "types": "./dist/commands/analyze-in-process.d.ts",
       "import": "./dist/commands/analyze-in-process.js"
     },
     "./commands/analyze-core": {
+      "truecourse-source": "./src/commands/analyze-core.ts",
       "types": "./dist/commands/analyze-core.d.ts",
       "import": "./dist/commands/analyze-core.js"
     },
     "./commands/analyze-persist": {
+      "truecourse-source": "./src/commands/analyze-persist.ts",
       "types": "./dist/commands/analyze-persist.d.ts",
       "import": "./dist/commands/analyze-persist.js"
     },
     "./commands/diff-in-process": {
+      "truecourse-source": "./src/commands/diff-in-process.ts",
       "types": "./dist/commands/diff-in-process.d.ts",
       "import": "./dist/commands/diff-in-process.js"
     },
     "./commands/spec-in-process": {
+      "truecourse-source": "./src/commands/spec-in-process.ts",
       "types": "./dist/commands/spec-in-process.d.ts",
       "import": "./dist/commands/spec-in-process.js"
     },
     "./commands/spec-sources": {
+      "truecourse-source": "./src/commands/spec-sources.ts",
       "types": "./dist/commands/spec-sources.d.ts",
       "import": "./dist/commands/spec-sources.js"
     },
     "./commands/guard-in-process": {
+      "truecourse-source": "./src/commands/guard-in-process.ts",
       "types": "./dist/commands/guard-in-process.d.ts",
       "import": "./dist/commands/guard-in-process.js"
     },
-    "./commands/guard-summary": {
-      "types": "./dist/commands/guard-summary.d.ts",
-      "import": "./dist/commands/guard-summary.js"
-    },
     "./commands/guard-setup": {
+      "truecourse-source": "./src/commands/guard-setup.ts",
       "types": "./dist/commands/guard-setup.d.ts",
       "import": "./dist/commands/guard-setup.js"
     },
     "./commands/guard-seed": {
+      "truecourse-source": "./src/commands/guard-seed.ts",
       "types": "./dist/commands/guard-seed.d.ts",
       "import": "./dist/commands/guard-seed.js"
     },
     "./commands/guard-interfaces": {
+      "truecourse-source": "./src/commands/guard-interfaces.ts",
       "types": "./dist/commands/guard-interfaces.d.ts",
       "import": "./dist/commands/guard-interfaces.js"
     },
     "./commands/guard-dependencies": {
+      "truecourse-source": "./src/commands/guard-dependencies.ts",
       "types": "./dist/commands/guard-dependencies.d.ts",
       "import": "./dist/commands/guard-dependencies.js"
     },
     "./commands/guard-adjudicate": {
+      "truecourse-source": "./src/commands/guard-adjudicate.ts",
       "types": "./dist/commands/guard-adjudicate.d.ts",
       "import": "./dist/commands/guard-adjudicate.js"
     },
     "./commands/guard-externals": {
+      "truecourse-source": "./src/commands/guard-externals.ts",
       "types": "./dist/commands/guard-externals.d.ts",
       "import": "./dist/commands/guard-externals.js"
     },
     "./commands/guard-read": {
+      "truecourse-source": "./src/commands/guard-read.ts",
       "types": "./dist/commands/guard-read.d.ts",
       "import": "./dist/commands/guard-read.js"
     },
     "./commands/repo-events": {
+      "truecourse-source": "./src/commands/repo-events.ts",
       "types": "./dist/commands/repo-events.d.ts",
       "import": "./dist/commands/repo-events.js"
     },
     "./progress": {
+      "truecourse-source": "./src/progress.ts",
       "types": "./dist/progress.d.ts",
       "import": "./dist/progress.js"
     },
     "./config": {
+      "truecourse-source": "./src/config/index.ts",
       "types": "./dist/config/index.d.ts",
       "import": "./dist/config/index.js"
     },
     "./config/paths": {
+      "truecourse-source": "./src/config/paths.ts",
       "types": "./dist/config/paths.d.ts",
       "import": "./dist/config/paths.js"
     },
     "./config/registry": {
+      "truecourse-source": "./src/config/registry.ts",
       "types": "./dist/config/registry.d.ts",
       "import": "./dist/config/registry.js"
     },
     "./config/project-config": {
+      "truecourse-source": "./src/config/project-config.ts",
       "types": "./dist/config/project-config.d.ts",
       "import": "./dist/config/project-config.js"
     },
     "./config/current-project": {
+      "truecourse-source": "./src/config/current-project.ts",
       "types": "./dist/config/current-project.d.ts",
       "import": "./dist/config/current-project.js"
     },
     "./config/ui-state": {
+      "truecourse-source": "./src/config/ui-state.ts",
       "types": "./dist/config/ui-state.d.ts",
       "import": "./dist/config/ui-state.js"
     },
     "./config/env": {
+      "truecourse-source": "./src/config/env.ts",
       "types": "./dist/config/env.d.ts",
       "import": "./dist/config/env.js"
     },
     "./config/llm-models": {
+      "truecourse-source": "./src/config/llm-models.ts",
       "types": "./dist/config/llm-models.d.ts",
       "import": "./dist/config/llm-models.js"
     },
     "./config/global-config": {
+      "truecourse-source": "./src/config/global-config.ts",
       "types": "./dist/config/global-config.d.ts",
       "import": "./dist/config/global-config.js"
     },
     "./lib/logger": {
+      "truecourse-source": "./src/lib/logger.ts",
       "types": "./dist/lib/logger.d.ts",
       "import": "./dist/lib/logger.js"
     },
     "./lib/analysis-store": {
+      "truecourse-source": "./src/lib/analysis-store.ts",
       "types": "./dist/lib/analysis-store.d.ts",
       "import": "./dist/lib/analysis-store.js"
     },
     "./lib/sessions-store": {
+      "truecourse-source": "./src/lib/sessions-store.ts",
       "types": "./dist/lib/sessions-store.d.ts",
       "import": "./dist/lib/sessions-store.js"
     },
     "./lib/contract-store": {
+      "truecourse-source": "./src/lib/contract-store.ts",
       "types": "./dist/lib/contract-store.d.ts",
       "import": "./dist/lib/contract-store.js"
     },
     "./lib/spec-store": {
+      "truecourse-source": "./src/lib/spec-store.ts",
       "types": "./dist/lib/spec-store.d.ts",
       "import": "./dist/lib/spec-store.js"
     },
     "./lib/safe-path": {
+      "truecourse-source": "./src/lib/safe-path.ts",
       "types": "./dist/lib/safe-path.d.ts",
       "import": "./dist/lib/safe-path.js"
     },
     "./lib/guard-store": {
+      "truecourse-source": "./src/lib/guard-store.ts",
       "types": "./dist/lib/guard-store.d.ts",
       "import": "./dist/lib/guard-store.js"
     },
     "./lib/guard-overlays": {
+      "truecourse-source": "./src/lib/guard-overlays.ts",
       "types": "./dist/lib/guard-overlays.d.ts",
       "import": "./dist/lib/guard-overlays.js"
     },
     "./lib/spec-sources": {
+      "truecourse-source": "./src/lib/spec-sources.ts",
       "types": "./dist/lib/spec-sources.d.ts",
       "import": "./dist/lib/spec-sources.js"
     },
     "./lib/guard-read-tree": {
+      "truecourse-source": "./src/lib/guard-read-tree.ts",
       "types": "./dist/lib/guard-read-tree.d.ts",
       "import": "./dist/lib/guard-read-tree.js"
     },
     "./lib/guard-executor": {
+      "truecourse-source": "./src/lib/guard-executor.ts",
       "types": "./dist/lib/guard-executor.d.ts",
       "import": "./dist/lib/guard-executor.js"
     },
     "./lib/guard-gate-pending": {
+      "truecourse-source": "./src/lib/guard-gate-pending.ts",
       "types": "./dist/lib/guard-gate-pending.d.ts",
       "import": "./dist/lib/guard-gate-pending.js"
     },
     "./lib/guard-generate-enqueue": {
+      "truecourse-source": "./src/lib/guard-generate-enqueue.ts",
       "types": "./dist/lib/guard-generate-enqueue.d.ts",
       "import": "./dist/lib/guard-generate-enqueue.js"
     },
     "./lib/guard-pr-regen-enqueue": {
+      "truecourse-source": "./src/lib/guard-pr-regen-enqueue.ts",
       "types": "./dist/lib/guard-pr-regen-enqueue.d.ts",
       "import": "./dist/lib/guard-pr-regen-enqueue.js"
     },
     "./lib/repo-lifecycle": {
+      "truecourse-source": "./src/lib/repo-lifecycle.ts",
       "types": "./dist/lib/repo-lifecycle.d.ts",
       "import": "./dist/lib/repo-lifecycle.js"
     },
     "./lib/spec-inheritance-hook": {
+      "truecourse-source": "./src/lib/spec-inheritance-hook.ts",
       "types": "./dist/lib/spec-inheritance-hook.d.ts",
       "import": "./dist/lib/spec-inheritance-hook.js"
     },
     "./lib/knowledge-ledger-reader": {
+      "truecourse-source": "./src/lib/knowledge-ledger-reader.ts",
       "types": "./dist/lib/knowledge-ledger-reader.d.ts",
       "import": "./dist/lib/knowledge-ledger-reader.js"
     },
     "./lib/inferred-action-store": {
+      "truecourse-source": "./src/lib/inferred-action-store.ts",
       "types": "./dist/lib/inferred-action-store.d.ts",
       "import": "./dist/lib/inferred-action-store.js"
     },
     "./lib/inferred-decisions": {
+      "truecourse-source": "./src/lib/inferred-decisions.ts",
       "types": "./dist/lib/inferred-decisions.d.ts",
       "import": "./dist/lib/inferred-decisions.js"
     },
     "./lib/artifact-diff": {
+      "truecourse-source": "./src/lib/artifact-diff.ts",
       "types": "./dist/lib/artifact-diff.d.ts",
       "import": "./dist/lib/artifact-diff.js"
     },
-    "./lib/spec-origin-resolver": {
-      "types": "./dist/lib/spec-origin-resolver.d.ts",
-      "import": "./dist/lib/spec-origin-resolver.js"
-    },
     "./lib/workspace-doc-links": {
+      "truecourse-source": "./src/lib/workspace-doc-links.ts",
       "types": "./dist/lib/workspace-doc-links.d.ts",
       "import": "./dist/lib/workspace-doc-links.js"
     },
     "./lib/repo-doc-reader": {
+      "truecourse-source": "./src/lib/repo-doc-reader.ts",
       "types": "./dist/lib/repo-doc-reader.d.ts",
       "import": "./dist/lib/repo-doc-reader.js"
     },
     "./lib/background-tasks": {
+      "truecourse-source": "./src/lib/background-tasks.ts",
       "types": "./dist/lib/background-tasks.d.ts",
       "import": "./dist/lib/background-tasks.js"
     },
     "./lib/repo-ref": {
+      "truecourse-source": "./src/lib/repo-ref.ts",
       "types": "./dist/lib/repo-ref.d.ts",
       "import": "./dist/lib/repo-ref.js"
     },
     "./lib/analyze-lock": {
+      "truecourse-source": "./src/lib/analyze-lock.ts",
       "types": "./dist/lib/analyze-lock.d.ts",
       "import": "./dist/lib/analyze-lock.js"
     },
     "./lib/git": {
+      "truecourse-source": "./src/lib/git.ts",
       "types": "./dist/lib/git.d.ts",
       "import": "./dist/lib/git.js"
     },
     "./lib/errors": {
+      "truecourse-source": "./src/lib/errors.ts",
       "types": "./dist/lib/errors.d.ts",
       "import": "./dist/lib/errors.js"
     },
     "./lib/cli-binary": {
+      "truecourse-source": "./src/lib/cli-binary.ts",
       "types": "./dist/lib/cli-binary.d.ts",
       "import": "./dist/lib/cli-binary.js"
     },
     "./services/guard-setup/bundle": {
+      "truecourse-source": "./src/services/guard-setup/bundle.ts",
       "types": "./dist/services/guard-setup/bundle.d.ts",
       "import": "./dist/services/guard-setup/bundle.js"
     },
     "./services/analyzer": {
+      "truecourse-source": "./src/services/analyzer.service.ts",
       "types": "./dist/services/analyzer.service.d.ts",
       "import": "./dist/services/analyzer.service.js"
     },
     "./services/graph": {
+      "truecourse-source": "./src/services/graph.service.ts",
       "types": "./dist/services/graph.service.d.ts",
       "import": "./dist/services/graph.service.js"
     },
     "./services/flow": {
+      "truecourse-source": "./src/services/flow.service.ts",
       "types": "./dist/services/flow.service.d.ts",
       "import": "./dist/services/flow.service.js"
     },
     "./services/interface": {
+      "truecourse-source": "./src/services/interface.service.ts",
       "types": "./dist/services/interface.service.d.ts",
       "import": "./dist/services/interface.service.js"
     },
     "./services/interface-author": {
+      "truecourse-source": "./src/services/interface-author/index.ts",
       "types": "./dist/services/interface-author/index.d.ts",
       "import": "./dist/services/interface-author/index.js"
     },
     "./services/violation-query": {
+      "truecourse-source": "./src/services/violation-query.service.ts",
       "types": "./dist/services/violation-query.service.d.ts",
       "import": "./dist/services/violation-query.service.js"
     },
     "./services/violation": {
+      "truecourse-source": "./src/services/violation.service.ts",
       "types": "./dist/services/violation.service.d.ts",
       "import": "./dist/services/violation.service.js"
     },
     "./services/analysis-registry": {
+      "truecourse-source": "./src/services/analysis-registry.ts",
       "types": "./dist/services/analysis-registry.d.ts",
       "import": "./dist/services/analysis-registry.js"
     },
     "./services/rules": {
+      "truecourse-source": "./src/services/rules.service.ts",
       "types": "./dist/services/rules.service.d.ts",
       "import": "./dist/services/rules.service.js"
     },
     "./services/stable-keys": {
+      "truecourse-source": "./src/services/stable-keys.ts",
       "types": "./dist/services/stable-keys.d.ts",
       "import": "./dist/services/stable-keys.js"
     },
     "./services/llm/provider": {
+      "truecourse-source": "./src/services/llm/provider.ts",
       "types": "./dist/services/llm/provider.d.ts",
       "import": "./dist/services/llm/provider.js"
     },
     "./services/llm/spec-estimate": {
+      "truecourse-source": "./src/services/llm/spec-estimate.ts",
       "types": "./dist/services/llm/spec-estimate.d.ts",
       "import": "./dist/services/llm/spec-estimate.js"
     },
     "./services/llm/model-prices": {
+      "truecourse-source": "./src/services/llm/model-prices.ts",
       "types": "./dist/services/llm/model-prices.d.ts",
       "import": "./dist/services/llm/model-prices.js"
     },
     "./services/llm/session-driver": {
+      "truecourse-source": "./src/services/llm/session-driver.ts",
       "types": "./dist/services/llm/session-driver.d.ts",
       "import": "./dist/services/llm/session-driver.js"
     },
     "./services/llm/install-transport": {
+      "truecourse-source": "./src/services/llm/install-transport.ts",
       "types": "./dist/services/llm/install-transport.d.ts",
       "import": "./dist/services/llm/install-transport.js"
     },
     "./services/llm/probe": {
+      "truecourse-source": "./src/services/llm/probe.ts",
       "types": "./dist/services/llm/probe.d.ts",
       "import": "./dist/services/llm/probe.js"
     },
     "./services/llm/guard-visual-judge": {
+      "truecourse-source": "./src/services/llm/guard-visual-judge.ts",
       "types": "./dist/services/llm/guard-visual-judge.d.ts",
       "import": "./dist/services/llm/guard-visual-judge.js"
     },
     "./services/telemetry": {
+      "truecourse-source": "./src/services/telemetry.service.ts",
       "types": "./dist/services/telemetry.service.d.ts",
       "import": "./dist/services/telemetry.service.js"
     },
     "./types/snapshot": {
+      "truecourse-source": "./src/types/snapshot.ts",
       "types": "./dist/types/snapshot.d.ts",
       "import": "./dist/types/snapshot.js"
     },
     "./lib/activity-journal": {
+      "truecourse-source": "./src/lib/activity-journal.ts",
       "types": "./dist/lib/activity-journal.d.ts",
       "import": "./dist/lib/activity-journal.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/agent-loop": "workspace:*",

--- a/packages/data-store/package.json
+++ b/packages/data-store/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/core": "workspace:*",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",

--- a/packages/github-app/package.json
+++ b/packages/github-app/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@octokit/auth-app": "^7.1.3",

--- a/packages/guard-generator/package.json
+++ b/packages/guard-generator/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/guard-runner": "workspace:*",

--- a/packages/guard-runner/package.json
+++ b/packages/guard-runner/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@lydell/node-pty": "^1.2.0-beta.14",

--- a/packages/interface-mapper/package.json
+++ b/packages/interface-mapper/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/guard-runner": "workspace:*",

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/core": "workspace:*",

--- a/packages/llm-api/package.json
+++ b/packages/llm-api/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "^4.0.0",

--- a/packages/llm-claude-agent/package.json
+++ b/packages/llm-claude-agent/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/agent-loop": "workspace:*",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -7,14 +7,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,34 +7,40 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./llm": {
+      "truecourse-source": "./src/llm/transport.ts",
       "types": "./dist/llm/transport.d.ts",
       "import": "./dist/llm/transport.js"
     },
     "./openapi": {
+      "truecourse-source": "./src/openapi/index.ts",
       "types": "./dist/openapi/index.d.ts",
       "import": "./dist/openapi/index.js"
     },
     "./openapi-node": {
+      "truecourse-source": "./src/openapi/node-ref-context.ts",
       "types": "./dist/openapi/node-ref-context.d.ts",
       "import": "./dist/openapi/node-ref-context.js"
     },
     "./activity-stream": {
+      "truecourse-source": "./src/activity-stream.ts",
       "types": "./dist/activity-stream.d.ts",
       "import": "./dist/activity-stream.js"
     },
     "./next-routing-node": {
+      "truecourse-source": "./src/next-routing-node.ts",
       "types": "./dist/next-routing-node.d.ts",
       "import": "./dist/next-routing-node.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "ignore": "^7.0.5",

--- a/packages/spec-consolidator/package.json
+++ b/packages/spec-consolidator/package.json
@@ -7,18 +7,20 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "truecourse-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./types": {
+      "truecourse-source": "./src/types.ts",
       "types": "./dist/types.d.ts",
       "import": "./dist/types.js"
     }
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@truecourse/llm": "workspace:*",

--- a/tests/analyzer/deterministic-scan.test.ts
+++ b/tests/analyzer/deterministic-scan.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import path from 'node:path'
 import os from 'node:os'
 import fs from 'node:fs'
@@ -94,11 +94,8 @@ describe('runDeterministicScanIsolated (controller)', () => {
     await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
   }, 15_000)
 
-  it('falls back to in-thread when no worker can be resolved', async () => {
-    // A bogus workerPath is ignored (falsey check is on resolve, not existence),
-    // so force the fallback by pointing resolution at a non-existent bundled
-    // layout: pass an empty override and rely on resolveWorkerPath returning null
-    // under vitest (source layout has no sibling worker.js / det-scan-worker.mjs).
+  it('runs the real source worker without falling back to the main thread', async () => {
+    const onFallback = vi.fn()
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'det-scan-'))
     const filePath = path.join(dir, 'empty-catch.ts')
     fs.writeFileSync(filePath, 'try { doSomething(); } catch (e) {}\n')
@@ -111,11 +108,12 @@ describe('runDeterministicScanIsolated (controller)', () => {
         tsFiles: [],
         databaseResult: undefined,
       },
-      { fileTimeoutMs: 5_000 }, // no workerPath → resolveWorkerPath() returns null under source layout → in-thread
+      { fileTimeoutMs: 5_000, onFallback },
     )
 
     fs.rmSync(dir, { recursive: true, force: true })
     expect(result.skipped).toEqual([])
+    expect(onFallback).not.toHaveBeenCalled()
     expect(result.violations.some((v: any) => v.ruleKey === 'bugs/deterministic/empty-catch')).toBe(true)
   })
 })

--- a/tests/architecture/source-development.test.ts
+++ b/tests/architecture/source-development.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = fileURLToPath(new URL('../../', import.meta.url));
+
+describe('workspace source exports', () => {
+  it('resolves every library export to source only when explicitly requested', () => {
+    for (const base of ['packages', 'ee/packages']) {
+      const folder = path.join(root, base);
+      if (!fs.existsSync(folder)) continue;
+      for (const entry of fs.readdirSync(folder)) {
+        const dir = path.join(folder, entry);
+        const manifest = path.join(dir, 'package.json');
+        if (!fs.existsSync(manifest)) continue;
+        const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+        if (pkg.scripts?.build !== 'tsc') continue;
+        expect(pkg.scripts.dev, pkg.name).toBeUndefined();
+        const specifiers = Object.keys(pkg.exports).map(key => pkg.name + (key === '.' ? '' : key.slice(1)));
+        const resolve = (source: boolean) => JSON.parse(execFileSync(process.execPath, [
+          ...(source ? ['--conditions=truecourse-source'] : []),
+          '--input-type=module', '-e',
+          `console.log(JSON.stringify(${JSON.stringify(specifiers)}.map(id => import.meta.resolve(id))))`,
+        ], { cwd: dir, encoding: 'utf8', timeout: 10000 }));
+        const sourcePaths = resolve(true);
+        const productionPaths = resolve(false);
+        Object.values(pkg.exports).forEach((target: any, i) => {
+          const source = path.resolve(dir, target['truecourse-source']);
+          expect(fs.existsSync(source), specifiers[i]).toBe(true);
+          expect(sourcePaths[i], specifiers[i]).toBe(pathToFileURL(source).href);
+          expect(productionPaths[i], specifiers[i]).toBe(pathToFileURL(path.resolve(dir, target.import)).href);
+          expect(target.types, specifiers[i]).toMatch(/^\.\/dist\/.*\.d\.ts$/);
+        });
+      }
+    }
+  });
+});

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "echo 'CLI is not used in dev mode'",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clack/prompts": "^1.2.0",

--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,10 @@
     "lint": {
       "dependsOn": ["^build"]
     },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "clean": {
       "cache": false
     }


### PR DESCRIPTION
Development currently runs TypeScript watchers across workspace libraries. Resolve workspace imports directly to TypeScript source through the `truecourse-source` export condition, enabled by the dashboard's tsx watcher and Vite dev server. Remove library watchers and add a separate `pnpm typecheck` command with limited concurrency. Production imports continue to resolve to `dist`.

Add a tsx entry for deterministic-scan worker threads, remove stale package exports, and correct the enterprise spec source's no-op scan return value. Regression coverage checks source and production export resolution and verifies that source scans use a real worker.

Validation: `git diff --check` passed. Tests were not run while opening this PR.
