### PR TITLE
Harden CLI analyze handling of invalid project paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The deterministic scan runs in a worker thread with a per-file time budget, so a
 ## Commands
 
 ```bash
-truecourse analyze                    # Analyze current repo (prompts before stashing dirty trees)
+truecourse analyze [project-path]      # Analyze a repository (defaults to the current directory)
 truecourse analyze --stash            # Pre-approve stashing pending changes (CI-friendly)
 truecourse analyze --no-stash         # Analyze working tree as-is, no stash
 truecourse analyze --diff             # New/resolved violations from your uncommitted changes

--- a/tests/cli/analyze.test.ts
+++ b/tests/cli/analyze.test.ts
@@ -165,7 +165,7 @@ for (const c of E2E_CASES) {
 // exit with a clear message; absent flag + clean does nothing.
 // ---------------------------------------------------------------------------
 
-import { resolveStashDecision } from '../../tools/cli/src/commands/analyze';
+import { resolveStashDecision, validateProjectPath, runAnalyze } from '../../tools/cli/src/commands/analyze';
 
 describe('resolveStashDecision', () => {
   let workDir: string;
@@ -250,6 +250,53 @@ describe('resolveStashDecision', () => {
       expect(result).toEqual({ skipStash: false });
     } finally {
       fs.rmSync(nonGitDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('analyze project path validation', () => {
+  it('rejects a missing path before initializing project state', () => {
+    const missing = path.join(os.tmpdir(), `truecourse-missing-${Date.now()}-${Math.random()}`);
+    expect(() => validateProjectPath(missing)).toThrow(`Project path does not exist: ${missing}`);
+  });
+
+  it('rejects a regular file as a project path', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'truecourse-invalid-project-'));
+    const file = path.join(dir, 'project.txt');
+    fs.writeFileSync(file, 'not a directory\n');
+    try {
+      expect(() => validateProjectPath(file)).toThrow(`Project path is not a directory: ${file}`);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a directory that cannot be read', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'truecourse-unreadable-project-'));
+    const accessSpy = vi.spyOn(fs, 'accessSync').mockImplementationOnce(() => {
+      throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    });
+    try {
+      expect(() => validateProjectPath(dir)).toThrow(`Project path is not readable: ${dir}`);
+    } finally {
+      accessSpy.mockRestore();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports invalid input through the CLI error path with a nonzero exit', async () => {
+    const missing = path.join(os.tmpdir(), `truecourse-missing-${Date.now()}-${Math.random()}`);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(runAnalyze({ projectPath: missing, llm: false })).rejects.toThrow('process.exit called');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(`error: Project path does not exist: ${missing}`);
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
     }
   });
 });

--- a/tools/cli/src/commands/analyze.ts
+++ b/tools/cli/src/commands/analyze.ts
@@ -16,11 +16,61 @@ import { promptLlmEstimate } from "./llm-prompt.js";
 import { showFirstRunNotice } from "../telemetry.js";
 import { recordAnalyzeAndMaybePrompt } from "../community-prompts.js";
 
-async function resolveOrInitProject(): Promise<RegistryEntry> {
-  const repoDir = resolveRepoDir(process.cwd()) ?? process.cwd();
+async function resolveOrInitProject(projectPath = process.cwd()): Promise<RegistryEntry> {
+  const requestedPath = validateProjectPath(projectPath);
+  const repoDir = resolveRepoDir(requestedPath) ?? requestedPath;
   ensureRepoTruecourseDir(repoDir);
   return registerProject(repoDir);
 }
+
+/**
+ * Validate the directory supplied to `analyze` before creating any project
+ * state or starting the analysis pipeline.
+ */
+export function validateProjectPath(projectPath: string): string {
+  const resolvedPath = path.resolve(projectPath);
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(resolvedPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      throw new Error(`Project path does not exist: ${projectPath}`);
+    }
+    if (code === "EACCES" || code === "EPERM") {
+      throw new Error(`Project path is not readable: ${projectPath}`);
+    }
+    throw new Error(`Unable to access project path ${projectPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (!stat.isDirectory()) {
+    throw new Error(`Project path is not a directory: ${projectPath}`);
+  }
+
+  try {
+    fs.accessSync(resolvedPath, fs.constants.R_OK | fs.constants.X_OK);
+  } catch {
+    throw new Error(`Project path is not readable: ${projectPath}`);
+  }
+
+  return resolvedPath;
+}
+
+function resolveRequestedProjectPath(projectPath: string | undefined): string {
+  if (projectPath) return projectPath;
+  try {
+    return process.cwd();
+  } catch {
+    throw new Error("Unable to determine the current project path; pass a readable directory to analyze.");
+  }
+}
+
+function exitForInvalidProjectPath(error: unknown): never {
+  console.error(`error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+  throw error;
+}
+
 
 /**
  * Cheap check: does the repo contain any C# source? Decides whether the
@@ -152,6 +202,8 @@ function stopSpinner(): void {
  * Same shape as `installSkills` below.
  */
 export interface AnalyzeOptions {
+  /** Directory to analyze; defaults to the current working directory. */
+  projectPath?: string;
   /** Override `enableLlmRules` for this run (whether LLM rules run at all). */
   llm?: boolean;
   /**
@@ -258,10 +310,16 @@ export async function resolveStashDecision(
 }
 
 export async function runAnalyze(options: AnalyzeOptions = {}): Promise<void> {
+  let project: RegistryEntry;
+  try {
+    project = await resolveOrInitProject(resolveRequestedProjectPath(options.projectPath));
+  } catch (error) {
+    exitForInvalidProjectPath(error);
+  }
+
   p.intro("Analyzing repository");
   showFirstRunNotice();
 
-  const project = await resolveOrInitProject();
   p.log.step(`Repository: ${project.name}`);
 
   // First-time setup convenience: offer to install Claude Code skills if
@@ -384,13 +442,19 @@ export async function runAnalyze(options: AnalyzeOptions = {}): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export async function runAnalyzeDiff(options: AnalyzeOptions = {}): Promise<void> {
+  let project: RegistryEntry;
+  try {
+    project = await resolveOrInitProject(resolveRequestedProjectPath(options.projectPath));
+  } catch (error) {
+    exitForInvalidProjectPath(error);
+  }
+
   const { diffInProcess } = await import("@truecourse/core/commands/diff-in-process");
   const { renderDiffResultsSummary } = await import("./helpers.js");
 
   p.intro("Running diff check");
   showFirstRunNotice();
 
-  const project = await resolveOrInitProject();
   p.log.step(`Repository: ${project.name}`);
 
   // Same first-run skill convenience as `runAnalyze`.

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -176,8 +176,8 @@ function resolveInstallSkills(
 }
 
 program
-  .command("analyze")
-  .description("Analyze the current repository")
+  .command("analyze [project-path]")
+  .description("Analyze a repository (defaults to the current directory)")
   .option("--diff", "Run diff check against latest analysis")
   // `--llm` and `--no-llm` are auto-paired by commander — they both control
   // `options.llm`. Passing `--llm` → true, `--no-llm` → false, neither →
@@ -190,11 +190,11 @@ program
   .option("--no-stash", "Analyze the working tree as-is without stashing")
   .option("--install-skills", "Install Claude Code skills without prompting")
   .option("--no-skills", "Skip the Claude Code skills prompt")
-  .action(async (options) => {
+  .action(async (projectPath, options) => {
     const llm: boolean | undefined = typeof options.llm === "boolean" ? options.llm : undefined;
     const stash: boolean | undefined = typeof options.stash === "boolean" ? options.stash : undefined;
     const installSkills = resolveInstallSkills(options);
-    const common = { llm, stash, installSkills, llmTransport: options.llmTransport, io: options.io };
+    const common = { projectPath, llm, stash, installSkills, llmTransport: options.llmTransport, io: options.io };
     if (options.diff) {
       await runAnalyzeDiff(common);
     } else {


### PR DESCRIPTION
## Summary
- Allow `truecourse analyze [project-path]`, defaulting to the current directory.
- Validate the requested path before creating `.truecourse` state or starting analysis, with actionable errors and exit status 1.
- Add focused coverage for missing, file, unreadable, and CLI error-path inputs.
- Update the command reference in README.

## Validation
- `git diff --check` passed.

Validation observed for this change:
- `git diff --check`

<!-- repo-agent-case:1dd79939-f7f3-4f53-8ff8-84a8c3695253 -->