### PR TITLE
feat(guard): scope authoring context and confirm typed web failures

### DIFF
--- a/apps/dashboard/client/src/components/sessions/RunConversationPage.tsx
+++ b/apps/dashboard/client/src/components/sessions/RunConversationPage.tsx
@@ -32,7 +32,6 @@ import { STEP_DOT, formatDuration } from './run-model';
 import { useRunConversation } from './useRunConversation';
 import type { ConversationLine, DataField, SessionBlock, StepBlock } from './conversation-model';
 
-const EMPTY_STEPS: readonly StepBlock[] = [];
 
 /** The reading column: wide enough for a quoted diff, narrow enough to read. */
 const COLUMN = 'mx-auto w-[780px] max-w-full';
@@ -47,18 +46,17 @@ const WORK_DOT: Record<SessionStatus, string> = {
 };
 
 export function RunConversationPage({ run, repoId }: { run: PublicSessionRun; repoId: string }) {
-  const { conversation, loading, error, connectionError } = useRunConversation(run, repoId);
-  // History lands page by page; painting it as it comes shows every row before
-  // its lines, so the page waits for the whole of it and paints once.
-  const steps = loading ? EMPTY_STEPS : conversation.steps;
+  const [params, setParams] = useSearchParams();
+  const selectedId = params.get('work');
+  const { conversation, loading, error, connectionError, hasOlder, loadingOlder, loadOlder } = useRunConversation(run, repoId, selectedId);
+  // Session metadata is sufficient to show the work list immediately.
+  const steps = conversation.steps;
   // The step the run stopped on, which is where its reason belongs: the one
   // that errored, else the one still open when the run died.
   const stoppedAt = conversation.error
     ? (steps.find((step) => step.status === 'error') ?? steps.find((step) => step.status === 'active'))?.key
     : undefined;
 
-  const [params, setParams] = useSearchParams();
-  const selectedId = params.get('work');
   const blocks = useMemo(() => {
     const map = new Map<string, SessionBlock>();
     for (const step of steps) for (const block of step.sessions) map.set(block.sessionId, block);
@@ -176,7 +174,7 @@ export function RunConversationPage({ run, repoId }: { run: PublicSessionRun; re
       </div>
       {selected && (
         <FindingResolveProvider repoId={repoId} active={hasDispute}>
-          <WorkPane block={selected} onClose={() => select(null)} />
+          <WorkPane block={selected} onClose={() => select(null)} loading={loading} hasOlder={hasOlder} loadingOlder={loadingOlder} loadOlder={loadOlder} />
         </FindingResolveProvider>
       )}
     </div>
@@ -425,7 +423,9 @@ function WorkDot({ status, className = '' }: { status: SessionStatus; className?
  * its own scroll, following the end while it runs unless the reader scrolled
  * up.
  */
-function WorkPane({ block, onClose }: { block: SessionBlock; onClose: () => void }) {
+function WorkPane({ block, onClose, loading, hasOlder, loadingOlder, loadOlder }: {
+  block: SessionBlock; onClose: () => void; loading: boolean; hasOlder: boolean; loadingOlder: boolean; loadOlder: () => void;
+}) {
   const scroller = useRef<HTMLDivElement>(null);
   const follow = useRef(true);
   const toEnd = useCallback(() => {
@@ -471,6 +471,11 @@ function WorkPane({ block, onClose }: { block: SessionBlock; onClose: () => void
         }}
         className="min-h-0 flex-1 overflow-y-auto px-5 pb-6"
       >
+        {hasOlder && <button type="button" disabled={loadingOlder} onClick={loadOlder}
+          className="my-3 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50">
+          {loadingOlder ? 'Loading older messages…' : 'Load older messages'}
+        </button>}
+        {loading && <p role="status" className="my-3 text-sm text-muted-foreground">Loading messages…</p>}
         <Transcript block={block} />
       </div>
     </aside>

--- a/apps/dashboard/client/src/components/sessions/run-model.ts
+++ b/apps/dashboard/client/src/components/sessions/run-model.ts
@@ -119,7 +119,7 @@ export interface RunStarter {
   /** Whether a run of this command can be started from here. */
   supports: (command: string) => boolean;
   /** Fire it. Refusals are announced by the starter, so there is nothing to catch. */
-  start: (command: string) => void;
+  start: (command: string, resumeRunId?: string) => void;
   /** A start is in flight. */
   pending: boolean;
   /** What a repository with no runs at all is offered, when there is an offer. */

--- a/apps/dashboard/client/src/components/sessions/useRunConversation.ts
+++ b/apps/dashboard/client/src/components/sessions/useRunConversation.ts
@@ -15,7 +15,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { ActivityEvent, ActivityProgress } from '@truecourse/shared/activity-stream';
+import { compactRunSnapshots, type ActivityEvent, type ActivityProgress } from '@truecourse/shared/activity-stream';
 import * as api from '@/lib/api';
 import type { PublicSessionRun } from '@/lib/api';
 import { followActivity } from '@/lib/activity-stream';
@@ -85,7 +85,7 @@ export function useRunConversation(run: PublicSessionRun, repoId: string): RunCo
           seen.add(event.cursor);
           next.push(event);
         }
-        return next.length === prev.length ? prev : next.sort((a, b) => a.cursor - b.cursor);
+        return next.length === prev.length ? prev : compactRunSnapshots(next).sort((a, b) => a.cursor - b.cursor);
       });
     };
 
@@ -96,7 +96,7 @@ export function useRunConversation(run: PublicSessionRun, repoId: string): RunCo
       }
       let after = -1;
       for (;;) {
-        const page = await api.readRunActivity(repoId, command, runId, after, PAGE);
+        const page = await api.readRunActivity(repoId, command, runId, after, PAGE, controller.signal);
         if (cancelled) return;
         absorb(page.events);
         after = page.nextCursor;

--- a/apps/dashboard/client/src/components/sessions/useRunConversation.ts
+++ b/apps/dashboard/client/src/components/sessions/useRunConversation.ts
@@ -1,171 +1,105 @@
-/**
- * Reading one conversation: the journal by page, then the live tail.
- *
- * History is paged (1000 events a request, so a 3000-event journal is three
- * round trips) and the page grows as each one lands, which is why a long
- * conversation paints before it has finished loading. When the work is still
- * going, the stream opens FROM the cursor the last page reached and appends;
- * chunks merge into the one event array, deduped by cursor, so a replayed
- * overlap can never double a line.
- *
- * A repository whose store predates the journal (file mode) has no cursor to
- * page: its record names its work, and each piece of work has a transcript of
- * its own. Those are read and stitched into the same event shape, so the fold
- * below is the same fold.
- */
-
+/** The run record supplies the work list; only the opened session loads messages. */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { compactRunSnapshots, type ActivityEvent, type ActivityProgress } from '@truecourse/shared/activity-stream';
+import type { ActivityEvent } from '@truecourse/shared/activity-stream';
+import type { SessionEvent, SessionProgress } from '@truecourse/agent-loop';
 import * as api from '@/lib/api';
 import type { PublicSessionRun } from '@/lib/api';
-import { followActivity } from '@/lib/activity-stream';
-import { getServerUrl } from '@/lib/server-url';
 import { foldConversation, type Conversation } from './conversation-model';
-
-const PAGE = 1000;
-
-/** Event types that end whatever the live line was saying about a turn. */
-const SETTLES_A_TURN = new Set(['assistant-turn', 'tool-result', 'outcome', 'failure']);
 
 export interface RunConversationState {
   conversation: Conversation;
-  /** History is still arriving. Lines already read render underneath it. */
   loading: boolean;
   error: string | null;
-  /** The live tail dropped, in the words the reader gets at the bottom. */
   connectionError: string | null;
+  hasOlder: boolean;
+  loadingOlder: boolean;
+  loadOlder: () => void;
 }
 
-export function useRunConversation(run: PublicSessionRun, repoId: string): RunConversationState {
-  const [events, setEvents] = useState<ActivityEvent[]>([]);
-  const [progress, setProgress] = useState<ActivityProgress>({});
-  const [loading, setLoading] = useState(true);
+export function useRunConversation(run: PublicSessionRun, repoId: string, sessionId: string | null): RunConversationState {
+  const [history, setHistory] = useState<{ key: string; events: SessionEvent[] }>({ key: '', events: [] });
+  const [progress, setProgress] = useState<SessionProgress | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [hasOlder, setHasOlder] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [connectionError, setConnectionError] = useState<string | null>(null);
-
-  // The record moves while the reader watches (a step lands, a status flips).
-  // Held in a ref so a fresh record never restarts the read.
   const latest = useRef(run);
   latest.current = run;
+  const older = useRef<() => void>(() => {});
+  const { command, runId } = run;
+  const key = `${repoId}:${command}:${runId}:${sessionId ?? ''}`;
 
-  const { command, runId, activityStream } = run;
   useEffect(() => {
-    let cancelled = false;
     const controller = new AbortController();
-    setEvents([]);
-    setProgress({});
-    setLoading(true);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let events: SessionEvent[] = [];
+    let olderPending = false;
+    setHistory({ key, events });
+    setLoading(!!sessionId);
+    setLoadingOlder(false);
+    setHasOlder(false);
+    setProgress(null);
     setError(null);
-    setConnectionError(null);
+    older.current = () => {};
+    if (!sessionId) return () => controller.abort();
 
-    const absorb = (arriving: readonly ActivityEvent[]): void => {
-      if (arriving.length === 0) return;
-      // A partial turn is superseded the moment its finished form arrives, and
-      // a record that says the work is over ends every live line at once. The
-      // stream does not re-send an empty progress map to say so.
-      setProgress((prev) => {
-        let next = prev;
-        for (const event of arriving) {
-          if (event.kind === 'run') {
-            if (event.run.status !== 'running') next = {};
-          } else if (SETTLES_A_TURN.has(event.event.type)) {
-            if (next[event.sessionId]) {
-              next = { ...next };
-              delete next[event.sessionId];
-            }
-          }
+    const absorb = (incoming: SessionEvent[]) => {
+      const bySeq = new Map(events.map(e => [e.seq, e]));
+      for (const e of incoming) bySeq.set(e.seq, e);
+      events = [...bySeq.values()].sort((a, b) => a.seq - b.seq);
+      setHistory({ key, events });
+    };
+    const failed = (e: unknown) => {
+      if (!controller.signal.aborted) setError(e instanceof Error ? e.message : String(e));
+    };
+    const poll = async (initial = false) => {
+      try {
+        let since = initial ? undefined : events.at(-1)?.seq ?? -1;
+        for (;;) {
+          const page = await api.getSessionTranscriptPage(repoId, command, runId, sessionId,
+            since === undefined ? {} : { since }, controller.signal);
+          if (controller.signal.aborted) return;
+          absorb(page.events);
+          setProgress(page.progress ?? null);
+          setError(null);
+          if (initial) { setHasOlder(page.hasMore); break; }
+          if (!page.hasMore || !page.events.length) break;
+          since = page.events.at(-1)!.seq;
         }
-        return next;
-      });
-      setEvents((prev) => {
-        const seen = new Set(prev.map((e) => e.cursor));
-        const next = [...prev];
-        for (const event of arriving) {
-          if (seen.has(event.cursor)) continue;
-          seen.add(event.cursor);
-          next.push(event);
+      } catch (e) { failed(e); }
+      finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+          // Sequential incremental polling never transfers siblings or overlaps requests.
+          const entry = latest.current.sessions.find(s => s.sessionId === sessionId);
+          if (entry?.status === 'running' || entry?.status === 'waiting' || (!entry && latest.current.status === 'running'))
+            timer = setTimeout(() => { void poll(); }, 3000);
         }
-        return next.length === prev.length ? prev : compactRunSnapshots(next).sort((a, b) => a.cursor - b.cursor);
-      });
-    };
-
-    const read = async (): Promise<void> => {
-      if (!activityStream) {
-        absorb(await readTranscripts(repoId, latest.current));
-        return;
       }
-      let after = -1;
-      for (;;) {
-        const page = await api.readRunActivity(repoId, command, runId, after, PAGE, controller.signal);
-        if (cancelled) return;
-        absorb(page.events);
-        after = page.nextCursor;
-        if (page.done) break;
-      }
-      if (cancelled || latest.current.status !== 'running') return;
-      void followActivity({
-        url: `${getServerUrl()}/api/repos/${encodeURIComponent(repoId)}/sessions/runs/${command}/${encodeURIComponent(runId)}/stream`,
-        runId,
-        from: after,
-        signal: controller.signal,
-        onEvent: (event) => absorb([event]),
-        onProgress: (next) => setProgress(next),
-        onConnection: (message) => {
-          if (!controller.signal.aborted) setConnectionError(message);
-        },
-      });
     };
-
-    read()
-      .catch((e: unknown) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-      controller.abort();
+    older.current = () => {
+      if (olderPending || !events.length || controller.signal.aborted) return;
+      olderPending = true;
+      setLoadingOlder(true);
+      void api.getSessionTranscriptPage(repoId, command, runId, sessionId, { before: events[0].seq }, controller.signal)
+        .then(page => {
+          if (controller.signal.aborted) return;
+          absorb(page.events);
+          setHasOlder(page.hasMore);
+          setError(null);
+        }).catch(failed).finally(() => {
+          olderPending = false;
+          if (!controller.signal.aborted) setLoadingOlder(false);
+        });
     };
-    // The record itself is deliberately not a dependency: it changes on every
-    // write, and the journal it names does not.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [repoId, command, runId, activityStream]);
+    void poll(true);
+    return () => { controller.abort(); clearTimeout(timer); older.current = () => {}; };
+  }, [repoId, command, runId, sessionId, key]);
 
-  // Folded on the events array's identity: absorbing nothing new keeps the
-  // previous array, so a heartbeat re-render costs nothing.
-  const conversation = useMemo(
-    () => foldConversation(run, events, progress),
-    [run, events, progress],
-  );
-
-  return { conversation, loading, error, connectionError };
-}
-
-/**
- * A store with no journal, in journal shape: the record first, then each piece
- * of work's transcript in the order the record lists it. Cursors are minted
- * here and mean only "this came before that", which is all the fold reads.
- */
-async function readTranscripts(
-  repoId: string,
-  run: PublicSessionRun,
-): Promise<ActivityEvent[]> {
-  const events: ActivityEvent[] = [{ cursor: 0, kind: 'run', run }];
-  let cursor = 1;
-  const transcripts = await Promise.all(
-    run.sessions.map((entry) =>
-      api
-        .getSessionTranscript(repoId, run.command, run.runId, entry.sessionId)
-        .then((res) => ({ sessionId: entry.sessionId, events: res.events }))
-        .catch(() => ({ sessionId: entry.sessionId, events: [] })),
-    ),
-  );
-  for (const transcript of transcripts) {
-    for (const event of transcript.events) {
-      events.push({ cursor: cursor++, kind: 'session-event', sessionId: transcript.sessionId, event });
-    }
-  }
-  return events;
+  const conversation = useMemo(() => {
+    const events: ActivityEvent[] = history.key === key && sessionId
+      ? history.events.map(e => ({ cursor: e.seq, kind: 'session-event', sessionId, event: e })) : [];
+    return foldConversation(run, events, history.key === key && sessionId && progress ? { [sessionId]: progress } : {});
+  }, [run, history, key, sessionId, progress]);
+  return { conversation, loading, error, connectionError: null, hasOlder, loadingOlder, loadOlder: () => older.current() };
 }

--- a/apps/dashboard/client/src/lib/api.ts
+++ b/apps/dashboard/client/src/lib/api.ts
@@ -1569,8 +1569,10 @@ export function readRunActivity(
   runId: string,
   after: number,
   limit: number,
+  signal?: AbortSignal,
 ): Promise<{ events: ActivityEvent[]; nextCursor: number; done: boolean }> {
   return fetchApi<{ events: ActivityEvent[]; nextCursor: number; done: boolean }>(
-    `/api/repos/${repoId}/sessions/runs/${command}/${encodeURIComponent(runId)}/activity?after=${after}&limit=${limit}`,
+    `/api/repos/${repoId}/sessions/runs/${command}/${encodeURIComponent(runId)}/activity?after=${after}&limit=${limit}&compact=1`,
+    { signal },
   );
 }

--- a/apps/dashboard/client/src/lib/api.ts
+++ b/apps/dashboard/client/src/lib/api.ts
@@ -1576,3 +1576,11 @@ export function readRunActivity(
     { signal },
   );
 }
+
+export function getSessionTranscriptPage(repoId: string, command: SessionCommand, runId: string, sessionId: string,
+  options: { before?: number; since?: number }, signal?: AbortSignal): Promise<{ events: SessionEvent[]; hasMore: boolean; progress?: import("@truecourse/agent-loop").SessionProgress | null }> {
+  const query = new URLSearchParams({ limit: '100' });
+  if (options.before !== undefined) query.set('before', String(options.before));
+  if (options.since !== undefined) query.set('since', String(options.since));
+  return fetchApi(`/api/repos/${encodeURIComponent(repoId)}/sessions/runs/${command}/${encodeURIComponent(runId)}/transcript/${encodeURIComponent(sessionId)}?${query}`, { signal });
+}

--- a/apps/dashboard/client/src/preview/data/run-triggers.ts
+++ b/apps/dashboard/client/src/preview/data/run-triggers.ts
@@ -10,7 +10,7 @@
 
 import { startGuardGenerate, startGuardSetup, startSpecScan, type RunStart } from './scan';
 
-export type RunTrigger = (repoId: string) => Promise<RunStart>;
+export type RunTrigger = (repoId: string, resumeRunId?: string) => Promise<RunStart>;
 
 const RUN_TRIGGERS: Record<string, RunTrigger> = {
   'spec-scan': startSpecScan,

--- a/apps/dashboard/client/src/preview/data/scan.ts
+++ b/apps/dashboard/client/src/preview/data/scan.ts
@@ -27,7 +27,7 @@ export type RunStart =
   | { kind: 'failed'; message: string };
 
 /** POST a repo-scoped start route (`spec/corpus/scan`, `guard/setup`, …). */
-export async function startRun(repoId: string, path: string): Promise<RunStart> {
+export async function startRun(repoId: string, path: string, payload?: unknown): Promise<RunStart> {
   const url = `${getServerUrl()}/api/repos/${encodeURIComponent(repoId)}/${path}`;
   let res: Response;
   try {
@@ -35,6 +35,7 @@ export async function startRun(repoId: string, path: string): Promise<RunStart> 
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
+      ...(payload === undefined ? {} : { body: JSON.stringify(payload) }),
     });
   } catch (e) {
     return { kind: 'failed', message: e instanceof Error ? e.message : String(e) };
@@ -61,5 +62,5 @@ export const startSpecScan = (repoId: string): Promise<RunStart> =>
 export const startGuardSetup = (repoId: string): Promise<RunStart> =>
   startRun(repoId, 'guard/setup');
 
-export const startGuardGenerate = (repoId: string): Promise<RunStart> =>
-  startRun(repoId, 'guard/generate');
+export const startGuardGenerate = (repoId: string, resumeRunId?: string): Promise<RunStart> =>
+  startRun(repoId, 'guard/generate', resumeRunId ? { resumeRunId } : undefined);

--- a/apps/dashboard/client/src/preview/pages/AgentPage.tsx
+++ b/apps/dashboard/client/src/preview/pages/AgentPage.tsx
@@ -273,6 +273,7 @@ function ConversationRoute({ runId }: { runId: string }) {
   if (!run) return null;
 
   const canRerun = run.status === 'failed' || run.status === 'interrupted';
+  const canResume = run.command === 'guard-generate';
 
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col">
@@ -289,10 +290,10 @@ function ConversationRoute({ runId }: { runId: string }) {
               <button
                 type="button"
                 disabled={starter.pending}
-                onClick={() => starter.start(run.command)}
+                onClick={() => starter.start(run.command, canResume ? run.runId : undefined)}
                 className="rounded border border-border px-2 py-0.5 font-medium text-foreground hover:bg-muted/60 disabled:opacity-50"
               >
-                {starter.pending ? 'Starting…' : 'Run again'}
+                {starter.pending ? 'Starting…' : canResume ? 'Resume' : 'Run again'}
               </button>
             )}
           </span>

--- a/apps/dashboard/client/src/preview/shell/use-run-trigger.ts
+++ b/apps/dashboard/client/src/preview/shell/use-run-trigger.ts
@@ -48,12 +48,12 @@ export function useRunTrigger(repoId: string): RunStarter {
   const inFlight = useRef(false);
 
   const start = useCallback(
-    (command: string) => {
+    (command: string, resumeRunId?: string) => {
       const trigger = triggerFor(command);
       if (!trigger || inFlight.current) return;
       inFlight.current = true;
       setPending(true);
-      void trigger(repoId)
+      void trigger(repoId, resumeRunId)
         .then((outcome) => {
           switch (outcome.kind) {
             case 'started':

--- a/apps/dashboard/server/src/jobs/guard-generate-resume.ts
+++ b/apps/dashboard/server/src/jobs/guard-generate-resume.ts
@@ -1,0 +1,18 @@
+import { guardGenerateResume, type GuardGenerateResume } from '@truecourse/core/commands/guard-in-process';
+import { openStoredSessionRun, SessionRunNotFoundError } from '@truecourse/core/lib/sessions-store';
+import { createAppError } from '@truecourse/core/lib/errors';
+
+/** Resolve through the authorized repository, never a workspace-wide run-id lookup. */
+export async function readGuardGenerateResume(repoKey: string, runId: unknown): Promise<GuardGenerateResume> {
+  if (typeof runId !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(runId)) {
+    throw createAppError('Invalid resume run ID.', 400);
+  }
+  try {
+    const run = await openStoredSessionRun(repoKey, 'guard-generate', runId);
+    try { return guardGenerateResume(run.record()); }
+    catch (error) { throw createAppError((error as Error).message, 422); }
+  } catch (error) {
+    if (error instanceof SessionRunNotFoundError) throw createAppError('Guard generation run not found.', 404);
+    throw error;
+  }
+}

--- a/apps/dashboard/server/src/jobs/tasks/repo-guard-generate.ts
+++ b/apps/dashboard/server/src/jobs/tasks/repo-guard-generate.ts
@@ -30,6 +30,7 @@ import { materializeGuardOverlays } from '@truecourse/core/lib/guard-overlays';
 import { materializeGuardSetupBundle } from '@truecourse/core/services/guard-setup/bundle';
 import {
   buildGuardReport,
+  assertGuardGenerateResumeCommit,
   buildOpenConflictsReport,
   guardGenerateInProcess,
   GUARD_GENERATE_STEPS,
@@ -38,6 +39,7 @@ import {
 import type { JobDefinition, JobPayload } from '@truecourse/jobs';
 import { startWorkspaceLlm, type WorkspaceLlm } from '../../services/workspace-llm.service.js';
 import { acquireWorkTree } from '../../services/work-tree.service.js';
+import { readGuardGenerateResume } from '../guard-generate-resume.js';
 import { materializeStoredSpec } from '../materialize-spec.js';
 import {
   materializeStoredGuardState,
@@ -48,7 +50,7 @@ import { firstLine, type OnboardingJobRequest } from './onboarding.js';
 
 export const REPO_GUARD_GENERATE_TASK = 'repo.guard-generate';
 
-export type GuardGenerateJobRequest = OnboardingJobRequest;
+export type GuardGenerateJobRequest = OnboardingJobRequest & { resumeRunId?: string };
 
 export type GuardGenerateJobPayload = GuardGenerateJobRequest & JobPayload;
 
@@ -88,12 +90,18 @@ export function createRepoGuardGenerateTask(
     async run(ctx) {
       return dashboardActivity(ctx, 'guard-generate', GUARD_GENERATE_STEPS, async (activityRun, activityTracker) => {
         const { repoFullName } = ctx.payload;
+        // Re-read at execution time as well: the queue payload carries identity,
+        // never client-supplied completed steps or a trusted snapshot of status.
+        const resume = ctx.payload.resumeRunId
+          ? await readGuardGenerateResume(repoFullName, ctx.payload.resumeRunId)
+          : undefined;
         const llm = await startLlm(ctx.payload.workspaceOrgId);
 
         await ctx.phase('clone');
         const tree = await acquireWorkTree(repoFullName);
         try {
           const commitSha = await resolveCommitSha(tree.dir);
+          if (resume) assertGuardGenerateResumeCommit(resume, commitSha);
           activityRun.setGitRef?.(commitSha);
           activityTracker.fact('clone', `cloned ${repoFullName} at ${commitSha.slice(0, 8)}`);
           const ref = { repoKey: repoFullName, commitSha };
@@ -139,6 +147,7 @@ export function createRepoGuardGenerateTask(
               sessionRun: activityRun,
               tracker: activityTracker,
               requireExistingRecipe: true,
+              ...(resume ? { resume } : {}),
               ...(ctx.signal ? { signal: ctx.signal } : {}),
             }));
           } catch (err) {

--- a/apps/dashboard/server/src/jobs/tasks/repo-guard-setup.ts
+++ b/apps/dashboard/server/src/jobs/tasks/repo-guard-setup.ts
@@ -124,24 +124,18 @@ export function createRepoGuardSetupTask(
           const files = collectGuardSetupBundle(tree.dir);
           if (Object.keys(files).length > 0) await saveGuardSetupBundle(ref, files);
 
+          // Preserve the failed bundle above, then fail the job so its status
+          // agrees with Activity and it cannot chain into generation.
+          if (report.status !== 'ok') throw new Error(report.reason || 'Setup did not complete');
           const reason = firstLine(report.reason);
-          if (report.status !== 'ok') activityRun.setError({ message: reason || 'Setup did not complete' });
           return {
             result: { repoFullName, status: report.status, ...(reason ? { reason } : {}) },
-            notification:
-              report.status === 'ok'
-                ? {
-                    level: 'success',
-                    title: 'Guard setup complete',
-                    body: `${repoFullName} — the recipe and its dependencies are ready.`,
-                    data: { repoFullName },
-                  }
-                : {
-                    level: 'error',
-                    title: 'Guard setup did not complete',
-                    body: `${repoFullName} — ${reason || 'setup was refused.'}`,
-                    data: { repoFullName },
-                  },
+            notification: {
+              level: 'success',
+              title: 'Guard setup complete',
+              body: `${repoFullName} — the recipe and its dependencies are ready.`,
+              data: { repoFullName },
+            },
           };
         } finally {
           tree.dispose();

--- a/apps/dashboard/server/src/routes/guard-actions.ts
+++ b/apps/dashboard/server/src/routes/guard-actions.ts
@@ -48,6 +48,7 @@
  */
 
 import { Router, type Request, type Response, type NextFunction } from 'express';
+import { readGuardGenerateResume } from '../jobs/guard-generate-resume.js';
 import { resolveProjectForRequest } from '@truecourse/core/config/current-project';
 import {
   estimateGuard,
@@ -229,6 +230,8 @@ router.get('/:id/guard/estimate', async (req: Request, res: Response, next: Next
 router.post('/:id/guard/generate', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const repo = await resolveProjectForRequest(req.params.id as string);
+    const resumeRunId: unknown = req.body?.resumeRunId;
+    const resume = resumeRunId === undefined ? undefined : await readGuardGenerateResume(repo.path, resumeRunId);
     // Extracting both sides of an unresolved overlap births a paid finding that
     // is really the dispute. Answered BEFORE the provider check: nothing about a
     // blocked corpus is fixed by a provider, and the full report is the remedy.
@@ -246,6 +249,7 @@ router.post('/:id/guard/generate', async (req: Request, res: Response, next: Nex
       repoFullName: repo.path,
       workspaceOrgId: orgOf(req),
       source: 'manual',
+      ...(resume ? { resumeRunId: resume.runId } : {}),
     });
     if (outcome.status === 'busy') {
       res.status(409).json({ error: 'A guard job is already running for this repo.' });

--- a/apps/dashboard/server/src/routes/sessions.ts
+++ b/apps/dashboard/server/src/routes/sessions.ts
@@ -27,6 +27,7 @@ import { Router, type Request, type Response, type NextFunction } from 'express'
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { createUIMessageStreamResponse } from 'ai';
+import { readActivityProgress } from '@truecourse/core/lib/activity-journal';
 import { createActivityStream } from '../services/activity-stream.service.js';
 import { RunStatusSchema, SessionCommandSchema } from '@truecourse/agent-loop';
 import { createAppError } from '@truecourse/core/lib/errors';
@@ -38,6 +39,7 @@ import {
   listStoredSessionRunsForRepos,
   openStoredSessionRun,
   readStoredActivityPage,
+  readStoredTranscriptPage,
   sessionRunCursor,
   parseSessionRunCursor,
   toPublicRunRecord,
@@ -211,8 +213,24 @@ router.get(
         // Resolve the run before reading its session. File reads sanitize the
         // session ID; Postgres reads filter by session and sequence in the query.
         const run = await openStoredSessionRun(repo.path, command, req.params.runId as string);
-        const events = await readStoredTranscript(run, req.params.sessionId as string, since);
-        res.json({ events });
+        if (req.query.limit !== undefined) {
+          const limit = parseLimit(req.query.limit, 100, 100);
+          const before = req.query.before === undefined ? undefined : Number(req.query.before);
+          if (limit === null || !Number.isSafeInteger(since) || since < -1 ||
+              (before !== undefined && (!Number.isSafeInteger(before) || before < 0)) ||
+              (before !== undefined && req.query.since !== undefined)) {
+            res.status(400).json({ error: 'Invalid transcript page: limit 1–100; use before or since with integer sequence cursors.' }); return;
+          }
+          const sessionId = req.params.sessionId as string;
+          const page = await readStoredTranscriptPage(run, sessionId, {
+            limit, ...(before === undefined ? {} : { before }),
+            ...(req.query.since === undefined ? {} : { since }),
+          });
+          res.json({ ...page, progress: readActivityProgress(run.dir)[sessionId] ?? null });
+        } else {
+          const events = await readStoredTranscript(run, req.params.sessionId as string, since);
+          res.json({ events });
+        }
       } catch (error) {
         if (!(error instanceof SessionRunNotFoundError)) throw error;
         res.status(404).json({ error: 'Session run not found.' });

--- a/apps/dashboard/server/src/routes/sessions.ts
+++ b/apps/dashboard/server/src/routes/sessions.ts
@@ -131,6 +131,9 @@ router.get('/:id/sessions/runs/:command/:runId/activity', async (req: Request, r
     if (after === null) { res.status(400).json({ error: 'after must be a journal cursor' }); return; }
     const limit = parseLimit(req.query.limit, 500, 1000);
     if (limit === null) { res.status(400).json({ error: 'limit must be between 1 and 1000' }); return; }
+    if (req.query.compact !== undefined && req.query.compact !== '1') {
+      res.status(400).json({ error: 'compact must be 1 when supplied' }); return;
+    }
     const repo = await resolveProjectForRequest(req.params.id as string);
     let run;
     try { run = await openStoredSessionRun(repo.path, command, req.params.runId as string); }
@@ -143,7 +146,7 @@ router.get('/:id/sessions/runs/:command/:runId/activity', async (req: Request, r
     }
     if (!run.readActivity) recoverSessionActivity(run);
     try {
-      res.json(await readStoredActivityPage(run, after, limit));
+      res.json(await readStoredActivityPage(run, after, limit, req.query.compact === '1'));
     } catch (error) {
       if (error instanceof Error && error.message.startsWith('Activity cursor')) {
         res.status(400).json({ error: error.message }); return;

--- a/apps/dashboard/server/src/services/activity-stream.service.ts
+++ b/apps/dashboard/server/src/services/activity-stream.service.ts
@@ -1,7 +1,7 @@
 import type { UIMessageChunk } from 'ai';
 import type { ActivityEvent } from '@truecourse/shared/activity-stream';
 import { readActivityProgress, subscribeActivity } from '@truecourse/core/lib/activity-journal';
-import { readStoredActivity, type SessionRunStore } from '@truecourse/core/lib/sessions-store';
+import { readStoredActivityPage, type SessionRunStore } from '@truecourse/core/lib/sessions-store';
 
 /** Replay once, then deliver published events directly, independently of the job. */
 export function createActivityStream(
@@ -63,7 +63,9 @@ async function* chunks(run: SessionRunStore, after: number, signal: AbortSignal)
         // Enable live queuing before awaiting storage, so a commit during the
         // history query is either replayed or queued, never dropped.
         replay = false;
-        batch = await readStoredActivity(run, after);
+        const page = await readStoredActivityPage(run, after, 128, true);
+        batch = page.events;
+        if (!page.done) replay = true;
       } else { batch = pending; pending = []; }
       for (const event of batch) {
         if (signal.aborted) return;

--- a/packages/core/src/commands/guard-in-process.ts
+++ b/packages/core/src/commands/guard-in-process.ts
@@ -712,7 +712,7 @@ export async function guardGenerateInProcess(
       // One line per THING the run did, filed under the step that did it. The
       // engine's phase names ARE this checklist's keys, so they line up.
       onFact: (step, line) => tracker?.fact(step, line),
-      onFlowSettled: (settled, total) => {
+      onFlowSettled: async (settled, total) => {
         throwIfAborted();
         building = false;
         flowsDone = settled;
@@ -720,6 +720,9 @@ export async function guardGenerateInProcess(
         // Gap-only flows settle without any worker running — only re-render a
         // LIVE validate line; never start the step early.
         if (validateStarted || settled > 0) renderValidate();
+        // Drain persistence before advancing: a synchronous settlement burst
+        // must not retain hundreds of complete progress snapshots.
+        await run.flush?.();
       },
     });
 

--- a/packages/core/src/commands/guard-in-process.ts
+++ b/packages/core/src/commands/guard-in-process.ts
@@ -52,6 +52,8 @@ import {
   type CorpusConflict,
 } from '@truecourse/shared';
 import path from 'node:path';
+import { assertGuardGenerateResumeCommit, GuardGenerateResumeError, type GuardGenerateResume } from '../services/guard-generate/resume.js';
+import { GenerateStepNotReadyError } from '../services/guard-generate/run.js';
 import type { RunError, SessionDriver, SessionLlm } from '@truecourse/agent-loop';
 import { getGit } from '../lib/git.js';
 import { getGuardExecutor } from '../lib/guard-executor.js';
@@ -90,6 +92,7 @@ import {
 } from '../services/guard-generate/index.js';
 export { GenerateStepNotReadyError } from '../services/guard-generate/index.js';
 export { GENERATE_SESSION_STEPS, type GenerateStep } from '@truecourse/guard-generator';
+export { assertGuardGenerateResumeCommit, guardGenerateResume, GuardGenerateResumeError, type GuardGenerateResume } from '../services/guard-generate/resume.js';
 import { readGuardRecipeCard } from './guard-read.js';
 import { readCorpus, readDecisions } from '@truecourse/spec-consolidator';
 import type { LlmEstimate } from './analyze-core.js';
@@ -207,6 +210,8 @@ const GUARD_STEP_STAGES: Record<string, StageId[]> = {
 
 export interface GuardGenerateInProcessOptions {
   tracker?: StepTracker;
+  /** Restore this interrupted run's completed stages without repeating their LLM work. */
+  resume?: GuardGenerateResume;
   /**
    * LLM transport: `cli` (spawn `claude -p`), `agent` (mailbox under `io`), or
    * `api` (the provider configured in `~/.truecourse/config.json`). Unset
@@ -362,7 +367,7 @@ function resolveTransport(options: {
   llm?: 'cli' | 'agent' | 'api';
   io?: string;
   transport?: LlmTransport;
-}): LlmTransport | undefined {
+}): LlmTransport {
   // An explicit instance is the whole answer — it already carries the
   // credentials the caller chose for this run.
   if (options.transport) return options.transport;
@@ -392,6 +397,7 @@ export async function guardGenerateInProcess(
   options: GuardGenerateInProcessOptions = {},
 ): Promise<GuardGenerateInProcessResult> {
   const { tracker } = options;
+  const restored = new Set(options.resume?.completedSteps ?? []);
   // The transport this run actually uses decides the models — never the saved
   // selection a `--llm-transport` flag just overrode. An explicit transport IS
   // the selection, and its caller says which mode it runs in (a stored
@@ -427,6 +433,7 @@ export async function guardGenerateInProcess(
   };
 
   let transport: LlmTransport | undefined;
+  let resumeFailure: GuardGenerateResumeError | undefined;
   try {
     // Hard-fail on unresolved spec conflicts BEFORE the estimate — never ask to
     // spend, then fail. Extracting both sides of an open overlap births noise.
@@ -446,6 +453,19 @@ export async function guardGenerateInProcess(
     }
 
     transport = resolveTransport(options);
+    if (options.resume) {
+      assertGuardGenerateResumeCommit(options.resume, await resolveCommitSha(repoRoot));
+      const liveTransport = transport;
+      transport = async request => {
+        const completed = Object.entries(GUARD_STEP_STAGES).find(([step, stages]) =>
+          restored.has(step) && stages.some(stage => stage === request.stage));
+        if (completed) {
+          resumeFailure = new GuardGenerateResumeError(completed[0]);
+          throw resumeFailure;
+        }
+        return liveTransport(request);
+      };
+    }
   } catch (e) {
     // The gates run before the first step opens, so they stop on `index`, the
     // step a reader is looking at when the run ends there: a refusal takes the
@@ -459,7 +479,9 @@ export async function guardGenerateInProcess(
       throw e;
     }
     const reason =
-      e instanceof OpenConflictsError
+      e instanceof GuardGenerateResumeError
+        ? e.message
+        : e instanceof OpenConflictsError
         ? (firstLine(e.message) ?? e.message)
         : `the LLM provider is unusable (${(e as Error).message})`;
     tracker?.fact('index', `stopped: ${reason}`);
@@ -467,7 +489,7 @@ export async function guardGenerateInProcess(
     untap?.();
     // The record carries the reason under the gate's own kind.
     finishRun('failed', {
-      error: { message: reason, kind: e instanceof OpenConflictsError ? 'open-conflicts' : 'llm-config' },
+      error: { message: reason, kind: e instanceof GuardGenerateResumeError ? 'resume' : e instanceof OpenConflictsError ? 'open-conflicts' : 'llm-config' },
     });
     throw e;
   }
@@ -478,6 +500,7 @@ export async function guardGenerateInProcess(
   const startedAt = Date.now();
 
   const throwIfAborted = (): void => {
+    if (resumeFailure) throw resumeFailure;
     if (options.signal?.aborted) throw new GuardGenerateAborted();
   };
 
@@ -488,7 +511,7 @@ export async function guardGenerateInProcess(
     const ni = STEPS.indexOf(key);
     if (ni <= cur) return;
     for (let i = cur; i < ni; i++) tracker?.done(STEPS[i]);
-    tracker?.start(key);
+    if (!restored.has(key)) tracker?.start(key);
     cur = ni;
   };
 
@@ -583,6 +606,7 @@ export async function guardGenerateInProcess(
           // Single-step mode: the seams enforce the cache-only replay of every
           // step before the chosen one (the engine enforces the stop after it).
           ...(options.only ? { only: options.only } : {}),
+          ...(options.resume ? { replaySteps: (['extract', 'flows'] as const).filter(step => restored.has(step)) } : {}),
         });
   const extractSession = options.extractSession ?? sessionSeams!.extractSession;
   // An injected extraction seam owns no cache, so the production reuse seam
@@ -594,7 +618,11 @@ export async function guardGenerateInProcess(
   const flowsEpicSession = options.flowsEpicSession ?? sessionSeams!.flowsEpicSession;
   const flowWorkerSession = options.flowWorkerSession ?? sessionSeams!.flowWorkerSession;
 
-  tracker?.start('index');
+  if (options.resume) {
+    for (const key of restored) tracker?.done(key, `Restoring completed work from ${options.resume.runId}`);
+    tracker?.fact('index', `Resuming ${options.resume.runId}; completed authoring is replayed from saved results`);
+  }
+  if (!restored.has('index')) tracker?.start('index');
   try {
     // A stop asked for before the first step ends the run as interrupted, on
     // the record, like one asked for at any later boundary.
@@ -645,7 +673,7 @@ export async function guardGenerateInProcess(
         cur = STEPS.indexOf('extract');
         // No detail yet — the seam's initial onDoc(0, total) supplies the
         // "docs 0/N" counter the moment the pool is planned.
-        tracker?.start('extract');
+        if (!restored.has('extract')) tracker?.start('extract');
       },
       onExtractProgress: (done, total) => {
         advanceTo('extract');
@@ -726,6 +754,8 @@ export async function guardGenerateInProcess(
       },
     });
 
+    throwIfAborted();
+
     // An early abort (no corpus, an unusable recipe, a stage that lost every LLM
     // call) ran NO phase past the one it died in: the step it died in takes the
     // error, and every later step stays
@@ -781,7 +811,10 @@ export async function guardGenerateInProcess(
     if (!options.sessionRun) finishRun('completed');
 
     return { guard, sessionsRunDir: run.dir };
-  } catch (e) {
+  } catch (caught) {
+    const e = options.resume && caught instanceof GenerateStepNotReadyError
+      ? new GuardGenerateResumeError(caught.step)
+      : caught;
     tracker?.error(STEPS[cur], (e as Error).message);
     // A stop the caller asked for is not a failure; anything else lands its
     // reason on the record, the only place a watcher can read it.

--- a/packages/core/src/lib/sessions-store.ts
+++ b/packages/core/src/lib/sessions-store.ts
@@ -103,6 +103,7 @@ export interface SessionRunStore {
   validateActivityCursor?(after: number): Promise<void>;
   /** Dashboard reads load only this session; synchronous persistence reads belong to live writers. */
   readTranscript?(sessionId: string, since: number): Promise<SessionEvent[]>;
+  readTranscriptPage?(sessionId: string, options: TranscriptPageOptions): Promise<TranscriptPage>;
   setGitRef?(gitRef: string): void;
   /** What `runAgentLoop` persists through. */
   readonly persistence: SessionPersistence;
@@ -535,4 +536,14 @@ export async function readStoredTranscript(run: SessionRunStore, sessionId: stri
 /** undefined means the caller should watch the file store. */
 export function subscribeStoredSessionRuns(repoKey: string, notify: () => void): (() => void) | undefined {
   return backend && !path.isAbsolute(repoKey) ? backend.subscribeRepo(repoKey, notify) : undefined;
+}
+
+/** Initial/older pages read backwards; live catch-up reads forwards after since. */
+export interface TranscriptPageOptions { limit: number; before?: number; since?: number }
+export interface TranscriptPage { events: SessionEvent[]; hasMore: boolean }
+export async function readStoredTranscriptPage(run: SessionRunStore, sessionId: string, options: TranscriptPageOptions): Promise<TranscriptPage> {
+  if (run.readTranscriptPage) return run.readTranscriptPage(sessionId, options);
+  const events = (await readStoredTranscript(run, sessionId, options.since ?? -1))
+    .filter(e => options.before === undefined || e.seq < options.before).sort((a, b) => a.seq - b.seq);
+  return { events: options.since === undefined ? events.slice(-options.limit) : events.slice(0, options.limit), hasMore: events.length > options.limit };
 }

--- a/packages/core/src/lib/sessions-store.ts
+++ b/packages/core/src/lib/sessions-store.ts
@@ -25,7 +25,7 @@ import {
   type SessionIndexEntry,
   type SessionPersistence,
 } from '@truecourse/agent-loop';
-import type { ActivityEvent } from '@truecourse/shared/activity-stream';
+import { compactRunSnapshots, type ActivityEvent } from '@truecourse/shared/activity-stream';
 import { getRepoTruecourseDir } from '../config/paths.js';
 import { atomicWriteJson } from './atomic-write.js';
 import { appendActivityEvent, publishActivityProgress, readActivityEvents, validateActivityCursor } from './activity-journal.js';
@@ -98,6 +98,8 @@ export interface SessionRunStore {
   /** One bounded slice of the journal, so a reader pages a long run instead of
    *  loading every event to show its first screen. */
   readActivityPage?(after: number, limit: number): Promise<ActivityEvent[]>;
+  /** The same cursor window, omitting superseded run snapshots before transfer. */
+  readCompactActivityPage?(after: number, limit: number): Promise<ActivityPage>;
   validateActivityCursor?(after: number): Promise<void>;
   /** Dashboard reads load only this session; synchronous persistence reads belong to live writers. */
   readTranscript?(sessionId: string, since: number): Promise<SessionEvent[]>;
@@ -505,12 +507,18 @@ export async function readStoredActivityPage(
   run: SessionRunStore,
   after: number,
   limit: number,
+  compact = false,
 ): Promise<ActivityPage> {
+  if (compact && run.readCompactActivityPage) return run.readCompactActivityPage(after, limit);
   const events = run.readActivityPage
     ? await run.readActivityPage(after, limit)
     : (await readStoredActivity(run, after)).slice(0, limit);
   const last = events[events.length - 1];
-  return { events, nextCursor: last ? last.cursor : after, done: events.length < limit };
+  return {
+    events: compact ? compactRunSnapshots(events) : events,
+    nextCursor: last ? last.cursor : after,
+    done: events.length < limit,
+  };
 }
 
 export async function validateStoredActivityCursor(run: SessionRunStore, after: number): Promise<void> {

--- a/packages/core/src/services/guard-generate/flow-worker.ts
+++ b/packages/core/src/services/guard-generate/flow-worker.ts
@@ -39,6 +39,7 @@ import {
   GENERATE_API_SYSTEM_PROMPT,
   GENERATE_WEB_SYSTEM_PROMPT,
   workerCacheKey,
+  AUTHOR_CATALOG_VERSION,
   type FlowWorkerTask,
   type WorkerFidelityJudge,
 } from '@truecourse/guard-generator'
@@ -167,7 +168,7 @@ no run behind it is refused once and costs you a turn.`
 
 export const FLOW_WORKER_CLI_SYSTEM_PROMPT = GENERATE_SYSTEM_PROMPT + WORKER_ADDENDUM
 export const FLOW_WORKER_API_SYSTEM_PROMPT = GENERATE_API_SYSTEM_PROMPT + WORKER_ADDENDUM
-export const FLOW_WORKER_WEB_SYSTEM_PROMPT = GENERATE_WEB_SYSTEM_PROMPT + WORKER_ADDENDUM
+export const FLOW_WORKER_WEB_SYSTEM_PROMPT = GENERATE_WEB_SYSTEM_PROMPT + WORKER_ADDENDUM + `\n${AUTHOR_CATALOG_VERSION}: Use search_interfaces to discover setup actions and get_interfaces to fetch their authoritative fields and resource readables. Fetch continuation pages until the action appears in actionCompleteIds before using it. All requested action fields precede optional resource pages; fetch further resource pages only when their evidence is needed for the scenario. The complete flag covers the full resource payload, not action readiness. Summaries are candidates, never proof. Retrieval errors must be resolved before dependent authoring; zero search results do not establish product drift.\nWeb confirmation evidence v1: run_scenario returns observationId for supported failures. Submit it in the expected red with exactly the same YAML bytes and step. Never construct observation objects. The engine confirms typed assertion and page evidence in a fresh run. Copy the canonical expectedReds from the acceptance's final outcome hint when settling; it replaces the temporary ID with recorded evidence. Changed YAML requires another run_scenario.`
 
 /** Exported for the step-20 estimate rework (probe the REAL keys). */
 export const FLOW_WORKER_CLI_PROMPT_FINGERPRINT = promptFingerprint(FLOW_WORKER_CLI_SYSTEM_PROMPT)
@@ -293,7 +294,7 @@ const submitScenarioTool = (
     inputSchema: z
       .object({
         yaml: z.string().min(1),
-        expectedReds: z.array(GuardExpectedRedSchema).default([]),
+        expectedReds: z.array(GuardExpectedRedSchema.omit({ observation: true })).default([]),
         /** Edit mode: the prior scenario this submission replaces (keeps its id). */
         replaces: z.string().min(1).optional(),
       })
@@ -323,6 +324,27 @@ const dropScenarioTool = (task: FlowWorkerTask): SessionTool =>
     },
   })
 
+function catalogTools(task: FlowWorkerTask): SessionTool[] {
+  if (task.surface !== 'web' || !task.catalog) return []
+  const catalog = task.catalog
+  return [
+    defineSessionTool({
+      name: 'search_interfaces', kind: 'read-interface-catalog',
+      description: 'Search eligible browser action metadata. Results omit action details; fetch IDs with get_interfaces. Continue using nextCursor.',
+      readOnly: true, destructive: false,
+      inputSchema: z.object({ query: z.string().max(500), purpose: z.enum(['task', 'control']).optional(), resource: z.string().min(1).max(200).optional(), limit: z.number().int().min(1).max(20).optional(), cursor: z.string().max(1000).optional() }).strict(),
+      async execute(args) { return catalog.search(args) },
+    }),
+    defineSessionTool({
+      name: 'get_interfaces', kind: 'read-interface-catalog',
+      description: 'Read authoritative fields of 1–5 browser actions and resources. Items carry action ID, JSON field path and exact value. Partial pages require nextCursor with the same IDs; never infer absence from incomplete retrieval.',
+      readOnly: true, destructive: false,
+      inputSchema: z.object({ ids: z.array(z.string().min(1).max(200)).min(1).max(5), cursor: z.string().max(1000).optional() }).strict(),
+      async execute(args) { return catalog.get(args) },
+    }),
+  ]
+}
+
 export interface FlowWorkerSessionInput {
   task: FlowWorkerTask
   /** Build the fidelity judge for one tool invocation — needs the invocation's
@@ -336,7 +358,7 @@ export function flowWorkerSessionDef(input: FlowWorkerSessionInput): SessionDef<
     kind: FLOW_WORKER_SESSION_KIND,
     display: { title: 'Scenario author' },
     systemPrompt: flowWorkerSystemPrompt(task.surface),
-    tools: [runScenarioTool(task), submitScenarioTool(task, input.judgeWith), dropScenarioTool(task)],
+    tools: [...catalogTools(task), runScenarioTool(task), submitScenarioTool(task, input.judgeWith), dropScenarioTool(task)],
     outcomeSchema: GuardFlowWorkerOutcomeSchema,
     validateOutcome: outcome => task.validateOutcome(outcome),
     outcomeSchemaRepairs: 2,

--- a/packages/core/src/services/guard-generate/resume.ts
+++ b/packages/core/src/services/guard-generate/resume.ts
@@ -1,0 +1,48 @@
+import type { PublicRunRecord } from '../../lib/sessions-store.js';
+import { ChecklistItemSchema } from '@truecourse/agent-loop';
+
+/** A resume replays completed authoring from durable caches. Live proof still runs. */
+export interface GuardGenerateResume {
+  runId: string;
+  gitRef: string;
+  completedSteps: string[];
+}
+
+const STEPS = ['index', 'extract', 'interfaces', 'flows', 'match', 'author', 'validate'];
+
+export function guardGenerateResume(record: PublicRunRecord): GuardGenerateResume {
+  if (record.command !== 'guard-generate' || !['interrupted', 'failed'].includes(record.status)) {
+    throw new Error('Only interrupted or failed guard generation can be resumed.');
+  }
+  const items = (record.display?.blocks.flatMap(block =>
+    block.kind === 'checklist' && Array.isArray(block.items) ? block.items : []) ?? [])
+    .flatMap(item => {
+      const parsed = ChecklistItemSchema.safeParse(item);
+      return parsed.success ? [parsed.data] : [];
+    });
+  // A pool may tick done before its final fold/epic pass. A later step must
+  // have started too. Author and validate overlap, so neither is replay-only.
+  const completedSteps: string[] = [];
+  for (const key of STEPS.slice(0, 5)) {
+    const index = STEPS.indexOf(key);
+    const laterStarted = items.some(item => STEPS.indexOf(item.key) > index && item.status !== 'pending');
+    if (items.find(item => item.key === key)?.status !== 'done' || !laterStarted) break;
+    completedSteps.push(key);
+  }
+  return { runId: record.runId, gitRef: record.gitRef, completedSteps };
+}
+
+export class GuardGenerateResumeError extends Error {
+  constructor(step: string, reason?: string) {
+    super(reason ?? `Cannot resume: saved ${step} results are missing or no longer match the inputs. Completed work was not restarted. Start a new generation explicitly to regenerate it.`);
+    this.name = 'GuardGenerateResumeError';
+  }
+}
+
+export function assertGuardGenerateResumeCommit(resume: GuardGenerateResume, commitSha: string): void {
+  // A failure before checkout has no commit or completed generation to protect.
+  if ((!resume.gitRef || resume.gitRef === 'unknown') && resume.completedSteps.length === 0) return;
+  if (commitSha !== resume.gitRef) {
+    throw new GuardGenerateResumeError('index', 'Cannot resume: the repository commit has changed. Start a new generation explicitly.');
+  }
+}

--- a/packages/core/src/services/guard-generate/run.ts
+++ b/packages/core/src/services/guard-generate/run.ts
@@ -603,7 +603,7 @@ export function createGuardGenerateSessionSeams(
     }
     const fidelityTally = emptyFidelityTally()
     const byTask = new Map<string, FlowWorkerSessionResult>()
-    const total = input.tasks.length + input.epicTasks.length + input.mutatorTasks.length
+    const total = input.tasks.length + input.epicTasks.length + (input.preparedMutatorTasks?.length ?? 0) + input.mutatorTasks.length
     let done = 0
     input.onTask?.(0, total)
     // Each tick carries the task's outcome kind so the engine can render a live
@@ -797,6 +797,9 @@ export function createGuardGenerateSessionSeams(
     // The epic wave starts only after the first has fully folded — the barrier
     // that lets epic briefings carry members' settled scenarios read-only.
     await runWave(input.epicTasks)
+    // These tasks enforce private database ownership at every execution. Keep
+    // their DB/server provisioning bounded independently of the general pool.
+    await runWave(input.preparedMutatorTasks ?? [], Math.min(6, Math.max(1, opts.concurrency ?? 6)))
     // The mutator wave runs LAST and SERIALIZED: a destructive draft (a
     // password change, an account deletion) executes only against a world no
     // sibling is still reading, one session at a time.

--- a/packages/core/src/services/guard-generate/run.ts
+++ b/packages/core/src/services/guard-generate/run.ts
@@ -1,3 +1,4 @@
+import { log } from '../../lib/logger.js'
 /**
  * THE GUARD-GENERATE SESSION SEAMS — the implementations `@truecourse/core`
  * injects into `generateGuards` for plan 04 steps 15 (claim extraction) and 16
@@ -66,6 +67,7 @@ import {
   type GuardDoc,
   type GuardSessionSummary,
   flowAreaKey,
+  AUTHOR_INITIAL_BYTES,
 } from '@truecourse/guard-generator'
 import { createSessionRun, type SessionRunStartedInfo, type SessionRunStore } from '../../lib/sessions-store.js'
 import { resolveCommitSha } from '../../lib/repo-ref.js'
@@ -106,6 +108,7 @@ import {
   cacheableWorkerOutcome,
   flowWorkerCacheKey,
   flowWorkerSessionDef,
+  flowWorkerSystemPrompt,
   type CachedWorkerEntry,
 } from './flow-worker.js'
 import { FIDELITY_SESSION_KIND, emptyFidelityTally, judgeWorkerFidelity } from './fidelity.js'
@@ -659,7 +662,24 @@ export function createGuardGenerateSessionSeams(
       // purpose — cli briefings spawn probe sandboxes, and a stampede of them
       // is exactly what the probe cache exists to avoid paying twice.
       const briefings = new Map<string, string>()
-      for (const task of misses) briefings.set(task.workItem, await task.prepare())
+      const ready: FlowWorkerTask[] = []
+      for (const task of misses) {
+        const briefing = await task.prepare()
+        const initialBytes = Buffer.byteLength(flowWorkerSystemPrompt(task.surface), 'utf8') + Buffer.byteLength(briefing, 'utf8')
+        log.info(`[Guard author] ${task.workItem}: initialInputBytes=${initialBytes}`)
+        if (task.surface === 'web' && initialBytes > AUTHOR_INITIAL_BYTES) {
+          const reason = `author-initial-context-oversize: ${initialBytes} UTF-8 bytes exceeds ${AUTHOR_INITIAL_BYTES}; required obligations were retained. Split the flow or reduce its authoritative input before retrying.`
+          summary.failed++
+          summary.allTransport = false
+          summary.firstError ??= reason
+          byTask.set(task.workItem, { kind: 'failed', reason })
+          tick('failed')
+          continue
+        }
+        briefings.set(task.workItem, briefing)
+        ready.push(task)
+      }
+      if (ready.length === 0) return
       // The same construction guard `runCachedGuardPool` applies: an
       // unconstructible driver fails every miss of the wave transport-class
       // instead of crashing the generate.
@@ -669,7 +689,7 @@ export function createGuardGenerateSessionSeams(
       } catch (e) {
         const outcome = driverConstructionFailure(e)
         const reason = describeSessionFailure(outcome.failure)
-        for (const task of misses) {
+        for (const task of ready) {
           summary.ran++
           summary.failed++
           summary.firstError ??= reason
@@ -680,7 +700,7 @@ export function createGuardGenerateSessionSeams(
       }
       const { driver, persistence } = acquiredCtx
       await runSessionPool<FlowWorkerTask, GuardFlowWorkerOutcome>({
-        items: misses,
+        items: ready,
         workItem: (t) => t.workItem,
         session: (t) =>
           flowWorkerSessionDef({

--- a/packages/core/src/services/guard-generate/run.ts
+++ b/packages/core/src/services/guard-generate/run.ts
@@ -191,6 +191,8 @@ export interface CreateGuardGenerateSeamsOptions {
    * (`generateGuards({ only })`) returns before calling their seams.
    */
   only?: GenerateStep
+  /** Completed steps of an interrupted run: cache replay only, with no stop after. */
+  replaySteps?: readonly GenerateStep[]
   /**
    * Test seam: a lazy thunk overriding the internal
    * `createConfiguredSessionDriver` path — the spec-scan analog's shape, plus
@@ -446,7 +448,8 @@ export function createGuardGenerateSessionSeams(
   }
   /** Single-step mode: is `step` PRIOR to the chosen one (replay, never spend)? */
   const replayOnly = (step: GenerateStep): boolean =>
-    opts.only !== undefined && GENERATE_SESSION_STEPS.indexOf(step) < GENERATE_SESSION_STEPS.indexOf(opts.only)
+    opts.replaySteps?.includes(step) === true ||
+    (opts.only !== undefined && GENERATE_SESSION_STEPS.indexOf(step) < GENERATE_SESSION_STEPS.indexOf(opts.only))
 
   const extractSession: ExtractSessionSeam = async (input) => {
     const universe = buildGuardDocUniverse(input.docs)

--- a/packages/core/src/services/guard-setup/preparation-session.ts
+++ b/packages/core/src/services/guard-setup/preparation-session.ts
@@ -10,10 +10,16 @@ import type {
 } from '@truecourse/guard-generator';
 import {
   RecipePreparationSchema,
+  preparationDependencyBriefing,
+  resolvePreparationDependencies,
+  PREPARATION_VERIFY_INPUTS_SOURCE,
   RecipeSchema,
   prepareScenario,
   recipePath,
   runBuild,
+  runInstall,
+  buildCredentialRedactor,
+  type BuildResult,
   hashableRecipeText,
   type Recipe,
 } from '@truecourse/guard-runner';
@@ -33,14 +39,24 @@ export const PreparationDraftSchema = z
         .object({
           name: z.string().regex(/^[a-z0-9][a-z0-9._-]*$/),
           baseline: z.enum(['empty', 'seeded']),
-          baselineChecks: RecipePreparationSchema.shape.baselineChecks.unwrap(),
-          env: RecipePreparationSchema.shape.env,
+          needs: RecipePreparationSchema.innerType().shape.needs.unwrap(),
+          baselineChecks: RecipePreparationSchema.innerType().shape.baselineChecks.unwrap(),
+          env: RecipePreparationSchema.innerType().shape.env,
+          postgres: RecipePreparationSchema.innerType().shape.postgres,
           seed: z.string().min(1),
-          provides: RecipePreparationSchema.shape.seed.shape.provides,
+          provides: RecipePreparationSchema.innerType().shape.seed.shape.provides,
           verify: z.string().min(1),
           cleanup: z.string().min(1).optional(),
         })
-        .strict(),
+        .strict().superRefine((profile, ctx) => {
+          const result = RecipePreparationSchema.safeParse({
+            baseline: profile.baseline, needs: profile.needs, scope: 'instance', env: profile.env, postgres: profile.postgres,
+            baselineChecks: profile.baselineChecks,
+            seed: { script: 'seed.mjs', provides: profile.provides },
+            verify: { script: 'verify.mjs' }, ...(profile.cleanup ? { cleanup: { script: 'cleanup.mjs' } } : {}),
+          });
+          if (!result.success) for (const issue of result.error.issues) ctx.addIssue(issue);
+        }),
     ),
     findings: z.array(z.string().min(1)),
   })
@@ -62,6 +78,9 @@ export async function verifyPreparationDraft(
   draft = PreparationDraftSchema.parse(draft);
   if (new Set(draft.profiles.map((p) => p.name)).size !== draft.profiles.length)
     throw new Error('Preparation names must be unique');
+  // Check every profile before staging scripts or executing any earlier profile.
+  for (const profile of draft.profiles)
+    resolvePreparationDependencies(input.repoRoot, input.recipe, profile.needs);
   const snapshots = new Map<string, Buffer | null>();
   const record = (file: string, body: string) => {
     if (!snapshots.has(file))
@@ -88,8 +107,10 @@ export async function verifyPreparationDraft(
       profiles[draftProfile.name] = {
         scope: 'instance',
         baseline: draftProfile.baseline,
+        needs: draftProfile.needs,
         baselineChecks: draftProfile.baselineChecks,
         env: draftProfile.env,
+        ...(draftProfile.postgres ? { postgres: draftProfile.postgres } : {}),
         seed: {
           script: script('seed', draftProfile.seed),
           provides: draftProfile.provides,
@@ -140,7 +161,31 @@ export function buildPreparationSession(
   return async (input) => {
     let servicesStarted = false;
     let verified: string | undefined;
+    let verificationFailure: string | undefined;
+    const secrets = new Map(Object.entries({ ...input.recipe.env, ...input.recipe.api?.env }));
+    for (const [key, value] of [...secrets]) {
+      try {
+        const password = new URL(value).password;
+        if (password) {
+          secrets.set(`${key}.password`, password);
+          secrets.set(`${key}.decoded-password`, decodeURIComponent(password));
+        }
+      } catch { /* Non-URL environment values are already covered. */ }
+    }
+    const redact = buildCredentialRedactor(secrets);
+    const failure = (stage: string, result: BuildResult) => ({
+      status: 'failed' as const,
+      reason: `${stage} failed before private preparation verification (${opts.signal?.aborted ? 'cancelled' : result.timedOut ? 'timed out' : `exit ${result.exitCode ?? 'unknown'}`}):\n${redact(result.output).trim().slice(-4000) || 'No command output was captured.'}`,
+    });
     try {
+      // A targeted hosted run starts in a fresh clone; replaying recipe/seed
+      // artifacts does not install the application's dependencies there.
+      if (input.recipe.install) {
+        input.onPhase?.('installing application dependencies', 'install');
+        const install = await runInstall(input.repoRoot, input.recipe.install, input.recipe.env, 600_000, opts.signal);
+        if (!install.ok) return failure('Application install', install);
+      }
+      input.onPhase?.('building the application', 'build');
       const build = await runBuild(
         input.repoRoot,
         input.recipe.build,
@@ -148,13 +193,9 @@ export function buildPreparationSession(
         600_000,
         opts.signal,
       );
-      if (!build.ok)
-        return {
-          status: 'failed',
-          reason:
-            'Application build failed before private preparation verification',
-        };
+      if (!build.ok) return failure('Application build', build);
       if (input.recipe.api?.services) {
+        input.onPhase?.('starting shared services', 'services');
         const up = await runBuild(
           input.repoRoot,
           input.recipe.api.services.up,
@@ -162,14 +203,10 @@ export function buildPreparationSession(
           600_000,
           opts.signal,
         );
-        if (!up.ok)
-          return {
-            status: 'failed',
-            reason:
-              'Shared services failed before private preparation verification',
-          };
+        if (!up.ok) return failure('Shared services', up);
         servicesStarted = true;
       }
+      input.onPhase?.('authoring and verifying private starting states', 'preparations');
       const { driver, persistence } = await context.acquire();
       const def: SessionDef<PreparationDraft> = {
         kind: PREPARATION_SESSION_KIND,
@@ -188,18 +225,23 @@ export function buildPreparationSession(
             readOnly: false,
             destructive: false,
             async execute(draft) {
+              if (!draft.profiles.length)
+                return { isError: true, content: 'verify_preparations requires at least one profile; an empty draft cannot resolve a verification failure.' };
               try {
                 await verifyPreparationDraft(input, draft, {
                   signal: opts.signal,
                 });
                 verified = identity(draft);
+                verificationFailure = undefined;
                 return {
                   content:
                     'Private baseline and cross-world independence verified through the application.',
                 };
               } catch (error) {
+                verified = undefined;
+                verificationFailure = redact(error instanceof Error ? error.message : String(error));
                 return {
-                  content: `Preparation verification refused: ${error instanceof Error ? error.message : String(error)}`,
+                  content: `Preparation verification refused: ${verificationFailure}`,
                   isError: true,
                 };
               }
@@ -208,7 +250,9 @@ export function buildPreparationSession(
         ],
         outcomeSchema: PreparationDraftSchema,
         validateOutcome(outcome) {
-          return outcome.profiles.length > 0 && identity(outcome) !== verified
+          if (verificationFailure)
+            return `Repair the failed preparation and pass verify_preparations before ending. Returning no profiles cannot turn a verification failure into unsupported isolation. Last failure: ${verificationFailure}`;
+          return (outcome.profiles.length > 0 || verified !== undefined) && identity(outcome) !== verified
             ? 'Run verify_preparations on this exact draft and repair every refusal before ending.'
             : undefined;
         },
@@ -225,6 +269,7 @@ export function buildPreparationSession(
             recipe: JSON.parse(
               hashableRecipeText(JSON.stringify(input.recipe)),
             ),
+            dependencyAvailability: preparationDependencyBriefing(input.repoRoot, input.recipe),
             specExcerpts: input.specExcerpts,
             repoRoot: input.repoRoot,
           }),
@@ -246,7 +291,9 @@ export function buildPreparationSession(
       if (result.status !== 'completed')
         return {
           status: 'failed',
-          reason: describeSessionFailure(result.failure),
+          reason: verificationFailure
+            ? `Preparation verification failed: ${verificationFailure}`
+            : describeSessionFailure(result.failure),
         };
       if (opts.signal?.aborted)
         return { status: 'failed', reason: 'Preparation authoring aborted' };
@@ -263,7 +310,7 @@ export function buildPreparationSession(
     } catch (error) {
       return {
         status: 'failed',
-        reason: error instanceof Error ? error.message : String(error),
+        reason: redact(error instanceof Error ? error.message : String(error)),
       };
     } finally {
       if (servicesStarted && input.recipe.api?.services?.down)
@@ -278,9 +325,12 @@ export function buildPreparationSession(
 }
 
 export const PREPARATION_PROMPT = `Author private starting states supported by THIS application's actual configuration. Read the datastore path/URL/schema handling and business specs. Preserve existing main seed, interfaces, dependencies, credentials and profiles. Return no profiles with precise findings when the application cannot isolate the actual query scope. A tenant cannot establish instance-wide totals.
-Use named profiles with baseline empty or seeded, instance scope, and environment bindings using \${directory} or \${namespace}. For SQLite use the app's supported path variable pointing inside \${directory}. No fabricated universal PostgreSQL/MySQL isolation or global resets.
+Use named profiles with baseline empty or seeded, instance scope, and environment bindings using \${directory} or \${namespace}. For SQLite use the app's supported path variable pointing inside \${directory}. For PostgreSQL use postgres:{isolation:'database',urlEnvs:['APP_DATABASE_URL','APP_DIRECT_URL']} with the ACTUAL app env names; env may be empty in this case. The runner derives private URLs from the resolved recipe/account bindings, preserving connection options and selecting the allocated database name. Read datasource configuration, all runtime/direct clients, migration commands and SQL before authoring. Prisma schema parameters alone do NOT isolate migrations or raw SQL that names public explicitly. No global resets or unsupported MySQL isolation.
+The briefing includes dependencyAvailability resolved from the dependency catalog and the local registrations, including catalog-only services. Treat provided, incomplete and unprovided states as constraints. Each profile MUST declare needs: ['canonical-catalog-name'] for every supplied dependency used by its seed, baseline reads, verifier mutations or cleanup; use needs: [] only when none are used. Do not assume an SDK import, API schema or recipe declaration means an account is provided. An unrelated unavailable service must not block local preparation. Select operations supported by the recipe's actual configuration without that service. Before selecting an observation or mutation, read its IMPLEMENTATION and follow its dependency and configuration guards; an API contract alone is insufficient. For example, database-backed upload storage cannot use an S3-only document endpoint when S3 is unprovided. Do not switch transports, fabricate accounts or omit a dependency to make the gate pass. Supplied path/config-directory instances cannot currently be materialized by preparation scripts; use a supported alternative or report the limitation. Choose mutations affecting the business records whose isolation you are proving, not an unrelated entity merely because it is easy to mutate.
 An empty profile contains ZERO business records. Provision schema and required credentials only; never copy the main seed's business fixtures into it. Keep example expenses, orders, or other business records in a separate seeded profile.
-Each profile MUST declare baselineChecks: [{path:'/unfiltered-collection', server?:'recipe-server', credential?:'provided-credential-name', counts:{'json.path.to.globalCount':0}, totals?:{'json.path.to.globalTotal':0}}]. Read the actual API and spec to name each instance-wide collection and its global count, not a page length or filtered count. Empty profiles require every count and total to equal zero. Seeded counts and totals must come from independently known authored inputs. The runner boots the real app and executes these reads itself before and after your verifier; your script's marker cannot substitute for them. These non-secret expected values are visible to scenario authors. If the app exposes no supported unfiltered JSON observation of its baseline, report that limitation instead of fabricating a check.
-The seed, verify and optional cleanup fields are Node ES-module source. Scripts receive GUARD_REPO_ROOT, GUARD_PREPARATION_DIRECTORY, GUARD_PREPARATION_NAMESPACE, GUARD_PREPARATION_BASELINE. Import application modules dynamically using GUARD_REPO_ROOT; source and final script directories differ. Seed uses the app's own provisioning path and writes the established {credentials:{name:{value}},fixtures:{name:{field:value}}} JSON to GUARD_SEED_OUT. Publish all required fields and credential header/server metadata through provides. Input amounts/dates/categories must be known independently, never copied from aggregate outputs.
-verify receives primary environment, GUARD_PREPARATION_PEER_ENV JSON, GUARD_PREPARATION_FIXTURES and PEER_FIXTURES, GUARD_PREPARATION_CREDENTIALS and PEER_CREDENTIALS. Start both actual apps on free ports with their respective environments; authenticate through these private credentials. Assert empty/seeded baseline and exact independent expected values through the app. Mutate the PEER, then prove primary unchanged at its declared baseline. Stop every process before exiting. Only after these assertions pass write {fixtures:{verification:{baseline:'empty' or 'seeded',isolated:true}}} to GUARD_SEED_OUT. Do not just emit this marker; the observations are the proof. A broken aggregate or false isolation must fail. Cleanup must use only its provided owned namespace/directory and never a default/shared reset. It runs even after seed failed before publishing a manifest.
-Call verify_preparations and repair failures. Return exact verified profiles and findings. Existing profiles need edits only when their configuration or script actually needs repair.`;
+Each profile MUST declare baselineChecks: [{path:'/unfiltered-collection', query?:{input:'serialized protocol input'}, server?:'recipe-server', credential?:'provided-credential-name', counts:{'json.path.to.globalCount':0}, totals?:{'json.path.to.globalTotal':0}}]. Read the actual API and spec to name each instance-wide collection and its global count, not a page length or filtered count. Empty profiles require every count and total to equal zero. Seeded counts and totals must come from independently known authored inputs. The runner boots the real app and executes these reads itself before and after your verifier; your script's marker cannot substitute for them. These non-secret expected values are visible to scenario authors. Use query for required transport parameters, such as tRPC's serialized input. Query presence or absence does not prove global scope: inspect the endpoint and omit business filters. A global count may be nested in result.data.json.count. If the app exposes no supported unfiltered JSON observation of its baseline, report that limitation instead of fabricating a check.
+The seed, verify and optional cleanup fields are Node ES-module source. Scripts receive GUARD_REPO_ROOT, GUARD_PREPARATION_DIRECTORY, GUARD_PREPARATION_NAMESPACE, GUARD_PREPARATION_BASELINE. Import application modules dynamically using GUARD_REPO_ROOT; source and final script directories differ. Seed uses the app's own provisioning path and writes the established {credentials:{name:{value}},fixtures:{name:{field:value}}} JSON to GUARD_SEED_OUT. Publish all required fields and credential header/server metadata through provides. Input amounts/dates/categories must be known independently, never copied from aggregate outputs. PostgreSQL seed and cleanup additionally receive GUARD_PREPARATION_POSTGRES_BASE_URLS, a JSON map from the declared URL env names to their original resolved URLs. Use the original direct connection only to create/drop the exact allocated database. Require /^guard_[a-f0-9]{32}$/ for that identifier and quote it; never interpolate an unchecked name. Create a fresh database from template0, apply the app's noninteractive deploy migrations against the PRIVATE direct URL, then import app code and seed using private URLs. Check that all selected connection routes reach the same owned database. A missing CREATEDB privilege is an explicit preparation finding. Never rewrite migrations, use db push instead of migrations, copy shared mutable rows, or reuse shared sessions. Cleanup is mandatory for PostgreSQL, disconnects clients, drops only that database and tolerates creation never having succeeded. Do not log or publish base/private URLs or passwords.
+verify receives the primary environment plus the following required JSON inputs. Start the verifier with this input parsing code, before starting either app:
+${PREPARATION_VERIFY_INPUTS_SOURCE}
+Use requiredPreparationCredential(credentials, 'actual-provided-name') for primary authentication and requiredPreparationCredential(peerCredentials, 'actual-provided-name') for peer authentication. Never default missing JSON to {}, reuse primary credentials for the peer, or send an undefined credential header. Missing inputs must fail explicitly before any requests. The verifier receives port templates intact. Allocate each app port and replace every \${PORT} template in its environment with that port before importing app configuration or spawning a server. Start both actual apps on free ports with their respective environments; authenticate through these private credentials. Assert empty/seeded baseline and exact independent expected values through the app. Prove the provided session authenticates and the promised document/resource status and relations exist through real app reads. Publish numeric legacy IDs and envelope IDs as distinct fixture fields when the app uses both. Mutate the PEER, then prove primary unchanged at its declared baseline. Stop every process before exiting. Only after these assertions pass write {fixtures:{verification:{baseline:'empty' or 'seeded',isolated:true}}} to GUARD_SEED_OUT. Do not just emit this marker; the observations are the proof. A broken aggregate or false isolation must fail. Cleanup must use only its provided owned namespace/directory and never a default/shared reset. It runs even after seed failed before publishing a manifest.
+Call verify_preparations with nonempty profiles and repair failures. A verification error is a failed preparation, not evidence that isolation is unsupported; do not discard failed profiles and return only findings. Return exact verified profiles and findings. Existing profiles need edits only when their configuration or script actually needs repair.`;

--- a/packages/core/src/services/llm/spec-estimate.ts
+++ b/packages/core/src/services/llm/spec-estimate.ts
@@ -161,6 +161,7 @@ import {
 } from '@truecourse/shared';
 import {
   computeRecipeFingerprint,
+  computePreparationFingerprint,
   resolvePrerequisites,
   buildRouteManifest,
   loadDependencyCatalog,
@@ -1104,7 +1105,7 @@ export async function estimateGuardSetup(
   // ---- private preparations: one authoring session per changed recipe --------
   // A profile is not evidence that this setup step already settled. The runtime
   // skips only its current recorded fingerprint; old setups must run this step.
-  const preparationSettled = recipe !== undefined && settled('preparations') === computeRecipeFingerprint(repoRoot) &&
+  const preparationSettled = recipe !== undefined && settled('preparations') === computePreparationFingerprint(repoRoot) &&
     preparationCatalog(recipe).length === Object.keys(recipe.preparations ?? {}).length;
   const preparationItems = preparationSettled ? 0 : 1;
   // Upstream recipe/seed work can move the fingerprint before this step starts.
@@ -1187,7 +1188,7 @@ export async function estimateGuardSetup(
       budget: PREPARATION_SESSION_BUDGET,
       items: preparationItems,
       maxItems: preparationMax,
-      bound: 'one private preparation authoring session; skipped only when its recipe fingerprint is unchanged',
+      bound: 'one private preparation authoring session; skipped only when its recipe and preparation contract are unchanged',
     }),
     setupStage({
       kind: AUTH_PROOF_SESSION_KIND,

--- a/packages/data-store/src/session-run-store.ts
+++ b/packages/data-store/src/session-run-store.ts
@@ -307,12 +307,24 @@ export class PgSessionRunStore implements SessionRunBackend {
     let pending = Promise.resolve();
     let failure: unknown;
     const flush = async () => { await pending; if (failure) throw failure; };
-    const enqueue = (body: ActivityEventBody, snapshot?: Record) => {
+    // Only adjacent checklist updates can replace one another. Transcript and
+    // lifecycle events are ordering barriers and are always persisted.
+    let checklistTail: { value: ActivityEventBody; state?: Record } | undefined;
+    const enqueue = (body: ActivityEventBody, snapshot?: Record, coalesce = false) => {
       if (failure) throw failure;
       const value = clone(body);
-      const state = snapshot ? clone(toPublicRunRecord(snapshot)) : undefined;
+      const state = snapshot && value.kind === 'run' ? value.run as Record : undefined;
+      if (coalesce && checklistTail) {
+        checklistTail.value = value;
+        checklistTail.state = state;
+        return;
+      }
+      const queued = { value, state };
+      checklistTail = coalesce ? queued : undefined;
       pending = pending.then(async () => {
+        if (checklistTail === queued) checklistTail = undefined;
         if (failure) return;
+        const { value, state } = queued;
         const event = await this.db.transaction(async tx => {
           const [row] = await tx.select({ ...getTableColumns(activityRuns), leaseActive: sql<boolean>`${activityRuns.leaseUntil} > CURRENT_TIMESTAMP` }).from(activityRuns).where(and(eq(activityRuns.runId, record.runId), eq(activityRuns.repoKey, repoKey))).for('update');
           if (!row) throw new Error('Session run was removed');
@@ -341,7 +353,7 @@ export class PgSessionRunStore implements SessionRunBackend {
     }, 20_000);
     heartbeat.unref();
     if (!owned) clearInterval(heartbeat);
-    const write = () => enqueue({ kind: 'run', run: toPublicRunRecord(record) }, record);
+    const write = (coalesce = false) => enqueue({ kind: 'run', run: toPublicRunRecord(record) }, record, coalesce);
     return {
       runId: record.runId, dir, record: () => record, flush,
       subscribeActivity: notify => this.subscribe(`run:${record.runId}`, notify),
@@ -358,7 +370,7 @@ export class PgSessionRunStore implements SessionRunBackend {
         const at = blocks.findIndex(block => block.kind === 'checklist');
         const checklist = { kind: 'checklist' as const, items };
         record.display = { blocks: at < 0 ? [checklist, ...blocks] : blocks.map((block, i) => i === at ? checklist : block) };
-        write();
+        write(true);
       },
       setError(error) { record.error = error; write(); },
       finish(status, options) {

--- a/packages/data-store/src/session-run-store.ts
+++ b/packages/data-store/src/session-run-store.ts
@@ -5,7 +5,7 @@ import { activityRuns, activityEvents, type Db, type Pool, type PoolClient } fro
 import {
   SessionRunNotFoundError, createSessionRun, listSessionRuns, openSessionRun, parseSessionRunCursor,
   sessionRunDir, toPublicRunRecord,
-  type RepoRunRecord, type SessionRunBackend, type SessionRunQuery, type SessionRunStore,
+  type ActivityPage, type RepoRunRecord, type SessionRunBackend, type SessionRunQuery, type SessionRunStore,
 } from '@truecourse/core/lib/sessions-store';
 import { publishActivityProgress, publishCommittedActivity, readActivityEvents } from '@truecourse/core/lib/activity-journal';
 import { ActivityEventSchema, type ActivityEvent, type ActivityEventBody } from '@truecourse/shared/activity-stream';
@@ -277,6 +277,30 @@ export class PgSessionRunStore implements SessionRunBackend {
     });
   }
 
+  private async readCompactPage(runId: string, after: number, limit: number): Promise<ActivityPage> {
+    await this.validateCursor(runId, after);
+    // Select the cursor window first. Only fetch bodies that the conversation
+    // uses: thousands of run snapshots can dwarf the entire transcript.
+    const result = await this.db.execute(sql`
+      WITH page AS MATERIALIZED (
+        SELECT cursor, body->>'kind' AS kind FROM ${activityEvents}
+        WHERE run_id = ${runId} AND cursor > ${after} ORDER BY cursor LIMIT ${limit}
+      )
+      SELECT e.cursor, e.body, (SELECT count(*) FROM page) AS page_count
+      FROM ${activityEvents} e JOIN page p ON e.cursor = p.cursor
+      WHERE e.run_id = ${runId}
+        AND (p.kind IS DISTINCT FROM 'run' OR p.cursor = (SELECT max(cursor) FROM page WHERE kind = 'run'))
+      ORDER BY e.cursor
+    `);
+    const rows = result.rows as { cursor: string | number; body: { [key: string]: unknown }; page_count: string | number }[];
+    const events = rows.map(row => decodeActivityEvent(row.body, Number(row.cursor)));
+    return {
+      events,
+      nextCursor: events.at(-1)?.cursor ?? after,
+      done: Number(rows[0]?.page_count ?? 0) < limit,
+    };
+  }
+
   private handle(repoKey: string, record: Record, owned = true): SessionRunStore {
     const dir = sessionRunDir(repoKey, record.command, record.runId);
     const transcripts = new Map<string, Event[]>();
@@ -323,6 +347,7 @@ export class PgSessionRunStore implements SessionRunBackend {
       subscribeActivity: notify => this.subscribe(`run:${record.runId}`, notify),
       readActivity: async after => { await flush(); await this.reconcile([repoKey]); return this.readEvents(record.runId, after); },
       readActivityPage: async (after, limit) => { await flush(); await this.reconcile([repoKey]); return this.readEvents(record.runId, after, limit); },
+      readCompactActivityPage: async (after, limit) => { await flush(); await this.reconcile([repoKey]); return this.readCompactPage(record.runId, after, limit); },
       validateActivityCursor: async after => { await flush(); await this.validateCursor(record.runId, after); },
       readTranscript: async (sessionId, since) => { await flush(); return this.readTranscript(record.runId, sessionId, since); },
       setGitRef(gitRef) { record.gitRef = gitRef; write(); },

--- a/packages/data-store/src/session-run-store.ts
+++ b/packages/data-store/src/session-run-store.ts
@@ -1,11 +1,11 @@
 import fs from 'node:fs';
 import { randomUUID } from 'node:crypto';
-import { and, asc, eq, gt, inArray, sql, getTableColumns } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, inArray, sql, getTableColumns } from 'drizzle-orm';
 import { activityRuns, activityEvents, type Db, type Pool, type PoolClient } from '@truecourse/db';
 import {
   SessionRunNotFoundError, createSessionRun, listSessionRuns, openSessionRun, parseSessionRunCursor,
   sessionRunDir, toPublicRunRecord,
-  type ActivityPage, type RepoRunRecord, type SessionRunBackend, type SessionRunQuery, type SessionRunStore,
+  type TranscriptPageOptions, type TranscriptPage, type ActivityPage, type RepoRunRecord, type SessionRunBackend, type SessionRunQuery, type SessionRunStore,
 } from '@truecourse/core/lib/sessions-store';
 import { publishActivityProgress, publishCommittedActivity, readActivityEvents } from '@truecourse/core/lib/activity-journal';
 import { ActivityEventSchema, type ActivityEvent, type ActivityEventBody } from '@truecourse/shared/activity-stream';
@@ -277,6 +277,23 @@ export class PgSessionRunStore implements SessionRunBackend {
     });
   }
 
+  private async readTranscriptPage(runId: string, sessionId: string, options: TranscriptPageOptions): Promise<TranscriptPage> {
+    const seq = sql`(${activityEvents.body}->'event'->>'seq')::bigint`;
+    const rows = await this.db.select().from(activityEvents).where(and(
+      eq(activityEvents.runId, runId),
+      sql`${activityEvents.body}->>'kind' = 'session-event'`,
+      sql`${activityEvents.body}->>'sessionId' = ${sessionId}`,
+      options.before === undefined ? undefined : sql`${seq} < ${options.before}`,
+      options.since === undefined ? undefined : sql`${seq} > ${options.since}`,
+    )).orderBy(options.since === undefined ? desc(activityEvents.cursor) : asc(activityEvents.cursor)).limit(options.limit + 1);
+    const events = rows.slice(0, options.limit).map(row => {
+      const decoded = decodeActivityEvent(row.body, row.cursor);
+      if (decoded.kind !== 'session-event') throw new Error('Expected transcript event');
+      return decoded.event;
+    });
+    return { events: events.sort((a, b) => a.seq - b.seq), hasMore: rows.length > options.limit };
+  }
+
   private async readCompactPage(runId: string, after: number, limit: number): Promise<ActivityPage> {
     await this.validateCursor(runId, after);
     // Select the cursor window first. Only fetch bodies that the conversation
@@ -362,6 +379,7 @@ export class PgSessionRunStore implements SessionRunBackend {
       readCompactActivityPage: async (after, limit) => { await flush(); await this.reconcile([repoKey]); return this.readCompactPage(record.runId, after, limit); },
       validateActivityCursor: async after => { await flush(); await this.validateCursor(record.runId, after); },
       readTranscript: async (sessionId, since) => { await flush(); return this.readTranscript(record.runId, sessionId, since); },
+      readTranscriptPage: async (sessionId, options) => { await flush(); return this.readTranscriptPage(record.runId, sessionId, options); },
       setGitRef(gitRef) { record.gitRef = gitRef; write(); },
       setEndpoint(endpoint) { record.endpoint = endpoint; write(); },
       setLlm(llm) { record.llm = llm; write(); },

--- a/packages/guard-generator/src/author-catalog.ts
+++ b/packages/guard-generator/src/author-catalog.ts
@@ -1,0 +1,130 @@
+/** Deterministic, invocation-local author lookup. No source or execution access. */
+import { createHash } from 'node:crypto'
+import type { Interface, InterfaceResource } from '@truecourse/shared'
+import { buildResourceHints } from './grounding.js'
+
+export const AUTHOR_CATALOG_VERSION = 'web-author-catalog-v3'
+export const AUTHOR_TOOL_RESULT_CHARS = 12_000
+export const AUTHOR_INITIAL_BYTES = 120_000
+export const AUTHOR_SUMMARY_CHARS = 1_500
+export interface CatalogSearch { query: string; purpose?: 'task' | 'control'; resource?: string; limit?: number; cursor?: string }
+export interface CatalogGet { ids: string[]; cursor?: string }
+export interface CatalogReport { content: string; isError?: boolean }
+export interface AuthorCatalogSummary { id?: string; title?: string; entry?: Interface['entry']; purpose?: string; at?: string; to?: string; startingState?: string; endState?: string; omittedFields: string[]; error?: string; identityHash?: string; instruction?: string }
+export interface AuthorCatalog {
+  fingerprint: string
+  search(input: CatalogSearch): CatalogReport
+  get(input: CatalogGet): CatalogReport
+  candidates(own: readonly Interface[], terms: string): AuthorCatalogSummary[]
+}
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`
+  if (value && typeof value === 'object') return `{${Object.entries(value).filter(([, v]) => v !== undefined).sort(([a], [b]) => a.localeCompare(b)).map(([k, v]) => `${JSON.stringify(k)}:${stable(v)}`).join(',')}}`
+  return JSON.stringify(value) ?? 'null'
+}
+const hash = (v: unknown): string => createHash('sha256').update(stable(v)).digest('hex')
+const error = (code: string): CatalogReport => ({ content: JSON.stringify({ error: code, instruction: 'Retrieval failed; do not infer absent product behavior. Resolve retrieval before authoring dependent steps.' }), isError: true })
+function summary(i: Interface) {
+  return { id: i.id, title: i.title, entry: i.entry, purpose: i.purpose, at: i.at, to: i.to, startingState: i.startingState, endState: i.endState }
+}
+/** Optional metadata is omitted whole, never clipped. Search still uses the full metadata. */
+function boundedSummary(full: ReturnType<typeof summary>): AuthorCatalogSummary {
+  // The fetch tool accepts at most 200 characters per ID. A larger identity cannot
+  // be used through that contract; report it without blocking later search rows.
+  if (full.id.length > 200) return {
+    error: 'oversized-interface-id', identityHash: hash(full.id),
+    omittedFields: ['id', 'all metadata'],
+    instruction: 'The action ID exceeds the 200-character retrieval limit. Dependent authoring is blocked; continue paging to discover other actions.',
+  }
+  const optional = Object.entries(full).filter(([key, value]) => key !== 'id' && value !== undefined)
+  const result: AuthorCatalogSummary = { id: full.id, omittedFields: ['steps', 'resource readables; use get_interfaces', ...optional.map(([key]) => key)] }
+  for (const [key, value] of optional) {
+    const proposed = { ...result, [key]: value, omittedFields: result.omittedFields.filter(field => field !== key) }
+    if (JSON.stringify(proposed).length <= AUTHOR_SUMMARY_CHARS) Object.assign(result, proposed)
+  }
+  return structuredClone(result)
+}
+/** Page at complete field boundaries. Indexed paths preserve array order and permit lossless reconstruction. */
+function fields(value: unknown, path: (string | number)[] = []): { path: (string | number)[]; value: unknown }[] {
+  if (value && typeof value === 'object' && Object.keys(value).length) return Object.entries(value).flatMap(([key, v]) => fields(v, [...path, Array.isArray(value) ? Number(key) : key]))
+  return [{ path, value }]
+}
+export function createAuthorCatalog(interfaces: readonly Interface[], resources?: Record<string, InterfaceResource[]>): AuthorCatalog {
+  // Clone once: callers cannot mutate a running snapshot or its continuation keys.
+  const entries = structuredClone(interfaces.filter(i => i.type === 'web')).sort((a, b) => a.id.localeCompare(b.id))
+  const registry = structuredClone(resources ?? {})
+  const payloads = new Map(entries.map(i => [i.id, { interface: i, resources: buildResourceHints([i], registry) }]))
+  const reachableResources = [...new Map([...payloads.values()].flatMap(p => p.resources).map(r => [r.id, r])).values()].sort((a, b) => a.id.localeCompare(b.id))
+  const fingerprint = hash([AUTHOR_CATALOG_VERSION, entries, reachableResources])
+  const summaries = entries.map(summary)
+  function page(items: unknown[], binding: unknown, limit: number, cursor?: string, metadata?: (end: number) => object): CatalogReport {
+    const key = hash([fingerprint, binding])
+    let start = 0
+    if (cursor) {
+      try {
+        const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'))
+        if (parsed.key !== key || !Number.isSafeInteger(parsed.offset) || parsed.offset < 0 || parsed.offset >= items.length) return error('invalid-or-stale-cursor')
+        start = parsed.offset
+      } catch { return error('invalid-or-stale-cursor') }
+    }
+    const render = (selected: unknown[], end: number): string => JSON.stringify({ snapshot: fingerprint, total: items.length, offset: start, items: selected, ...metadata?.(end), complete: end === items.length, omittedFields: end === items.length ? [] : ['remaining items; continue with nextCursor'], ...(end < items.length ? { nextCursor: Buffer.from(JSON.stringify({ key, offset: end })).toString('base64url') } : {}) })
+    const selected: unknown[] = []
+    for (let n = start; n < items.length && selected.length < limit; n++) {
+      if (render([...selected, items[n]], n + 1).length > AUTHOR_TOOL_RESULT_CHARS) {
+        if (!selected.length) return error('oversized-indivisible-field')
+        break
+      }
+      selected.push(items[n])
+    }
+    return { content: render(selected, start + selected.length) }
+  }
+  const ranked = (query: string): ReturnType<typeof summary>[] => {
+    const q = query.trim().toLowerCase()
+    const terms = q.split(/\s+/).filter(Boolean)
+    return summaries.map(s => {
+      const text = stable(s).toLowerCase()
+      const exact = s.id.toLowerCase() === q || Object.values(s.entry).some(v => typeof v === 'string' && v.toLowerCase() === q)
+      return { s, score: exact ? 10000 : terms.reduce((n, t) => n + Number(text.includes(t)), 0) }
+    }).filter(r => !q || r.score > 0).sort((a, b) => b.score - a.score || a.s.id.localeCompare(b.s.id)).map(r => r.s)
+  }
+  return {
+    fingerprint,
+    search(input) {
+      if (input.query.length > 500 || (input.resource?.length ?? 0) > 200 || (input.cursor?.length ?? 0) > 1000 || (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1 || input.limit > 20))) return error('invalid-search-input')
+      const results = ranked(input.query).filter(s => (!input.purpose || s.purpose === input.purpose) && (!input.resource || payloads.get(s.id)!.resources.some(r => r.id === input.resource)))
+      return page(results.map(boundedSummary), { kind: 'search', query: input.query, purpose: input.purpose, resource: input.resource, limit: input.limit ?? 8 }, input.limit ?? 8, input.cursor)
+    },
+    get(input) {
+      if (input.ids.length < 1 || input.ids.length > 5 || new Set(input.ids).size !== input.ids.length || input.ids.some(id => !payloads.has(id))) return error('unknown-or-invalid-interface-ids')
+      if ((input.cursor?.length ?? 0) > 1000) return error('invalid-or-stale-cursor')
+      // Every requested action precedes optional resource pages, so a large
+      // resource on the first action cannot hide the second action's steps.
+      const actionEnds: { id: string; end: number }[] = []
+      const items: { id: string; path: (string | number)[]; value: unknown }[] = []
+      for (const id of input.ids) {
+        items.push(...fields(payloads.get(id)!.interface, ['interface']).map(f => ({ id, ...f })))
+        actionEnds.push({ id, end: items.length })
+      }
+      for (const id of input.ids) items.push(...fields(payloads.get(id)!.resources, ['resources']).map(f => ({ id, ...f })))
+      return page(items, { kind: 'get', ids: input.ids }, Infinity, input.cursor,
+        end => ({ actionCompleteIds: actionEnds.filter(action => action.end <= end).map(action => action.id) }))
+    },
+    candidates(own, terms) {
+      const ids = new Set(own.map(i => i.id))
+      return ranked(`${terms} ${own.map(i => [i.title, i.at, i.to, i.startingState, i.endState].filter(Boolean).join(' ')).join(' ')}`).filter(s => !ids.has(s.id)).slice(0, 6).map(boundedSummary)
+    },
+  }
+}
+
+/** Keep resource identity and only readables explicitly referenced by selected action data. */
+export function scopedAuthorResources(own: readonly Interface[], resources?: Record<string, InterfaceResource[]>): InterfaceResource[] {
+  const actionText = stable(own)
+  const referenced = new Set(actionText.match(/[A-Za-z0-9_/-]+/g) ?? [])
+  return buildResourceHints(own, resources).map(resource => {
+    const { readables, ...identity } = resource
+    if (!readables) return identity
+    const selected = Object.fromEntries(Object.entries(readables).map(([kind, rows]) => [kind, rows.filter(row => (row.id && referenced.has(row.id)) || ('control' in row && actionText.includes(stable(row.control))) || ('element' in row && actionText.includes(stable(row.element))))]))
+    const present = Object.fromEntries(Object.entries(selected).filter(([, rows]) => rows.length > 0))
+    return Object.keys(present).length ? { ...identity, readables: present } : identity
+  })
+}

--- a/packages/guard-generator/src/failure-observation.ts
+++ b/packages/guard-generator/src/failure-observation.ts
@@ -1,0 +1,23 @@
+import { GuardFailureObservationSchema, type GuardFailureObservation } from '@truecourse/shared'
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`
+  if (value && typeof value === 'object') return `{${Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([key, entry]) => `${JSON.stringify(key)}:${stable(entry)}`).join(',')}}`
+  return JSON.stringify(value)
+}
+
+/** Undefined means exact supported evidence equivalence; prose is never compared. */
+export function compareFailureObservations(
+  predicted: GuardFailureObservation,
+  actual: GuardFailureObservation,
+): string | undefined {
+  const left = GuardFailureObservationSchema.safeParse(predicted)
+  const right = GuardFailureObservationSchema.safeParse(actual)
+  if (!left.success || !right.success) return 'invalid or unsupported observation version'
+  if (left.data.kind === 'web-target' && left.data.visibility === 'unknown') return 'target visibility was not observed'
+  if (right.data.kind === 'web-target' && right.data.visibility === 'unknown') return 'target visibility was not observed'
+  for (const key of new Set([...Object.keys(left.data), ...Object.keys(right.data)])) {
+    if (stable((left.data as Record<string, unknown>)[key]) !== stable((right.data as Record<string, unknown>)[key])) return `observation ${key} differs`
+  }
+  return undefined
+}

--- a/packages/guard-generator/src/generate.ts
+++ b/packages/guard-generator/src/generate.ts
@@ -716,7 +716,7 @@ export interface GenerateGuardsOptions {
    *  The wider signature is kept so the runner's own phase type still fits. */
   onBirthPhase?: (phase: 'build' | 'run' | 'confirm', total?: number) => void
   /** Per-FLOW settle progress: `total` = the flows this run had work for. */
-  onFlowSettled?: (settled: number, total: number) => void
+  onFlowSettled?: (settled: number, total: number) => void | Promise<void>
   /**
    * One line per THING the run did, filed under the phase that did it: the
    * section that changed, the doc that was extracted, the interface that was
@@ -2086,7 +2086,7 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
   }
   // Announce the settle denominator before the first (slow) authoring/birth phase,
   // so the live counter is never a bare count without context.
-  options.onFlowSettled?.(0, changedWorks.length)
+  await options.onFlowSettled?.(0, changedWorks.length)
 
   // 7. Workers — one `guard-generate.flow-worker` session per (flow, surface
   // with a plan). The build is kicked first: every execution inside the worker
@@ -4089,7 +4089,7 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
     for (const gap of work.gaps) {
       fact('validate', `${work.flow.id} x ${gap.surface}: ${gap.kind} gap, ${asLine(gap.reason)}`)
     }
-    options.onFlowSettled?.(++flowsSettled, settleTotal)
+    await options.onFlowSettled?.(++flowsSettled, settleTotal)
   }
   flowsReport.settled += flowsReport.skipped
   // A committed flow that no longer exists is treated by INTENT, not by symmetry:

--- a/packages/guard-generator/src/generate.ts
+++ b/packages/guard-generator/src/generate.ts
@@ -55,6 +55,7 @@ import { scenarioReviewFingerprint } from '@truecourse/shared/guard-proof-node'
 import { createHash } from 'node:crypto'
 import { isDeepStrictEqual } from 'node:util'
 import { WorkerObservations, redObservationMismatch } from './worker-observations.js'
+import { privateAuthoringProfiles, privateAuthoringDefect } from './private-authoring.js'
 import fs from 'node:fs'
 import path from 'node:path'
 import pLimit from 'p-limit'
@@ -939,8 +940,11 @@ export type FlowWorkerSessionResult =
 export type FlowWorkerSessionSeam = (input: {
   tasks: readonly FlowWorkerTask[]
   epicTasks: readonly FlowWorkerTask[]
+  /** After members/epics, author up to six private-preparation mutators together.
+   * Engine execution gates refuse any draft that touches shared dependencies. */
+  preparedMutatorTasks?: readonly FlowWorkerTask[]
   /**
-   * Wave 3: the flows the world classifier judged WORLD-MUTATING (credential
+   * Final wave: the flows the world classifier judged WORLD-MUTATING (credential
    * changes, account deletion, session revocation, global config). Run LAST and
    * SERIALIZED — one session at a time — so a destructive draft executes only
    * after every shared-world sibling has settled; the engine restores the world
@@ -2551,6 +2555,10 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
       // waves finish (unless the session settled anyway with a rewrite that
       // does not mutate).
       const deferredMutatorRefs = new Set<string>()
+      const privateMutatorRefs = new Set<string>()
+      const localDependencies = new Set(prerequisiteResolution.dependencies.dependencies
+        .filter(d => d.state === null && d.entry.class !== 'supplied').map(d => d.name))
+      const privateProfiles = privateAuthoringProfiles(recipe, localDependencies)
 
       /**
        * The DETERMINISTIC mutator gate, enforced where execution happens — the
@@ -2706,6 +2714,16 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
         candidate: BirthCandidate,
         task: AuthorTask,
       ): Promise<{ report: FlowWorkerToolReport } | { result: GuardScenarioResult }> => {
+        if (privateMutatorRefs.has(taskKey(task))) {
+          const defect = privateAuthoringDefect(candidate.scenario, privateProfiles, localDependencies)
+          if (defect) {
+            deferredMutatorRefs.add(taskKey(task))
+            return { report: {
+              content: `not executed — private authoring requires you to ${defect}. Use an eligible preparation for every trial and submission, or end blocked with capability "deferred to the serialized mutator wave". The engine will retry unfinished deferred flows serially.`,
+              isError: true,
+            } }
+          }
+        }
         // Nothing executes against a world under repair: the verdict decides
         // whether this execution runs against a repaired world or short-circuits.
         if (worldRepair) await worldRepair
@@ -3176,6 +3194,8 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
               'Work the loop: draft the scenario as YAML, `run_scenario` it, revise on the evidence, then `submit_scenario`; end the session with the outcome object.',
             )
             lines.push('', 'OUTSTANDING ASSIGNED OBLIGATIONS:', outstandingFeedback(state))
+            if (privateMutatorRefs.has(ref)) lines.push('',
+              `PRIVATE AUTHORING: every trial and submission must select one of these private Postgres preparations: ${[...privateProfiles].join(', ')}. Supplied accounts and shared services are not isolated. If your required starting state cannot use these profiles, end blocked with capability "deferred to the serialized mutator wave"; the engine will retry serially.`)
             return lines.join('\n')
           },
           runScenario: async (yamlText) => {
@@ -3401,12 +3421,17 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
       const epicTasks = workerStates
         .filter((s) => s.task.work.flow.composedOf.length > 0 && !isMutatorState(s))
         .map(makeWorkerTask)
-      // The serialized third wave: destructive flows (epics included — their
-      // members settled in the earlier waves). The dirty marker outlives a
-      // crash mid-wave so the next world boot resets before building on the
-      // damage; the reset after persist clears it.
-      const mutatorTasks = workerStates.filter(isMutatorState).map(makeWorkerTask)
-      if (mutatorTasks.length > 0) {
+      // The final waves: private HTTP/browser mutations first, then serialized
+      // shared mutations. Keep epics in the tail so their members finish first.
+      // The shared world's dirty marker survives a crash; its next boot resets
+      // the damage, and the reset after persistence clears the marker.
+      const mutatorStates = workerStates.filter(isMutatorState)
+      const preparedStates = mutatorStates.filter(s => privateProfiles.size > 0 &&
+        s.task.work.flow.composedOf.length === 0 && (s.task.surface === 'api' || s.task.surface === 'web'))
+      for (const state of preparedStates) privateMutatorRefs.add(taskKey(state.task))
+      const preparedMutatorTasks = preparedStates.map(makeWorkerTask)
+      const sharedMutatorTasks = mutatorStates.filter(s => !privateMutatorRefs.has(taskKey(s.task))).map(makeWorkerTask)
+      if (sharedMutatorTasks.length > 0) {
         mutatorPhasePlanned = true
         fs.mkdirSync(path.dirname(guardWorldDirtyMarkerPath(repoRoot)), { recursive: true })
         fs.writeFileSync(guardWorldDirtyMarkerPath(repoRoot), 'guard-generate\n')
@@ -3429,7 +3454,8 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
       const phaseA = await options.flowWorkerSession({
         tasks: waveTasks,
         epicTasks,
-        mutatorTasks,
+        preparedMutatorTasks,
+        mutatorTasks: sharedMutatorTasks,
         docs,
         onTask: (done, total, outcome) => {
           if (outcome === 'settled') workerSettledCount++
@@ -3448,12 +3474,17 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
       // a rewrite that does not mutate. The gate opens for them by adding
       // their flow ids to `destructiveFlowIds` first.
       const deferredStates = [...states.values()].filter((s) => {
-        if (!deferredMutatorRefs.has(taskKey(s.task))) return false
         const result = byTask.get(`flow:${s.task.work.flow.id}:${s.task.surface}`)
+        const explicitlyDeferred = result?.kind === 'outcome' && result.outcome.kind === 'blocked' &&
+          result.outcome.perMilestone?.some(m => m.capability.includes('deferred to the serialized mutator wave'))
+        if (!deferredMutatorRefs.has(taskKey(s.task)) && !(privateMutatorRefs.has(taskKey(s.task)) && explicitlyDeferred)) return false
         return !(result?.kind === 'outcome' && result.outcome.kind === 'settled')
       })
       if (deferredStates.length > 0 && !anomalyLatch && !runRefusal) {
-        for (const s of deferredStates) destructiveFlowIds.add(s.task.work.flow.id)
+        for (const s of deferredStates) {
+          destructiveFlowIds.add(s.task.work.flow.id)
+          privateMutatorRefs.delete(taskKey(s.task))
+        }
         if (!mutatorPhasePlanned) {
           mutatorPhasePlanned = true
           fs.mkdirSync(path.dirname(guardWorldDirtyMarkerPath(repoRoot)), { recursive: true })

--- a/packages/guard-generator/src/generate.ts
+++ b/packages/guard-generator/src/generate.ts
@@ -1,3 +1,4 @@
+import { createAuthorCatalog, scopedAuthorResources, type AuthorCatalog } from './author-catalog.js'
 import { completeRealization } from './match.js'
 import { navigationGroundingProblem } from './proof-grounding.js'
 import { resolvePrerequisites } from '@truecourse/guard-runner'
@@ -52,6 +53,8 @@ import { scenarioReviewFingerprint } from '@truecourse/shared/guard-proof-node'
  */
 
 import { createHash } from 'node:crypto'
+import { isDeepStrictEqual } from 'node:util'
+import { WorkerObservations, redObservationMismatch } from './worker-observations.js'
 import fs from 'node:fs'
 import path from 'node:path'
 import pLimit from 'p-limit'
@@ -866,6 +869,8 @@ export interface FlowWorkerTask {
    *  from-scratch author. */
   prior?: { scenarios: readonly { id: string; yaml: string }[] }
   cacheMaterial: FlowWorkerCacheMaterial
+  /** Web-only immutable catalog access. */
+  catalog?: AuthorCatalog
   /**
    * Render the briefing — today's `buildAuthorCtx` payload through
    * `buildAuthorUserPrompt`, plus (epics) the members' settled scenarios.
@@ -1462,6 +1467,7 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
   // not itself walk when a SETUP step needs one (sign up, then sign in, then test
   // favorites). Empty for a repo with no api interfaces — the block simply renders not.
   const apiInterfaces = catalogs.get('api')?.interfaces ?? []
+  const authorCatalog = createAuthorCatalog((catalogs.get('web')?.interfaces ?? []).filter(i => !servedByOtherApp(serverIndex, recipe.web?.app, interfaceEntryPath(i))), mapped.resources)
   // The counts describe what this run GROUNDED ON — the surface catalogs, not the
   // catalog file — which is why the total is their sum. They are read when flows
   // settle unrealized, and an entry the matcher never sees (an RPC-derived
@@ -2760,13 +2766,13 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
       ): boolean => {
         if (result.outcome === 'pass') return expectedReds.length === 0
         if (result.outcome !== 'fail') return false
-        if (expectedReds.length === 0) return false
+        if (expectedReds.length !== 1) return false
         const step = result.failure?.step ?? 1
         if (expectedReds.some((r) => r.step !== step)) return false
         const declared = expectedReds.find((r) => r.step === step)
         return (
           declared !== undefined &&
-          actualMatchesPrediction(result.failure?.actual ?? '', declared.predictedActual)
+          redObservationMismatch(result, declared) === undefined
         )
       }
 
@@ -2853,6 +2859,8 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
         if (outcome.kind !== 'settled') return undefined
         if (settledScenariosOf(outcome).some(s => stash.get(s.scenarioYamlSha)?.candidate.ref !== taskKey(state.task)))
           return 'Outcome refused: the settled outcome references a sha the engine never accepted for this task.'
+        if (settledScenariosOf(outcome).some(s => !isDeepStrictEqual(s.expectedReds, stash.get(s.scenarioYamlSha)?.expectedReds)))
+          return 'Outcome refused: expectedReds must exactly match the canonical evidence returned by the accepted submission.'
         if (outcome.droppedScenarios?.some(d => !state.drops.some(p => p.id === d.id)))
           return 'Outcome refused: a dropped scenario must first be accepted through drop_scenario.'
         if (!progress.complete) return 'Outcome refused: generation is incomplete. Submit one complete candidate verifying these remaining obligations before settling:\n' +
@@ -3024,13 +3032,12 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
           }
         }
         const declared = expectedReds.find((r) => r.step === step)!
-        const actual = result.failure?.actual ?? ''
-        if (!actualMatchesPrediction(actual, declared.predictedActual)) {
+        const mismatch = expectedReds.length !== 1
+          ? 'Declare only one prediction for the first failing step.'
+          : redObservationMismatch(result, declared)
+        if (mismatch) {
           return {
-            content:
-              `not accepted — the confirmation's actual at step ${step} does not match your predictedActual.\n` +
-              `predicted: ${declared.predictedActual}\nobserved:  ${actual}\n` +
-              'Copy the observed actual into predictedActual (the prediction proves you ran it), then submit again.',
+            content: `not accepted — ${mismatch}\nRun the exact candidate again and use its observationId for supported web failures. Repair changed semantic evidence before submitting.`,
             isError: true,
           }
         }
@@ -3077,6 +3084,7 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
         return out
       }
 
+      const observationStores = new Set<WorkerObservations>()
       const makeWorkerTask = (state: WorkerTaskState): FlowWorkerTask => {
         const task = state.task
         const ref = taskKey(task)
@@ -3084,6 +3092,8 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
         const epic = task.work.flow.composedOf.length > 0
         const priorScenarios = [...state.priors.entries()].map(([id, yaml]) => ({ id, yaml }))
         const editMode = priorScenarios.length > 0
+        const observations = new WorkerObservations(task.surface)
+        observationStores.add(observations)
         return {
           workItem: `flow:${task.work.flow.id}:${task.surface}`,
           flowId: task.work.flow.id,
@@ -3092,13 +3102,14 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
           milestoneCount: new Set(task.plan.steps.map((s) => s.milestone)).size,
           ...(taint ? { taint: { title: taint.title, mismatch: taint.mismatch } } : {}),
           ...(editMode ? { prior: { scenarios: priorScenarios } } : {}),
+          ...(task.surface === 'web' ? { catalog: authorCatalog } : {}),
           cacheMaterial: {
             flowFingerprint: task.work.flow.fingerprint,
             sectionKeys: task.work.sectionKeys,
             interfaceFingerprints: [
               realizationAssignmentFingerprint(task.plan),
               ...task.plan.interfaces.map((j) => j.fingerprint),
-              ...(task.surface === 'web' ? [catalogs.get('web')!.fingerprint] : []),
+              ...(task.surface === 'web' ? [authorCatalog.fingerprint] : []),
             ],
             recipeFingerprint,
             mode: editMode ? 'edit' : 'scratch',
@@ -3118,7 +3129,7 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
                 docText,
                 externalServices: externalServiceHints,
                 apiInterfaces,
-                webInterfaces: catalogs.get('web')?.interfaces ?? [],
+                authorCatalog,
                 outboundRequests: outboundRequestHints,
                 outboundRequestsOverflow,
                 ...(mapped.resources ? { resources: mapped.resources } : {}),
@@ -3188,12 +3199,15 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
                 }
               }
             }
+            const observationId = observations.record(yamlText, run.result)
             return {
-              content: renderCondensedResult(run.result),
+              content: renderCondensedResult(run.result) + (observationId ? `\nobservationId: ${observationId}\nUse this ID only with this exact YAML and failing step in submit_scenario.` : ''),
               ...(run.result.outcome === 'pass' ? {} : { isError: true }),
             }
           },
           submitScenario: async (yamlText, expectedReds, judge, replaces) => {
+            const evidence = observations.resolve(yamlText, expectedReds)
+            if ('error' in evidence) return { content: `not accepted — ${evidence.error}`, isError: true }
             // Id resolution. Scratch mode: the pre-assigned id, every attempt
             // (`replaces` is meaningless there). Edit mode: `replaces` keeps a
             // briefed prior's id; omitted, the submission is a NEW scenario
@@ -3239,10 +3253,14 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
             }
             const run = await executeOnce(built.candidate, task)
             if ('report' in run) return run.report
-            return settleSubmission(state, built.candidate, run.result, expectedReds, judge)
+            return settleSubmission(state, built.candidate, run.result, evidence.expectedReds, judge)
           },
           hasStash: (sha) => stash.get(sha)?.candidate.ref === ref,
-          validateOutcome: outcome => validateTaskOutcome(state, outcome),
+          validateOutcome: outcome => {
+            const defect = validateTaskOutcome(state, outcome)
+            if (!defect) observations.clear()
+            return defect
+          },
           stashedReview: sha => stash.get(sha)?.candidate.ref === ref ? stash.get(sha)?.review : undefined,
           stashedYaml: (sha) => {
             const entry = stash.get(sha)
@@ -3418,7 +3436,7 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
           else if (outcome === 'blocked') workerBlockedCount++
           options.onWorkerProgress?.({ done, total, settled: workerSettledCount, blocked: workerBlockedCount })
         },
-      })
+      }).finally(() => { for (const observations of observationStores) observations.clear() })
       const byTask = phaseA.byTask
       let summary = phaseA.summary
       let fidelitySummary = phaseA.fidelitySummary
@@ -3451,7 +3469,7 @@ export async function generateGuards(options: GenerateGuardsOptions): Promise<Gu
             else if (outcome === 'blocked') workerBlockedCount++
             options.onWorkerProgress?.({ done, total, settled: workerSettledCount, blocked: workerBlockedCount })
           },
-        })
+        }).finally(() => { for (const observations of observationStores) observations.clear() })
         for (const [workItem, result] of phaseB.byTask) byTask.set(workItem, result)
         summary = mergeSummaries(summary, phaseB.summary)
         if (phaseB.fidelitySummary) {
@@ -4733,7 +4751,7 @@ function assembleAuthorCtx(opts: {
   docText: ReadonlyMap<string, string>
   externalServices: ExternalServiceHint[]
   apiInterfaces: Interface[]
-  webInterfaces: Interface[]
+  authorCatalog: AuthorCatalog
   outboundRequests: OutboundRequestHint[]
   outboundRequestsOverflow: number
   resources?: Record<string, InterfaceResource[]>
@@ -4746,11 +4764,6 @@ function assembleAuthorCtx(opts: {
     ? opts.apiInterfaces.filter((j) => !servedByOtherApp(opts.serverIndex, boundApp, interfaceEntryPath(j)))
     : opts.apiInterfaces
   const other = buildOtherOperationHints(reachableInterfaces, interfaceContracts)
-  const webApp = opts.recipe.web?.app
-  const webSetup = task.surface === 'web'
-    ? opts.webInterfaces.filter((j) => !task.plan.interfaces.some((own) => own.id === j.id) &&
-        !servedByOtherApp(opts.serverIndex, webApp, interfaceEntryPath(j)))
-    : []
   const ctx = buildAuthorCtx(
     task.work,
     task.surface,
@@ -4767,10 +4780,10 @@ function assembleAuthorCtx(opts: {
       otherOperationsOverflow: other.overflow,
       outboundRequests: opts.outboundRequests,
       outboundRequestsOverflow: opts.outboundRequestsOverflow,
-      resources: buildResourceHints([...task.plan.interfaces, ...webSetup], opts.resources),
+      resources: task.surface === 'web' ? scopedAuthorResources(task.plan.interfaces, opts.resources) : buildResourceHints(task.plan.interfaces, opts.resources),
     },
   )
-  return { ...ctx, ...(webSetup.length ? { webSetupInterfaces: webSetup.map(interfaceDigest) } : {}) }
+  return { ...ctx, ...(task.surface === 'web' ? { webSetupCandidates: opts.authorCatalog.candidates(task.plan.interfaces, JSON.stringify(task.work.flow)) } : {}) }
 }
 
 // --- Flow-worker helpers (plan 04 step 17) -----------------------------------
@@ -4854,19 +4867,6 @@ function worldLostMessage(failure: GuardScenarioResult, boots: number, repairs: 
     'the world down — a container that exited, a port another process took, a reset run under the pool — and ' +
     're-run `truecourse guard generate`.'
   )
-}
-
-/**
- * Whether the confirmation's observed actual matches a declared prediction:
- * whitespace-normalized equality or containment. Containment, deliberately —
- * the worker copies `predictedActual` off its own run, and the runner's display
- * truncation must not fail an honest prediction.
- */
-function actualMatchesPrediction(actual: string, predicted: string): boolean {
-  const norm = (t: string): string => t.replace(/\s+/g, ' ').trim()
-  const na = norm(actual)
-  const np = norm(predicted)
-  return na === np || na.includes(np)
 }
 
 /**

--- a/packages/guard-generator/src/grounding.ts
+++ b/packages/guard-generator/src/grounding.ts
@@ -113,10 +113,10 @@ export function buildResourceHints(
   const hints: InterfaceResource[] = []
   const seen = new Set<string>()
   const add = (area: string, id: string | undefined): void => {
-    if (!id || seen.has(id)) return
+    if (!id || seen.has(`${area}:${id}`)) return
     const resource = (resources[area] ?? []).find((r) => r.id === id)
     if (!resource) return
-    seen.add(id)
+    seen.add(`${area}:${id}`)
     hints.push(resource)
     add(area, resource.of)
   }

--- a/packages/guard-generator/src/index.ts
+++ b/packages/guard-generator/src/index.ts
@@ -460,3 +460,5 @@ export type { GuardSetupPreparationSession, GuardSetupPreparationSessionInput } 
 export { bindClaimPrerequisites, partitionFlowPrerequisites, flowPrerequisiteStateMaterial, flowInvocationGaps } from './prerequisites.js'
 
 export { completeRealization } from './match.js'
+
+export { createAuthorCatalog, scopedAuthorResources, AUTHOR_CATALOG_VERSION, AUTHOR_TOOL_RESULT_CHARS, AUTHOR_INITIAL_BYTES, type AuthorCatalog, type CatalogSearch, type CatalogGet } from './author-catalog.js'

--- a/packages/guard-generator/src/private-authoring.ts
+++ b/packages/guard-generator/src/private-authoring.ts
@@ -1,0 +1,24 @@
+import { preparationCatalog, scenarioDependencyNames, type Recipe } from '@truecourse/guard-runner'
+import type { GuardScenario } from '@truecourse/shared'
+
+/** Eligibility is deliberately narrower than general preparation support: a
+ * private database does not isolate a supplied account or an external service. */
+export function privateAuthoringProfiles(recipe: Recipe, localDependencies: ReadonlySet<string>): Set<string> {
+  return new Set(preparationCatalog(recipe).filter(({ name }) => {
+    const profile = recipe.preparations![name]!
+    return profile.postgres?.isolation === 'database' && profile.needs !== undefined &&
+      profile.needs.every(name => localDependencies.has(name))
+  }).map(profile => profile.name))
+}
+
+export function privateAuthoringDefect(
+  scenario: GuardScenario,
+  profiles: ReadonlySet<string>,
+  localDependencies: ReadonlySet<string>,
+): string | undefined {
+  if (!scenario.setup?.preparation || !profiles.has(scenario.setup.preparation))
+    return 'select an eligible private Postgres preparation with only local dependencies'
+  const shared = scenarioDependencyNames(scenario).find(name => !localDependencies.has(name))
+  if (shared) return `dependency "${shared}" is not isolated by the private database`
+  return undefined
+}

--- a/packages/guard-generator/src/prompts.ts
+++ b/packages/guard-generator/src/prompts.ts
@@ -1290,6 +1290,7 @@ export function buildAuthorUserPrompt(ctx: AuthorUserContext): string {
     lines.push('', 'PRIVATE PREPARATIONS — select one with setup.preparation:',
       ...ctx.preparations.map(p => JSON.stringify(p)),
       'Each run gets a fresh private allocation, provisioned and checked before the app starts. Runtime paths and values are never authored.',
+      'Stateful flows may select a profile whose fixtures and credentials establish their documented starting state. Do not pick an arbitrary seeded profile or rediscover database provisioning in scenario steps.',
       'An empty case requires baseline empty. Exact global totals/counts and pagination boundaries require controlled private state.',
       'baselineChecks lists independently known counts and totals that the runner has checked through the real app. Use these expected values when calculating totals after your own writes; never derive the expected baseline from the aggregate response under test.',
       'Only the selected profile’s fixture/credential catalog is available inside that world. The global catalogs below apply only without setup.preparation.',

--- a/packages/guard-generator/src/prompts.ts
+++ b/packages/guard-generator/src/prompts.ts
@@ -1,3 +1,4 @@
+import type { AuthorCatalogSummary } from './author-catalog.js'
 import type { preparationCatalog } from '@truecourse/guard-runner'
 import type { GuardVerification } from '@truecourse/shared'
 /**
@@ -1033,8 +1034,8 @@ export interface AuthorUserContext {
    * keeps the prompt byte-identical. USER-prompt only.
    */
   otherOperations?: InterfaceContractHint[]
-  /** Other mapped browser actions, for arranging prerequisites without inventing controls. */
-  webSetupInterfaces?: InterfaceDigest[]
+  /** At most six metadata candidates; full action/resource fields are fetched lazily. */
+  webSetupCandidates?: AuthorCatalogSummary[]
   /** How many other operations the cap dropped, so the block can say so. */
   otherOperationsOverflow?: number
   /**
@@ -1537,17 +1538,16 @@ export function buildAuthorUserPrompt(ctx: AuthorUserContext): string {
       'nothing FAILS its step, so capture only what these places really show.',
     )
   }
-  if (ctx.driver === 'web' && ctx.webSetupInterfaces?.length) {
-    lines.push('', 'BROWSER ACTIONS AVAILABLE FOR SETUP',
-      'Use these mapped actions to create the records this flow needs before its assertions.',
-      'Create your own records with ${unique} for edit/delete flows. A missing seed row',
-      'does not block a record the app can create. Keep arrange steps untagged; the',
-      'selected milestones still need browser assertions. Do not edit shared fixtures.',
-      'These actions supply setup, not proof of otherwise omitted cases.');
-    for (const j of ctx.webSetupInterfaces) {
-      lines.push('', `--- id: ${j.id}`, `title: ${j.title}`, `entry: ${j.entry}`,
-        ...(j.context ?? []), ...j.steps);
-    }
+  if (ctx.driver === 'web' && ctx.webSetupCandidates) {
+    lines.push('', 'BROWSER SETUP CANDIDATES (summaries only)',
+      'Fetch full action and resource fields with get_interfaces before using a candidate.',
+      'Search the available catalog with search_interfaces for other prerequisites. These candidates',
+      'are metadata associations, not execution evidence or an exhaustive list. Resource readables',
+      'omitted above are available through get_interfaces for the selected action IDs.',
+      'A zero-result search or retrieval error does not prove missing product behavior.',
+      'Resolve retrieval errors before authoring dependent steps; keep all assigned obligations.',
+      'Create independent records with ${unique}; setup summaries never prove milestone coverage.');
+    for (const candidate of ctx.webSetupCandidates) lines.push(JSON.stringify(candidate));
   }
   // The flow's own operations as the repo's ROUTE REGISTRATIONS declare
   // them — the exact paths, and what each handler reads off the request. api-only and

--- a/packages/guard-generator/src/setup.ts
+++ b/packages/guard-generator/src/setup.ts
@@ -12,7 +12,7 @@
  *                                                    above this package); the adapter
  *                                                    fails before calling in.
  *   0.5  a corpus must exist                       — HARD: setup runs after scan.
- *   1    the recipe                                — THE ONLY HARD GATE. Discovery
+ *   1    the recipe                                — HARD. Discovery
  *                                                    (deterministic → the repair
  *                                                    session or the one-shot LLM →
  *                                                    verify by running) plus a live
@@ -27,6 +27,8 @@
  *                                                    (both behind `authorInterfaces`).
  *   5    the one seed (data AND auth)              — SOFT, never blocks. The seed
  *                                                    authoring session (`seedSession`).
+ *   5.5  private preparations                      — HARD on execution failure;
+ *                                                    unsupported profiles may skip.
  *   6    auth                                      — SOFT; the one step that may end
  *                                                    `blocked`. The auth-proof
  *                                                    session (`verifyAuth`).
@@ -58,6 +60,7 @@ import {
   buildRouteManifest,
   loadResolvedExternals,
   computeRecipeFingerprint,
+  computePreparationFingerprint,
   preparationCatalog,
   dependenciesPath,
   loadDependencyCatalog,
@@ -175,8 +178,7 @@ export interface GuardSetupOptions {
    * AFTER it never start, `detect` always runs, and the persisted report merges
    * over the previous one so the untouched steps keep their record.
    *
-   * The one exception to the merge is a HARD failure, which only `--only-recipe`
-   * can reach (every other step replays the recipe rather than re-deriving it):
+   * The exception to the merge is a recipe failure in `--only-recipe`:
    * a failed run reports the rows it reached and nothing else, exactly as a
    * whole run does — a recipe that no longer holds is no basis for calling the
    * steps that were computed against it settled.
@@ -394,6 +396,7 @@ export interface GuardSetupPreparationSessionInput {
   recipe: Recipe
   specExcerpts: { doc: string; text: string }[]
   fingerprint: string
+  onPhase?: (running: string, done: string) => void
 }
 export type GuardSetupPreparationSession = (input: GuardSetupPreparationSessionInput) => Promise<{
   status: 'ok' | 'skipped' | 'failed'
@@ -436,7 +439,7 @@ export interface GuardSetupResult {
 
 /**
  * Run the whole stage. Never throws for a repo-shaped problem: step 0.5 and the
- * recipe gate come back as `status: 'failed'` with a reason, and every soft step
+ * recipe/preparation failures come back as `status: 'failed'` with a reason, and every soft step
  * records its own outcome without demoting the run.
  *
  * SKIP-WHEN-SETTLED (plan 03 step 8): every taxonomy step records an input
@@ -493,7 +496,7 @@ export async function runGuardSetup(opts: GuardSetupOptions): Promise<GuardSetup
     return mappedOnce
   }
 
-  // ---- Step 1: the recipe. THE ONLY HARD GATE. -----------------------------
+  // ---- Step 1: the recipe. A failure prevents later setup. -----------------
   opts.onStep?.('recipe')
   phases.step('recipe')
   // The recipe step's fingerprint is the SUBJECT (the ecosystem manifests), never
@@ -999,8 +1002,9 @@ export async function runGuardSetup(opts: GuardSetupOptions): Promise<GuardSetup
   }
 
   // Private state is its own targeted setup step; it never replaces the main seed.
+  let preparationFailure: string | undefined
   if (enter('preparations')) {
-    const preparationFp = computeRecipeFingerprint(repoRoot)
+    const preparationFp = computePreparationFingerprint(repoRoot)
     const preparationRecipe = reloadRecipe(repoRoot) ?? current
     if (replayed('preparations')) {
       fact('preparations', 'replayed: the existing private preparation profiles stand as they are')
@@ -1015,10 +1019,11 @@ export async function runGuardSetup(opts: GuardSetupOptions): Promise<GuardSetup
     } else {
       const result = opts.preparationSession
         ? await opts.preparationSession({ repoRoot, recipe: preparationRecipe,
-            specExcerpts: readSpecExcerpts(repoRoot), fingerprint: preparationFp })
+            specExcerpts: readSpecExcerpts(repoRoot), fingerprint: preparationFp,
+            onPhase: (running, done) => phases.enter({ running, done }) })
         : { status: 'skipped' as const, reason: 'private preparation authoring is unavailable; only profiles with runner-verified baseline checks are usable' }
       steps.push({ key: 'preparations', status: result.status, ...(result.reason ? { reason: result.reason } : {}),
-        inputFingerprint: computeRecipeFingerprint(repoRoot), ...('sessionRunId' in result && result.sessionRunId ? { sessionRunId: result.sessionRunId } : {}) })
+        inputFingerprint: opts.preparationSession ? computePreparationFingerprint(repoRoot) : 'authoring-unavailable', ...('sessionRunId' in result && result.sessionRunId ? { sessionRunId: result.sessionRunId } : {}) })
       // The session's findings are its outcome, read in the session itself;
       // the step only counts them.
       const findings = result.findings ?? []
@@ -1030,14 +1035,15 @@ export async function runGuardSetup(opts: GuardSetupOptions): Promise<GuardSetup
             : `no private starting state was authored: ${firstReasonLine(result.reason ?? result.status)}`
       fact('preparations', summary)
       for (const line of preparationFacts(reloadRecipe(repoRoot) ?? preparationRecipe)) fact('preparations', line)
-      opts.onStepDone?.('preparations', findings.length > 0 ? summary : (result.reason ?? result.status))
+      if (result.status === 'failed') preparationFailure = result.reason || 'Private preparation failed'
+      else opts.onStepDone?.('preparations', findings.length > 0 ? summary : (result.reason ?? result.status))
     }
   }
 
   // ---- Step 6: auth. Framework row only until plan step 14 wires it. -------
   // The ONE step that may end `blocked` (a supplied credential waiting on a user
   // registration) without demoting the run.
-  if (enter('auth')) {
+  if (!preparationFailure && enter('auth')) {
     const authFp = authFingerprint(repoRoot)
     if (settled('auth') === authFp) {
       steps.push({ key: 'auth', status: 'skipped', reason: 'unchanged', inputFingerprint: authFp })
@@ -1078,7 +1084,8 @@ export async function runGuardSetup(opts: GuardSetupOptions): Promise<GuardSetup
     recipe: reloadRecipe(repoRoot) ?? current,
     report: {
       ranAt: new Date().toISOString(),
-      status: 'ok',
+      status: preparationFailure ? 'failed' : 'ok',
+      ...(preparationFailure ? { reason: preparationFailure } : {}),
       steps: only ? mergeStepSpine(steps, prior) : steps,
       recipe: recipeStep,
       ...(externals ? { externals } : {}),
@@ -1258,7 +1265,7 @@ export function settledFingerprints(
   const prior = readGuardSetup(repoRoot)
   const byKey = new Map<GuardSetupTaxonomyKey, string>()
   for (const row of prior?.steps ?? []) {
-    if (row.status === 'ok' || (row.status === 'skipped' && row.reason === 'unchanged')) {
+    if (row.status === 'ok' || (row.status === 'skipped' && (row.reason === 'unchanged' || row.key === 'preparations'))) {
       byKey.set(row.key, row.inputFingerprint)
     }
   }

--- a/packages/guard-generator/src/worker-observations.ts
+++ b/packages/guard-generator/src/worker-observations.ts
@@ -1,0 +1,59 @@
+import { createHash, randomUUID } from 'node:crypto'
+import type { GuardDriverId, GuardExpectedRed, GuardFailureObservation, GuardScenarioResult } from '@truecourse/shared'
+import { compareFailureObservations } from './failure-observation.js'
+
+const yamlFingerprint = (yaml: string): string => createHash('sha256').update(yaml).digest('hex')
+
+/** Evidence is scoped to one worker and exact submitted bytes, never a model-authored object. */
+export class WorkerObservations {
+  private readonly records = new Map<string, { sha: string; step: number; observation: GuardFailureObservation }>()
+
+  constructor(private readonly surface: GuardDriverId, private readonly limit = 16) {}
+
+  record(yaml: string, result: GuardScenarioResult): string | undefined {
+    if (this.surface !== 'web' || result.outcome !== 'fail' || result.preparationFailure ||
+      result.blockedPrecondition || result.failure?.observationUnavailable || !result.failure?.observation) return undefined
+    const id = randomUUID()
+    this.records.set(id, { sha: yamlFingerprint(yaml), step: result.failure.step,
+      observation: structuredClone(result.failure.observation) })
+    while (this.records.size > this.limit) this.records.delete(this.records.keys().next().value!)
+    return id
+  }
+
+  resolve(yaml: string, predictions: readonly GuardExpectedRed[]): { expectedReds: GuardExpectedRed[] } | { error: string } {
+    const expectedReds: GuardExpectedRed[] = []
+    const steps = new Set<number>()
+    for (const prediction of predictions) {
+      if (!prediction.predictedActual.trim()) return { error: 'predictedActual must contain a non-whitespace observation.' }
+      if (steps.has(prediction.step)) return { error: 'Declare only one prediction for the first failing step.' }
+      steps.add(prediction.step)
+      if (prediction.observation) return { error: 'Do not submit observation objects; use the observationId returned by run_scenario.' }
+      const { observationId, ...payload } = prediction
+      // Match the shared schema's canonical form even for non-tool callers.
+      const red = { ...payload, predictedActual: payload.predictedActual.trim() }
+      if (observationId !== undefined) {
+        const observed = this.records.get(observationId)
+        if (this.surface !== 'web' || !observed || observed.sha !== yamlFingerprint(yaml) || observed.step !== red.step)
+          return { error: 'Unknown, expired, or changed-candidate observationId. Run this exact YAML through run_scenario again.' }
+        expectedReds.push({ ...red, observation: structuredClone(observed.observation) })
+      } else expectedReds.push(red)
+    }
+    return { expectedReds }
+  }
+
+  clear(): void { this.records.clear() }
+}
+
+/** Shared live/cache gate. A supported observation never falls back to prose. */
+export function redObservationMismatch(result: GuardScenarioResult, predicted: GuardExpectedRed): string | undefined {
+  if (!predicted.predictedActual.trim()) return 'predictedActual must contain a non-whitespace observation.'
+  if (result.failure?.observationUnavailable) return `Typed web evidence is unavailable: ${result.failure.observationUnavailable}`
+  if (predicted.observation || result.failure?.observation) {
+    if (!predicted.observation) return 'This web failure requires an observationId from run_scenario for the exact candidate.'
+    if (!result.failure?.observation) return 'The confirmation did not produce the required typed web observation.'
+    return compareFailureObservations(predicted.observation, result.failure.observation)
+  }
+  const norm = (value: string): string => value.replace(/\s+/g, ' ').trim()
+  return norm(result.failure?.actual ?? '').includes(norm(predicted.predictedActual))
+    ? undefined : 'The confirmation actual does not match your predictedActual.'
+}

--- a/packages/guard-runner/src/api/run-api-scenario.ts
+++ b/packages/guard-runner/src/api/run-api-scenario.ts
@@ -1,3 +1,4 @@
+import type { GuardFailureObservation } from '@truecourse/shared'
 /**
  * Run one api scenario end-to-end: seed a sandbox, boot the recipe's server IN
  * that sandbox (fresh state + fresh port per scenario — the api analog of the
@@ -1100,7 +1101,7 @@ function failResult(
   /** The failing step's flow milestone, when it realizes one. */
   milestone: number | undefined,
   start: number,
-  mismatch: { expected: string; actual: string; subject?: string; detail?: string[] },
+  mismatch: { expected: string; actual: string; subject?: string; detail?: string[]; observation?: GuardFailureObservation; observationUnavailable?: string },
   capture: ApiStepCapture | null,
   redact: (t: string) => string,
   bootAttempts: number | undefined,
@@ -1140,6 +1141,8 @@ function failResult(
       step: stepIndex,
       expected: redact(mismatch.expected),
       actual: redact(mismatch.actual),
+      ...(mismatch.observation ? { observation: mismatch.observation } : {}),
+      ...(mismatch.observationUnavailable ? { observationUnavailable: mismatch.observationUnavailable } : {}),
       ...apiExcerpts(capture, serverLogs, redact),
     },
     evidencePath,

--- a/packages/guard-runner/src/api/seed.ts
+++ b/packages/guard-runner/src/api/seed.ts
@@ -69,6 +69,8 @@ export interface RunSeedOptions {
   env?: Record<string, string>
   /** Wall-clock budget; defaults to the build timeout. */
   timeoutMs?: number
+  /** A verifier owns app ports and must receive the complete primary/peer configuration. */
+  preservePortTemplates?: boolean
   signal?: AbortSignal
   /**
    * Already-resolved recipe credential values (Phase 1 `api.credentials`), name → value.
@@ -105,9 +107,11 @@ export async function runSeed(opts: RunSeedOptions): Promise<SeedResult> {
     // dotenv-expand over the process env, and `PORT=${PORT}` expands into
     // itself forever (documenso 2026-08-30: every seed draft spun at 100% CPU
     // to its timeout before the script started). Entries carrying the
-    // placeholder are dropped — absent is truer than a fake port.
+    // placeholder are dropped — absent is truer than a fake port. A preparation
+    // verifier allocates ports itself and must retain these templates, including
+    // the serialized peer env that contains them.
     const env = Object.fromEntries(
-      Object.entries(opts.env ?? {}).filter(([, value]) => !value.includes(PORT_PLACEHOLDER)),
+      Object.entries(opts.env ?? {}).filter(([, value]) => opts.preservePortTemplates || !value.includes(PORT_PLACEHOLDER)),
     )
     const run = await spawnSeed(
       repoRoot,

--- a/packages/guard-runner/src/dependencies.ts
+++ b/packages/guard-runner/src/dependencies.ts
@@ -383,7 +383,7 @@ export function externalServiceStates(
  * a token the author wrote without listing the name is still a real binding and
  * must gate the run rather than land on disk verbatim.
  */
-export function scenarioDependencyNames(scenario: GuardScenario): string[] {
+export function scenarioDependencyNames(scenario: GuardScenario | Pick<GuardScenario, 'needs' | 'prerequisites'>): string[] {
   // DECLARED order first, then the token-discovered rest: the author's ordering is
   // the meaningful one when a scenario binds several (it decides which dependency a
   // blocked result names), and only deduplication is imposed on top of it.

--- a/packages/guard-runner/src/drivers/types.ts
+++ b/packages/guard-runner/src/drivers/types.ts
@@ -92,6 +92,8 @@ export interface StepRunContext {
   resolveEnv(env: Record<string, string>): Record<string, string>
   /** Apply the scenario's normalizers (used for stream and file comparison). */
   normText(text: string): string
+  /** Redacts all known run secrets before evidence digests are computed. */
+  redact?: (text: string) => string
   /** Publish what this step captured, for the steps after it. */
   publishCaptures(values: Record<string, string>): void
   /** The run's default per-step budget; a step's own `timeoutMs` wins over it. */

--- a/packages/guard-runner/src/drivers/web-driver.ts
+++ b/packages/guard-runner/src/drivers/web-driver.ts
@@ -145,6 +145,8 @@ export function webStepDriver(opts: WebStepDriverOptions): StepDriver {
       const result = await executeWebStep({
         page: session.page,
         baseUrl: session.baseUrl,
+        originBinding: 'web',
+        ...(ctx.redact ? { redact: ctx.redact } : {}),
         step: resolved,
         stepIndex: ctx.stepIndex,
         evidenceDir: ctx.evidenceDir,

--- a/packages/guard-runner/src/expect.ts
+++ b/packages/guard-runner/src/expect.ts
@@ -8,6 +8,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type {
+  GuardFailureObservation,
   GuardComparand,
   GuardComparison,
   GuardExpect,
@@ -17,6 +18,10 @@ import type {
 import { describeOffset } from '@truecourse/shared'
 
 export interface ExpectMismatch {
+  observation?: GuardFailureObservation
+  observationUnavailable?: string
+  /** Producer-only identity of the first failing text operator. */
+  matcherOperator?: 'equals' | 'contains' | 'matches' | 'compare'
   /**
    * What disagreed. Two subjects no matcher produces: `prompt` — a scripted answer
    * whose question the command never asked (see `pty.ts`) — and `capture` — a
@@ -188,6 +193,7 @@ export function matchTextMatcher(
     const caseOnly = value.toLowerCase() === matcher.equals.toLowerCase()
     return {
       subject,
+      ...(subject === 'text' ? { matcherOperator: 'equals' as const } : {}),
       expected: `${label} equals ${JSON.stringify(truncate(matcher.equals))}`,
       actual: `${label} was ${JSON.stringify(truncate(value, limit))}${caseNote(caseOnly)}`,
       detail: [
@@ -203,6 +209,7 @@ export function matchTextMatcher(
     const caseOnly = value.toLowerCase().includes(matcher.contains.toLowerCase())
     return {
       subject,
+      ...(subject === 'text' ? { matcherOperator: 'contains' as const } : {}),
       expected: `${label} contains ${JSON.stringify(matcher.contains)}`,
       actual: `${label} was ${JSON.stringify(truncate(value, limit))}${caseNote(caseOnly)}`,
       detail: [
@@ -226,6 +233,7 @@ export function matchTextMatcher(
       const caseOnly = re !== null && new RegExp(matcher.matches, 'i').test(value)
       return {
         subject,
+        ...(subject === 'text' ? { matcherOperator: 'matches' as const } : {}),
         expected: `${label} matches /${matcher.matches}/${reError ? ` (invalid regex: ${reError})` : ''}`,
         actual: `${label} was ${JSON.stringify(truncate(value, limit))}${caseNote(caseOnly)}`,
         detail: [
@@ -239,7 +247,7 @@ export function matchTextMatcher(
   }
   if (matcher.compare) {
     const m = matchComparison(label, matcher.compare, value, limit)
-    if (m) return { ...m, subject }
+    if (m) return { ...m, subject, ...(subject === 'text' ? { matcherOperator: 'compare' as const } : {}) }
   }
   return null
 }

--- a/packages/guard-runner/src/index.ts
+++ b/packages/guard-runner/src/index.ts
@@ -458,5 +458,12 @@ export { RecipePreparationSchema, RecipePreparationScriptSchema, resolvePreparat
 export type { RecipePreparation } from './recipe.js'
 export { prepareScenario, validateScenarioPreparation, preparationCatalog } from './preparation.js'
 export type { PreparedScenarioWorld } from './preparation.js'
+export { PREPARATION_VERIFY_ENV, PREPARATION_VERIFY_INPUTS_SOURCE } from './preparation-contract.js'
 
 export * from './prerequisites.js'
+
+export { preparationOwnedEnvKeys, bindPreparationPostgres } from './preparation-postgres.js'
+
+export { computePreparationFingerprint } from './recipe.js'
+
+export { preparationDependencyBriefing, resolvePreparationDependencies } from './preparation-dependencies.js'

--- a/packages/guard-runner/src/preparation-contract.ts
+++ b/packages/guard-runner/src/preparation-contract.ts
@@ -1,0 +1,27 @@
+/** Shared by the runner and the preparation author's executable input example. */
+export const PREPARATION_VERIFY_ENV = {
+  peer: 'GUARD_PREPARATION_PEER_ENV',
+  fixtures: 'GUARD_PREPARATION_FIXTURES',
+  peerFixtures: 'GUARD_PREPARATION_PEER_FIXTURES',
+  credentials: 'GUARD_PREPARATION_CREDENTIALS',
+  peerCredentials: 'GUARD_PREPARATION_PEER_CREDENTIALS',
+} as const;
+
+/** Standalone ES-module source: generated scripts run inside the target app. */
+export const PREPARATION_VERIFY_INPUTS_SOURCE = `function requiredPreparationJson(name) {
+  const raw = process.env[name];
+  if (!raw) throw new Error('Missing preparation input: ' + name);
+  let value;
+  try { value = JSON.parse(raw); }
+  catch { throw new Error('Invalid preparation JSON: ' + name); }
+  if (!value || typeof value !== 'object' || Array.isArray(value))
+    throw new Error('Preparation input must be an object: ' + name);
+  return value;
+}
+${Object.entries(PREPARATION_VERIFY_ENV).map(([variable, name]) => `const ${variable} = requiredPreparationJson('${name}');`).join('\n')}
+function requiredPreparationCredential(worldCredentials, name) {
+  const value = worldCredentials[name]?.value;
+  if (typeof value !== 'string' || !value.trim())
+    throw new Error('Missing preparation credential: ' + name);
+  return value;
+}`;

--- a/packages/guard-runner/src/preparation-dependencies.ts
+++ b/packages/guard-runner/src/preparation-dependencies.ts
@@ -1,0 +1,34 @@
+import { prerequisiteProblems, resolveGuardPrerequisite } from '@truecourse/shared';
+import { resolvePrerequisites, scenarioAccountEnvironment } from './prerequisites.js';
+import type { Recipe } from './recipe.js';
+
+/** Only registration status and declarations enter the authoring conversation. */
+export function preparationDependencyBriefing(repoRoot: string, recipe: Recipe) {
+  const resolved = resolvePrerequisites(repoRoot, recipe.api?.externals);
+  return {
+    catalog: resolved.dependencies.dependencies.map(d => ({
+      name: d.name, class: d.entry.class, summary: d.entry.summary,
+      services: d.entry.services ?? [], state: d.state,
+      condition: d.entry.condition, obtain: d.entry.obtain,
+      registrationKind: d.entry.registration?.kind,
+      requirements: d.requirements.map(r => ({ field: r.field, resolved: r.resolved, optional: r.optional ?? false })),
+    })),
+    services: resolved.targets.map(t => ({ name: t.name, aliases: t.aliases, state: t.state })),
+  };
+}
+
+/** The same catalog/legacy-service resolution as scenario execution, before scripts run. */
+export function resolvePreparationDependencies(repoRoot: string, recipe: Recipe, needs: string[]) {
+  const resolved = resolvePrerequisites(repoRoot, recipe.api?.externals);
+  const supplied = needs.filter(name => !resolved.dependencies.dependencies.some(d => d.name === name && d.state === null));
+  const problem = prerequisiteProblems(supplied.map(dependency => ({ dependency, mode: 'provided' })), resolved.targets)[0];
+  if (problem) throw new Error(`Preparation dependency "${problem.dependency}" is unavailable: ${problem.reason}`);
+  for (const name of supplied) {
+    const match = resolveGuardPrerequisite(name, resolved.targets);
+    const dependency = match.kind === 'resolved'
+      ? resolved.dependencies.dependencies.find(d => d.name === match.target.name) : undefined;
+    if (dependency?.entry.registration && dependency.entry.registration.kind !== 'env')
+      throw new Error(`Preparation dependency "${name}" requires ${dependency.entry.registration.kind} materialization, which preparation scripts do not support`);
+  }
+  return scenarioAccountEnvironment({ needs }, resolved);
+}

--- a/packages/guard-runner/src/preparation-postgres.ts
+++ b/packages/guard-runner/src/preparation-postgres.ts
@@ -1,0 +1,47 @@
+import type { RecipePreparation } from './recipe.js';
+
+/** Include derived bindings wherever scenario env ownership is enforced. */
+export function preparationOwnedEnvKeys(profile: RecipePreparation): Set<string> {
+  return new Set([...Object.keys(profile.env), ...(profile.postgres?.urlEnvs ?? [])]);
+}
+
+/** Pure binding only. Repository scripts provision and drop the owned database. */
+export function bindPreparationPostgres(
+  profile: RecipePreparation,
+  resolvedEnv: Readonly<Record<string, string>>,
+  namespace: string,
+): { env: Record<string, string>; provisioningEnv: Record<string, string>; secrets: Map<string, string> } {
+  const env: Record<string, string> = {};
+  const baseUrls: Record<string, string> = {};
+  const secrets = new Map<string, string>();
+  if (!profile.postgres) return { env, provisioningEnv: {}, secrets };
+  if (!/^guard_[a-f0-9]{32}$/.test(namespace)) throw new Error('Invalid runner-owned Postgres database name');
+  for (const key of profile.postgres.urlEnvs) {
+    const value = Object.hasOwn(resolvedEnv, key) ? resolvedEnv[key] : undefined;
+    let url: URL;
+    try {
+      if (!value) throw new Error();
+      url = new URL(value);
+      if (!['postgres:', 'postgresql:'].includes(url.protocol) || !url.hostname ||
+          !url.pathname.slice(1) || url.hash || url.searchParams.has('dbname') || url.searchParams.has('database')) throw new Error();
+    } catch {
+      // URL parser messages include their input. Do not let those cross this boundary.
+      throw new Error(`Postgres preparation requires a valid resolved database URL in ${key}`);
+    }
+    baseUrls[key] = value!;
+    secrets.set(`postgres.${key}.base`, value!);
+    if (url.password) {
+      secrets.set(`postgres.${key}.password`, url.password);
+      try { secrets.set(`postgres.${key}.decoded-password`, decodeURIComponent(url.password)); } catch { /* Keep encoded value. */ }
+    }
+    url.pathname = `/${namespace}`;
+    env[key] = url.toString();
+    secrets.set(`postgres.${key}.private`, env[key]);
+  }
+  return {
+    env,
+    // Only seed and cleanup receive these. App servers and authored evidence do not.
+    provisioningEnv: { GUARD_PREPARATION_POSTGRES_BASE_URLS: JSON.stringify(baseUrls) },
+    secrets,
+  };
+}

--- a/packages/guard-runner/src/preparation.ts
+++ b/packages/guard-runner/src/preparation.ts
@@ -1,5 +1,6 @@
 /** Runner-owned private data lifetimes, independent of shared service ownership. */
 import fs from 'node:fs';
+import { resolvePreparationDependencies } from './preparation-dependencies.js';
 import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
@@ -7,6 +8,9 @@ import type {
   GuardScenario,
   GuardPreparationEvidence,
 } from '@truecourse/shared';
+import { preparationOwnedEnvKeys, bindPreparationPostgres } from './preparation-postgres.js';
+import { PREPARATION_VERIFY_ENV } from './preparation-contract.js';
+import { buildCredentialRedactor } from './api/redact.js';
 import { runSeed, type SeedResult } from './api/seed.js';
 import { runBuild } from './build.js';
 import { resolveApiServers, resolveWebSurface, resolveEntry, credentialServers, type Recipe, type RecipePreparation } from './recipe.js';
@@ -17,6 +21,8 @@ import { constructChildEnv, BUILD_PASSTHROUGH } from './child-env.js';
 export interface PreparedScenarioWorld extends SeedResult {
   env: Record<string, string>;
   evidence: GuardPreparationEvidence;
+  /** Runtime-only values used to redact database diagnostics during execution. */
+  secrets: ReadonlyMap<string, string>;
   close(): Promise<void>;
 }
 
@@ -26,6 +32,7 @@ export function preparationCatalog(recipe: Recipe) {
     name,
     baseline: p.baseline,
     scope: p.scope,
+    needs: p.needs ?? [],
     baselineChecks: p.baselineChecks,
     fixtures: p.seed.provides.fixtures ?? {},
     credentials: p.seed.provides.credentials ?? {},
@@ -55,7 +62,7 @@ export function validateScenarioPreparation(
   const invalidBaseline = baselineDefect(name, profile);
   if (invalidBaseline) return invalidBaseline;
   const owned = new Set([
-    ...Object.keys(profile.env),
+    ...preparationOwnedEnvKeys(profile),
     'GUARD_PREPARATION_DIRECTORY',
     'GUARD_PREPARATION_NAMESPACE',
     'GUARD_PREPARATION_BASELINE',
@@ -101,6 +108,7 @@ interface Allocation {
   directory: string;
   namespace: string;
   env: Record<string, string>;
+  provisioningEnv: Record<string, string>;
 }
 
 /** A fresh namespace for EVERY call. Polls/restarts inside the caller retain the returned world. */
@@ -118,7 +126,11 @@ export async function prepareScenario(opts: {
     throw new Error(`Unknown preparation profile "${opts.profile}"`);
   const invalidBaseline = baselineDefect(opts.profile, profile);
   if (invalidBaseline) throw new Error(invalidBaseline);
+  const account = resolvePreparationDependencies(opts.repoRoot, opts.recipe, profile.needs ?? []);
+  const accountEnv = { ...account.env, ...opts.accountEnv };
+  const externalSecrets = new Map([...(opts.externalSecrets ?? []), ...account.secrets]);
   const checks = profile.baselineChecks!;
+  const ownedKeys = preparationOwnedEnvKeys(profile);
   const seedScript = scriptPath(opts.repoRoot, profile.seed.script);
   const verifyScript = scriptPath(opts.repoRoot, profile.verify.script);
   const cleanupScript =
@@ -133,7 +145,7 @@ export async function prepareScenario(opts: {
         const result = await runBuild(
           opts.repoRoot,
           nodeScript(cleanupScript),
-          allocation.env,
+          allocation.provisioningEnv,
           timeoutMs,
         );
         if (!result.ok)
@@ -161,12 +173,15 @@ export async function prepareScenario(opts: {
       );
   };
   const allocate = (): Allocation => {
-    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-guard-world-'));
     const namespace = `guard_${crypto.randomUUID().replaceAll('-', '')}`;
+    const baseEnv = { ...opts.recipe.env, ...opts.recipe.api?.env, ...accountEnv };
+    // Resolve URLs before allocating files or running any provisioning script.
+    const postgres = bindPreparationPostgres(profile, baseEnv, namespace);
+    for (const [name, value] of postgres.secrets) secrets.set(`allocation${allocations.length}.${name}`, value);
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-guard-world-'));
     const env = {
-      ...(opts.recipe.env ?? {}),
-      ...(opts.recipe.api?.env ?? {}),
-      ...opts.accountEnv,
+      ...baseEnv,
+      ...postgres.env,
       ...Object.fromEntries(
         Object.entries(profile.env).map(([key, value]) => [
           key,
@@ -180,7 +195,7 @@ export async function prepareScenario(opts: {
       GUARD_PREPARATION_NAMESPACE: namespace,
       GUARD_PREPARATION_BASELINE: profile.baseline,
     };
-    const allocation = { directory, namespace, env };
+    const allocation = { directory, namespace, env, provisioningEnv: { ...env, ...postgres.provisioningEnv } };
     allocations.push(allocation);
     return allocation;
   };
@@ -188,11 +203,11 @@ export async function prepareScenario(opts: {
     const result = await runSeed({
       repoRoot: opts.repoRoot,
       seed: { ...profile.seed, command: nodeScript(seedScript) },
-      env: allocation.env,
+      env: allocation.provisioningEnv,
       signal: opts.signal,
       timeoutMs,
       knownCredentials: secrets,
-      externalSecrets: opts.externalSecrets,
+      externalSecrets,
     });
     for (const [name, credential] of result.credentials)
       secrets.set(`${allocation.namespace}.${name}`, credential.value);
@@ -216,14 +231,19 @@ export async function prepareScenario(opts: {
       const started = await startApiServer({
         resolvedServe: resolveEntry(opts.repoRoot, server.serve),
         cwd: server.cwd === 'repo' ? opts.repoRoot : allocation.directory,
-        env: constructChildEnv({ passthrough: BUILD_PASSTHROUGH, recipeEnv: { ...server.env, ...opts.accountEnv,
-          ...Object.fromEntries(Object.entries(allocation.env).filter(([key]) => key in profile.env || key.startsWith('GUARD_'))) } }),
+        env: constructChildEnv({ passthrough: BUILD_PASSTHROUGH, recipeEnv: { ...server.env, ...accountEnv,
+          ...Object.fromEntries(Object.entries(allocation.env).filter(([key]) => ownedKeys.has(key) || key.startsWith('GUARD_'))) } }),
         healthPath: server.healthPath, readyTimeoutMs: server.readyTimeoutMs, signal: opts.signal,
       });
-      if (!started.ok) throw new Error(`Preparation "${opts.profile}" baseline server failed: ${started.reason}`);
+      if (!started.ok) throw new Error(buildCredentialRedactor(secrets, externalSecrets)(
+        `Preparation "${opts.profile}" baseline server failed: ${started.reason}${started.stderr ? '\n' + started.stderr.slice(-2_000) : ''}`,
+      ));
       try {
         const signal = opts.signal ? AbortSignal.any([opts.signal, AbortSignal.timeout(timeoutMs)]) : AbortSignal.timeout(timeoutMs);
-        const response = await fetch(started.server.baseUrl + check.path, { headers, signal, redirect: 'error' });
+        const url = new URL(check.path, started.server.baseUrl);
+        if (url.origin !== new URL(started.server.baseUrl).origin) throw new Error('Preparation baseline must stay on its declared server.');
+        for (const [key, value] of Object.entries(check.query ?? {})) url.searchParams.set(key, value);
+        const response = await fetch(url, { headers, signal, redirect: 'error' });
         if (!response.ok) throw new Error(`Preparation "${opts.profile}" baseline read ${check.path} returned ${response.status}.`);
         const body: unknown = await response.json();
         for (const [key, expected] of Object.entries({ ...check.counts, ...check.totals })) {
@@ -244,6 +264,7 @@ export async function prepareScenario(opts: {
     // This is an executable app-level verifier, not a persisted boolean capability.
     // It sees two independently seeded worlds mutates the peer and proves primary remains at its baseline.
     const verification = await runSeed({
+      preservePortTemplates: true,
       repoRoot: opts.repoRoot,
       seed: {
         command: nodeScript(verifyScript),
@@ -252,24 +273,24 @@ export async function prepareScenario(opts: {
       env: {
         ...primary.env,
         GUARD_PREPARATION_BASELINE: profile.baseline,
-        GUARD_PREPARATION_PEER_ENV: JSON.stringify(peer.env),
-        GUARD_PREPARATION_FIXTURES: JSON.stringify(
+        [PREPARATION_VERIFY_ENV.peer]: JSON.stringify(peer.env),
+        [PREPARATION_VERIFY_ENV.fixtures]: JSON.stringify(
           Object.fromEntries(primarySeed.fixtures),
         ),
-        GUARD_PREPARATION_PEER_FIXTURES: JSON.stringify(
+        [PREPARATION_VERIFY_ENV.peerFixtures]: JSON.stringify(
           Object.fromEntries(peerSeed.fixtures),
         ),
-        GUARD_PREPARATION_CREDENTIALS: JSON.stringify(
+        [PREPARATION_VERIFY_ENV.credentials]: JSON.stringify(
           Object.fromEntries(primarySeed.credentials),
         ),
-        GUARD_PREPARATION_PEER_CREDENTIALS: JSON.stringify(
+        [PREPARATION_VERIFY_ENV.peerCredentials]: JSON.stringify(
           Object.fromEntries(peerSeed.credentials),
         ),
       },
       signal: opts.signal,
       timeoutMs,
       knownCredentials: secrets,
-      externalSecrets: opts.externalSecrets,
+      externalSecrets,
     });
     const proof = verification.fixtures.get('verification');
     if (proof?.baseline !== profile.baseline || proof?.isolated !== true) {
@@ -284,7 +305,7 @@ export async function prepareScenario(opts: {
       ...primarySeed,
       env: Object.fromEntries(
         Object.entries(primary.env).filter(
-          ([key]) => key in profile.env || key.startsWith('GUARD_PREPARATION_'),
+          ([key]) => ownedKeys.has(key) || key.startsWith('GUARD_PREPARATION_'),
         ),
       ),
       evidence: {
@@ -292,6 +313,7 @@ export async function prepareScenario(opts: {
         baseline: profile.baseline,
         scope: 'instance',
       },
+      secrets: new Map([...externalSecrets, ...secrets]),
       close,
     };
   } catch (error) {

--- a/packages/guard-runner/src/prerequisites.ts
+++ b/packages/guard-runner/src/prerequisites.ts
@@ -124,7 +124,7 @@ export function resolvePrerequisites(
 export type ResolvedPrerequisites = ReturnType<typeof resolvePrerequisites>
 
 /** The same selected accounts feed preparation, execution, and evidence redaction. */
-export function scenarioAccountEnvironment(scenario: GuardScenario, resolved: ResolvedPrerequisites) {
+export function scenarioAccountEnvironment(scenario: GuardScenario | Pick<GuardScenario, 'needs' | 'prerequisites' | 'setup'>, resolved: ResolvedPrerequisites) {
   const env = externalsInjectEnv(resolved.externals)
   const secrets = externalsSecrets(resolved.externals)
   const names = new Set(scenarioDependencyNames(scenario).map(name => {

--- a/packages/guard-runner/src/recipe.ts
+++ b/packages/guard-runner/src/recipe.ts
@@ -199,7 +199,8 @@ export const RecipePreparationScriptSchema = z.object({
 /** Runner-executed, unfiltered collection reads. Expected values are known inputs,
  * not values captured from the application response being checked. */
 export const RecipePreparationBaselineCheckSchema = z.object({
-  path: z.string().regex(/^\/(?!\/)/).refine(p => !p.includes('?') && !p.includes('#'), 'baseline reads must be unfiltered collection paths'),
+  path: z.string().regex(/^\/(?!\/)/).refine(p => !/[?#[\]\\\s]/.test(p), 'baseline paths must omit query/fragment; use query for transport parameters'),
+  query: z.record(z.string().min(1), z.string()).optional(),
   server: z.string().min(1).optional(),
   credential: z.string().min(1).optional(),
   counts: z.record(z.string().min(1), z.number().int().nonnegative()).refine(v => Object.keys(v).length > 0, 'declare at least one global record count'),
@@ -207,11 +208,18 @@ export const RecipePreparationBaselineCheckSchema = z.object({
 }).strict()
 export const RecipePreparationSchema = z.object({
   baseline: GuardPreparationBaselineSchema,
+  /** Catalog dependencies required by seed, baseline reads, verifier mutations, or cleanup. */
+  needs: z.array(z.string().min(1)).refine(names => new Set(names).size === names.length, 'Preparation dependencies must be unique').optional(),
   scope: z.literal('instance'),
   // Optional only to read older recipes. Execution refuses profiles without checks.
   baselineChecks: z.array(RecipePreparationBaselineCheckSchema).min(1).optional(),
+  postgres: z.object({
+    isolation: z.literal('database'),
+    urlEnvs: z.array(z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/)
+      .refine(key => !key.startsWith('GUARD_'), 'GUARD_ bindings are runner-owned')).min(1)
+      .refine(keys => new Set(keys).size === keys.length, 'Postgres URL bindings must be unique'),
+  }).strict().optional(),
   env: z.record(z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/).refine((key) => !key.startsWith('GUARD_'), 'GUARD_ bindings are runner-owned'), z.string().min(1))
-    .refine((env) => Object.keys(env).length > 0, 'a profile must own datastore bindings')
     .refine((env) => Object.values(env).every((v) => /\$\{(?:directory|namespace)\}/.test(v) &&
       !/\$\{(?!directory\}|namespace\})/.test(v)), 'every binding must use ${directory} or ${namespace}, with no other references'),
   seed: RecipeApiSeedSchema.omit({ command: true }).extend({ script: RecipePreparationScriptSchema.shape.script }),
@@ -220,7 +228,15 @@ export const RecipePreparationSchema = z.object({
   verify: RecipePreparationScriptSchema,
   /** Optional namespace cleanup. Receives only the owned allocation, even after failed seeding. */
   cleanup: RecipePreparationScriptSchema.optional(),
-}).strict()
+}).strict().superRefine((profile, ctx) => {
+  if (!profile.postgres && !Object.keys(profile.env).length)
+    ctx.addIssue({ code: 'custom', path: ['env'], message: 'a profile must own datastore bindings' });
+  if (profile.postgres) {
+    if (!profile.cleanup) ctx.addIssue({ code: 'custom', path: ['cleanup'], message: 'Postgres preparation requires owned database cleanup' });
+    if (profile.postgres.urlEnvs.some(key => Object.hasOwn(profile.env, key)))
+      ctx.addIssue({ code: 'custom', path: ['postgres', 'urlEnvs'], message: 'Postgres URL bindings cannot also be owned by env' });
+  }
+})
 export type RecipePreparation = z.infer<typeof RecipePreparationSchema>
 
 /**
@@ -1045,6 +1061,12 @@ export function loadRecipe(repoRoot: string, recipeFile: string): LoadedRecipe |
     throw new RecipeError(`recipe.json is invalid: ${result.error.issues.map((i) => `${i.path.join('.')} ${i.message}`).join('; ')}`)
   }
   return { recipe: result.data, fingerprint: computeRecipeFingerprint(repoRoot) }
+}
+
+/** Version preparation semantics independently so cached unsupported outcomes can be retried once. */
+export function computePreparationFingerprint(repoRoot: string): string {
+  return crypto.createHash('sha256').update('guard-preparations:4-dependency-availability\n')
+    .update(computeRecipeFingerprint(repoRoot)).digest('hex');
 }
 
 /** Hash the present discovery-input files (sorted, path-tagged) into one digest. */

--- a/packages/guard-runner/src/run-scenario.ts
+++ b/packages/guard-runner/src/run-scenario.ts
@@ -204,7 +204,7 @@ function applyCapturedExpect<E extends GuardExpect | GuardFileExpect>(
 }
 
 export async function runScenario(scenario: GuardSandboxScenario, ctx: RunScenarioContext): Promise<GuardScenarioResult> {
-  const redact = buildCredentialRedactor(new Map(), ctx.externalSecrets)
+  const redact = buildCredentialRedactor(new Map([...(ctx.credentials ?? [])].map(([name, credential]) => [name, credential.value])), ctx.externalSecrets)
   return redactScenarioResult(await runScenarioInternal(scenario, ctx), redact)
 }
 
@@ -212,7 +212,7 @@ async function runScenarioInternal(
   scenario: GuardSandboxScenario,
   ctx: RunScenarioContext,
 ): Promise<GuardScenarioResult> {
-  const redact = buildCredentialRedactor(new Map(), ctx.externalSecrets)
+  const redact = buildCredentialRedactor(new Map([...(ctx.credentials ?? [])].map(([name, credential]) => [name, credential.value])), ctx.externalSecrets)
   const writeEvidence = (params: Parameters<typeof writeEvidenceFile>[0]) => writeEvidenceFile(redactEvidence(params, redact))
   const start = Date.now()
   // The result keys on the PRIMARY bind (the result schema carries one section);
@@ -390,6 +390,7 @@ async function runScenarioInternal(
       resolveExpect,
       resolveEnv,
       normText,
+      redact,
       publishCaptures: (values: Record<string, string>) => {
         for (const [name, value] of Object.entries(values)) captured.set(name, value)
       },
@@ -570,6 +571,8 @@ async function runScenarioInternal(
           step: stepIndex,
           expected: outcome.mismatch.expected,
           actual: outcome.mismatch.actual,
+          ...(outcome.mismatch.observation ? { observation: outcome.mismatch.observation } : {}),
+          ...(outcome.mismatch.observationUnavailable ? { observationUnavailable: outcome.mismatch.observationUnavailable } : {}),
           // The RAW output that produced this mismatch (NOT the normalized text
           // matched against) — head-truncated, empty streams omitted.
           ...(outcome.excerpts ?? {}),

--- a/packages/guard-runner/src/run.ts
+++ b/packages/guard-runner/src/run.ts
@@ -585,6 +585,16 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
   }[] = []
   const currentFlows = readGuardFlowsCorpus(repoRoot)?.flows ?? []
   const runnable = prepared.filter((p) => {
+    const preparation = p.scenario.setup?.preparation;
+    const preparationNeeds = preparation ? loaded.recipe.preparations?.[preparation]?.needs ?? [] : [];
+    if (preparationNeeds.length) {
+      const suppliedNeeds = preparationNeeds.filter(name => !resolvedDependencies.dependencies.some(d => d.name === name && d.state === null))
+      p.scenario = {
+        ...p.scenario,
+        needs: [...new Set([...(p.scenario.needs ?? []), ...preparationNeeds])],
+        prerequisites: [...(p.scenario.prerequisites ?? []), ...suppliedNeeds.map(dependency => ({ dependency, mode: 'provided' as const }))],
+      }
+    }
     const flow = currentFlows.find(flow => flow.id === p.scenario.flow?.id)
     if (flow) {
       const prerequisites = scenarioMilestoneProof(p.scenario.steps).flatMap(proof => flow.milestones.find(m => m.order === proof.milestone)?.verification?.cases?.filter(c => !proof.checks || proof.checks.includes(c.id)).flatMap(c => c.prerequisites ?? []) ?? [])
@@ -1228,6 +1238,7 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
         accountEnv: account.env,
         signal: cancel.signal, timeoutMs: opts.buildTimeoutMs,
       })
+      const executionSecrets = new Map([...account.secrets, ...(privateWorld?.secrets ?? [])]);
       const privateCredentials = privateWorld && new Map([...privateWorld.credentials].map(([name, c]) => [name, c.value]))
       const privateCredentialView = (serverName: string) => {
         const credentials = new Map<string, string>()
@@ -1257,7 +1268,7 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
               credentials: scenarioCredentialsFor(boundServerById.get(scenario.id)!.name).credentials,
               foreignCredentials: scenarioCredentialsFor(boundServerById.get(scenario.id)!.name).foreign,
               servesPath: servesPathFor(boundServerById.get(scenario.id)!),
-              externalSecrets: account.secrets,
+              externalSecrets: executionSecrets,
               externalTargets,
               fixtures: privateWorld?.fixtures ?? apiFixtures,
               responseSchemas: resolveScenarioResponseSchemas(
@@ -1275,7 +1286,7 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
               runId,
               unique: scenarioUnique(runNonce, scenario.id),
               resolvedEntry: resolvedEntry!,
-              externalSecrets: account.secrets,
+              externalSecrets: executionSecrets,
               recipeEnv: { ...loaded.recipe.env, ...account.env, ...(privateWorld?.env ?? {}) },
               ...(loaded.recipe.expose ? { expose: loaded.recipe.expose } : {}),
               // Every binding is `provided` by construction — the gate above kept the
@@ -1305,7 +1316,7 @@ export async function runGuard(opts: RunGuardOptions): Promise<RunGuardResult> {
           preparationFailure: { profile: scenario.setup!.preparation!, stage: 'prepare' },
           durationMs: Date.now() - startedAt,
           failure: { step: 0, expected: 'the selected preparation to provide a verified private baseline',
-            actual: buildCredentialRedactor(new Map(), account.secrets)(error instanceof Error ? error.message : String(error)) } }
+            actual: buildCredentialRedactor(privateWorld?.secrets ?? new Map(), account.secrets)(error instanceof Error ? error.message : String(error)) } }
       } finally {
         // Driver routines close browsers and servers before returning; data cleanup runs last.
         try { await privateWorld?.close() } catch {

--- a/packages/guard-runner/src/web/executor.ts
+++ b/packages/guard-runner/src/web/executor.ts
@@ -17,6 +17,7 @@
  */
 
 import path from 'node:path'
+import { createHash } from 'node:crypto'
 import type { Locator, Page } from 'playwright-core'
 import {
   describeWebAttribute,
@@ -33,6 +34,7 @@ import {
   isWebUploadStep,
   webStateAssertions,
   webVisibleTargets,
+  type GuardFailureObservation,
   type GuardWebCapture,
   type GuardWebCaptures,
   type GuardWebExpect,
@@ -43,6 +45,62 @@ import {
 import { describeTextMatcher, matchTextMatcher, truncate, type ExpectMismatch } from '../expect.js'
 import type { ArmedFileChooser } from './browser.js'
 import type { WebFilePayload } from './upload.js'
+
+type ObservationDraft =
+  | { kind: 'web-target'; operation: string; locator: GuardWebLocator; matchCount: number; visibility: 'visible' | 'hidden' | 'not-checked' | 'unknown'; reason: 'absent' | 'ambiguous' | 'hidden'; assertion?: string; page: string }
+  | { kind: 'web-text'; scope?: GuardWebLocator; matcher: NonNullable<GuardWebExpect['text']>; operator: 'equals' | 'contains' | 'matches' | 'compare'; text: string; assertion?: string; page: string }
+const observationDrafts = new WeakMap<ExpectMismatch, ObservationDraft>()
+
+/** Replace a URL's exact runner-owned origin only. Arbitrary text and external ports retain identity. */
+export function canonicalWebObservationUrl(raw: string, baseUrl: string, binding?: string): string {
+  if (!binding) return raw
+  try {
+    const url = new URL(raw)
+    const base = new URL(baseUrl)
+    if (url.origin !== base.origin || url.username || url.password) return raw
+    return `guard-server://${encodeURIComponent(binding)}${url.pathname}${url.search}${url.hash}`
+  } catch { return raw }
+}
+
+/** URL occurrences are parsed individually; a lookalike host or longer port is never replaced. */
+function canonicalObservationText(text: string, opts: ExecuteWebStepOptions): string {
+  return text.replace(/https?:\/\/[^\s"'<>]+/g, raw => canonicalWebObservationUrl(raw, opts.baseUrl, opts.originBinding))
+}
+
+function canonicalObservationValue<T>(value: T, opts: ExecuteWebStepOptions): T {
+  if (typeof value === 'string') return canonicalObservationText(value, opts) as T
+  if (Array.isArray(value)) return value.map(entry => canonicalObservationValue(entry, opts)) as T
+  if (value && typeof value === 'object') return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, canonicalObservationValue(entry, opts)])) as T
+  return value
+}
+
+function attachObservation(mismatch: ExpectMismatch, opts: ExecuteWebStepOptions): void {
+  const draft = observationDrafts.get(mismatch)
+  if (!draft) return
+  const redact = opts.redact ?? ((text: string) => text)
+  // Masking two different secrets to one label is not evidence of equivalence.
+  // Decline this observation rather than hashing secret bytes or equating masks.
+  if (redact(JSON.stringify(draft)) !== JSON.stringify(draft)) {
+    mismatch.observationUnavailable = 'failure evidence contains sensitive values'
+    return
+  }
+  if (draft.kind === 'web-target' && draft.visibility === 'unknown') {
+    mismatch.observationUnavailable = 'the browser could not observe target visibility'
+    return
+  }
+  const identity = {
+    version: 1 as const,
+    assertion: draft.assertion ?? 'action',
+    page: canonicalWebObservationUrl(draft.page, opts.baseUrl, opts.originBinding),
+  }
+  const observation: GuardFailureObservation = draft.kind === 'web-target'
+    ? { ...identity, kind: draft.kind, operation: draft.operation, locator: canonicalObservationValue(draft.locator, opts),
+        matchCount: draft.matchCount, visibility: draft.visibility, reason: draft.reason }
+    : { ...identity, kind: draft.kind, ...(draft.scope ? { scope: canonicalObservationValue(draft.scope, opts) } : {}),
+        matcher: canonicalObservationValue(draft.matcher, opts), operator: draft.operator, observed: false,
+        textDigest: `sha256:${createHash('sha256').update(canonicalObservationText(redact(draft.text), opts)).digest('hex')}` }
+  mismatch.observation = observation
+}
 
 /**
  * Default budget for one web step's observable state to arrive. Shorter than the
@@ -115,6 +173,10 @@ export interface ExecuteWebStepOptions {
   page: Page
   /** `http://127.0.0.1:<port>` — what a `navigate` path is appended to. */
   baseUrl: string
+  /** Runner-established server identity; absent callers get no origin normalization. */
+  originBinding?: string
+  /** Applied before evidence is hashed; sensitive semantic fields decline evidence. */
+  redact?: (text: string) => string
   /** The step, with every `${…}` token already resolved. */
   step: GuardWebStep
   /** 1-based step index — it names the screenshot. */
@@ -220,7 +282,24 @@ async function targetMismatch(
   target: GuardWebLocator,
   found: number,
   what: string,
+  visibility: 'visible' | 'hidden' | 'not-checked' | 'unknown' = found === 0 ? 'hidden' : found === 1 ? 'hidden' : 'not-checked',
 ): Promise<ExpectMismatch> {
+  // Role queries omit accessibility-hidden elements. Inspect them only after
+  // resolution failed, so evidence distinguishes hidden from absent without
+  // making hidden duplicates interfere with a visible action target.
+  if ('role' in target && found === 0 && visibility !== 'unknown') {
+    try {
+      const allMatches = webLocator(page, target, true)
+      found = await allMatches.count()
+      visibility = found === 1
+        ? (await allMatches.isVisible() ? 'unknown' : 'hidden')
+        : found === 0 ? 'hidden' : 'not-checked'
+      // A visible match excluded from the original role query may be aria-hidden
+      // or may have appeared between reads. Neither proves a hidden failure.
+    } catch {
+      visibility = 'unknown'
+    }
+  }
   const inventory = await roleInventory(page, target)
   const text = await readVisibleText(page)
   const missing =
@@ -228,10 +307,14 @@ async function targetMismatch(
       ? `no ${target.role}${target.name === undefined ? '' : ` named “${target.name}”`} is on the page`
       : `nothing on the page matches ${describeWebLocator(target)}`
   const actual =
-    found === 0
+    visibility === 'unknown'
+      ? `the browser could not establish the count and visibility of ${describeWebLocator(target)}`
+      : found === 0
       ? missing
-      : `${found} elements match ${describeWebLocator(target)} — a target must be unambiguous`
-  return {
+      : found === 1
+        ? `${describeWebLocator(target)} is on the page but not visible`
+        : `${found} elements match ${describeWebLocator(target)} — a target must be unambiguous`
+  const mismatch: ExpectMismatch = {
     subject: 'target',
     expected: `${what} ${describeWebLocator(target)}`,
     actual,
@@ -248,6 +331,9 @@ async function targetMismatch(
       truncate(text, WEB_TEXT_LIMIT),
     ],
   }
+  observationDrafts.set(mismatch, { kind: 'web-target', operation: what, locator: target,
+    matchCount: found, visibility, reason: found === 0 ? 'absent' : found > 1 ? 'ambiguous' : 'hidden', page: page.url() })
+  return mismatch
 }
 
 /** Sleep between polls — the only place a duration appears, and it waits on nothing. */
@@ -269,8 +355,9 @@ async function awaitTarget(
   signal?: AbortSignal,
 ): Promise<{ locator: Locator } | { mismatch: ExpectMismatch }> {
   let found = 0
+  let visibility: 'visible' | 'hidden' | 'not-checked' | 'unknown' = 'unknown'
   for (;;) {
-    if (signal?.aborted) return { mismatch: await targetMismatch(page, target, found, what) }
+    if (signal?.aborted) return { mismatch: await targetMismatch(page, target, found, what, visibility) }
     const locator = webLocator(page, target)
     try {
       if (target.within) {
@@ -282,12 +369,14 @@ async function awaitTarget(
         }
       }
       found = await locator.count()
-      if (found === 1 && (await locator.isVisible())) return { locator }
+      visibility = found === 1 ? (await locator.isVisible() ? 'visible' : 'hidden') : found === 0 ? 'hidden' : 'not-checked'
+      if (found === 1 && visibility === 'visible') return { locator }
     } catch {
       // A navigation mid-poll destroys the execution context; the next poll re-reads.
       found = 0
+      visibility = 'unknown'
     }
-    if (Date.now() >= deadline) return { mismatch: await targetMismatch(page, target, found, what) }
+    if (Date.now() >= deadline) return { mismatch: await targetMismatch(page, target, found, what, visibility) }
     await tick()
   }
 }
@@ -308,7 +397,7 @@ async function visibleMatchCount(
   } catch {
     const expected = `to count visible matches of ${describeWebLocator(target)}`
     const actual = 'the browser could not read the matching elements'
-    return { mismatch: { subject: 'target', expected, actual, detail: [expected, actual] } }
+    return { mismatch: { subject: 'target', expected, actual, detail: [expected, actual], observationUnavailable: 'the browser could not read the matching elements' } }
   }
 }
 
@@ -327,7 +416,8 @@ async function resolveOne(
     if ('mismatch' in scope) return scope
   }
   const locator = webLocator(page, target)
-  const found = await locator.count().catch(() => 0)
+  const found = await locator.count().catch(() => null)
+  if (found === null) return { mismatch: { subject: 'target', expected: what, actual: 'the browser could not read the target', detail: [], observationUnavailable: 'the browser could not read the target' } }
   if (found === 1) return { locator }
   return { mismatch: await targetMismatch(page, target, found, what) }
 }
@@ -474,7 +564,11 @@ async function evaluateWebExpect(page: Page, expect: GuardWebExpect): Promise<We
   let mismatch: ExpectMismatch | null = null
   /** Record one member. The FIRST miss becomes the failure; later ones only record. */
   const record = (check: Omit<WebCheck, 'ok'>, miss: ExpectMismatch | null): void => {
-    if (miss) mismatch ??= miss
+    if (miss) {
+      const draft = observationDrafts.get(miss)
+      if (draft) draft.assertion = `${check.subject}:${checks.length}`
+      mismatch ??= miss
+    }
     checks.push({ ...check, ok: miss === null })
   }
 
@@ -495,21 +589,31 @@ async function evaluateWebExpect(page: Page, expect: GuardWebExpect): Promise<We
     let scoped: { text: string } | { mismatch: ExpectMismatch }
     if (expect.within) {
       const scope = await resolveOne(page, expect.within, 'the text of')
-      scoped = 'mismatch' in scope ? scope : { text: await scope.locator.innerText().catch(() => '') }
+      if ('mismatch' in scope) scoped = scope
+      else {
+        try { scoped = { text: await scope.locator.innerText() } }
+        catch { scoped = { mismatch: { subject: 'text', expected, actual: 'the browser could not read text', detail: [], observationUnavailable: 'the browser could not read text' } } }
+      }
     } else {
-      scoped = { text: await readVisibleText(page) }
+      try { scoped = { text: await page.locator('body').innerText({ timeout: 1_000 }) } }
+      catch { scoped = { mismatch: { subject: 'text', expected, actual: 'the browser could not read text', detail: [], observationUnavailable: 'the browser could not read text' } } }
     }
     if ('mismatch' in scoped) {
       // The text could not be read at all — the scope is the miss, and its own
       // words are the honest actual for the text member.
       record({ subject: 'text', expected, actual: scoped.mismatch.actual }, scoped.mismatch)
     } else {
+      const textMiss = matchTextMatcher('text', label, expect.text, scoped.text, WEB_TEXT_LIMIT)
+      if (textMiss?.matcherOperator) observationDrafts.set(textMiss, {
+        kind: 'web-text', matcher: expect.text, operator: textMiss.matcherOperator,
+        ...(expect.within ? { scope: expect.within } : {}), text: scoped.text, page: page.url(),
+      })
       record(
         // The page-text channel carries WEB_TEXT_LIMIT chars, and the check's actual
         // carries the same width — a narrower cut here once hid the deciding content
         // from the very line that reported the miss.
         { subject: 'text', expected, actual: `${label} was ${JSON.stringify(truncate(scoped.text, WEB_TEXT_LIMIT))}` },
-        matchTextMatcher('text', label, expect.text, scoped.text, WEB_TEXT_LIMIT),
+        textMiss,
       )
     }
   }
@@ -524,11 +628,11 @@ async function evaluateWebExpect(page: Page, expect: GuardWebExpect): Promise<We
     }
     const locator = resolved.locator
     const found = 1
-    const visible = await locator.isVisible().catch(() => false)
+    const visible = await locator.isVisible().catch(() => null)
     if (visible) {
       record({ subject: 'visible', expected, actual: expected }, null)
     } else {
-      const miss = await targetMismatch(page, target, found === 1 ? 0 : found, 'to see')
+      const miss = await targetMismatch(page, target, found, 'to see', visible === null ? 'unknown' : 'hidden')
       record(
         {
           subject: 'visible',
@@ -997,6 +1101,7 @@ export async function executeWebStep(opts: ExecuteWebStepOptions): Promise<WebSt
     else captured = read.values
   }
 
+  if (mismatch) attachObservation(mismatch, opts)
   const shot = await screenshot(page, opts.evidenceDir, opts.stepIndex)
   return {
     url: pageAddress(page),

--- a/packages/shared/src/activity-stream.ts
+++ b/packages/shared/src/activity-stream.ts
@@ -15,6 +15,15 @@ export const ActivityEventSchema = z.discriminatedUnion('kind', [
   }),
 ]);
 export type ActivityEvent = z.infer<typeof ActivityEventSchema>;
+
+/** Conversation readers need every transcript event, but only the newest run
+ * snapshot. Keep its original cursor so paging and live replay still agree. */
+export function compactRunSnapshots(events: readonly ActivityEvent[]): ActivityEvent[] {
+  let latest = -1;
+  for (const event of events) if (event.kind === 'run') latest = Math.max(latest, event.cursor);
+  return events.filter(event => event.kind !== 'run' || event.cursor === latest);
+}
+
 export type ActivityEventBody = ActivityEvent extends infer E
   ? E extends ActivityEvent ? Omit<E, 'cursor'> : never : never;
 

--- a/packages/shared/src/guard/coverage-progress.ts
+++ b/packages/shared/src/guard/coverage-progress.ts
@@ -2,7 +2,7 @@ import type { GuardFlowMilestone } from './flows.js'
 import type { GuardMilestoneProof } from './proof.js'
 
 /** Bump when old reviews no longer establish the current assertion contract. */
-export const GUARD_REVIEW_POLICY_VERSION = 4
+export const GUARD_REVIEW_POLICY_VERSION = 5
 
 export interface GuardObligation {
   milestone: number

--- a/packages/shared/src/guard/failure-observation.ts
+++ b/packages/shared/src/guard/failure-observation.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+import { GuardWebLocatorSchema } from './web-steps.js'
+import { GuardStreamMatcherSchema } from './step-parts.js'
+
+const identity = {
+  version: z.literal(1),
+  /** Stable producer assertion position within the failing step. */
+  assertion: z.string().min(1),
+  /** Full page URL; only a proven runner origin may use a server marker. */
+  page: z.string().min(1),
+}
+
+export const GuardFailureObservationSchema = z.discriminatedUnion('kind', [
+  z.object({
+    ...identity,
+    kind: z.literal('web-target'),
+    operation: z.string().min(1),
+    locator: GuardWebLocatorSchema,
+    matchCount: z.number().int().nonnegative(),
+    visibility: z.enum(['visible', 'hidden', 'not-checked', 'unknown']),
+    reason: z.enum(['absent', 'ambiguous', 'hidden']),
+  }).strict(),
+  z.object({
+    ...identity,
+    kind: z.literal('web-text'),
+    scope: GuardWebLocatorSchema.optional(),
+    matcher: GuardStreamMatcherSchema,
+    operator: z.enum(['equals', 'contains', 'matches', 'compare']),
+    observed: z.literal(false),
+    /** SHA-256 of complete captured text, before display truncation. */
+    textDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  }).strict(),
+]).superRefine((observation, ctx) => {
+  if (observation.kind !== 'web-target') return
+  const consistent = observation.reason === 'absent'
+    ? observation.matchCount === 0
+    : observation.reason === 'hidden'
+      ? observation.matchCount === 1 && observation.visibility === 'hidden'
+      : observation.matchCount > 1
+  if (!consistent) ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'target reason must agree with observed count and visibility' })
+})
+export type GuardFailureObservation = z.infer<typeof GuardFailureObservationSchema>

--- a/packages/shared/src/guard/flows.ts
+++ b/packages/shared/src/guard/flows.ts
@@ -1,3 +1,4 @@
+import { GuardFailureObservationSchema } from './failure-observation.js'
 /**
  * Guard FLOWS — the spec-side generation unit (WHAT to test), stored in
  * `.truecourse/scenarios/flows.json` (committable, next to `manifest.json`).
@@ -203,7 +204,9 @@ export const GuardExpectedRedSchema = z
     step: z.number().int().positive(),
     /** The actual the worker OBSERVED (copied off its own run) and predicts the
      *  confirmation run reproduces. */
-    predictedActual: z.string().min(1),
+    predictedActual: z.string().trim().min(1),
+    observationId: z.string().min(1).optional(),
+    observation: GuardFailureObservationSchema.optional(),
     /** The worker's drift verdict — `generation-defect` is deliberately absent:
      *  a worker that authored a defective scenario fixes or retires it in-loop. */
     verdict: z.enum(['doc-drift', 'code-drift']),

--- a/packages/shared/src/guard/index.ts
+++ b/packages/shared/src/guard/index.ts
@@ -34,3 +34,5 @@ export * from './coverage-progress.js'
 export * from './preparation.js'
 
 export * from './prerequisites.js'
+
+export * from './failure-observation.js'

--- a/packages/shared/src/guard/result.ts
+++ b/packages/shared/src/guard/result.ts
@@ -1,3 +1,4 @@
+import { GuardFailureObservationSchema } from './failure-observation.js'
 import { GuardPreparationEvidenceSchema } from './preparation.js'
 /**
  * Guard run result types — the materialized current state a `guard run` writes to
@@ -145,6 +146,9 @@ export const GuardFailureDetailSchema = z
     step: z.number().int().positive(),
     expected: z.string(),
     actual: z.string(),
+    observation: GuardFailureObservationSchema.optional(),
+    /** Supported evidence could not be captured safely; never use prose as proof. */
+    observationUnavailable: z.string().min(1).optional(),
     /**
      * The failing step's RAW program output (see {@link OutputExcerptsSchema}),
      * attached on EVERY expect-mismatch so the retry/finding sees the usage error

--- a/scripts/benchmark-guard-authoring.ts
+++ b/scripts/benchmark-guard-authoring.ts
@@ -1,0 +1,105 @@
+/** Offline structural regression report; never initializes a model or application. */
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { execFileSync } from 'node:child_process'
+import { authoringFixture, FIXTURE_VERSION, missingDialogObservation } from '../tests/fixtures/guard-authoring-benchmark/fixture.js'
+import type { TurnUsage } from '../packages/agent-loop/src/session-events.js'
+
+export interface AttemptMetric { sessionId: string; parentId?: string; durationMs: number; costUsd: number; acceptedReviewed: number; coveredObligations: number }
+/** Input events must already obey TurnUsage's disjoint input/cache buckets. */
+export function summarizeUsageEvents(events: { sessionId: string; eventId: string; usage: TurnUsage }[]) {
+  const unique = [...new Map(events.map(e => [`${e.sessionId}:${e.eventId}`, e])).values()]
+  if (!unique.length) return { usage: null, reason: 'No assistant-turn usage events were supplied.' }
+  const sum = (key: keyof Pick<TurnUsage, 'inputTokens' | 'outputTokens' | 'cacheReadTokens' | 'cacheCreateTokens' | 'costUsd'>) => unique.reduce((n, e) => n + e.usage[key], 0)
+  const usage = { inputTokens: sum('inputTokens'), outputTokens: sum('outputTokens'), cacheReadTokens: sum('cacheReadTokens'),
+    cacheCreateTokens: sum('cacheCreateTokens'), reasoningTokens: unique.every(e => e.usage.reasoningTokens !== undefined)
+      ? unique.reduce((n, e) => n + e.usage.reasoningTokens!, 0) : null,
+    costUsd: unique.some(e => e.usage.costSource === 'unpriced') ? null : sum('costUsd'),
+    costSources: [...new Set(unique.map(e => e.usage.costSource))].sort() }
+  return { usage: { ...usage, totalTokens: usage.inputTokens + usage.outputTokens + usage.cacheReadTokens + usage.cacheCreateTokens }, reason: null }
+}
+export function summarizeAttempts(attempts: AttemptMetric[], wallTimeMs: number) {
+  const unique = [...new Map(attempts.map(a => [a.sessionId, a])).values()]
+  const costUsd = unique.reduce((s, a) => s + a.costUsd, 0)
+  const acceptedReviewed = unique.reduce((s, a) => s + a.acceptedReviewed, 0)
+  const coveredObligations = unique.reduce((s, a) => s + a.coveredObligations, 0)
+  return { costUsd, acceptedReviewed, coveredObligations, wallTimeMs,
+    summedSessionDurationMs: unique.reduce((s, a) => s + a.durationMs, 0),
+    costPerAcceptedReviewed: acceptedReviewed ? costUsd / acceptedReviewed : null,
+    wallMsPerAcceptedReviewed: acceptedReviewed ? wallTimeMs / acceptedReviewed : null,
+    costPerCoveredObligation: coveredObligations ? costUsd / coveredObligations : null,
+    wallMsPerCoveredObligation: coveredObligations ? wallTimeMs / coveredObligations : null }
+}
+
+export async function offlineReport(revision: string | null = null) {
+  const { createAuthorCatalog, scopedAuthorResources } = await import('../packages/guard-generator/src/author-catalog.js')
+  const { buildAuthorUserPrompt } = await import('../packages/guard-generator/src/prompts.js')
+  const { flowWorkerSystemPrompt } = await import('../packages/core/src/services/guard-generate/flow-worker.js')
+  const { compareFailureObservations } = await import('../packages/guard-generator/src/failure-observation.js')
+  const { canonicalWebObservationUrl } = await import('../packages/guard-runner/src/web/executor.js')
+  const f = authoringFixture()
+  const catalog = createAuthorCatalog(f.interfaces, f.resources)
+  const candidates = catalog.candidates([f.own], 'organisation creation dialog')
+  const briefing = buildAuthorUserPrompt({ ...f.context, resources: scopedAuthorResources([f.own], f.resources), webSetupCandidates: candidates })
+  let peakToolResultChars = 0
+  let lookupCalls = 0
+  let pages = 0
+  let cursor: string | undefined
+  const ids: string[] = []
+  do {
+    const result = catalog.search({ query: '', limit: 20, ...(cursor ? { cursor } : {}) })
+    if (result.isError) throw new Error(result.content)
+    lookupCalls++; pages++; peakToolResultChars = Math.max(peakToolResultChars, result.content.length)
+    const page = JSON.parse(result.content)
+    ids.push(...page.items.map((i: { id: string }) => i.id))
+    cursor = page.nextCursor
+  } while (cursor)
+  const fetch = catalog.get({ ids: [f.late.id] })
+  if (fetch.isError) throw new Error(fetch.content)
+  lookupCalls++; peakToolResultChars = Math.max(peakToolResultChars, fetch.content.length)
+  const unavailable = 'Structural offline replay does not execute a model, candidate, fidelity judge, or upstream cache.'
+  const observed = missingDialogObservation()
+  const initialUtf8Bytes = Buffer.byteLength(flowWorkerSystemPrompt('web') + briefing, 'utf8')
+  const sameOrigin = canonicalWebObservationUrl('http://localhost:31001/plans?limit=5', 'http://localhost:31001', 'web') ===
+    canonicalWebObservationUrl('http://localhost:32002/plans?limit=5', 'http://localhost:32002', 'web')
+  const cases = [
+    { id: 'organisation-dialog', assertion: 'same typed missing-dialog result reproduces', passed: compareFailureObservations(observed, structuredClone(observed)) === undefined },
+    { id: 'cross-screen-members', assertion: 'member action remains discoverable outside shortlist', passed: ids.includes(f.late.id) && !candidates.some(i => i.id === f.late.id) },
+    { id: 'plan-limit-origin', assertion: 'only runner-owned origin changes normalize', passed: sameOrigin },
+    { id: 'role-prerequisite', assertion: 'login redirect does not equal authenticated-page evidence', passed: compareFailureObservations(observed, { ...observed, page: 'guard-server://web/login' }) !== undefined },
+    { id: 'large-catalog', assertion: 'all catalog actions retrieved within payload bounds', passed: ids.length === f.interfaces.length && initialUtf8Bytes <= 120000 && peakToolResultChars <= 12000 },
+    { id: 'different-failure', assertion: 'different dialog remains a different failure', passed: compareFailureObservations(observed, { ...observed, locator: { role: 'dialog', name: 'Delete organisation' } }) !== undefined },
+  ]
+  return { schemaVersion: 1, fixtureVersion: FIXTURE_VERSION, mode: 'offline' as const, revision,
+    execution: 'scripted catalog and briefing replay', model: null,
+    initialUtf8Bytes, cases,
+    peakToolResultChars, lookupCalls, lookupMisses: 0, lookupPages: pages,
+    catalogActions: f.interfaces.length, retrievedActions: ids.length,
+    lateEntryRetrieved: ids.includes(f.late.id), lateEntryOutsideShortlist: !candidates.some(i => i.id === f.late.id),
+    selectedObligations: f.context.milestones.map(m => m.claim),
+    modelTurns: null, workerTasks: null, runAttempts: null, submitAttempts: null, acceptedScenarios: null,
+    failed: null, blocked: null, unreviewed: null, reviewedObligationCoverage: null,
+    cacheByStage: { extract: null, flows: null, match: null, author: null },
+    costPerAcceptedReviewed: null, timePerAcceptedReviewed: null, costPerCoveredObligation: null,
+    timePerCoveredObligation: null, missingMetricReason: unavailable }
+}
+
+export async function benchmarkMain(args: string[]) {
+  if (args.length === 1 && args[0] === '--help') {
+    process.stdout.write('Usage: pnpm exec tsx scripts/benchmark-guard-authoring.ts --offline --output /tmp/report.json\nNo model, app server, or database is contacted.\n')
+    return
+  }
+  if (args.length !== 3 || args[0] !== '--offline' || args[1] !== '--output' || !args[2]) throw new Error('Use --help; only --offline --output <file> is supported.')
+  let revision: string | null = null
+  try { revision = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim() } catch { /* source archive */ }
+  fs.writeFileSync(path.resolve(args[2]), JSON.stringify(await offlineReport(revision), null, 2) + '\n', { flag: 'wx' })
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  // Workspace packages expose their source through this explicit condition.
+  // Re-enter using Node's tsx loader, which creates no CLI IPC listener.
+  if (!process.execArgv.includes('--conditions=truecourse-source') && process.argv[2] !== '--help') {
+    try { execFileSync(process.execPath, ['--conditions=truecourse-source', '--import', 'tsx', process.argv[1], ...process.argv.slice(2)], { stdio: 'inherit' }) }
+    catch { process.exitCode = 1 }
+  } else benchmarkMain(process.argv.slice(2)).catch(e => { process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`); process.exitCode = 1 })
+}

--- a/tests/core/guard-authoring-cache-reuse.test.ts
+++ b/tests/core/guard-authoring-cache-reuse.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getCacheEntry, setCacheEntry } from '@truecourse/llm'
+import { flowFingerprint, GUARD_REVIEW_POLICY_VERSION, type GuardFlow } from '@truecourse/shared'
+import { collectWorkDocs, planGuardWork, type FlowSynthesisArea } from '@truecourse/guard-generator'
+import { buildSurfaceCatalogs, matchCacheKey, matchFlow, MATCH_CACHE_NAME, readCachedMatch } from '../../packages/guard-generator/src/match.js'
+import { createAuthorCatalog } from '../../packages/guard-generator/src/author-catalog.js'
+import { buildAuthorUserPrompt } from '../../packages/guard-generator/src/prompts.js'
+import type { FlowWorkerTask } from '../../packages/guard-generator/src/generate.js'
+import { createGuardGenerateSessionSeams } from '../../packages/core/src/services/guard-generate/run.js'
+import { EXTRACT_SESSION_CACHE_NAME, extractSessionCacheKey } from '../../packages/core/src/services/guard-generate/extract.js'
+import { FLOWS_SESSION_CACHE_NAME, flowsSessionCacheKey } from '../../packages/core/src/services/guard-generate/flows.js'
+import { CachedWorkerEntrySchema, flowWorkerCacheKey, flowWorkerPromptFingerprint } from '../../packages/core/src/services/guard-generate/flow-worker.js'
+import { authoringFixture } from '../fixtures/guard-authoring-benchmark/fixture.js'
+import { makeTempRepo, rmrf, writeCorpus, writeDoc, writeRecipe } from '../guard-generator/helpers.js'
+import { memoryPersistence, stubDriver } from './spec-scan-session-stub.js'
+
+const roots: string[] = []
+afterEach(() => { while (roots.length) rmrf(roots.pop()!) })
+const DOC = 'docs/tasks.md', ANCHOR = 'tasks/creating-tasks', CLAIM = '`relkit add <title>` creates a task'
+function seededRepo() {
+  const root = makeTempRepo(); roots.push(root)
+  writeRecipe(root); writeCorpus(root, [{ ref: DOC }]); writeDoc(root, DOC, '# Tasks\n\n## Creating tasks\n\n`relkit add <title>` creates a task.\n')
+  const doc = collectWorkDocs(root, planGuardWork(root))[0]
+  const area: FlowSynthesisArea = { areaId: 'tasks', claims: [{ doc: DOC, anchor: ANCHOR, title: CLAIM, driver: 'cli' }],
+    docs: [{ doc: DOC, outline: doc.sections.map(s => ({ anchor: s.anchor, headingText: s.headingText, level: s.level })) }] }
+  return { root, doc, area }
+}
+
+describe('author-only changes retain upstream cache compatibility', () => {
+  it('reads seeded extract and synthesis outcomes with zero upstream driver calls', async () => {
+    const { root, doc, area } = seededRepo()
+    const extract = { claims: [{ claim: CLAIM, driver: 'cli', sectionAnchor: ANCHOR, reason: 'stdout carries the id',
+      verification: { scope: 'configuration', method: 'behavior', observable: 'Task id', cases: [{ id: 'created-id', claim: 'Prints the id', method: 'behavior', requires: ['process'], conditions: [] }] }, needs: [] }], untestable: [] }
+    const flows = { flows: [{ title: 'Create task', goal: 'Create task', milestones: [{ order: 1, doc: DOC, anchor: ANCHOR, claimTitle: CLAIM }] }], noFlowClaims: [] }
+    const keys = [extractSessionCacheKey(doc), flowsSessionCacheKey(area)]
+    await setCacheEntry(root, EXTRACT_SESSION_CACHE_NAME, keys[0], extract)
+    await setCacheEntry(root, FLOWS_SESSION_CACHE_NAME, keys[1], flows)
+    const f = authoringFixture(); const catalog = createAuthorCatalog(f.interfaces, f.resources)
+    buildAuthorUserPrompt({ ...f.context, webSetupCandidates: catalog.candidates([f.own], 'organisation') })
+    const calls = vi.fn(() => { throw new Error('Warm upstream cache must never call a provider') })
+    const { driver } = stubDriver(calls)
+    const acquire = vi.fn(async () => ({ driver, persistence: memoryPersistence().persistence }))
+    const seams = createGuardGenerateSessionSeams({ repoRoot: root, driver: acquire })
+    expect((await seams.extractSession({ docs: [doc] })).summary).toMatchObject({ ran: 0, fromCache: 1 })
+    expect((await seams.flowsAreaSession({ areas: [area], docs: [doc] })).summary).toMatchObject({ ran: 0, fromCache: 1 })
+    expect(calls).not.toHaveBeenCalled()
+    expect(acquire).not.toHaveBeenCalled()
+    expect([extractSessionCacheKey(doc), flowsSessionCacheKey(area)]).toEqual(keys)
+  })
+  it('classifies valid, invalid, missing and deterministic no-call matching pairs individually', async () => {
+    const root = makeTempRepo(); roots.push(root)
+    const fixture = authoringFixture(); const catalog = buildSurfaceCatalogs([fixture.own]).get('web')!
+    const makeFlow = (id: string, implementation = false): GuardFlow => {
+      const milestones = [{ order: 1, doc: 'synthetic.md', anchor: id, claimTitle: 'Show dialog', proofDrivers: ['web' as const],
+        ...(implementation ? { verification: { method: 'implementation' as const, observable: 'Inspect source algorithm' } } : {}) }]
+      return { id, title: id, goal: 'Show dialog', fingerprint: flowFingerprint(milestones), milestones,
+        bindings: [{ doc: 'synthetic.md', anchor: id, fingerprint: 'sha256:doc' }], composedOf: [], synthesisInputsHash: 'same' }
+    }
+    const valid = makeFlow('valid'), invalid = makeFlow('invalid'), missing = makeFlow('missing'), skipped = makeFlow('skipped', true)
+    const reply = { plan: [{ interfaceId: fixture.own.id, milestone: 1 }], gaps: [] }
+    const originalKey = matchCacheKey(valid, catalog)
+    await setCacheEntry(root, MATCH_CACHE_NAME, originalKey, reply)
+    await setCacheEntry(root, MATCH_CACHE_NAME, matchCacheKey(invalid, catalog), { plan: [{ interfaceId: 'invented', milestone: 1 }] })
+    createAuthorCatalog(fixture.interfaces, fixture.resources).get({ ids: [fixture.late.id] })
+    expect(matchCacheKey(valid, catalog)).toBe(originalKey)
+    const calls = vi.fn(async () => reply)
+    expect(await readCachedMatch(root, valid, catalog)).not.toBeNull()
+    expect(await readCachedMatch(root, invalid, catalog)).toBeNull()
+    expect(await readCachedMatch(root, missing, catalog)).toBeNull()
+    expect(await matchFlow(root, valid, catalog, calls)).toMatchObject({ calls: 0 })
+    expect(await matchFlow(root, skipped, catalog, calls)).toMatchObject({ calls: 0, kind: 'gap' })
+    expect(calls).not.toHaveBeenCalled()
+    expect(await matchFlow(root, invalid, catalog, calls)).toMatchObject({ calls: 1 })
+    expect(await matchFlow(root, missing, catalog, calls)).toMatchObject({ calls: 1 })
+    expect(calls).toHaveBeenCalledTimes(2)
+  })
+  it('web author contract misses preserve old rows; review migration is independent of CLI/API input keys', async () => {
+    const root = makeTempRepo(); roots.push(root)
+    const f = authoringFixture()
+    const before = createAuthorCatalog(f.interfaces, f.resources)
+    const updatedResources = structuredClone(f.resources)
+    updatedResources.web[1].readables = { markers: [{ id: 'permission-marker', text: 'Manager access required' }] }
+    const after = createAuthorCatalog(f.interfaces, updatedResources)
+    expect(before.fingerprint).not.toBe(after.fingerprint)
+    const task = (surface: 'cli' | 'api' | 'web', catalog = before): FlowWorkerTask => ({ surface, catalog,
+      cacheMaterial: { flowFingerprint: 'same-flow', sectionKeys: ['same-section'], recipeFingerprint: 'same-recipe',
+        interfaceFingerprints: ['matched-interface', ...(surface === 'web' ? [catalog.fingerprint] : [])], mode: 'scratch', priorShas: [] } } as unknown as FlowWorkerTask)
+    const oldWeb = flowWorkerCacheKey(task('web', before)), newWeb = flowWorkerCacheKey(task('web', after))
+    await setCacheEntry(root, 'guard/generate', oldWeb, { retained: true })
+    expect(oldWeb).not.toBe(newWeb)
+    expect(await getCacheEntry(root, 'guard/generate', newWeb)).toBeNull()
+    expect(await getCacheEntry(root, 'guard/generate', oldWeb)).toEqual({ retained: true })
+    for (const surface of ['cli', 'api'] as const) {
+      // Only web consumes the catalog dependency. The actual worker helper
+      // cannot accidentally include a catalog supplied on another surface.
+      expect(flowWorkerCacheKey(task(surface, after))).toBe(flowWorkerCacheKey(task(surface, before)))
+      expect(flowWorkerPromptFingerprint(surface)).not.toBe(flowWorkerPromptFingerprint('web'))
+    }
+    const cached = { version: GUARD_REVIEW_POLICY_VERSION - 1,
+      outcome: { kind: 'settled', scenarioYamlSha: 'sha', expectedReds: [] }, scenarioYaml: 'yaml', reviews: [] }
+    expect(CachedWorkerEntrySchema.safeParse(cached).success).toBe(false)
+    expect(CachedWorkerEntrySchema.safeParse({ ...cached, version: GUARD_REVIEW_POLICY_VERSION }).success).toBe(true)
+  })
+})

--- a/tests/core/guard-generate-resume-driver.test.ts
+++ b/tests/core/guard-generate-resume-driver.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  guardGenerateInProcess, GUARD_GENERATE_STEPS, GuardGenerateResumeError,
+} from '../../packages/core/src/commands/guard-in-process.js';
+import { StepTracker } from '../../packages/core/src/progress.js';
+import { resetSpecStore } from '../../packages/core/src/lib/spec-store.js';
+import { flowStageSeams, makeTempRepo, rmrf, writeCorpus, writeDoc, writeRecipe } from '../guard-generator/helpers.js';
+import { stubDriver } from './spec-scan-session-stub.js';
+
+let repo: string;
+beforeEach(() => {
+  resetSpecStore();
+  repo = makeTempRepo();
+  writeRecipe(repo);
+  writeCorpus(repo, [{ ref: 'docs/cli.md' }]);
+  writeDoc(repo, 'docs/cli.md', '## version\n`relkit --version` prints the version and exits 0.\n');
+});
+afterEach(() => rmrf(repo));
+
+describe('resume through the generate driver', () => {
+  it('refuses a completed matcher cache miss before spending or starting workers', async () => {
+    const transport = vi.fn(async () => '{}');
+    const workers = vi.fn(async () => { throw new Error('workers must not start after failed replay'); });
+    const active: string[] = [];
+    const tracker = new StepTracker(progress => {
+      active.push(...(progress.steps ?? []).filter(step => step.status === 'active').map(step => step.key));
+    }, GUARD_GENERATE_STEPS.map(step => ({ ...step })));
+
+    await expect(guardGenerateInProcess(repo, {
+      ...flowStageSeams(repo),
+      matchRunner: undefined,
+      flowWorkerSession: workers,
+      transport,
+      tracker,
+      requireExistingRecipe: true,
+      resume: { runId: 'old-run', gitRef: '', completedSteps: ['index', 'extract', 'interfaces', 'flows', 'match'] },
+    })).rejects.toBeInstanceOf(GuardGenerateResumeError);
+
+    expect(transport).not.toHaveBeenCalled();
+    expect(workers).not.toHaveBeenCalled();
+    expect(active).toEqual([]);
+  });
+
+  it('reports a missing completed extraction result without constructing a session driver', async () => {
+    const { driver, calls } = stubDriver(() => { throw new Error('completed extraction must not run'); });
+    await expect(guardGenerateInProcess(repo, {
+      ...flowStageSeams(repo),
+      extractSession: undefined,
+      driver,
+      transport: async () => '{}',
+      resume: { runId: 'old-run', gitRef: '', completedSteps: ['index', 'extract'] },
+    })).rejects.toThrow('Cannot resume: saved extract results are missing');
+    expect(calls).toEqual([]);
+  });
+});

--- a/tests/core/guard-generate-resume.test.ts
+++ b/tests/core/guard-generate-resume.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import type { PublicRunRecord } from '../../packages/core/src/lib/sessions-store.js';
+import { assertGuardGenerateResumeCommit, guardGenerateResume } from '../../packages/core/src/services/guard-generate/resume.js';
+
+const keys = ['index', 'extract', 'interfaces', 'flows', 'match', 'author', 'validate'];
+function run(statuses: string[], status = 'interrupted'): PublicRunRecord {
+  return {
+    runId: 'interrupted-run', command: 'guard-generate', status, gitRef: 'a'.repeat(40),
+    startedAt: '2026-09-12T10:00:00Z', sessions: [],
+    display: { blocks: [{ kind: 'checklist', items: keys.map((key, i) => ({ key, label: key, status: statuses[i] ?? 'pending' })) }] },
+  } as PublicRunRecord;
+}
+
+describe('guard generation resume boundaries', () => {
+  it('restores the completed stages when settling was interrupted, keeping workers resumable', () => {
+    expect(guardGenerateResume(run(['done', 'done', 'done', 'done', 'done', 'active', 'active'])))
+      .toEqual({ runId: 'interrupted-run', gitRef: 'a'.repeat(40), completedSteps: keys.slice(0, 5) });
+  });
+
+  it('does not mistake the area counter for a completed epic synthesis pass', () => {
+    expect(guardGenerateResume(run(['done', 'done', 'done', 'done'])).completedSteps)
+      .toEqual(keys.slice(0, 3));
+  });
+
+  it('does not skip extraction interrupted after its final pool tick but before fold', () => {
+    expect(guardGenerateResume(run(['done', 'done'])).completedSteps).toEqual(['index']);
+  });
+
+  it('does not assume missing or malformed progress completed anything', () => {
+    const record = run([]);
+    record.display = { blocks: [{ kind: 'checklist', items: [{ key: 'extract', status: 'done' }, null] }] };
+    expect(guardGenerateResume(record).completedSteps).toEqual([]);
+  });
+
+  it.each(['running', 'completed'])('rejects a %s run', status => {
+    expect(() => guardGenerateResume(run([], status))).toThrow('Only interrupted or failed');
+  });
+
+  it('rejects another command', () => {
+    expect(() => guardGenerateResume({ ...run([]), command: 'spec-scan' })).toThrow('Only interrupted or failed');
+  });
+
+  it('allows retrying an interruption before checkout established a commit', () => {
+    const resume = guardGenerateResume({ ...run([]), gitRef: 'unknown' });
+    expect(() => assertGuardGenerateResumeCommit(resume, 'b'.repeat(40))).not.toThrow();
+    expect(() => assertGuardGenerateResumeCommit({ ...resume, completedSteps: ['index'] }, 'b'.repeat(40)))
+      .toThrow('commit has changed');
+  });
+});

--- a/tests/core/guard-generate-session-cache.test.ts
+++ b/tests/core/guard-generate-session-cache.test.ts
@@ -106,6 +106,23 @@ const EXTRACT_DRAFT = {
 const transportFailure = { kind: 'failure' as const, failure: { kind: 'transport' as const, detail: 'gone', class: 'provider' as const, retryability: 'none' as const } }
 
 describe('the extract seam’s cache', () => {
+  it('resumes completed extraction without constructing a driver, and refuses a missing result', async () => {
+    const r = docRepo()
+    const [doc] = docsOf(r)
+    sessionScript = async call => {
+      await callTool(call, 'check_claims', EXTRACT_DRAFT)
+      return outcome(EXTRACT_DRAFT)
+    }
+    await createGuardGenerateSessionSeams({ repoRoot: r }).extractSession({ docs: [doc] })
+    const before = constructions
+    sessionScript = () => { throw new Error('completed extraction must not run again') }
+    const resumed = createGuardGenerateSessionSeams({ repoRoot: r, replaySteps: ['extract', 'flows'] })
+    expect((await resumed.extractSession({ docs: [doc] })).summary).toMatchObject({ ran: 0, fromCache: 1 })
+    await expect(resumed.extractSession({ docs: [{ ...doc, content: `${doc.content}\nNew requirement` }] }))
+      .rejects.toMatchObject({ name: 'GenerateStepNotReadyError', step: 'extract' })
+    expect(constructions).toBe(before)
+  })
+
   it('runs a session on a miss, writes the entry, and serves the next run from it', async () => {
     const r = docRepo()
     const [doc] = docsOf(r)
@@ -242,10 +259,15 @@ describe('the flows seam’s cache', () => {
     expect(result.inputsKey).toBe(flowsSessionCacheKey(area))
     expect(await getCacheEntry(r, FLOWS_SESSION_CACHE_NAME, flowsSessionCacheKey(area))).toEqual(CLEAN_FLOWS)
 
-    const second = await createGuardGenerateSessionSeams({ repoRoot: r }).flowsAreaSession({ areas: [area], docs })
+    const resumed = createGuardGenerateSessionSeams({ repoRoot: r, replaySteps: ['extract', 'flows'] })
+    const second = await resumed.flowsAreaSession({ areas: [area], docs })
     expect(second.summary).toMatchObject({ ran: 0, fromCache: 1 })
     const hit = second.byArea.get('tasks')!
     expect(hit.ok && hit.fromCache).toBe(true)
+    const before = constructions
+    await expect(resumed.flowsAreaSession({ areas: [{ ...area, areaId: 'uncached-area' }], docs }))
+      .rejects.toMatchObject({ name: 'GenerateStepNotReadyError', step: 'flows' })
+    expect(constructions).toBe(before)
   })
 
   // The session had its chance in-session: `check_flows` told it. An outcome the

--- a/tests/core/guard-generate-worker-seam.test.ts
+++ b/tests/core/guard-generate-worker-seam.test.ts
@@ -1,3 +1,4 @@
+import { createAuthorCatalog } from '../../packages/guard-generator/src/author-catalog.js'
 /**
  * THE FLOW-WORKER SEAM AND THE FIDELITY CHILD (plan 04 steps 17 + 18) — core's
  * half: the session def, the `guard/generate` cache (kept name, session prompt
@@ -180,6 +181,27 @@ async function callTool(call: StubCall, name: string, args: unknown): Promise<{ 
 // ---------------------------------------------------------------------------
 
 describe('flowWorkerSessionDef', () => {
+  it('offers web-only bounded catalog tools without weakening the execution gate', async () => {
+    const catalog = createAuthorCatalog([{ id: 'web/setup-late', type: 'web', title: 'Create prerequisite', entry: { method: 'GET', path: '/setup' }, steps: [{ kind: 'activate', target: 'button "Create"' }], fingerprint: 'setup-v1' }])
+    const { task } = fakeTask({ surface: 'web', catalog })
+    const def = flowWorkerSessionDef({ task, judgeWith: () => async () => ({ kind: 'faithful' }) })
+    expect(def.tools.map(t => t.name)).toEqual(['search_interfaces', 'get_interfaces', 'run_scenario', 'submit_scenario', 'drop_scenario'])
+    expect(def.outcomePrecondition?.tool).toBe('run_scenario')
+    const ctx = { workItem: task.workItem, signal: new AbortController().signal, dispatchChild: async () => { throw new Error('unexpected child') } }
+    const search = def.tools.find(t => t.name === 'search_interfaces')!
+    const fetch = def.tools.find(t => t.name === 'get_interfaces')!
+    expect(search.readOnly).toBe(true)
+    expect(search.destructive).toBe(false)
+    expect(fetch.readOnly).toBe(true)
+    const found = await search.execute({ query: 'prerequisite' }, ctx)
+    expect(found.content).toContain('web/setup-late')
+    const full = await fetch.execute({ ids: ['web/setup-late'] }, ctx)
+    expect(full.content).toContain('Create')
+    expect((await fetch.execute({ ids: ['web/another-app'] }, ctx)).isError).toBe(true)
+    const cli = flowWorkerSessionDef({ task: fakeTask({ catalog }).task, judgeWith: () => async () => ({ kind: 'faithful' }) })
+    expect(cli.tools.some(t => t.name === 'search_interfaces')).toBe(false)
+  })
+
   const def = (surface: 'cli' | 'api' | 'web') =>
     flowWorkerSessionDef({
       task: { ...fakeTask().task, surface },
@@ -318,6 +340,28 @@ describe('cacheableWorkerOutcome', () => {
 // ---------------------------------------------------------------------------
 
 const workerSeam = (r: string) => createGuardGenerateSessionSeams({ repoRoot: r }).flowWorkerSession
+
+describe('web initial context budget', () => {
+  it('rejects an oversized briefing before building a model driver', async () => {
+    const r = docRepo()
+    const { task } = fakeTask({ surface: 'web', prepare: async () => 'required obligation '.repeat(10_000) })
+    const { byTask, summary } = await workerSeam(r)({ tasks: [task], epicTasks: [], mutatorTasks: [], docs: docsOf(r) })
+    expect(constructions).toBe(0)
+    expect(summary.failed).toBe(1)
+    expect(summary.ran).toBe(0)
+    expect(byTask.get(task.workItem)).toMatchObject({ kind: 'failed', reason: expect.stringContaining('author-initial-context-oversize') })
+  })
+
+  it('lets another task finish when one web briefing is oversized', async () => {
+    const r = docRepo()
+    const large = fakeTask({ surface: 'web', prepare: async () => 'required obligation '.repeat(10_000) }, 'large').task
+    const normal = fakeTask({}, 'normal').task
+    sessionScript = settleScript
+    const { byTask, summary } = await workerSeam(r)({ tasks: [large, normal], epicTasks: [], mutatorTasks: [], docs: docsOf(r) })
+    expect(summary).toMatchObject({ failed: 1, ran: 1 })
+    expect(byTask.get(normal.workItem)).toMatchObject({ kind: 'outcome', outcome: { kind: 'settled' } })
+  })
+})
 
 /** Script a driver that submits `YAML` and settles on the accepted sha. */
 const settleScript: StubScript = async (call) => {

--- a/tests/core/guard-generate-worker-seam.test.ts
+++ b/tests/core/guard-generate-worker-seam.test.ts
@@ -684,6 +684,54 @@ describe('the flow-worker pool’s cache', () => {
 })
 
 describe('the flow-worker pool’s waves and progress', () => {
+  it('reuses a settled cache when a mutator moves into the private pool on Resume', async () => {
+    const r = docRepo()
+    sessionScript = settleScript
+    const first = fakeTask()
+    await workerSeam(r)({ tasks: [], epicTasks: [], mutatorTasks: [first.task], docs: docsOf(r) })
+    const priorConstructions = constructions
+    const resumed = fakeTask()
+    sessionScript = () => { throw new Error('a compatible settled cache must not be reauthored') }
+    const result = await workerSeam(r)({ tasks: [], epicTasks: [], preparedMutatorTasks: [resumed.task],
+      mutatorTasks: [], docs: docsOf(r) })
+    expect(result.summary).toMatchObject({ ran: 0, fromCache: 1, failed: 0 })
+    expect(resumed.calls.confirm).toHaveLength(1)
+    expect(resumed.calls.prepare).toBe(0)
+    expect(constructions).toBe(priorConstructions)
+  })
+
+  it.each([20, 2])('bounds private authoring and keeps shared mutations serial with configured concurrency %i', async concurrency => {
+    const r = docRepo()
+    let active = 0
+    let peak = 0
+    let privateDone = 0
+    let sharedActive = 0
+    const prepared = Array.from({ length: 8 }, (_, i) => fakeTask({}, `private-${i}`).task)
+    const shared = Array.from({ length: 2 }, (_, i) => fakeTask({}, `shared-${i}`).task)
+    sessionScript = async call => {
+      if (call.briefing.includes('private-')) {
+        active++
+        peak = Math.max(peak, active)
+        await new Promise(resolve => setTimeout(resolve, 20))
+        active--
+        privateDone++
+      } else {
+        expect(privateDone).toBe(8)
+        expect(++sharedActive).toBe(1)
+        await new Promise(resolve => setTimeout(resolve, 5))
+        sharedActive--
+      }
+      return outcome({ kind: 'blocked', perMilestone: [{ order: 1, capability: 'test fixture' }] })
+    }
+    const seams = createGuardGenerateSessionSeams({ repoRoot: r, concurrency })
+    const ticks: number[] = []
+    const result = await seams.flowWorkerSession({ tasks: [], epicTasks: [], preparedMutatorTasks: prepared,
+      mutatorTasks: shared, docs: docsOf(r), onTask: (_done, total) => ticks.push(total) })
+    expect(peak).toBe(Math.min(6, concurrency))
+    expect(result.summary.ran).toBe(10)
+    expect(new Set(ticks)).toEqual(new Set([10]))
+  })
+
   it('runs non-epics, then epics, then the serialized mutator wave — ticking per settled task', async () => {
     const r = docRepo()
     const order: string[] = []

--- a/tests/core/guard-setup-preparation-session.test.ts
+++ b/tests/core/guard-setup-preparation-session.test.ts
@@ -4,7 +4,7 @@ import {
   outcome,
 } from './spec-scan-session-stub';
 import type { GuardSetupSessionContext } from '../../packages/core/src/services/guard-setup/session-context';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -13,6 +13,7 @@ import {
   verifyPreparationDraft,
   buildPreparationSession,
   PreparationDraftSchema,
+  PREPARATION_PROMPT,
   type PreparationDraft,
 } from '../../packages/core/src/services/guard-setup/preparation-session';
 import {
@@ -21,6 +22,7 @@ import {
 } from '../../packages/core/src/services/guard-setup/bundle';
 import {
   prepareScenario,
+  PREPARATION_VERIFY_INPUTS_SOURCE,
   loadRecipe,
   recipePath,
   type Recipe,
@@ -60,6 +62,7 @@ function fixture() {
       {
         name: 'ledger',
         baseline: 'seeded',
+        needs: [],
         baselineChecks: [{ path: '/rows', credential: 'owner', counts: { count: 8 }, totals: { total: 36 } }],
         env: { DATA_FILE: '${directory}/ledger.json' },
         seed: source('seed'),
@@ -84,6 +87,29 @@ function fixture() {
   };
 }
 describe('targeted preparation authoring and hosted bundle protocol', () => {
+  it('authenticates both worlds with the verifier input example supplied to the author', async () => {
+    const { input, draft } = fixture();
+    expect(PREPARATION_PROMPT).toContain(PREPARATION_VERIFY_INPUTS_SOURCE);
+    draft.profiles[0].verify = draft.profiles[0].verify
+      .replace('const env=process.env, peer=JSON.parse(env.GUARD_PREPARATION_PEER_ENV)',
+        PREPARATION_VERIFY_INPUTS_SOURCE + '\nconst env=process.env')
+      .replace('const creds=JSON.parse(env.GUARD_PREPARATION_CREDENTIALS),peerCreds=JSON.parse(env.GUARD_PREPARATION_PEER_CREDENTIALS)',
+        "assert.equal(fixtures.inputs.count,8);assert.equal(peerFixtures.inputs.count,8);assert.notEqual(credentials.owner.value,peerCredentials.owner.value)")
+      .replace('creds.owner.value', "requiredPreparationCredential(credentials,'owner')")
+      .replace('peerCreds.owner.value', "requiredPreparationCredential(peerCredentials,'owner')");
+    await expect(verifyPreparationDraft(input, draft)).resolves.toBeUndefined();
+  }, 30_000);
+
+  it('checks dependencies for every profile before staging or executing any draft', async () => {
+    const { root, input, draft } = fixture();
+    const before = collectGuardSetupBundle(root);
+    draft.profiles[0].seed = "throw new Error('must not execute the first profile')";
+    draft.profiles.push({ ...draft.profiles[0], name: 'requires-aws', needs: ['aws'] });
+    await expect(verifyPreparationDraft(input, draft, { persist: true })).rejects.toThrow('Preparation dependency "aws"');
+    expect(collectGuardSetupBundle(root)).toEqual(before);
+    expect(fs.existsSync(path.join(root, '.truecourse/scenarios/preparations'))).toBe(false);
+  });
+
   it('proves a draft without saved writes, then persists while retaining existing setup', async () => {
     const { root, recipe, draft, input } = fixture();
     const original = fs.readFileSync(recipePath(root), 'utf8');
@@ -143,6 +169,92 @@ describe('targeted preparation authoring and hosted bundle protocol', () => {
 });
 
 describe('preparation authoring session completion gate', () => {
+  function contextFor(stub = stubDriver(() => outcome({ profiles: [], findings: ['No private state needed by this fixture'] }))) {
+    const persistence = memoryPersistence();
+    const acquire = vi.fn(async () => ({ runId: 'preparation-run', driver: stub.driver, persistence: persistence.persistence }));
+    const context: GuardSetupSessionContext = {
+      acquire, runId: () => 'preparation-run', note: () => {}, addSpend: () => {}, usageTotals: () => null, finish: () => {},
+    };
+    return { context, acquire };
+  }
+
+  it('briefs unavailable catalog-only AWS and provided accounts without their values', async () => {
+    const { root, input, draft } = fixture();
+    fs.writeFileSync(path.join(root, '.truecourse/scenarios/dependencies.json'), JSON.stringify({ dependencies: [
+      { name: 'aws', class: 'supplied', summary: 'S3 object storage', services: ['s3'], needs: [], registration: { kind: 'env', vars: [{ name: 'AWS_SECRET_ACCESS_KEY', description: 'Secret', secret: true }] } },
+      { name: 'database', class: 'supplied', summary: 'Database', needs: [], registration: { kind: 'env', vars: [{ name: 'DATABASE_URL', description: 'Connection', secret: true }] } },
+    ] }));
+    fs.writeFileSync(path.join(root, '.truecourse/scenarios/dependencies.local.json'), JSON.stringify({ database: { env: { DATABASE_URL: 'postgres://secret-briefing-test' } } }));
+    input.recipe.api!.env = { NEXT_PUBLIC_UPLOAD_TRANSPORT: 'database' };
+    const stub = stubDriver(call => {
+      const briefing = JSON.parse(call.briefing);
+      expect(briefing.dependencyAvailability.catalog).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'aws', state: 'unprovided', services: ['s3'] }),
+        expect.objectContaining({ name: 'database', state: 'provided' }),
+      ]));
+      expect(briefing.recipe.api.env.NEXT_PUBLIC_UPLOAD_TRANSPORT).toBe('database');
+      expect(call.briefing).not.toContain('secret-briefing-test');
+      expect(call.def.systemPrompt).toContain('read its IMPLEMENTATION');
+      return outcome({ profiles: [], findings: ['No isolation required'] });
+    });
+    const { context } = contextFor(stub);
+    expect(await buildPreparationSession(context)(input)).toMatchObject({ status: 'skipped' });
+    expect(stub.calls).toHaveLength(1);
+    draft.profiles[0].needs = ['database'];
+    await expect(verifyPreparationDraft(input, draft, { persist: true })).resolves.toBeUndefined();
+    expect(loadRecipe(root, recipePath(root))!.recipe.preparations!.ledger.needs).toEqual(['database']);
+  });
+
+  it('installs a local package before building and opening authoring on a fresh checkout', async () => {
+    const { root, input } = fixture();
+    fs.mkdirSync(path.join(root, 'local-package'));
+    fs.writeFileSync(path.join(root, 'local-package/package.json'), JSON.stringify({ name: 'preparation-fixture', version: '1.0.0', main: 'index.cjs' }));
+    fs.writeFileSync(path.join(root, 'local-package/index.cjs'), 'module.exports = 42;');
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ private: true, dependencies: { 'preparation-fixture': 'file:./local-package' } }));
+    fs.writeFileSync(path.join(root, 'build.cjs'), "require('node:assert').equal(require('preparation-fixture'), 42); require('node:fs').writeFileSync('built', 'ok');");
+    input.recipe.install = 'npm install --offline --ignore-scripts --package-lock=false --no-audit --no-fund --cache .npm-cache';
+    input.recipe.build = 'node build.cjs';
+    const phases: string[] = [];
+    const { context, acquire } = contextFor(stubDriver(() => {
+      expect(fs.readFileSync(path.join(root, 'built'), 'utf8')).toBe('ok');
+      return outcome({ profiles: [], findings: ['No private state needed by this fixture'] });
+    }));
+    expect(fs.existsSync(path.join(root, 'node_modules'))).toBe(false);
+    const result = await buildPreparationSession(context)({ ...input, onPhase: (_running, done) => phases.push(done) });
+    expect(result.status).toBe('skipped');
+    expect(acquire).toHaveBeenCalledOnce();
+    expect(phases).toEqual(['install', 'build', 'preparations']);
+  });
+
+  it.each(['install', 'build', 'services'] as const)('retains redacted %s diagnostics and never starts authoring after failure', async stage => {
+    const { root, input } = fixture();
+    const secret = 'local-password-for-test';
+    input.recipe.env = { DATABASE_URL: `postgres://user:${secret}@localhost/private` };
+    fs.writeFileSync(path.join(root, 'fail.cjs'), "console.error('fixture dependency missing', process.env.DATABASE_URL, new URL(process.env.DATABASE_URL).password); process.exit(7);");
+    fs.writeFileSync(path.join(root, 'build.cjs'), "require('node:fs').writeFileSync('built', 'ok');");
+    input.recipe.install = stage === 'install' ? 'node fail.cjs' : 'true';
+    input.recipe.build = stage === 'build' ? 'node fail.cjs' : 'node build.cjs';
+    if (stage === 'services') input.recipe.api!.services = { up: 'node fail.cjs', down: 'true' };
+    const { context, acquire } = contextFor();
+    const result = await buildPreparationSession(context)(input);
+    expect(result.status).toBe('failed');
+    expect(result.reason).toContain('exit 7');
+    expect(result.reason).toContain('fixture dependency missing');
+    expect(result.reason).not.toContain(secret);
+    expect(acquire).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(root, 'built'))).toBe(stage === 'services');
+  });
+
+  it('does not install, build, or open authoring when already cancelled', async () => {
+    const { root, input } = fixture();
+    input.recipe.install = "node -e \"require('fs').writeFileSync('installed', 'yes')\"";
+    const { context, acquire } = contextFor();
+    const result = await buildPreparationSession(context, { signal: AbortSignal.abort() })(input);
+    expect(result).toMatchObject({ status: 'failed', reason: expect.stringContaining('cancelled') });
+    expect(fs.existsSync(path.join(root, 'installed'))).toBe(false);
+    expect(acquire).not.toHaveBeenCalled();
+  });
+
   it('rejects an unverified outcome, verifies the exact draft on resume, then persists', async () => {
     const { root, draft, input } = fixture();
     const persistence = memoryPersistence();
@@ -192,6 +304,88 @@ describe('preparation authoring session completion gate', () => {
       loadRecipe(root, recipePath(root))!.recipe.preparations?.ledger,
     ).toBeDefined();
   }, 30_000);
+  it.each([false, true])('fails instead of caching an empty outcome after verification refusal (empty tool call: %s)', async emptyToolCall => {
+    const { root, input, draft } = fixture();
+    const original = collectGuardSetupBundle(root);
+    draft.profiles[0].verify = "throw new Error('peer credential lookup failed')";
+    const empty = { profiles: [], findings: ['Unable to verify private credentials'] };
+    let calls = 0;
+    const stub = stubDriver(async call => {
+      const tool = call.def.tools.find(tool => tool.name === 'verify_preparations')!;
+      const toolContext = { workItem: 'preparations', signal: new AbortController().signal, dispatchChild: async () => { throw new Error('no child'); } };
+      if (++calls === 1) {
+        const result = await tool.execute(draft, toolContext);
+        expect(result).toMatchObject({ isError: true, content: expect.stringContaining('peer credential lookup failed') });
+        if (emptyToolCall) expect(await tool.execute(empty, toolContext)).toMatchObject({ isError: true });
+      } else {
+        expect(call.input.initialMessages.join(' ')).toContain('peer credential lookup failed');
+      }
+      return outcome(empty);
+    });
+    const { context } = contextFor(stub);
+    expect(await buildPreparationSession(context)(input)).toMatchObject({ status: 'failed', reason: expect.stringContaining('peer credential lookup failed') });
+    expect(calls).toBeGreaterThan(1);
+    expect(collectGuardSetupBundle(root)).toEqual(original);
+  }, 30_000);
+
+  it('rejects an empty outcome that discards a successfully verified draft', async () => {
+    const { root, input, draft } = fixture();
+    const original = collectGuardSetupBundle(root);
+    let calls = 0;
+    const stub = stubDriver(async call => {
+      if (++calls === 1) {
+        const tool = call.def.tools.find(tool => tool.name === 'verify_preparations')!;
+        const checked = await tool.execute(draft, { workItem: 'preparations', signal: new AbortController().signal, dispatchChild: async () => { throw new Error('no child'); } });
+        expect(checked.isError).not.toBe(true);
+      }
+      return outcome({ profiles: [], findings: ['Discarded profiles'] });
+    });
+    const { context } = contextFor(stub);
+    expect(await buildPreparationSession(context)(input)).toMatchObject({ status: 'failed' });
+    expect(calls).toBeGreaterThan(1);
+    expect(collectGuardSetupBundle(root)).toEqual(original);
+  }, 30_000);
+
+  it('allows a repaired draft to resolve the verification failure and persist', async () => {
+    const { root, input, draft } = fixture();
+    let calls = 0;
+    const stub = stubDriver(async call => {
+      const tool = call.def.tools.find(tool => tool.name === 'verify_preparations')!;
+      const toolContext = { workItem: 'preparations', signal: new AbortController().signal, dispatchChild: async () => { throw new Error('no child'); } };
+      if (++calls === 1) {
+        const broken = structuredClone(draft);
+        broken.profiles[0].verify = "throw new Error('missing peer credential')";
+        expect(await tool.execute(broken, toolContext)).toMatchObject({ isError: true });
+        return outcome({ profiles: [], findings: ['Unable to verify'] });
+      }
+      expect((await tool.execute(draft, toolContext)).isError).not.toBe(true);
+      return outcome(draft);
+    });
+    const { context } = contextFor(stub);
+    expect(await buildPreparationSession(context)(input)).toMatchObject({ status: 'ok' });
+    expect(calls).toBe(2);
+    expect(loadRecipe(root, recipePath(root))!.recipe.preparations?.ledger).toBeDefined();
+  }, 30_000);
+
+  it('rejects missing Postgres cleanup before writes and keeps a valid declaration through persistence', async () => {
+    const { root, input, draft } = fixture();
+    const original = fs.readFileSync(recipePath(root), 'utf8');
+    draft.profiles[0].postgres = { isolation: 'database', urlEnvs: ['DATABASE_URL', 'DIRECT_URL'] };
+    const cleanup = draft.profiles[0].cleanup;
+    delete draft.profiles[0].cleanup;
+    await expect(verifyPreparationDraft(input, draft, { persist: true })).rejects.toThrow('cleanup');
+    expect(fs.readFileSync(recipePath(root), 'utf8')).toBe(original);
+    draft.profiles[0].cleanup = cleanup;
+    input.recipe.api!.env = { DATABASE_URL: 'postgres://local/shared', DIRECT_URL: 'postgres://direct/shared' };
+    await verifyPreparationDraft(input, draft, { persist: true });
+    expect(loadRecipe(root, recipePath(root))!.recipe.preparations!.ledger.postgres).toEqual(draft.profiles[0].postgres);
+    const bundle = collectGuardSetupBundle(root);
+    expect(Object.keys(bundle)).toContain('.truecourse/scenarios/preparations/ledger/cleanup.mjs');
+    const before = JSON.stringify(bundle);
+    draft.profiles[0].seed = "throw new Error('migration failed')";
+    await expect(verifyPreparationDraft(input, draft, { persist: true })).rejects.toThrow('migration failed');
+    expect(JSON.stringify(collectGuardSetupBundle(root))).toBe(before);
+  }, 30_000);
   it('rejects malformed drafts before any repository writes and requires reasons for unavailable isolation', async () => {
     const { root, input, draft } = fixture();
     const original = fs.readFileSync(recipePath(root), 'utf8');
@@ -204,6 +398,9 @@ describe('preparation authoring session completion gate', () => {
         findings: ['The application exposes no instance-wide namespace'],
       }).success,
     ).toBe(true);
+    const undeclared = structuredClone(draft);
+    delete (undeclared.profiles[0] as Partial<PreparationDraft['profiles'][number]>).needs;
+    expect(PreparationDraftSchema.safeParse(undeclared).success).toBe(false);
     draft.profiles[0].name = '../escape';
     await expect(
       verifyPreparationDraft(input, draft, { persist: true }),

--- a/tests/core/guard-setup-steps.test.ts
+++ b/tests/core/guard-setup-steps.test.ts
@@ -22,10 +22,11 @@ import type { GuardSetupPreparationSession } from '@truecourse/guard-generator';
 
 import { describe, it, expect, afterEach, afterAll, beforeAll, beforeEach } from 'vitest';
 import fs from 'node:fs';
+import { createHash } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { recipePath, readGuardSetup } from '@truecourse/guard-runner';
+import { recipePath, readGuardSetup, writeGuardSetup, computeRecipeFingerprint, computePreparationFingerprint } from '@truecourse/guard-runner';
 import { setDefaultTransport } from '@truecourse/shared/llm';
 import type {
   GuardSetupAuthStep,
@@ -160,7 +161,7 @@ function seams(): {
 const stepKeys = (r: string): string[] => (readGuardSetup(r)?.steps ?? []).map((s) => s.key);
 
 /** A real checklist tracker, plus a reader for the facts each step appended. */
-function factTracker(): { tracker: StepTracker; facts: (key: string) => string[] } {
+function factTracker(): { tracker: StepTracker; facts: (key: string) => string[]; steps: () => AnalysisStep[] } {
   let latest: AnalysisStep[] = [];
   const tracker = new StepTracker(
     (payload) => {
@@ -168,7 +169,7 @@ function factTracker(): { tracker: StepTracker; facts: (key: string) => string[]
     },
     GUARD_SETUP_STEPS.map((s) => ({ key: s.key, label: s.label })),
   );
-  return { tracker, facts: (key) => latest.find((s) => s.key === key)?.facts ?? [] };
+  return { tracker, facts: (key) => latest.find((s) => s.key === key)?.facts ?? [], steps: () => latest };
 }
 
 // ---------------------------------------------------------------------------
@@ -356,6 +357,28 @@ describe('estimateGuardSetupCost({ only })', () => {
 });
 
 describe('--only-preparations', () => {
+  it('fails the run and checklist, preserves other setup results, and retries the failed preparation', async () => {
+    const r = fixtureRepo(); writeRecipe(r);
+    await guardSetupInProcess(r, { interfaces: interfaces(), recipeRunner: neverCalled, ...seams() });
+    const before = readGuardSetup(r)!;
+    const track = factTracker();
+    const reason = 'Application build failed before private preparation verification (exit 7):\nmissing dependency';
+    const { report } = await guardSetupInProcess(r, {
+      only: 'preparations', refresh: true, interfaces: interfaces(), recipeRunner: neverCalled,
+      ...seams(), tracker: track.tracker, preparationSession: async () => ({ status: 'failed', reason }),
+    });
+    expect(report).toMatchObject({ status: 'failed', reason });
+    expect(readGuardSetup(r)).toMatchObject({ status: 'failed', reason });
+    expect(track.steps().find(step => step.key === 'preparations')?.status).toBe('error');
+    expect(track.steps().find(step => step.key === 'auth')?.status).toBe('pending');
+    for (const key of ['recipe', 'catalog', 'interfaces', 'seed', 'auth']) {
+      expect(report.steps.find(step => step.key === key)).toEqual(before.steps.find(step => step.key === key));
+    }
+    const retry = seams();
+    const recovered = await guardSetupInProcess(r, { only: 'preparations', interfaces: interfaces(), recipeRunner: neverCalled, ...retry });
+    expect(retry.reached).toEqual(['preparations']);
+    expect(recovered.report.status).toBe('ok');
+  });
   it('reauthors legacy profiles and estimates that work even when their old fingerprint is settled', async () => {
     const r = fixtureRepo();
     writeRecipe(r);
@@ -371,6 +394,28 @@ describe('--only-preparations', () => {
     const selected = seams();
     await guardSetupInProcess(r, { only: 'preparations', interfaces: interfaces(), recipeRunner: neverCalled, ...selected });
     expect(selected.reached).toEqual(['preparations']);
+  });
+  it.each(['legacy', 'postgres-v2', 'verifier-v3'])('refreshes a %s empty-profile skip once and gives the same answer to the estimator', async version => {
+    const r = fixtureRepo(); writeRecipe(r);
+    await guardSetupInProcess(r, { interfaces: interfaces(), recipeRunner: neverCalled, ...seams() });
+    const old = readGuardSetup(r)!;
+    old.steps.find(row => row.key === 'preparations')!.inputFingerprint = version === 'legacy'
+      ? computeRecipeFingerprint(r)
+      : createHash('sha256').update(version === 'postgres-v2' ? 'guard-preparations:2-postgres-database\n' : 'guard-preparations:3-verifier-inputs\n').update(computeRecipeFingerprint(r)).digest('hex');
+    writeGuardSetup(r, old);
+    const before = fs.readFileSync(recipePath(r), 'utf8');
+    const estimate = await estimateGuardSetupCost(r, { only: 'preparations' });
+    expect(estimate.stages?.find(stage => stage.stage === 'guard-setup.preparations')?.calls).toBeGreaterThan(0);
+    const refreshed = seams();
+    await guardSetupInProcess(r, { only: 'preparations', interfaces: interfaces(), recipeRunner: neverCalled, ...refreshed });
+    expect(refreshed.reached).toEqual(['preparations']);
+    expect(readGuardSetup(r)!.steps.find(row => row.key === 'preparations')!.inputFingerprint).toBe(computePreparationFingerprint(r));
+    const cached = seams();
+    await guardSetupInProcess(r, { only: 'preparations', interfaces: interfaces(), recipeRunner: neverCalled, ...cached });
+    expect(cached.reached).toEqual([]);
+    const cachedEstimate = await estimateGuardSetupCost(r, { only: 'preparations' });
+    expect(cachedEstimate.stages?.find(stage => stage.stage === 'guard-setup.preparations')?.calls ?? 0).toBe(0);
+    expect(fs.readFileSync(recipePath(r), 'utf8')).toBe(before);
   });
   it('refreshes private profiles without rerunning or replacing the existing seed and interfaces', async () => {
     const r = fixtureRepo();

--- a/tests/core/guard-setup.test.ts
+++ b/tests/core/guard-setup.test.ts
@@ -23,6 +23,7 @@ import { fileURLToPath } from 'node:url';
 import {
   recipePath,
   computeRecipeFingerprint,
+  computePreparationFingerprint,
   readGuardSetup,
   writeGuardSetup,
   dependenciesPath,
@@ -496,7 +497,7 @@ function settledRepo(): string {
       { key: 'catalog', status: 'ok', inputFingerprint: 'settled-catalog' },
       { key: 'interfaces', status: 'ok', inputFingerprint: interfacesFingerprint(r) },
       { key: 'seed', status: 'ok', inputFingerprint: computeSeedStepFingerprint(r) },
-      { key: 'preparations', status: 'ok', inputFingerprint: computeRecipeFingerprint(r) },
+      { key: 'preparations', status: 'ok', inputFingerprint: computePreparationFingerprint(r) },
       { key: 'auth', status: 'ok', inputFingerprint: authFingerprint(r) },
     ],
   };

--- a/tests/dashboard-client/conversation-model.test.ts
+++ b/tests/dashboard-client/conversation-model.test.ts
@@ -14,7 +14,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, it, expect } from 'vitest';
 import type { SessionEvent } from '@truecourse/agent-loop';
-import type { ActivityEvent } from '@truecourse/shared/activity-stream';
+import { compactRunSnapshots, type ActivityEvent } from '@truecourse/shared/activity-stream';
 import { foldConversation, latestRunRecord } from '@/components/sessions/conversation-model';
 import type { ConversationLine } from '@/components/sessions/conversation-model';
 import type { PublicSessionRun } from '@/lib/api';
@@ -24,6 +24,13 @@ const read = <T,>(name: string): T =>
 
 const SETUP_RUN = read<PublicSessionRun>('guard-setup-run.json');
 const SETUP_JOURNAL = read<ActivityEvent[]>('guard-setup-journal.json');
+
+it('renders the same conversation after discarding superseded snapshots', () => {
+  const compact = compactRunSnapshots(SETUP_JOURNAL);
+  expect(compact.filter(e => e.kind === 'run')).toHaveLength(1);
+  expect(compact.length).toBeLessThan(SETUP_JOURNAL.length);
+  expect(foldConversation(SETUP_RUN, compact)).toEqual(foldConversation(SETUP_RUN, SETUP_JOURNAL));
+});
 
 const RECIPE = '26356f92-1e71-46fe-a74a-d1eba5d1c020';
 const PREPARATIONS = 'f8c000b1-3a51-4da0-a1a6-1ce664249e73';

--- a/tests/dashboard-client/preview-scan-trigger.test.tsx
+++ b/tests/dashboard-client/preview-scan-trigger.test.tsx
@@ -227,6 +227,18 @@ describe('the surfaces of a connected repository', () => {
     );
   });
 
+  it.each(['interrupted', 'failed'] as const)('resumes %s generation with its run ID', async status => {
+    const run = failedScan({ command: 'guard-generate', status });
+    serve({ runs: [run], config: { provider: 'anthropic' } });
+    renderAt(conversation(run.runId));
+    await userEvent.setup().click(await screen.findByRole('button', { name: 'Resume' }));
+    await waitFor(() => expect(window.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/api/repos/${REAL.id}/guard/generate`),
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ resumeRunId: run.runId }) }),
+    ));
+    expect(screen.queryByRole('button', { name: 'Run again' })).toBeNull();
+  });
+
   it('leaves a finished one alone', async () => {
     const done = failedScan({ status: 'completed', error: undefined });
     serve({ runs: [done], config: { provider: 'anthropic' } });

--- a/tests/dashboard-client/run-conversation-page.test.tsx
+++ b/tests/dashboard-client/run-conversation-page.test.tsx
@@ -106,6 +106,25 @@ const pane = () => screen.getByRole('complementary', { name: 'Work' });
 const rx = (text: string) => new RegExp(`^${text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
 
 describe('one conversation, as a page', () => {
+  it('requests compact history and aborts its pending download when closed', async () => {
+    let signal: AbortSignal | undefined;
+    let requested: URL | undefined;
+    window.fetch = vi.fn((input, init) => {
+      requested = new URL(String(input), window.location.origin);
+      signal = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+      });
+    }) as typeof window.fetch;
+    const view = renderPage(SETUP_RUN);
+    await waitFor(() => expect(requested?.searchParams.get('compact')).toBe('1'));
+    expect(signal?.aborted).toBe(false);
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
+    await Promise.resolve();
+    expect(window.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it('lists the run’s steps in order, each with the work that happened under it as rows', async () => {
     serve(SETUP_JOURNAL);
     renderPage(SETUP_RUN);

--- a/tests/dashboard-client/run-conversation-page.test.tsx
+++ b/tests/dashboard-client/run-conversation-page.test.tsx
@@ -2,7 +2,7 @@
  * The conversation as a page: the run's work as a list on the left (steps as
  * headings, one row per piece of work with its status dot and title), and the
  * selected work's transcript on the right, verbatim, with the history behind
- * it read by page off the activity route.
+ * it read by page from the selected session transcript.
  *
  * The run under test is the real guard setup of `spiderhands/expense-tracker`,
  * served from the fixture journal exactly as the route would page it. What is
@@ -14,10 +14,9 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { createUIMessageStreamResponse, type UIMessageChunk } from 'ai';
 import type { SessionEvent } from '@truecourse/agent-loop';
 import type { ActivityEvent } from '@truecourse/shared/activity-stream';
 
@@ -47,14 +46,16 @@ function serve(journal: ActivityEvent[], pageSize = 1000) {
   window.fetch = vi.fn(async (input: RequestInfo | URL) => {
     const href = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
     const url = new URL(href, window.location.origin);
-    if (url.pathname.endsWith('/activity')) {
-      const after = Number(url.searchParams.get('after'));
-      const rest = journal.filter((e) => e.cursor > after);
-      const events = rest.slice(0, pageSize);
-      const last = events[events.length - 1];
-      return json({ events, nextCursor: last ? last.cursor : after, done: rest.length <= pageSize });
+    if (url.pathname.includes('/transcript/')) {
+      const id = decodeURIComponent(url.pathname.split('/transcript/')[1]);
+      let events = journal.filter((e): e is Extract<ActivityEvent, { kind: 'session-event' }> => e.kind === 'session-event' && e.sessionId === id).map(e => e.event);
+      const since = url.searchParams.get('since'), before = url.searchParams.get('before');
+      if (since !== null) events = events.filter(e => e.seq > Number(since));
+      if (before !== null) events = events.filter(e => e.seq < Number(before));
+      const limit = Math.min(pageSize, Number(url.searchParams.get('limit')));
+      return json({ events: since === null ? events.slice(-limit) : events.slice(0, limit), hasMore: events.length > limit });
     }
-    return json({ error: 'not found' }, 404);
+    throw new Error(`Unexpected request ${href}`);
   }) as unknown as typeof window.fetch;
 }
 
@@ -106,7 +107,7 @@ const pane = () => screen.getByRole('complementary', { name: 'Work' });
 const rx = (text: string) => new RegExp(`^${text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
 
 describe('one conversation, as a page', () => {
-  it('requests compact history and aborts its pending download when closed', async () => {
+  it('fetches only the opened agent and aborts its pending download when closed', async () => {
     let signal: AbortSignal | undefined;
     let requested: URL | undefined;
     window.fetch = vi.fn((input, init) => {
@@ -117,12 +118,35 @@ describe('one conversation, as a page', () => {
       });
     }) as typeof window.fetch;
     const view = renderPage(SETUP_RUN);
-    await waitFor(() => expect(requested?.searchParams.get('compact')).toBe('1'));
+    expect(window.fetch).not.toHaveBeenCalled();
+    await userEvent.click(row(rx(SETUP_RUN.sessions[0].workItem)));
+    await waitFor(() => expect(requested?.pathname).toContain(`/transcript/${RECIPE}`));
+    expect(requested?.searchParams.get('limit')).toBe('100');
     expect(signal?.aborted).toBe(false);
     view.unmount();
     expect(signal?.aborted).toBe(true);
     await Promise.resolve();
     expect(window.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a late response from the previously selected agent', async () => {
+    let release!: (response: Response) => void;
+    let previousSignal: AbortSignal | null | undefined;
+    window.fetch = vi.fn(async (input, init) => {
+      if (String(input).includes(`/transcript/${RECIPE}?`)) {
+        previousSignal = init?.signal;
+        return new Promise<Response>(resolve => { release = resolve; });
+      }
+      return json({ events: [{ type: 'user-message', seq: 0, ts: new Date().toISOString(), content: 'Selected agent message' }], hasMore: false });
+    }) as typeof window.fetch;
+    renderPage(SETUP_RUN);
+    await userEvent.click(row(rx(SETUP_RUN.sessions[0].workItem)));
+    await userEvent.click(row(rx(SETUP_RUN.sessions[1].workItem)));
+    expect(previousSignal?.aborted).toBe(true);
+    await screen.findByText('Selected agent message');
+    await act(async () => { release(json({ events: [{ type: 'user-message', seq: 0, ts: new Date().toISOString(), content: 'Stale agent message' }], hasMore: false })); });
+    expect(screen.queryByText('Stale agent message')).toBeNull();
+    expect(screen.getByText('Selected agent message')).toBeInTheDocument();
   });
 
   it('lists the run’s steps in order, each with the work that happened under it as rows', async () => {
@@ -406,111 +430,53 @@ describe('one conversation, as a page', () => {
     expect(screen.queryAllByRole('heading', { level: 2 })).toHaveLength(0);
   });
 
-  it('waits for the whole history, then paints it', async () => {
-    serve(SETUP_JOURNAL, 20);
+  it('renders the summary without fetching transcripts and loads older messages only on request', async () => {
+    serve(SETUP_JOURNAL, 10);
     renderPage(SETUP_RUN);
-
-    // Nothing half-read is painted: the list appears with the whole of it.
-    expect(screen.queryAllByRole('heading', { level: 2 })).toHaveLength(0);
-    expect(screen.getByRole('status')).toHaveTextContent('Reading the conversation…');
-    await screen.findByRole('heading', { level: 2, name: /Deriving the recipe/ });
     expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(8);
+    expect(window.fetch).not.toHaveBeenCalled();
+    await userEvent.click(row(rx(SETUP_RUN.sessions[0].workItem)));
+    await screen.findByRole('button', { name: 'Load older messages' });
+    expect(window.fetch).toHaveBeenCalledTimes(1);
+    await userEvent.click(screen.getByRole('button', { name: 'Load older messages' }));
+    await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(2));
+    expect(String(vi.mocked(window.fetch).mock.calls[1][0])).toContain('before=');
+    await userEvent.click(row(rx(SETUP_RUN.sessions[1].workItem)));
+    await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(3));
+    expect(String(vi.mocked(window.fetch).mock.calls[2][0])).toContain(`/transcript/${SETUP_RUN.sessions[1].sessionId}`);
   });
 
-  it('reads the history in pages, then tails what is still happening into the open work', async () => {
-    const live: PublicSessionRun = {
-      ...SETUP_RUN,
-      status: 'running',
-      finishedAt: undefined,
-      sessions: [{ ...SETUP_RUN.sessions[0], status: 'running' }],
-    } as PublicSessionRun;
-    // No record snapshots: this one is still going, and the journal's would say
-    // otherwise.
-    const history = SETUP_JOURNAL.filter(
-      (e) => e.kind === 'session-event' && e.sessionId === RECIPE,
-    );
-    serve(history, 20);
-    const paged = window.fetch;
-
-    let sink!: ReadableStreamDefaultController<UIMessageChunk>;
-    const stream = new ReadableStream<UIMessageChunk>({ start: (c) => (sink = c) });
-    window.fetch = vi.fn(async (input, init) => {
-      if (String(input).includes('/stream?')) return createUIMessageStreamResponse({ stream });
-      return paged(input, init);
-    }) as unknown as typeof window.fetch;
-
+  it('fetches only new events for the opened live agent', async () => {
+    const live = { ...SETUP_RUN, status: 'running', finishedAt: undefined, sessions: SETUP_RUN.sessions.map(s => s.sessionId === RECIPE ? { ...s, status: 'running' } : s) } as PublicSessionRun;
+    const history = [...SETUP_JOURNAL];
+    serve(history);
     const view = renderPage(live);
-    await screen.findByRole('heading', { level: 2, name: /Deriving the recipe/ });
-    const last = history[history.length - 1].cursor;
-    await waitFor(() =>
-      expect(window.fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`/stream?after=${last}`),
-        expect.objectContaining({ method: 'GET' }),
-      ),
-    );
-    expect(paged).toHaveBeenCalledTimes(Math.ceil(history.length / 20));
-
-    // The running piece of work wears the pulsing dot in the list.
-    const [running] = screen.getAllByRole('button', { pressed: false });
-    expect(running.querySelector('.animate-pulse')).not.toBeNull();
-    await userEvent.click(running);
-    const work = within(pane());
-
-    sink.enqueue({ type: 'start', messageId: live.runId });
-    // A partial turn stands as the live line until its finished form lands.
-    sink.enqueue({
-      type: 'data-progress',
-      transient: true,
-      data: { [RECIPE]: { kind: 'text', turnId: 'm1', text: 'Reading the recipe live' } },
-    });
-    await work.findByText('Reading the recipe live');
-
-    sink.enqueue({
-      type: 'data-activity',
-      id: 'live-1',
-      data: {
-        kind: 'session-event',
-        cursor: last + 1,
-        sessionId: RECIPE,
-        event: {
-          type: 'assistant-turn',
-          seq: 9999,
-          ts: '2026-09-09T16:31:00.000Z',
-          text: 'The recipe boots cleanly now.',
-          usage: {
-            inputTokens: 1,
-            outputTokens: 1,
-            cacheReadTokens: 0,
-            cacheCreateTokens: 0,
-            costUsd: 0,
-            costSource: 'unpriced',
-          },
-        },
-      },
-    });
-    expect(await work.findByText('The recipe boots cleanly now.')).toBeInTheDocument();
-    expect(work.getAllByText('The recipe boots cleanly now.')).toHaveLength(1);
-    expect(work.queryByText('Reading the recipe live')).toBeNull();
-
-    sink.enqueue({ type: 'finish', finishReason: 'stop' });
-    sink.close();
-    view.unmount();
+    await userEvent.click(row(rx(SETUP_RUN.sessions[0].workItem)));
+    await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByText('Loading messages…')).toBeNull());
+    vi.useFakeTimers();
+    try {
+      history.push({ cursor: 9999, kind: 'session-event', sessionId: RECIPE,
+        event: { type: 'user-message', seq: 9999, ts: '2026-09-09T16:31:00.000Z', content: 'A newly recorded message' } });
+      // The first timer was created before fake timers; trigger after mounting afresh.
+      view.unmount();
+      const fresh = render(<MemoryRouter initialEntries={[`/?work=${RECIPE}`]}><RunConversationPage run={live} repoId="r1" /></MemoryRouter>);
+      await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      expect(String(vi.mocked(window.fetch).mock.calls.at(-1)![0])).toContain('since=9999');
+      expect(within(pane()).getAllByText('A newly recorded message')).toHaveLength(1);
+      fresh.unmount();
+    } finally { vi.useRealTimers(); }
   });
 
-  it('says the connection dropped at the bottom of the list, never as a strip on top', async () => {
-    const live = { ...SETUP_RUN, status: 'running', finishedAt: undefined } as PublicSessionRun;
-    serve(SETUP_JOURNAL);
-    const paged = window.fetch;
-    window.fetch = vi.fn(async (input, init) => {
-      if (String(input).includes('/stream?')) return json({ error: 'gone' }, 403);
-      return paged(input, init);
-    }) as unknown as typeof window.fetch;
-
-    const view = renderPage(live);
-    const notice = await screen.findByText(/Activity access was denied/);
-    expect(notice).toHaveAttribute('role', 'status');
-    view.unmount();
+  it('shows a selected transcript error without downloading other agents', async () => {
+    window.fetch = vi.fn(async () => json({ error: 'Transcript unavailable' }, 500)) as typeof window.fetch;
+    renderPage(SETUP_RUN);
+    await userEvent.click(row(rx(SETUP_RUN.sessions[0].workItem)));
+    expect(await screen.findByText(/Transcript unavailable/)).toBeInTheDocument();
+    expect(window.fetch).toHaveBeenCalledTimes(1);
   });
+
 });
 
 describe('the words the page is allowed to use', () => {

--- a/tests/dashboard-server/guard-generate-resume.test.ts
+++ b/tests/dashboard-server/guard-generate-resume.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, afterEach, describe, it, expect } from 'vitest';
+import request from 'supertest';
+import path from 'node:path';
+import type { Express } from 'express';
+import { createSessionRun } from '@truecourse/core/lib/sessions-store';
+import { createTestApp, stubJobs, type StubJobs } from '../helpers/test-app';
+import { setupTestFixture, teardownTestFixture, type TestFixture } from '../helpers/test-db';
+
+describe('guard generate resume route', () => {
+  let fixture: TestFixture;
+  let app: Express;
+  let jobs: StubJobs;
+  const url = () => `/api/repos/${fixture.project.slug}/guard/generate`;
+  beforeEach(async () => {
+    fixture = await setupTestFixture();
+    jobs = stubJobs();
+    app = createTestApp({ jobs: jobs.mount });
+  });
+  afterEach(async () => { await teardownTestFixture(fixture.project.slug); });
+
+  it('enqueues the saved run identity, ignoring client-supplied completed steps', async () => {
+    const run = createSessionRun(fixture.repoPath, { command: 'guard-generate', gitRef: 'a'.repeat(40) });
+    run.finish('interrupted');
+    await request(app).post(url()).send({ resumeRunId: run.runId, completedSteps: ['author'] }).expect(202);
+    expect(jobs.guardGenerates).toEqual([expect.objectContaining({ resumeRunId: run.runId })]);
+    expect(jobs.guardGenerates[0]).not.toHaveProperty('completedSteps');
+  });
+
+  it.each(['running', 'completed'] as const)('does not resume a %s run', async status => {
+    const run = createSessionRun(fixture.repoPath, { command: 'guard-generate', gitRef: 'a'.repeat(40) });
+    if (status === 'completed') run.finish(status);
+    await request(app).post(url()).send({ resumeRunId: run.runId }).expect(422);
+    expect(jobs.guardGenerates).toEqual([]);
+  });
+
+  it('does not find another command under the generation namespace', async () => {
+    const run = createSessionRun(fixture.repoPath, { command: 'spec-scan', gitRef: 'a'.repeat(40) });
+    run.finish('interrupted');
+    await request(app).post(url()).send({ resumeRunId: run.runId }).expect(404);
+    expect(jobs.guardGenerates).toEqual([]);
+  });
+
+  it('does not resume a run owned by another repository', async () => {
+    const run = createSessionRun(path.join(fixture.repoPath, 'another-repo'), { command: 'guard-generate', gitRef: 'a'.repeat(40) });
+    run.finish('interrupted');
+    await request(app).post(url()).send({ resumeRunId: run.runId }).expect(404);
+    expect(jobs.guardGenerates).toEqual([]);
+  });
+
+  it.each([null, 7, '../other-repo/run', ''])('rejects malformed identity %j', async resumeRunId => {
+    await request(app).post(url()).send({ resumeRunId }).expect(400);
+    expect(jobs.guardGenerates).toEqual([]);
+  });
+
+  it('still permits an explicitly fresh generation', async () => {
+    await request(app).post(url()).send({}).expect(202);
+    expect(jobs.guardGenerates).toHaveLength(1);
+    expect(jobs.guardGenerates[0]).not.toHaveProperty('resumeRunId');
+  });
+});

--- a/tests/dashboard-server/onboarding-jobs.test.ts
+++ b/tests/dashboard-server/onboarding-jobs.test.ts
@@ -781,6 +781,61 @@ describe('the guard generate job', () => {
     expect(disposed).toEqual([clone]);
   });
 
+  it('resumes from Postgres history after the original clone and backend instance are gone', async () => {
+    setSessionRunBackend(new PgSessionRunStore(db));
+    const savedTree = path.join(makeTmpDir('tc-resume-input-'), 'tree');
+    generateImpl = async (repoRoot, options) => {
+      fs.cpSync(repoRoot, savedTree, { recursive: true });
+      for (const key of ['index', 'extract', 'interfaces', 'flows', 'match']) options?.tracker?.done(key);
+      options?.tracker?.start('author');
+      options?.tracker?.start('validate');
+      throw new Error('worker interrupted');
+    };
+    await saveSetupBundle();
+    await jobs.enqueueGuardGenerate(request);
+    await Promise.all(running);
+    const [source] = await listStoredSessionRuns(REPO, 'guard-generate');
+    expect(source.status).toBe('failed');
+    expect(fs.existsSync(clone)).toBe(false);
+
+    setSessionRunBackend(new PgSessionRunStore(db));
+    setWorkTreeProvider(async () => {
+      fs.cpSync(savedTree, clone, { recursive: true });
+      return { dir: clone, dispose: () => fs.rmSync(clone, { recursive: true, force: true }) };
+    });
+    let resumed = false;
+    generateImpl = async (repoRoot, options) => {
+      expect(options?.resume).toEqual({
+        runId: source.runId, gitRef: source.gitRef,
+        completedSteps: ['index', 'extract', 'interfaces', 'flows', 'match'],
+      });
+      resumed = true;
+      return authoring(repoRoot, options);
+    };
+    await jobs.enqueueGuardGenerate({ ...request, resumeRunId: source.runId });
+    await Promise.all(running);
+    expect(resumed).toBe(true);
+    expect((await jobsOfType('repo.guard-generate')).map(job => job.status).sort()).toEqual(['failed', 'succeeded']);
+    expect((await openStoredSessionRun(REPO, 'guard-generate', source.runId)).record().status).toBe('failed');
+  });
+
+  it('refuses a resume at a different commit before generation runs', async () => {
+    await saveSetupBundle();
+    generateImpl = async (_root, options) => {
+      options?.sessionRun?.setGitRef?.('a'.repeat(40));
+      throw new Error('interrupted');
+    };
+    await jobs.enqueueGuardGenerate(request);
+    await Promise.all(running);
+    const [source] = await listStoredSessionRuns(REPO, 'guard-generate');
+    let calls = 0;
+    generateImpl = async (...args) => { calls++; return authoring(...args); };
+    await jobs.enqueueGuardGenerate({ ...request, resumeRunId: source.runId });
+    await Promise.all(running);
+    expect(calls).toBe(0);
+    expect((await jobsOfType('repo.guard-generate')).some(job => job.error?.includes('commit has changed'))).toBe(true);
+  });
+
   it.each(['file', 'postgres'])('materializes and persists generated results with %s activity history', async storage => {
     if (storage === 'postgres') setSessionRunBackend(new PgSessionRunStore(db));
     await saveSetupBundle();

--- a/tests/dashboard-server/onboarding-jobs.test.ts
+++ b/tests/dashboard-server/onboarding-jobs.test.ts
@@ -317,6 +317,7 @@ describe('the guard setup job', () => {
   const catalogCalls: string[] = [];
   /** Whether the clone held the dependencies overlay when the engine looked. */
   const overlaysSeen: boolean[] = [];
+  let preparationError: string | undefined;
 
   /** A fresh clone of the fixture at a stable path, as a run really gets one. */
   function installWorkTree(): void {
@@ -358,6 +359,7 @@ describe('the guard setup job', () => {
   beforeEach(async () => {
     catalogCalls.length = 0;
     overlaysSeen.length = 0;
+    preparationError = undefined;
     installWorkTree();
     // The scan's output, as the store holds it: setup reads the curated doc
     // universe, and the job materializes it into the clone.
@@ -418,7 +420,9 @@ describe('the guard setup job', () => {
             },
             authorInterfaces: async () => ({ status: 'skipped', reason: 'stubbed in this suite' }),
             seedSession: async () => ({ status: 'skipped', reason: 'stubbed in this suite' }),
-            preparationSession: async () => ({ status: 'skipped', reason: 'stubbed in this suite' }),
+            preparationSession: async () => preparationError
+              ? { status: 'failed', reason: preparationError }
+              : { status: 'skipped', reason: 'stubbed in this suite' },
             verifyAuth: async () => ({ status: 'skipped', reason: 'stubbed in this suite' }),
           }),
       },
@@ -516,6 +520,27 @@ describe('the guard setup job', () => {
     expect(enqueuedPayloads[1]).toMatchObject({ jobId: generate?.id, repoFullName: REPO, source: 'chain' });
   }, 60_000);
 
+  it.each(['file', 'postgres'])('persists a preparation failure, fails the job and Activity, and chains nothing with %s history', async storage => {
+    if (storage === 'postgres') setSessionRunBackend(new PgSessionRunStore(db));
+    preparationError = 'Application install failed before private preparation verification (exit 7):\nfixture dependency missing';
+    await jobs.enqueueGuardSetup(request);
+    await Promise.all(running);
+    const [job] = await jobsOfType('repo.guard-setup');
+    expect(job).toMatchObject({ status: 'failed', error: preparationError });
+    expect(enqueued).toEqual(['repo.guard-setup']);
+    const bundle = (await loadGuardSetupBundle(REPO))!;
+    const report = JSON.parse(bundle['.truecourse/guard/setup.json']);
+    expect(report).toMatchObject({ status: 'failed', reason: preparationError });
+    expect(report.steps.find((step: { key: string }) => step.key === 'preparations')).toMatchObject({ status: 'failed', reason: preparationError });
+    expect(report.steps.some((step: { key: string }) => step.key === 'auth')).toBe(false);
+    const [run] = await listStoredSessionRuns(REPO, 'guard-setup');
+    expect(run).toMatchObject({ status: 'failed', error: { message: preparationError } });
+    const checklist = run.display?.blocks.find(block => block.kind === 'checklist') as { items: { key: string; status: string }[] };
+    expect(checklist.items.find(item => item.key === 'preparations')?.status).toBe('error');
+    expect(checklist.items.find(item => item.key === 'auth')?.status).toBe('pending');
+    expect(disposed).toEqual([clone]);
+  }, 60_000);
+
   it('chains nothing when setup was refused', async () => {
     await jobs.stop();
     jobs = createServerJobs({
@@ -525,8 +550,7 @@ describe('the guard setup job', () => {
       startWorker: fakeWorker(['repo.guard-setup']),
       guardSetup: {
         startLlm: async () => testLlm,
-        // A setup whose recipe gate failed: the job itself succeeds (the refusal
-        // is the report), but there is no recipe to generate against.
+        // A setup whose recipe gate failed must also fail the queued job.
         runSetup: async () =>
           ({
             report: { ranAt: '2026-01-01T00:00:00Z', status: 'failed', reason: 'no recipe', steps: [] },
@@ -542,7 +566,7 @@ describe('the guard setup job', () => {
 
     expect(enqueued).toEqual(['repo.guard-setup']);
     const [setup] = await jobsOfType('repo.guard-setup');
-    expect(setup).toMatchObject({ status: 'succeeded', result: { status: 'failed' } });
+    expect(setup).toMatchObject({ status: 'failed', error: 'no recipe' });
     expect(await jobsOfType('repo.guard-generate')).toEqual([]);
   });
 

--- a/tests/data-store/session-run-store.test.ts
+++ b/tests/data-store/session-run-store.test.ts
@@ -48,6 +48,26 @@ async function create(command: 'spec-scan' | 'guard-setup' | 'guard-generate' | 
 }
 
 describe('Postgres activity storage', () => {
+  it('coalesces a settlement burst while retaining facts and transcript ordering', async () => {
+    const run = await create();
+    const facts: string[] = [];
+    for (let i = 0; i < 687; i++) {
+      facts.push(`flow ${i}: ${'x'.repeat(500)}`);
+      run.setChecklist([{ key: 'validate', label: 'Settling', status: 'active', facts: [...facts] }]);
+    }
+    run.persistence.appendEvent('worker', event(0));
+    run.setChecklist([{ key: 'validate', label: 'Settling', status: 'done', facts: [...facts] }]);
+    run.finish('completed');
+    await run.flush!();
+    const history = await run.readActivity!(-1);
+    // Initial, one coalesced burst, transcript, final checklist, terminal.
+    expect(history).toHaveLength(5);
+    expect(history[1]).toMatchObject({ kind: 'run', run: { display: { blocks: [{ items: [{ status: 'active', facts }] }] } } });
+    expect(history[2]).toMatchObject({ kind: 'session-event', event: { type: 'user-message', seq: 0 } });
+    expect(history[3]).toMatchObject({ kind: 'run', run: { display: { blocks: [{ items: [{ status: 'done', facts }] }] } } });
+    expect(history[4]).toMatchObject({ kind: 'run', run: { status: 'completed' } });
+  });
+
   it('compacts snapshot-heavy pages without skipping transcripts or altering stored history', async () => {
     const run = await create();
     for (let i = 0; i < 100; i++) run.setGitRef!(`${i}-${'x'.repeat(10_000)}`);
@@ -187,6 +207,7 @@ describe('Postgres activity storage', () => {
       })());
     });
     run.setChecklist([{ key: 'a', label: 'Read documents', status: 'active' }]);
+    await run.flush!(); // Already-published snapshots must never be coalesced.
     run.setChecklist([{ key: 'a', label: 'Read documents', status: 'done' }]);
     await run.flush!(); await Promise.all(observations); unsubscribe();
     const events = await run.readActivity!(-1);

--- a/tests/data-store/session-run-store.test.ts
+++ b/tests/data-store/session-run-store.test.ts
@@ -48,6 +48,27 @@ async function create(command: 'spec-scan' | 'guard-setup' | 'guard-generate' | 
 }
 
 describe('Postgres activity storage', () => {
+  it('compacts snapshot-heavy pages without skipping transcripts or altering stored history', async () => {
+    const run = await create();
+    for (let i = 0; i < 100; i++) run.setGitRef!(`${i}-${'x'.repeat(10_000)}`);
+    run.persistence.appendEvent('s', event(0));
+    run.setGitRef!('latest');
+    run.persistence.appendEvent('s', event(1));
+    run.finish('completed');
+    await run.flush!();
+    const whole = await run.readActivity!(-1);
+    const first = await readStoredActivityPage(run, -1, 100, true);
+    expect(first).toEqual({ events: [whole[99]], nextCursor: 99, done: false });
+    expect(JSON.stringify(first).length).toBeLessThan(JSON.stringify(whole).length / 50);
+    const second = await readStoredActivityPage(run, first.nextCursor, 100, true);
+    expect(second.events).toEqual(whole.slice(100).filter(e => e.kind !== 'run' || e.cursor === whole.at(-1)!.cursor));
+    expect(second.nextCursor).toBe(whole.at(-1)!.cursor);
+    expect(second.done).toBe(true);
+    expect(await readStoredActivityPage(run, second.nextCursor, 100, true)).toEqual({ events: [], nextCursor: second.nextCursor, done: true });
+    expect(await run.readActivity!(-1)).toEqual(whole);
+    await expect(readStoredActivityPage(run, 900, 100, true)).rejects.toThrow('boundary');
+  });
+
   const arbitraryText = 'before\u0000after \\u0000 lone \ud800 emoji 🎉';
 
   it.each([false, true])('imports transcripts losslessly, with activity journal=%s', async activityStream => {

--- a/tests/data-store/session-run-store.test.ts
+++ b/tests/data-store/session-run-store.test.ts
@@ -48,6 +48,29 @@ async function create(command: 'spec-scan' | 'guard-setup' | 'guard-generate' | 
 }
 
 describe('Postgres activity storage', () => {
+  it('pages only the selected session in both directions with a SQL limit', async () => {
+    const run = await create();
+    for (let seq = 0; seq < 7; seq++) {
+      run.persistence.appendEvent('selected', event(seq));
+      run.persistence.appendEvent('sibling', { ...event(seq), content: 'Not requested' });
+    }
+    await run.flush!();
+    queries.length = 0;
+    const recent = await run.readTranscriptPage!('selected', { limit: 3 });
+    expect(recent.events.map(e => e.seq)).toEqual([4, 5, 6]);
+    expect(recent.hasMore).toBe(true);
+    expect(queries.some(q => q.query.includes('limit') && q.params.includes('selected') && q.params.includes(4))).toBe(true);
+    const older = await run.readTranscriptPage!('selected', { limit: 3, before: 4 });
+    expect(older.events.map(e => e.seq)).toEqual([1, 2, 3]);
+    const first = await run.readTranscriptPage!('selected', { limit: 3, before: 1 });
+    expect(first.events.map(e => e.seq)).toEqual([0]);
+    expect(first.hasMore).toBe(false);
+    const newer = await run.readTranscriptPage!('selected', { limit: 3, since: 1 });
+    expect(newer.events.map(e => e.seq)).toEqual([2, 3, 4]);
+    expect(newer.hasMore).toBe(true);
+    expect(await run.readTranscriptPage!('missing', { limit: 3 })).toEqual({ events: [], hasMore: false });
+  });
+
   it('coalesces a settlement burst while retaining facts and transcript ordering', async () => {
     const run = await create();
     const facts: string[] = [];

--- a/tests/fixtures/guard-authoring-benchmark/fixture.ts
+++ b/tests/fixtures/guard-authoring-benchmark/fixture.ts
@@ -1,0 +1,36 @@
+import type { Interface, InterfaceResource } from '../../../../packages/shared/src/index.js'
+import type { AuthorUserContext } from '../../../../packages/guard-generator/src/prompts.js'
+import type { GuardFailureObservation } from '../../../../packages/shared/src/guard/failure-observation.js'
+
+export const FIXTURE_VERSION = 1
+export function missingDialogObservation(): Extract<GuardFailureObservation, { kind: 'web-target' }> {
+  return { version: 1, kind: 'web-target', assertion: 'visible:0', page: 'guard-server://web/organisations',
+    operation: 'to see', locator: { role: 'dialog', name: 'Create organisation' }, matchCount: 0, visibility: 'hidden', reason: 'absent' }
+}
+export function authoringFixture() {
+  const interfaces: Interface[] = Array.from({ length: 1200 }, (_, n) => ({
+    id: `web/archive-${String(n).padStart(4, '0')}`, type: 'web', title: `Archive screen ${n}`,
+    entry: { method: 'GET', path: `/archive/${n}` }, steps: [{ kind: 'navigate', path: `/archive/${n}` }],
+    fingerprint: `sha256:synthetic-${n}`, at: `screen-${n}`,
+  } as Interface))
+  const own = { id: 'web/create-organisation', type: 'web', title: 'Create organisation',
+    entry: { method: 'GET', path: '/organisations' }, steps: [{ kind: 'navigate', path: '/organisations' }],
+    fingerprint: 'sha256:organisation', at: 'organisations' } as Interface
+  const late = { id: 'web/zz-member-invite', type: 'web', title: 'Invite member',
+    entry: { method: 'GET', path: '/teams/members' }, steps: [{ kind: 'navigate', path: '/teams/members' }],
+    fingerprint: 'sha256:invite', at: 'members' } as Interface
+  interfaces.push(own, late)
+  const resources: Record<string, InterfaceResource[]> = { web: [
+    { id: 'organisations', kind: 'screen', title: 'Organisations', address: '/organisations' },
+    { id: 'members', kind: 'panel', title: 'Members', of: 'organisations' },
+    ...Array.from({ length: 1200 }, (_, n) => ({ id: `screen-${n}`, kind: 'panel' as const,
+      title: `Archive panel ${n}`, of: 'organisations', description: `Unrelated archive record ${n}` })),
+  ] }
+  const context: AuthorUserContext = {
+    flow: { id: 'organisation', title: 'Create organisation', goal: 'Show the creation dialog' },
+    driver: 'web', areaTags: ['organisations'], interfacePath: [own.id],
+    milestones: [{ order: 1, claim: 'Creating an organisation displays its dialog', doc: 'synthetic.md',
+      sectionHeading: 'Creation', sectionText: 'Creating an organisation displays its dialog.', realization: ['navigate /organisations'] }],
+  }
+  return { interfaces, resources, own, late, context }
+}

--- a/tests/fixtures/guard-preparation-postgres/cleanup.mjs
+++ b/tests/fixtures/guard-preparation-postgres/cleanup.mjs
@@ -1,0 +1,8 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+const { admin, ownedName } = await import(pathToFileURL(path.join(process.env.GUARD_REPO_ROOT, 'db.mjs')));
+const name = ownedName(process.env);
+const connection = await admin(process.env);
+try { await connection.query(`DROP DATABASE IF EXISTS "${name}" WITH (FORCE)`); }
+finally { await connection.end(); }
+if (process.env.TEST_CLEANUP_FAILURE === 'yes') throw new Error('cleanup reporting failure');

--- a/tests/fixtures/guard-preparation-postgres/db.mjs
+++ b/tests/fixtures/guard-preparation-postgres/db.mjs
@@ -1,0 +1,17 @@
+import { PrismaClient } from '@prisma/client';
+import pg from 'pg';
+export const client = env => new PrismaClient({ datasources: { db: { url: env.DATABASE_URL } } });
+export function ownedName(env) {
+  const name = env.GUARD_PREPARATION_NAMESPACE;
+  if (!/^guard_[a-f0-9]{32}$/.test(name)) throw new Error('Invalid owned database');
+  for (const key of ['DATABASE_URL', 'DIRECT_URL']) {
+    if (new URL(env[key]).pathname !== '/' + name) throw new Error('Private database binding mismatch');
+  }
+  return name;
+}
+export async function admin(env) {
+  const base = JSON.parse(env.GUARD_PREPARATION_POSTGRES_BASE_URLS).DIRECT_URL;
+  const connection = new pg.Client({ connectionString: base });
+  await connection.connect();
+  return connection;
+}

--- a/tests/fixtures/guard-preparation-postgres/package-lock.json
+++ b/tests/fixtures/guard-preparation-postgres/package-lock.json
@@ -1,0 +1,544 @@
+{
+  "name": "guard-preparation-postgres-fixture",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "guard-preparation-postgres-fixture",
+      "dependencies": {
+        "@prisma/client": "6.19.0",
+        "pg": "8.13.1",
+        "prisma": "6.19.0"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.0.tgz",
+      "integrity": "sha512-QXFT+N/bva/QI2qoXmjBzL7D6aliPffIwP+81AdTGq0FXDoLxLkWivGMawG8iM5B9BKfxLIXxfWWAF6wbuJU6g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.0.tgz",
+      "integrity": "sha512-zwCayme+NzI/WfrvFEtkFhhOaZb/hI+X8TTjzjJ252VbPxAl2hWHK5NMczmnG9sXck2lsXrxIZuK524E25UNmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.18.4",
+        "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.0.tgz",
+      "integrity": "sha512-8hAdGG7JmxrzFcTzXZajlQCidX0XNkMJkpqtfbLV54wC6LSSX6Vni25W/G+nAANwLnZ2TmwkfIuWetA7jJxJFA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.0.tgz",
+      "integrity": "sha512-pMRJ+1S6NVdXoB8QJAPIGpKZevFjxhKt0paCkRDTZiczKb7F4yTgRP8M4JdVkpQwmaD4EoJf6qA+p61godDokw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.0",
+        "@prisma/engines-version": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
+        "@prisma/fetch-engine": "6.19.0",
+        "@prisma/get-platform": "6.19.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773.tgz",
+      "integrity": "sha512-gV7uOBQfAFlWDvPJdQxMT1aSRur3a0EkU/6cfbAC5isV67tKDWUrPauyaHNpB+wN1ebM4A9jn/f4gH+3iHSYSQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.0.tgz",
+      "integrity": "sha512-OOx2Lda0DGrZ1rodADT06ZGqHzr7HY7LNMaFE2Vp8dp146uJld58sRuasdX0OiwpHgl8SqDTUKHNUyzEq7pDdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.0",
+        "@prisma/engines-version": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
+        "@prisma/get-platform": "6.19.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.0.tgz",
+      "integrity": "sha512-ym85WDO2yDhC3fIXHWYpG3kVMBA49cL1XD2GCsCF8xbwoy2OkDQY44gEbAt2X46IQ4Apq9H6g0Ex1iFfPqEkHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
+      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/nypm": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.10.tgz",
+      "integrity": "sha512-W72Hrj1petq+b3Hk2aAC+9zswetlIFTnDW4s5djseZh2nYqBbyQLOtj472HwcbcWykPBUW1WpWpjOd4nK6gMRw==",
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.2.2",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.3.1"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+      "license": "MIT"
+    },
+    "node_modules/ohash": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.1.tgz",
+      "integrity": "sha512-OUir1A0rPNZlX//c7ksiu7crsGZTKSOXJPgtNiHGIlC9H0lO+NC6ZDYksSgBYY/thSWhnSRBv8w1lieNNGATNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.7.0",
+        "pg-protocol": "^1.7.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.6.tgz",
+      "integrity": "sha512-lqIfH7bdgsxHAY/ZnUOwm+aCFKrsHBDhSFuk9O0B9uCqJAIkrKTo/+LQqLPLUS4e04+jCmQVikxE3QipH5chPw==",
+      "license": "MIT"
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.3.tgz",
+      "integrity": "sha512-j/lCFdcppV0JxWpCEITdbDltBxPP6cHT+yNJ6Go2OgoSA9518X847X9z0p6LtA4Nc16+eQzCZjRrWanTGvHJ5w==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.3.1",
+        "exsolve": "^1.1.1",
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/pkg-types/node_modules/confbox": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.3.1.tgz",
+      "integrity": "sha512-cKUSoKa8YxFZZSmraVi7onONx3amu77ngK3kGpsYHDH7drPwCRkQE1RYMPlLRrMtnciRj274XNRxcHxnKmDSnA==",
+      "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.0.tgz",
+      "integrity": "sha512-F3eX7K+tWpkbhl3l4+VkFtrwJlLXbAM+f9jolgoUZbFcm1DgHZ4cq9AgVEgUym2au5Ad/TDLN8lg83D+M10ycw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.19.0",
+        "@prisma/engines": "6.19.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/tests/fixtures/guard-preparation-postgres/package.json
+++ b/tests/fixtures/guard-preparation-postgres/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "guard-preparation-postgres-fixture",
+  "private": true,
+  "type": "module",
+  "scripts": { "generate": "prisma generate" },
+  "dependencies": { "@prisma/client": "6.19.0", "prisma": "6.19.0", "pg": "8.13.1" }
+}

--- a/tests/fixtures/guard-preparation-postgres/prisma/migrations/20260912000000_init/migration.sql
+++ b/tests/fixtures/guard-preparation-postgres/prisma/migrations/20260912000000_init/migration.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "User" ("id" SERIAL PRIMARY KEY, "email" TEXT NOT NULL UNIQUE);
+CREATE TABLE "Session" ("token" TEXT PRIMARY KEY);
+CREATE TABLE "Document" ("id" SERIAL PRIMARY KEY, "tenant" TEXT NOT NULL, "status" TEXT NOT NULL);
+-- Reproduce Documenso's schema-qualified migration. This must run unchanged.
+INSERT INTO "public"."User" ("email") VALUES ('deleted-account@fixture.test');

--- a/tests/fixtures/guard-preparation-postgres/prisma/migrations/migration_lock.toml
+++ b/tests/fixtures/guard-preparation-postgres/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/tests/fixtures/guard-preparation-postgres/prisma/schema.prisma
+++ b/tests/fixtures/guard-preparation-postgres/prisma/schema.prisma
@@ -1,0 +1,20 @@
+generator client {
+  provider = "prisma-client-js"
+}
+datasource db {
+  provider = "postgresql"
+  url = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+}
+model User {
+  id Int @id @default(autoincrement())
+  email String @unique
+}
+model Session {
+  token String @id
+}
+model Document {
+  id Int @id @default(autoincrement())
+  tenant String
+  status String
+}

--- a/tests/fixtures/guard-preparation-postgres/seed.mjs
+++ b/tests/fixtures/guard-preparation-postgres/seed.mjs
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+const root = process.env.GUARD_REPO_ROOT;
+const { admin, ownedName, client } = await import(pathToFileURL(path.join(root, 'db.mjs')));
+const name = ownedName(process.env);
+const connection = await admin(process.env);
+try { await connection.query(`CREATE DATABASE "${name}" TEMPLATE template0`); }
+finally { await connection.end(); }
+if (process.env.TEST_SEED_FAILURE === 'yes') throw new Error('failed before migration: ' + process.env.DIRECT_URL);
+const require = createRequire(path.join(root, 'package.json'));
+execFileSync(process.execPath, [require.resolve('prisma/build/index.js'), 'migrate', 'deploy', '--schema', path.join(root, 'prisma/schema.prisma')], { env: process.env });
+const db = client(process.env);
+try {
+  const token = randomUUID();
+  await db.session.create({ data: { token } });
+  const inputs = process.env.GUARD_PREPARATION_BASELINE === 'empty' ? [] : [
+    { tenant: 'alpha', status: 'pending' }, { tenant: 'beta', status: 'completed' },
+  ];
+  await db.document.createMany({ data: inputs });
+  fs.writeFileSync(process.env.GUARD_SEED_OUT, JSON.stringify({ credentials: { owner: { value: token } }, fixtures: { documents: { count: inputs.length } } }));
+} finally { await db.$disconnect(); }

--- a/tests/fixtures/guard-preparation-postgres/server.mjs
+++ b/tests/fixtures/guard-preparation-postgres/server.mjs
@@ -1,0 +1,37 @@
+import http from 'node:http';
+import { pathToFileURL } from 'node:url';
+import fs from 'node:fs';
+import { client } from './db.mjs';
+export function app(env) {
+  if (env.TEST_SERVER_FAILURE === 'yes') throw new Error('boot failed: ' + env.DATABASE_URL);
+  const db = client(env);
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url, 'http://localhost');
+      if (url.pathname === '/health') return res.end('healthy');
+      const token = req.headers['x-world-token'];
+      if (typeof token !== 'string' || !await db.session.findUnique({ where: { token } })) { res.statusCode = 401; return res.end('unauthorized'); }
+      if (url.pathname === '/session') return res.end(JSON.stringify({ authenticated: true }));
+      if (url.pathname === '/private-env') return res.end(JSON.stringify({
+        database: new URL(env.DATABASE_URL).pathname,
+        direct: new URL(env.DIRECT_URL).pathname,
+        provisioning: !!env.GUARD_PREPARATION_POSTGRES_BASE_URLS,
+      }));
+      if (url.pathname === '/echo-secret') return res.end(JSON.stringify({ secret: env.DATABASE_URL }));
+      if (req.method === 'POST') await db.document.create({ data: { tenant: 'peer', status: 'pending' } });
+      if (req.method === 'DELETE') { await db.document.deleteMany(); await db.session.deleteMany(); }
+      if (!url.searchParams.has('input')) { res.statusCode = 400; return res.end('input required'); }
+      const input = JSON.parse(url.searchParams.get('input'));
+      const where = input.tenant ? { tenant: input.tenant } : {};
+      const rows = await db.document.findMany({ where, orderBy: { id: 'asc' } });
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ result: { data: { json: { count: rows.length, rows } } } }));
+    } catch { res.statusCode = 500; res.end('database request failed'); }
+  });
+  return { server, close: async () => { await new Promise(r => server.close(r)); await db.$disconnect(); } };
+}
+if (import.meta.url === pathToFileURL(fs.realpathSync(process.argv[1])).href) {
+  const instance = app(process.env);
+  instance.server.listen(Number(process.env.PORT), '127.0.0.1');
+  process.on('SIGTERM', async () => { await instance.close(); process.exit(0); });
+}

--- a/tests/fixtures/guard-preparation-postgres/verify.mjs
+++ b/tests/fixtures/guard-preparation-postgres/verify.mjs
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import assert from 'node:assert/strict';
+const { app } = await import(pathToFileURL(path.join(process.env.GUARD_REPO_ROOT, 'server.mjs')));
+const env = process.env, peer = JSON.parse(env.GUARD_PREPARATION_PEER_ENV);
+assert.equal(env.APP_ORIGIN, 'http://127.0.0.1:${PORT}');
+assert.equal(peer.APP_ORIGIN, env.APP_ORIGIN);
+const a = app(env), b = app(env.TEST_FALSE_ISOLATION === 'yes' ? env : peer);
+const start = instance => new Promise(resolve => instance.server.listen(0, '127.0.0.1', () => resolve(`http://127.0.0.1:${instance.server.address().port}`)));
+try {
+  const [urlA, urlB] = await Promise.all([start(a), start(b)]);
+  const headers = { 'x-world-token': JSON.parse(env.GUARD_PREPARATION_CREDENTIALS).owner.value };
+  const peerHeaders = { 'x-world-token': JSON.parse(env.GUARD_PREPARATION_PEER_CREDENTIALS).owner.value };
+  const read = async (url, headers) => {
+    const response = await fetch(url + '/rpc/documents?input=%7B%7D', { headers });
+    assert.equal(response.status, 200);
+    return (await response.json()).result.data.json;
+  };
+  for (const [url, auth] of [[urlA, headers], [urlB, peerHeaders]]) {
+    const response = await fetch(url + '/session', { headers: auth });
+    assert.equal(response.status, 200);
+  }
+  const before = await read(urlA, headers), other = await read(urlB, peerHeaders);
+  const count = env.GUARD_PREPARATION_BASELINE === 'empty' ? 0 : 2;
+  assert.equal(before.count, count); assert.equal(other.count, count);
+  if (count) assert.deepEqual(before.rows.map(row => row.status), ['pending', 'completed']);
+  const added = await fetch(urlB + '/rpc/documents?input=%7B%7D', { method: 'POST', headers: peerHeaders });
+  assert.equal(added.status, 200);
+  assert.equal((await read(urlB, peerHeaders)).count, count + 1);
+  assert.deepEqual(await read(urlA, headers), before);
+  fs.writeFileSync(env.GUARD_SEED_OUT, JSON.stringify({ fixtures: { verification: { baseline: env.GUARD_PREPARATION_BASELINE, isolated: true } } }));
+} finally { await Promise.all([a.close(), b.close()]); }

--- a/tests/fixtures/guard-preparation/seed.mjs
+++ b/tests/fixtures/guard-preparation/seed.mjs
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
 const token = process.env.GUARD_PREPARATION_NAMESPACE
-const rows = process.env.GUARD_PREPARATION_BASELINE==='empty'?[]:Array.from({length:8},(_,i)=>({id:i+1,amount:i+1,date:'2099-01-01'}))
+const rows = process.env.GUARD_PREPARATION_BASELINE==='empty'?[]:Array.from({length:8},(_,i)=>({id:i+1,amount:i+1,tenant:i%2?'b':'a',status:i%2?'pending':'completed',date:'2099-01-01'}))
 fs.writeFileSync(process.env.DATA_FILE,JSON.stringify({token,rows}))
 fs.writeFileSync(process.env.GUARD_SEED_OUT,JSON.stringify({credentials:{owner:{value:token}},fixtures:{inputs:{count:rows.length,total:rows.reduce((n,r)=>n+r.amount,0),rows}}}))

--- a/tests/fixtures/guard-preparation/server.mjs
+++ b/tests/fixtures/guard-preparation/server.mjs
@@ -5,6 +5,8 @@ export function app(env) {
   const file = env.DATA_FILE
   return http.createServer(async (req, res) => {
     if (req.url === '/health') return res.end('healthy')
+    const url = new URL(req.url, 'http://localhost')
+    if (url.pathname === '/redirect') { res.writeHead(302, { location: '/rows' }); return res.end() }
     let state = JSON.parse(fs.readFileSync(file, 'utf8'))
     if (req.headers['x-world-token'] !== state.token) { res.statusCode = 401; return res.end('unauthorized') }
     if (req.method === 'POST') {
@@ -12,6 +14,12 @@ export function app(env) {
       const rows = JSON.parse(raw)
       state.rows.push(...rows)
       fs.writeFileSync(file, JSON.stringify(state))
+    }
+    if (url.pathname === '/rpc/rows') {
+      if (!url.searchParams.has('input')) { res.statusCode = 400; return res.end('input required') }
+      const input = JSON.parse(url.searchParams.get('input'))
+      if (input.tenant) state.rows = state.rows.filter(row => row.tenant === input.tenant)
+      if (input.status) state.rows = state.rows.filter(row => row.status === input.status)
     }
     const ordered = [...state.rows].sort((a,b) => b.date.localeCompare(a.date) || b.id-a.id)
     if(env.BROKEN_ORDER==='yes')ordered.reverse()

--- a/tests/guard-generator/author-catalog.test.ts
+++ b/tests/guard-generator/author-catalog.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest'
+import { buildResourceHints } from '../../packages/guard-generator/src/grounding.js'
+import type { Interface, InterfaceResource } from '@truecourse/shared'
+import { createAuthorCatalog, scopedAuthorResources, AUTHOR_SUMMARY_CHARS, AUTHOR_TOOL_RESULT_CHARS } from '../../packages/guard-generator/src/author-catalog.js'
+
+const action = (n: number): Interface => ({ id: `web/action-${String(n).padStart(4, '0')}`, type: 'web', title: `Action ${n}`, entry: { method: 'GET', path: `/screen/${n}` }, steps: [{ kind: 'activate', target: `button "Action ${n}"` }], fingerprint: `fp${n}`, at: 'panel' })
+const resources: Record<string, InterfaceResource[]> = { web: [{ id: 'screen', title: 'Screen', kind: 'screen', address: '/screen' }, { id: 'panel', title: 'Panel', kind: 'panel', of: 'screen', readables: { markers: Array.from({ length: 1200 }, (_, n) => ({ id: `marker-${n}`, text: `Marker ${n}` })) } }] }
+const parse = (r: { content: string }) => JSON.parse(r.content)
+
+describe('author catalog', () => {
+  it('marks all requested actions complete before finishing optional resource pages', () => {
+    const entries = [action(0), action(1)]
+    const catalog = createAuthorCatalog(entries, resources)
+    const first = parse(catalog.get({ ids: entries.map(entry => entry.id) }))
+    expect(first.actionCompleteIds).toEqual(entries.map(entry => entry.id))
+    expect(first.complete).toBe(false)
+    expect(first.nextCursor).toBeDefined()
+    const firstResource = first.items.findIndex((item: { path: string[] }) => item.path[0] === 'resources')
+    expect(firstResource).toBeGreaterThan(0)
+    expect(first.items.slice(0, firstResource).every((item: { path: string[] }) => item.path[0] === 'interface')).toBe(true)
+    expect(first.items.slice(0, firstResource).some((item: { id: string }) => item.id === entries[1].id)).toBe(true)
+    const next = parse(catalog.get({ ids: entries.map(entry => entry.id), cursor: first.nextCursor }))
+    expect(next.actionCompleteIds).toEqual(entries.map(entry => entry.id))
+    expect(next.items.every((item: { path: string[] }) => item.path[0] === 'resources')).toBe(true)
+  })
+
+  it('never marks a partially returned action complete, and retains completion across resource pages', () => {
+    const first = action(0)
+    const second = { ...action(1), title: 't'.repeat(7000), startingState: 's'.repeat(7000) }
+    const catalog = createAuthorCatalog([first, second], resources)
+    const ids = [first.id, second.id]
+    const page1 = parse(catalog.get({ ids }))
+    expect(page1.actionCompleteIds).toEqual([first.id])
+    const page2 = parse(catalog.get({ ids, cursor: page1.nextCursor }))
+    expect(page2.actionCompleteIds).toEqual(ids)
+    expect(page2.complete).toBe(false)
+    const page3 = parse(catalog.get({ ids, cursor: page2.nextCursor }))
+    expect(page3.actionCompleteIds).toEqual(ids)
+  })
+
+  it('does not expose mutable snapshot metadata through candidate summaries', () => {
+    const catalog = createAuthorCatalog([action(0)])
+    const fingerprint = catalog.fingerprint
+    const before = catalog.search({ query: '/screen/0' }).content
+    const candidate = catalog.candidates([], 'Action')[0]
+    candidate.entry!.path = '/mutated'
+    candidate.omittedFields.push('invented')
+    expect(catalog.search({ query: '/screen/0' }).content).toBe(before)
+    expect(parse(catalog.search({ query: '/mutated' })).total).toBe(0)
+    expect(catalog.get({ ids: [action(0).id] }).content).not.toContain('/mutated')
+    expect(catalog.candidates([], 'Action')[0].omittedFields).not.toContain('invented')
+    expect(catalog.fingerprint).toBe(fingerprint)
+  })
+
+  it('bounds oversized optional summary metadata while retaining search recall and full retrieval', () => {
+    const entries = Array.from({ length: 6 }, (_, n) => ({
+      ...action(n), title: `needle ${'t'.repeat(7000)}`,
+      entry: { method: 'GET', path: `/${'p'.repeat(7000)}` },
+      startingState: 's'.repeat(7000), endState: 'e'.repeat(7000),
+    }))
+    const normal = { ...action(7), title: 'Normal late action' }
+    const catalog = createAuthorCatalog([...entries, normal])
+    const candidates = catalog.candidates([], 'needle')
+    expect(candidates).toHaveLength(6)
+    for (const candidate of candidates) {
+      expect(JSON.stringify(candidate).length).toBeLessThanOrEqual(AUTHOR_SUMMARY_CHARS)
+      expect(candidate.omittedFields).toContain('title')
+      expect(candidate.omittedFields).toContain('entry')
+    }
+    // All four fields individually fit a tool result but their summary does not.
+    // Omitting a field in summaries must not remove it from the search index.
+    expect(parse(catalog.search({ query: 'needle' })).total).toBe(6)
+    const ids: string[] = []
+    let cursor: string | undefined
+    do {
+      const report = catalog.search({ query: '', limit: 2, cursor })
+      expect(report.isError).toBeUndefined()
+      expect(report.content.length).toBeLessThanOrEqual(AUTHOR_TOOL_RESULT_CHARS)
+      const body = parse(report)
+      ids.push(...body.items.map((item: { id: string }) => item.id))
+      cursor = body.nextCursor
+    } while (cursor)
+    expect(ids).toEqual([...entries, normal].map(entry => entry.id))
+    const values: unknown[] = []
+    do {
+      const report = catalog.get({ ids: [entries[0].id], cursor })
+      expect(report.isError).toBeUndefined()
+      expect(report.content.length).toBeLessThanOrEqual(AUTHOR_TOOL_RESULT_CHARS)
+      const body = parse(report)
+      values.push(...body.items.map((item: { value: unknown }) => item.value))
+      cursor = body.nextCursor
+    } while (cursor)
+    expect(values).toContain(entries[0].title)
+    expect(values).toContain(entries[0].entry.path)
+    expect(values).toContain(entries[0].startingState)
+    expect(values).toContain(entries[0].endState)
+  })
+
+  it('reports an oversized ID as a bounded row and continues to normal later actions', () => {
+    const enormous = { ...action(0), id: `web/aaa-${'x'.repeat(20_000)}`, title: 'Needle enormous identity' }
+    const later = { ...action(1), id: 'web/zzz', title: 'Needle late normal identity' }
+    const catalog = createAuthorCatalog([enormous, later])
+    const first = catalog.search({ query: '', limit: 1 })
+    expect(first.isError).toBeUndefined()
+    expect(first.content.length).toBeLessThanOrEqual(AUTHOR_TOOL_RESULT_CHARS)
+    const firstBody = parse(first)
+    expect(firstBody.items[0].error).toBe('oversized-interface-id')
+    expect(firstBody.items[0].id).toBeUndefined()
+    expect(firstBody.nextCursor).toBeDefined()
+    const second = parse(catalog.search({ query: '', limit: 1, cursor: firstBody.nextCursor }))
+    expect(second.items[0].id).toBe(later.id)
+    expect(second.complete).toBe(true)
+    const candidates = catalog.candidates([], 'Needle')
+    expect(candidates[0].error).toBe('oversized-interface-id')
+    expect(candidates[1].id).toBe(later.id)
+    for (const candidate of candidates) expect(JSON.stringify(candidate).length).toBeLessThanOrEqual(AUTHOR_SUMMARY_CHARS)
+  })
+
+  it('deduplicates resource identity by surface and id', () => {
+    const items = [action(0), { ...action(0), type: 'api' as const }]
+    const registry = { web: [{ id: 'panel', kind: 'panel' as const, title: 'Web panel' }], api: [{ id: 'panel', kind: 'panel' as const, title: 'API panel' }] }
+    expect(buildResourceHints(items, registry).map(r => r.title)).toEqual(['Web panel', 'API panel'])
+  })
+
+  it('pages all 1200 summaries without repeats and ranks exact routes first', () => {
+    const entries = Array.from({ length: 1200 }, (_, n) => action(n))
+    const before = JSON.stringify(entries)
+    const catalog = createAuthorCatalog(entries, resources)
+    const ids: string[] = []
+    let cursor: string | undefined
+    do {
+      const result = catalog.search({ query: '', limit: 20, cursor })
+      expect(result.content.length).toBeLessThanOrEqual(AUTHOR_TOOL_RESULT_CHARS)
+      const body = parse(result)
+      ids.push(...body.items.map((i: Interface) => i.id))
+      cursor = body.nextCursor
+    } while (cursor)
+    expect(ids).toEqual(entries.map(i => i.id))
+    expect(parse(catalog.search({ query: '/screen/1199' })).items[0].id).toBe(entries[1199].id)
+    expect(catalog.candidates([entries[0]], 'Action')).toHaveLength(6)
+    expect(JSON.stringify(entries)).toBe(before)
+    expect(catalog.fingerprint).toBe(createAuthorCatalog([...entries].reverse(), resources).fingerprint)
+  })
+
+  it('retrieves every authoritative field including late readables and ancestors', () => {
+    const catalog = createAuthorCatalog([action(0)], resources)
+    const values: unknown[] = []
+    let cursor: string | undefined
+    let pages = 0
+    do {
+      const result = catalog.get({ ids: [action(0).id], cursor })
+      expect(result.isError).toBeUndefined()
+      expect(result.content.length).toBeLessThanOrEqual(AUTHOR_TOOL_RESULT_CHARS)
+      const body = parse(result)
+      values.push(...body.items.map((i: { value: unknown }) => i.value))
+      cursor = body.nextCursor
+      pages++
+    } while (cursor)
+    expect(pages).toBeGreaterThan(1)
+    expect(values).toContain('Marker 1199')
+    expect(values).toContain('/screen')
+    expect(values).toContain('button "Action 0"')
+    expect(values.filter(v => v === 'Marker 1199')).toHaveLength(1)
+  })
+
+  it('rejects malformed, cross-query, cross-snapshot cursors and unavailable ids', () => {
+    const catalog = createAuthorCatalog([action(0), action(1)])
+    const cursor = parse(catalog.search({ query: '', limit: 1 })).nextCursor
+    expect(catalog.search({ query: 'Action', limit: 1, cursor }).isError).toBe(true)
+    expect(createAuthorCatalog([action(0), action(2)]).search({ query: '', limit: 1, cursor }).isError).toBe(true)
+    expect(catalog.get({ ids: ['web/other-app'] }).isError).toBe(true)
+    expect(catalog.search({ query: '', cursor: 'garbage' }).isError).toBe(true)
+    expect(parse(catalog.search({ query: '.*' })).items).toEqual([])
+  })
+
+  it('reports an oversized indivisible locator explicitly without truncation', () => {
+    const entry = action(0)
+    entry.steps = [{ kind: 'activate', target: 'x'.repeat(13_000) }]
+    const catalog = createAuthorCatalog([entry])
+    let cursor: string | undefined
+    let failure: { content: string; isError?: boolean }
+    do {
+      failure = catalog.get({ ids: [entry.id], cursor })
+      cursor = parse(failure).nextCursor
+    } while (cursor)
+    expect(failure.isError).toBe(true)
+    expect(failure.content).toContain('oversized-indivisible-field')
+  })
+
+  it('fingerprints readable and metadata changes even when not initially briefed', () => {
+    const catalog = createAuthorCatalog([action(0)], resources)
+    const changed = structuredClone(resources)
+    changed.web[1].readables!.markers![1199].text = 'Changed'
+    expect(createAuthorCatalog([action(0)], changed).fingerprint).not.toBe(catalog.fingerprint)
+    expect(createAuthorCatalog([{ ...action(0), title: 'Changed' }], resources).fingerprint).not.toBe(catalog.fingerprint)
+    resources.web[0].title = 'Updated after construction'
+    expect(catalog.fingerprint).not.toBe(createAuthorCatalog([action(0)], resources).fingerprint)
+    expect(catalog.get({ ids: [action(0).id] }).content).not.toContain('Updated after construction')
+  })
+
+  it('keeps resource identity and ancestors while deferring unrelated readables', () => {
+    const selected = scopedAuthorResources([action(0)], resources)
+    expect(selected.map(r => r.id)).toEqual(['panel', 'screen'])
+    expect(selected[0].readables?.markers).toBeUndefined()
+    const entry = action(0)
+    entry.title = 'Selected marker-1199'
+    expect(scopedAuthorResources([entry], resources)[0].readables?.markers?.map(m => m.id)).toEqual(['marker-1199'])
+  })
+})

--- a/tests/guard-generator/authoring-benchmark.test.ts
+++ b/tests/guard-generator/authoring-benchmark.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { offlineReport, summarizeAttempts, summarizeUsageEvents } from '../../scripts/benchmark-guard-authoring.js'
+import { authoringFixture, missingDialogObservation } from '../fixtures/guard-authoring-benchmark/fixture.js'
+import { createAuthorCatalog } from '../../packages/guard-generator/src/author-catalog.js'
+import { compareFailureObservations } from '../../packages/guard-generator/src/failure-observation.js'
+import { canonicalWebObservationUrl } from '../../packages/guard-runner/src/web/executor.js'
+import type { GuardFailureObservation } from '../../packages/shared/src/guard/failure-observation.js'
+
+const target = missingDialogObservation
+
+describe('offline authoring structural benchmark — no model or application execution', () => {
+  it('organisation: matching missing-dialog observations reproduce independently of display prose', () => {
+    expect(compareFailureObservations(target(), structuredClone(target()))).toBeUndefined()
+  })
+  it('cross-screen team setup remains discoverable outside the candidate shortlist', () => {
+    const f = authoringFixture(); const c = createAuthorCatalog(f.interfaces, f.resources)
+    expect(c.candidates([f.own], 'organisation creation dialog').some(x => x.id === f.late.id)).toBe(false)
+    const page = JSON.parse(c.search({ query: 'Invite member' }).content)
+    expect(page.items.map((x: { id: string }) => x.id)).toContain(f.late.id)
+    const fetched = JSON.parse(c.get({ ids: [f.late.id] }).content)
+    expect(fetched.complete).toBe(true)
+    expect(fetched.items.some((x: { value: unknown }) => x.value === '/teams/members')).toBe(true)
+  })
+  it('plan-limit: only the runner-owned origin may change during confirmation', () => {
+    const a = canonicalWebObservationUrl('http://localhost:31001/plans?limit=5', 'http://localhost:31001', 'web')
+    const b = canonicalWebObservationUrl('http://localhost:32002/plans?limit=5', 'http://localhost:32002', 'web')
+    const text: GuardFailureObservation = { version: 1, kind: 'web-text', assertion: 'text:0', page: a,
+      matcher: { contains: 'Maximum 5 members' }, operator: 'contains', observed: false,
+      textDigest: `sha256:${createHash('sha256').update('Plan limit reached').digest('hex')}` }
+    expect(compareFailureObservations(text, { ...text, page: b })).toBeUndefined()
+    expect(compareFailureObservations(text, { ...text, page: b.replace('limit=5', 'limit=6') })).toBeTruthy()
+  })
+  it('role permissions: login redirect must not equal an observation from the required authenticated page', () => {
+    expect(compareFailureObservations(target(), { ...target(), page: 'guard-server://web/login' })).toBeTruthy()
+    // Comparison alone is never counted as accepted/reviewed coverage.
+    expect(summarizeAttempts([], 0).costPerAcceptedReviewed).toBeNull()
+  })
+  it('large catalog: pages retrieve all 1,202 entries within byte/result limits without losing claims', async () => {
+    const report = await offlineReport('synthetic-revision')
+    expect(report).toMatchObject({ mode: 'offline', catalogActions: 1202, retrievedActions: 1202, lateEntryRetrieved: true, lateEntryOutsideShortlist: true })
+    expect(report.initialUtf8Bytes).toBeLessThanOrEqual(120000)
+    expect(report.peakToolResultChars).toBeLessThanOrEqual(12000)
+    expect(report.lookupPages).toBeGreaterThan(1)
+    expect(report.selectedObligations).toEqual(['Creating an organisation displays its dialog'])
+    expect(report.modelTurns).toBeNull(); expect(report.acceptedScenarios).toBeNull()
+    expect(report.missingMetricReason).toContain('does not execute')
+    expect(report.cases).toHaveLength(6)
+    expect(report.cases.every(c => c.passed)).toBe(true)
+  })
+  it('uses live turn events, counts cached inputs once, and keeps reasoning a subset of output', () => {
+    const event = { sessionId: 'worker', eventId: 'turn-1', usage: { inputTokens: 10, outputTokens: 20,
+      cacheReadTokens: 30, cacheCreateTokens: 40, reasoningTokens: 5, costUsd: 1, costSource: 'model-priced' as const } }
+    expect(summarizeUsageEvents([event, event]).usage).toMatchObject({ totalTokens: 100, reasoningTokens: 5, costUsd: 1 })
+    expect(summarizeUsageEvents([]).usage).toBeNull()
+    expect(summarizeUsageEvents([{ ...event, usage: { ...event.usage, costSource: 'unpriced' } }]).usage?.costUsd).toBeNull()
+  })
+  it('semantically different failures with similar prose do not reproduce', () => {
+    expect(compareFailureObservations(target(), { ...target(), locator: { role: 'dialog', name: 'Delete organisation' } })).toBeTruthy()
+    expect(compareFailureObservations(target(), { ...target(), matchCount: 1, reason: 'hidden' })).toBeTruthy()
+  })
+  it('includes failed attempts in cost and counts children once without summing overlap as wall time', () => {
+    const attempts = [
+      { sessionId: 'failed', durationMs: 900, costUsd: 3, acceptedReviewed: 0, coveredObligations: 0 },
+      { sessionId: 'worker', durationMs: 600, costUsd: 2, acceptedReviewed: 2, coveredObligations: 3 },
+      { sessionId: 'review', parentId: 'worker', durationMs: 200, costUsd: 1, acceptedReviewed: 0, coveredObligations: 0 },
+    ]
+    expect(summarizeAttempts([...attempts, attempts[2]], 1000)).toEqual({ costUsd: 6, acceptedReviewed: 2,
+      coveredObligations: 3, wallTimeMs: 1000, summedSessionDurationMs: 1700, costPerAcceptedReviewed: 3,
+      wallMsPerAcceptedReviewed: 500, costPerCoveredObligation: 2, wallMsPerCoveredObligation: 1000 / 3 })
+    expect(summarizeAttempts([attempts[0]], 900).costPerAcceptedReviewed).toBeNull()
+  })
+  it('CLI help and output report require no provider and refuse overwriting an existing report', () => {
+    const run = (...args: string[]) => execFileSync(process.execPath, ['--conditions=truecourse-source', '--import', 'tsx',
+      'scripts/benchmark-guard-authoring.ts', ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+    expect(run('--help')).toContain('--offline --output')
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'guard-benchmark-report-'))
+    try {
+      const output = path.join(dir, 'report.json'); run('--offline', '--output', output)
+      expect(JSON.parse(fs.readFileSync(output, 'utf8'))).toMatchObject({ schemaVersion: 1, mode: 'offline', model: null })
+      expect(() => run('--offline', '--output', output)).toThrow()
+      expect(() => run('--live', '--output', output)).toThrow()
+    } finally { fs.rmSync(dir, { recursive: true, force: true }) }
+  })
+})

--- a/tests/guard-generator/failure-observation.test.ts
+++ b/tests/guard-generator/failure-observation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import type { GuardFailureObservation } from '@truecourse/shared'
+import { compareFailureObservations } from '../../packages/guard-generator/src/failure-observation.js'
+import { canonicalWebObservationUrl } from '../../packages/guard-runner/src/web/executor.js'
+
+const target: GuardFailureObservation = { version: 1, kind: 'web-target', assertion: 'visible:0', page: 'guard-server://web/settings', operation: 'to see', locator: { role: 'button', name: 'Save' }, matchCount: 0, visibility: 'hidden', reason: 'absent' }
+
+describe('supported web observation equivalence', () => {
+  it('ignores JSON object key order, never semantic field changes', () => {
+    expect(compareFailureObservations(target, { ...target, locator: { name: 'Save', role: 'button' } })).toBeUndefined()
+    for (const change of [
+      { assertion: 'visible:1' }, { page: 'guard-server://web/login' },
+      { page: 'guard-server://other/settings' }, { operation: 'to click' },
+      { locator: { role: 'button', name: 'save' } }, { matchCount: 1, reason: 'hidden' },
+      { matchCount: 2, reason: 'ambiguous', visibility: 'visible' }, { visibility: 'unknown' },
+      { locator: { role: 'button', name: 'Save', within: { role: 'dialog', name: 'Other' } } },
+    ]) expect(compareFailureObservations(target, { ...target, ...change } as GuardFailureObservation)).toBeTruthy()
+  })
+  it('normalizes only the proven origin and preserves page identity', () => {
+    const page = (port: number) => canonicalWebObservationUrl(`http://127.0.0.1:${port}/settings?team=123#tab`, `http://127.0.0.1:${port}`, 'web')
+    expect(page(1234)).toBe(page(5678))
+    expect(canonicalWebObservationUrl('https://external.test:1234/settings', 'http://127.0.0.1:1234', 'web')).toBe('https://external.test:1234/settings')
+    expect(canonicalWebObservationUrl('http://127.0.0.1:12345/settings', 'http://127.0.0.1:1234', 'web')).toBe('http://127.0.0.1:12345/settings')
+    expect(canonicalWebObservationUrl('http://127.0.0.1:1234/settings', 'http://127.0.0.1:1234')).toBe('http://127.0.0.1:1234/settings')
+    expect(canonicalWebObservationUrl('http://user:password@127.0.0.1:1234/settings', 'http://127.0.0.1:1234', 'web')).toContain('user:password')
+  })
+  it('requires complete captured text and the same matcher, scope and operator', () => {
+    const text: GuardFailureObservation = { version: 1, kind: 'web-text', assertion: 'text:0', page: target.page, matcher: { contains: 'Saved' }, operator: 'contains', observed: false, textDigest: `sha256:${'a'.repeat(64)}` }
+    expect(compareFailureObservations(text, { ...text })).toBeUndefined()
+    for (const change of [{ textDigest: `sha256:${'b'.repeat(64)}` }, { matcher: { contains: 'saved' } }, { operator: 'equals' }, { scope: { role: 'dialog', name: 'Save' } }]) {
+      expect(compareFailureObservations(text, { ...text, ...change } as GuardFailureObservation)).toBeTruthy()
+    }
+  })
+})

--- a/tests/guard-generator/flow-worker-observations.test.ts
+++ b/tests/guard-generator/flow-worker-observations.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GuardExecutor } from '@truecourse/guard-runner'
+import { readManifest } from '@truecourse/guard-runner'
+import type { FlowWorkerReview, WorkerFidelityJudge } from '@truecourse/guard-generator'
+import { interfaceFingerprint, type GuardExpectedRed, type GuardFailureObservation, type GuardFlowWorkerOutcome, type GuardScenarioResult, type Interface } from '@truecourse/shared'
+import { flowWorkerSystemPrompt } from '../../packages/core/src/services/guard-generate/flow-worker.js'
+import { acceptedSha, extractSessionBy, flowWorkerSessionOf, interfacesOf, makeTempRepo, rawWeb, rmrf,
+  runGenerate, scenarioYaml, writeCorpus, writeDoc, writeRecipe } from './helpers.js'
+
+const repos: string[] = []
+afterEach(() => { while (repos.length) rmrf(repos.pop()!) })
+const obs: GuardFailureObservation = { version: 1, kind: 'web-target', assertion: 'visible:0',
+  page: 'guard-server://web/', operation: 'to see', locator: { role: 'button', name: 'Save' },
+  matchCount: 0, visibility: 'hidden', reason: 'absent' }
+const yaml = scenarioYaml(rawWeb('Save is visible', [{ driver: 'web', navigate: '/', milestone: 1,
+  checks: ['save'], expect: { visible: { role: 'button', name: 'Save' } } }]))
+const prediction = (id?: string): GuardExpectedRed => ({ step: 1, predictedActual: 'Save is absent',
+  verdict: 'code-drift', brief: 'The required Save action is absent.', ...(id ? { observationId: id } : {}) })
+const observationId = (report: { content: string }): string => /observationId: (\S+)/.exec(report.content)?.[1] ?? ''
+const acceptedOutcome = (report: { content: string }): GuardFlowWorkerOutcome => JSON.parse(/Finish with: (.*)/.exec(report.content)![1])
+const judge: WorkerFidelityJudge = async () => ({ kind: 'faithful', evidence: [{ milestone: 1, caseId: 'save', steps: [1], reason: 'The visible Save assertion directly checks the required action.' }] })
+
+function action(id: string, title = id): Interface {
+  const shape = { type: 'web' as const, entry: { command: ['/'] }, steps: [{ kind: 'navigate' as const, route: '/' }] }
+  return { ...shape, id, title, fingerprint: interfaceFingerprint(shape) }
+}
+function seed() {
+  const repoRoot = makeTempRepo(); repos.push(repoRoot)
+  writeRecipe(repoRoot, { web: { serve: ['node', 'unused-fixture.mjs'] } })
+  writeCorpus(repoRoot, [{ ref: 'docs/app.md' }])
+  writeDoc(repoRoot, 'docs/app.md', '## home\nThe home page has a visible Save button.')
+  return repoRoot
+}
+function options(repoRoot: string) {
+  return { repoRoot, interfaces: interfacesOf(repoRoot, action('web/home', 'Home')),
+    browserPreflight: async () => ({ ok: true as const }),
+    extractSession: extractSessionBy({ home: [{ driver: 'web', verification: {
+      scope: 'web', method: 'behavior', observable: 'Save action',
+      cases: [{ id: 'save', claim: 'Save is visible', method: 'behavior', requires: ['browser'], conditions: [] }],
+    } }] }),
+  }
+}
+function executor(override: () => Partial<GuardScenarioResult> = () => ({})): GuardExecutor {
+  let calls = 0
+  return async input => {
+    calls++
+    const scenarios = input.scenarios.map(s => ({ id: s.id, title: s.title, binds: s.binds[0],
+      outcome: 'fail' as const, durationMs: 5,
+      failure: { step: 1, expected: 'Save visible', actual: calls % 2 ? 'no element with text Save' : 'nothing on the page matches Save', observation: obs },
+      ...override(),
+    }))
+    return { status: 'ok', latestPath: '', loadErrors: [], manifest: null,
+      latest: { run: { runId: `offline-${calls}`, ranAt: '2026-09-11T00:00:00Z', branch: null, commit: null, recipeFingerprint: 'fixture' },
+        summary: { total: scenarios.length, pass: 0, fail: scenarios.length, error: 0, stale: 0, orphaned: 0, blocked: 0 }, scenarios, sections: [] },
+    }
+  }
+}
+
+describe('web execution evidence through authoring and confirmation', () => {
+  it('finds a late setup action and accepts a complete reviewed red, with canonical evidence protected from outcome edits', async () => {
+    const repoRoot = seed()
+    const review = vi.fn(judge)
+    const res = await runGenerate({ ...options(repoRoot), executor: executor(),
+      interfaces: interfacesOf(repoRoot, action('web/home', 'Home'), ...Array.from({ length: 1200 }, (_, i) => action(`web/other-${i}`, `Unrelated ${i}`)), action('web/z-setup', 'Special setup')),
+      matchRunner: async ctx => ({ plan: ctx.milestones.map(m => ({ interfaceId: 'web/home', milestone: m.order, checks: ['save'] })) }),
+      flowWorkerSession: flowWorkerSessionOf(async task => {
+        const briefing = await task.prepare()
+        expect(Buffer.byteLength(flowWorkerSystemPrompt('web') + briefing)).toBeLessThanOrEqual(120_000)
+        expect(briefing).not.toContain('web/z-setup')
+        const search = task.catalog!.search({ query: 'Special setup' })
+        expect(search.isError).not.toBe(true)
+        expect(search.content).toContain('web/z-setup')
+        const fetched = task.catalog!.get({ ids: ['web/z-setup'] })
+        expect(fetched.content.length).toBeLessThanOrEqual(12_000)
+        expect(fetched.content).toContain('navigate')
+        const probe = await task.runScenario(yaml)
+        const id = observationId(probe)
+        expect(id).toBeTruthy()
+        const accepted = await task.submitScenario(yaml, [prediction(id)], review)
+        expect(accepted.isError, accepted.content).not.toBe(true)
+        const outcome = acceptedOutcome(accepted)
+        expect(outcome.expectedReds![0].observation).toEqual(obs)
+        expect(outcome.expectedReds![0].observationId).toBeUndefined()
+        expect(task.validateOutcome({ ...outcome, expectedReds: [prediction()] })).toContain('canonical evidence')
+        expect(task.validateOutcome(outcome)).toBeUndefined()
+        return { kind: 'outcome', outcome }
+      }),
+    })
+    expect(res.errors).toEqual([])
+    expect(res.written).toHaveLength(1)
+    expect(review).toHaveBeenCalledOnce()
+    expect(readManifest(repoRoot)!.flows[0].scenarios[0].caseEvidence).toHaveLength(1)
+    expect(readManifest(repoRoot)!.flows[0].scenarios[0].diagnosis!.expectedRed!.observation).toEqual(obs)
+  })
+
+  it('rejects missing, forged and changed-candidate IDs and semantic changes without relaxing review', async () => {
+    const repoRoot = seed()
+    let changed = false
+    const review = vi.fn(judge)
+    await runGenerate({ ...options(repoRoot), executor: executor(() => changed ? {
+      failure: { step: 1, expected: 'Save visible', actual: 'Save is absent', observation: { ...obs, page: 'guard-server://web/login' } },
+    } : {}), flowWorkerSession: flowWorkerSessionOf(async task => {
+      const id = observationId(await task.runScenario(yaml))
+      for (const [draft, reds] of [[yaml, [prediction()]], [yaml, [prediction('forged')]], [yaml + '\n', [prediction(id)]], [yaml, [prediction(id), prediction(id)]]] as const) {
+        const report = await task.submitScenario(draft, reds, review)
+        expect(report.isError, report.content).toBe(true)
+      }
+      changed = true
+      expect((await task.submitScenario(yaml, [prediction(id)], review)).isError).toBe(true)
+      expect(review).not.toHaveBeenCalled()
+      return { kind: 'failed', reason: 'negative evidence fixtures' }
+    }) })
+    expect(readManifest(repoRoot)!.flows[0].scenarios).toEqual([])
+  })
+
+  it('reconfirms cached typed reds, refuses legacy evidence, and retains fresh fidelity requirements', async () => {
+    const repoRoot = seed()
+    await runGenerate({ ...options(repoRoot), executor: executor(), flowWorkerSession: flowWorkerSessionOf(async task => {
+      const id = observationId(await task.runScenario(yaml))
+      const accepted = await task.submitScenario(yaml, [prediction(id)], judge)
+      const sha = acceptedSha(accepted)!
+      expect(sha, accepted.content).toBeTruthy()
+      const outcome = acceptedOutcome(accepted)
+      const cached = { yaml: task.stashedYaml(sha)!, expectedReds: outcome.expectedReds!, review: task.stashedReview(sha) as FlowWorkerReview }
+      expect(await task.confirmCached([{ ...cached, expectedReds: [prediction()] }])).toBe(false)
+      expect(await task.confirmCached([{ ...cached, review: undefined }])).toBe(false)
+      expect(await task.confirmCached([cached])).toBe(true)
+      return { kind: 'outcome', outcome }
+    }) })
+    expect(readManifest(repoRoot)!.flows[0].scenarios).toHaveLength(1)
+  })
+})

--- a/tests/guard-generator/generate-private-authoring.test.ts
+++ b/tests/guard-generator/generate-private-authoring.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import yaml from 'js-yaml'
+import { scenarioReviewFingerprint } from '@truecourse/shared/guard-proof-node'
+import { GUARD_REVIEW_POLICY_VERSION, type GuardScenario } from '@truecourse/shared'
+import type { GuardExecutor } from '@truecourse/guard-runner'
+import {
+  makeTempRepo, rmrf, writeApiRecipe, writeCorpus, writeDoc, extractSessionBy,
+  interfacesOf, apiInterface, rawApi, PASSING_API_STEPS, runGenerate,
+  scenarioYaml, stampMilestones, sessionSummary,
+} from './helpers.js'
+
+const repos: string[] = []
+afterEach(() => { while (repos.length) rmrf(repos.pop()!) })
+
+function seed() {
+  const r = makeTempRepo()
+  repos.push(r)
+  writeApiRecipe(r, { entry: null })
+  const file = path.join(r, '.truecourse/scenarios/recipe.json')
+  const recipe = JSON.parse(fs.readFileSync(file, 'utf8'))
+  recipe.api.services = { up: 'true', down: 'true', reset: 'true' }
+  recipe.preparations = { private: {
+    baseline: 'seeded', scope: 'instance', needs: [], env: {},
+    postgres: { isolation: 'database', urlEnvs: ['DATABASE_URL'] },
+    baselineChecks: [{ path: '/todos', counts: { 'todos.length': 0 } }],
+    seed: { script: 'seed.mjs', provides: { fixtures: {}, credentials: {} } },
+    verify: { script: 'verify.mjs' }, cleanup: { script: 'cleanup.mjs' },
+  } }
+  fs.writeFileSync(file, JSON.stringify(recipe))
+  writeCorpus(r, [{ ref: 'docs/api.md' }])
+  writeDoc(r, 'docs/api.md', '## list\nGET /todos returns 200 with the todo list.')
+  return r
+}
+
+const extraction = () => extractSessionBy({
+  list: [{ driver: 'api', claim: 'GET /todos returns 200 with the list', reason: 'HTTP status + body' }],
+})
+
+describe('prepared mutator execution boundary', () => {
+  it('gates trials, changed submissions and cached confirmations, then retries shared work serially', async () => {
+    const r = seed()
+    let executions = 0
+    let invocations = 0
+    let executedScenario: GuardScenario | undefined
+    const executor: GuardExecutor = async input => {
+      executions++
+      executedScenario = input.scenarios[0]
+      return { status: 'ok', latest: { scenarios: input.scenarios.map(s => ({
+        id: s.id, title: s.title, binds: s.binds[0], outcome: 'pass', durationMs: 10,
+      })) } } as never
+    }
+    const result = await runGenerate({
+      repoRoot: r, executor, extractSession: extraction(),
+      interfaces: interfacesOf(r, apiInterface('GET', '/todos')),
+      worldClassifyRunner: async flows => ({ mutators: flows.map(f => f.id) }),
+      flowWorkerSession: async ({ tasks, epicTasks, preparedMutatorTasks = [], mutatorTasks }) => {
+        invocations++
+        expect(tasks).toHaveLength(0)
+        expect(epicTasks).toHaveLength(0)
+        expect(preparedMutatorTasks).toHaveLength(invocations === 1 ? 1 : 0)
+        expect(mutatorTasks).toHaveLength(invocations === 1 ? 0 : 1)
+        const task = [...preparedMutatorTasks, ...mutatorTasks][0]!
+        const draft = (prepared: boolean) => scenarioYaml(stampMilestones(rawApi('List todos', PASSING_API_STEPS,
+          prepared ? { setup: { preparation: 'private' }, world: 'mutates' } : {}), task.milestoneCount))
+        const byTask = new Map()
+        if (invocations === 1) {
+          expect(await task.prepare()).toContain('PRIVATE AUTHORING')
+          expect((await task.runScenario(draft(false))).content).toContain('private authoring')
+          expect(executions).toBe(0)
+          expect((await task.runScenario(draft(true))).isError).not.toBe(true)
+          expect(executions).toBe(1)
+          expect((await task.submitScenario(draft(false), [], async () => ({ kind: 'faithful' }))).content).toContain('private authoring')
+          expect(executions).toBe(1)
+          // A previously accepted shared-state scenario has a valid review and
+          // unchanged cache identity. It must still obey the current pool gate.
+          const scenario = structuredClone(executedScenario!)
+          const cached = (s: GuardScenario) => [{ yaml: yaml.dump(s), expectedReds: [], review: {
+            policyVersion: GUARD_REVIEW_POLICY_VERSION,
+            scenarioFingerprint: scenarioReviewFingerprint(s), caseEvidence: [],
+          } }]
+          expect(await task.confirmCached(cached(scenario))).toBe(true)
+          expect(executions).toBe(2)
+          delete scenario.setup
+          const confirmed = await task.confirmCached(cached(scenario))
+          expect(confirmed).toBe(false)
+          expect(executions).toBe(2)
+          byTask.set(task.workItem, { kind: 'outcome', outcome: { kind: 'blocked',
+            perMilestone: [{ order: 1, capability: 'deferred to the serialized mutator wave' }] } })
+        } else {
+          expect(await task.prepare()).not.toContain('PRIVATE AUTHORING')
+          expect((await task.runScenario(draft(false))).isError).not.toBe(true)
+          expect(executions).toBe(3)
+          byTask.set(task.workItem, { kind: 'outcome', outcome: { kind: 'blocked',
+            perMilestone: [{ order: 1, capability: 'test ends after proving execution' }] } })
+        }
+        return { byTask, summary: sessionSummary('guard-generate.flow-worker', { ran: 1 }) }
+      },
+    })
+    expect(result.status).toBe('ok')
+    expect(invocations).toBe(2)
+  }, 60_000)
+
+  it('honors an explicit shared-state deferral before the author attempts execution', async () => {
+    const r = seed()
+    let invocations = 0
+    await runGenerate({
+      repoRoot: r, extractSession: extraction(),
+      interfaces: interfacesOf(r, apiInterface('GET', '/todos')),
+      worldClassifyRunner: async flows => ({ mutators: flows.map(f => f.id) }),
+      flowWorkerSession: async ({ preparedMutatorTasks = [], mutatorTasks }) => {
+        invocations++
+        expect(preparedMutatorTasks.length).toBe(invocations === 1 ? 1 : 0)
+        expect(mutatorTasks.length).toBe(invocations === 1 ? 0 : 1)
+        const task = [...preparedMutatorTasks, ...mutatorTasks][0]!
+        return { byTask: new Map([[task.workItem, { kind: 'outcome', outcome: { kind: 'blocked', perMilestone: [{
+          order: 1, capability: invocations === 1 ? 'deferred to the serialized mutator wave' : 'missing external account',
+        }] } }]]), summary: sessionSummary('guard-generate.flow-worker', { ran: 1 }) }
+      },
+    })
+    expect(invocations).toBe(2)
+  }, 60_000)
+})

--- a/tests/guard-generator/generate.test.ts
+++ b/tests/guard-generator/generate.test.ts
@@ -328,6 +328,7 @@ describe('browser setup grounding', () => {
       fingerprint: 'sha256:create' }
     const briefings: string[] = []
     const cacheInputs: string[][] = []
+    const fetched: string[] = []
     const run = (setup: Interface) => runGenerate({
       repoRoot: r,
       interfaces: interfacesOf(r, webInterface(), setup),
@@ -335,17 +336,20 @@ describe('browser setup grounding', () => {
       matchRunner: async () => ({ plan: [{ interfaceId: 'web/board', milestone: 1 }] }),
       flowWorkerSession: submitWorkerSessions((task) => {
         cacheInputs.push(task.cacheMaterial.interfaceFingerprints)
+        fetched.push(task.catalog!.get({ ids: [setup.id] }).content)
         return { blocked: [{ order: 1, capability: 'missing-data: record' }] }
       }, { onBriefing: (_task, briefing) => briefings.push(briefing) }),
     })
     await run(create)
     expect(briefings).toHaveLength(1)
-    expect(briefings[0]).toContain('BROWSER ACTIONS AVAILABLE FOR SETUP')
-    expect(briefings[0]).toContain('activate: button "Add record"')
-    expect(briefings[0]).toContain('Do not edit shared fixtures')
+    expect(briefings[0]).toContain('BROWSER SETUP CANDIDATES')
+    expect(briefings[0]).not.toContain('Add record')
+    expect(fetched[0]).toContain('Add record')
+    expect(briefings[0]).toContain('metadata associations')
     await run({ ...create, steps: [{ kind: 'activate', target: 'button "New record"' }], fingerprint: 'sha256:create-v2' })
     expect(briefings).toHaveLength(2)
-    expect(briefings[1]).toContain('activate: button "New record"')
+    expect(briefings[1]).not.toContain('New record')
+    expect(fetched[1]).toContain('New record')
     expect(cacheInputs[0]).not.toEqual(cacheInputs[1])
   })
 })

--- a/tests/guard-generator/helpers.ts
+++ b/tests/guard-generator/helpers.ts
@@ -452,14 +452,13 @@ export function flowWorkerSessionOf(
   handler: (task: FlowWorkerTask) => Promise<FlowWorkerSessionResult | undefined>,
   over: { summary?: Partial<GuardSessionSummary>; fidelitySummary?: GuardSessionSummary } = {},
 ): FlowWorkerSessionSeam {
-  return async ({ tasks, epicTasks, mutatorTasks, onTask }) => {
+  return async ({ tasks, epicTasks, preparedMutatorTasks = [], mutatorTasks, onTask }) => {
     const byTask = new Map<string, FlowWorkerSessionResult>()
-    const all = [...tasks, ...epicTasks, ...mutatorTasks]
+    const all = [...tasks, ...epicTasks, ...preparedMutatorTasks, ...mutatorTasks]
     let done = 0
     onTask?.(0, all.length)
-    // Three WAVES, like the real seam: non-epics, then epics, then the
-    // serialized world-mutator tail.
-    for (const wave of [tasks, epicTasks, mutatorTasks]) {
+    // Same wave order as the real seam; concurrency is tested at the core seam.
+    for (const wave of [tasks, epicTasks, preparedMutatorTasks, mutatorTasks]) {
       for (const task of wave) {
         const result = await handler(task)
         if (result) byTask.set(task.workItem, result)

--- a/tests/guard-generator/helpers.ts
+++ b/tests/guard-generator/helpers.ts
@@ -619,10 +619,11 @@ export function submitWorkerSessions(
     if ('red' in spec) {
       const yamlText = scenarioYaml(stampMilestones(spec.red, opts.milestones?.(task) ?? task.milestoneCount))
       // Round 1 observes the failure; round 2 declares it, as the gate requires.
-      const probe = await task.submitScenario(yamlText, [], judge, keepsPriorId(task))
+      const probe = await task.runScenario(yamlText)
       const expectedReds: GuardExpectedRed[] = [
         {
           step: observedStep(probe),
+          ...(/observationId: ([^\s]+)/.exec(probe.content)?.[1] ? { observationId: /observationId: ([^\s]+)/.exec(probe.content)![1] } : {}),
           predictedActual: observedActual(probe),
           verdict: spec.verdict ?? 'code-drift',
           brief: spec.brief ?? 'the doc and the code disagree',
@@ -632,7 +633,8 @@ export function submitWorkerSessions(
       opts.onSubmit?.(task, report)
       const sha = acceptedSha(report)
       if (sha === null) return refused(`the red submission was not accepted: ${report.content}`)
-      return { kind: 'outcome', outcome: { kind: 'settled', scenarioYamlSha: sha, expectedReds } }
+      const canonical = /Finish with: (.*)/.exec(report.content)?.[1]
+      return { kind: 'outcome', outcome: canonical ? JSON.parse(canonical) : { kind: 'settled', scenarioYamlSha: sha, expectedReds } }
     }
     const raw = 'scenario' in spec ? spec.scenario : spec
     const expectedReds = 'expectedReds' in spec ? spec.expectedReds : []

--- a/tests/guard-generator/private-authoring.test.ts
+++ b/tests/guard-generator/private-authoring.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { RecipeSchema } from '@truecourse/guard-runner'
+import type { GuardScenario } from '@truecourse/shared'
+import { privateAuthoringDefect, privateAuthoringProfiles } from '../../packages/guard-generator/src/private-authoring.js'
+
+const privateProfile = {
+  baseline: 'seeded', scope: 'instance', needs: ['user'], env: {},
+  postgres: { isolation: 'database', urlEnvs: ['DATABASE_URL'] },
+  baselineChecks: [{ path: '/users', counts: { count: 1 } }],
+  seed: { script: 'seed.mjs', provides: { fixtures: {}, credentials: {} } },
+  verify: { script: 'verify.mjs' }, cleanup: { script: 'cleanup.mjs' },
+}
+
+describe('private authoring eligibility', () => {
+  const locals = new Set(['user'])
+  it('admits declared local Postgres preparation, not legacy or supplied profiles', () => {
+    const recipe = RecipeSchema.parse({ build: 'true', api: { serve: ['node', 'server.mjs'] }, preparations: {
+      private: privateProfile,
+      supplied: { ...privateProfile, needs: ['stripe'] },
+      undeclared: { ...privateProfile, needs: undefined },
+      unchecked: { ...privateProfile, baselineChecks: undefined },
+      file: { ...privateProfile, postgres: undefined, env: { DATABASE_URL: '${directory}/db' } },
+    } })
+    expect([...privateAuthoringProfiles(recipe, locals)]).toEqual(['private'])
+  })
+
+  it('requires private preparation even for drafts that omit world: mutates', () => {
+    expect(privateAuthoringDefect({ steps: [] } as unknown as GuardScenario, new Set(['private']), locals))
+      .toMatch(/select an eligible/)
+  })
+
+  it.each([
+    { needs: ['stripe'] },
+    { prerequisites: [{ dependency: 'stripe', mode: 'provided' }] },
+    { steps: [{ request: { path: '/${supplied:stripe.account}' } }] },
+  ])('refuses supplied bindings on a prepared scenario: %j', extra => {
+    const scenario = { steps: [], setup: { preparation: 'private' }, ...extra } as unknown as GuardScenario
+    expect(privateAuthoringDefect(scenario, new Set(['private']), locals)).toMatch(/stripe/)
+  })
+
+  it('allows only the selected eligible profile and local dependencies', () => {
+    const scenario = { steps: [], setup: { preparation: 'private' }, needs: ['user'] } as unknown as GuardScenario
+    expect(privateAuthoringDefect(scenario, new Set(['private']), locals)).toBeUndefined()
+    expect(privateAuthoringDefect(scenario, new Set(), locals)).toMatch(/select an eligible/)
+  })
+})

--- a/tests/guard-generator/retirement.test.ts
+++ b/tests/guard-generator/retirement.test.ts
@@ -90,7 +90,9 @@ describe('flowGenerationInputsHash — the frozen retirement salt', () => {
    */
   // Intentionally rolled for case-granular matching, reviewed preparation profiles,
   // prerequisite eligibility, grounded proof, and the explicit review-policy version.
-  const GOLDEN = 'sha256:b79568ca52628636431e274f2545c4f714163307bfdbd671f4abbd478eb5ce80'
+  // Policy v5 deliberately revalidates committed coverage under typed web evidence;
+  // extraction, synthesis and matching cache-key algorithms are unchanged.
+  const GOLDEN = 'sha256:2eb1fc76cde7fdb99df25ea0d236fd9a29ba05b0de5a48e8b46f664cc7ef4125'
 
   it('retains the retirement salt with the current matching doctrine', () => {
     expect(

--- a/tests/guard-generator/setup.test.ts
+++ b/tests/guard-generator/setup.test.ts
@@ -326,6 +326,19 @@ describe('runGuardSetup — the step spine (plan 03 step 8)', () => {
     expect(report.steps.find((s) => s.key === 'preparations')?.reason).toBe(findings.join('; '))
   })
 
+  it('retries unavailable preparation authoring when a session becomes available', async () => {
+    const r = fixtureRepo(); writeRecipe(r);
+    writeGuardSetup(r, (await runGuardSetup(baseOpts(r, { seedSession: seedSeam().seam }))).report);
+    expect(readGuardSetup(r)!.steps.find(row => row.key === 'preparations')!.inputFingerprint).toBe('authoring-unavailable');
+    let calls = 0;
+    const options = baseOpts(r, { only: 'preparations', preparationSession: async () => {
+      calls++; return { status: 'skipped', reason: 'No supported datastore', findings: ['No supported datastore'] };
+    } });
+    writeGuardSetup(r, (await runGuardSetup(options)).report);
+    await runGuardSetup(options);
+    expect(calls).toBe(1);
+  });
+
   // `blocked` is the auth step's alone — a supplied credential waiting on a user
   // registration. Every other step is ok/skipped/failed.
   it('the shared schema allows `blocked` on auth and refuses it anywhere else', () => {

--- a/tests/guard-generator/worker-observations.test.ts
+++ b/tests/guard-generator/worker-observations.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import type { GuardExpectedRed, GuardFailureObservation, GuardScenarioResult } from '@truecourse/shared'
+import { WorkerObservations, redObservationMismatch } from '../../packages/guard-generator/src/worker-observations.js'
+
+const observation: GuardFailureObservation = {
+  version: 1, kind: 'web-target', assertion: 'visible:0', page: 'guard-server://web/settings',
+  operation: 'to see', locator: { role: 'button', name: 'Save' }, matchCount: 0, visibility: 'hidden', reason: 'absent',
+}
+const result = (over: Partial<GuardScenarioResult> = {}): GuardScenarioResult => ({
+  id: 'test', title: 'test', binds: { doc: 'spec.md', section: 'save', fingerprint: 'spec' },
+  outcome: 'fail', durationMs: 0,
+  failure: { step: 1, expected: 'Save visible', actual: 'no Save button', observation }, ...over,
+})
+const red = (over: Partial<GuardExpectedRed> = {}): GuardExpectedRed => ({
+  step: 1, predictedActual: 'no Save button', verdict: 'code-drift', brief: 'Save missing', ...over,
+})
+
+describe('worker-owned execution observations', () => {
+  it('binds a token to exact candidate bytes, step and task; never trusts model evidence', () => {
+    const worker = new WorkerObservations('web')
+    const id = worker.record('draft', result())!
+    expect(id).toBeTruthy()
+    expect(worker.resolve('draft', [red({ observationId: id })])).toEqual({ expectedReds: [red({ observation })] })
+    expect(worker.resolve('draft ', [red({ observationId: id })])).toHaveProperty('error')
+    expect(worker.resolve('draft', [red({ observationId: id, step: 2 })])).toHaveProperty('error')
+    expect(new WorkerObservations('web').resolve('draft', [red({ observationId: id })])).toHaveProperty('error')
+    expect(worker.resolve('draft', [red({ observation })])).toHaveProperty('error')
+  })
+
+  it('bounds retained observations and clears them on completion', () => {
+    const worker = new WorkerObservations('web', 2)
+    const first = worker.record('one', result())!
+    worker.record('two', result())
+    const last = worker.record('three', result())!
+    expect(worker.resolve('one', [red({ observationId: first })])).toHaveProperty('error')
+    expect(worker.resolve('three', [red({ observationId: last })])).toHaveProperty('expectedReds')
+    worker.clear()
+    expect(worker.resolve('three', [red({ observationId: last })])).toHaveProperty('error')
+  })
+
+  it('does not mint evidence for setup failure, unsafe evidence or other surfaces', () => {
+    const worker = new WorkerObservations('web')
+    expect(worker.record('draft', result({ preparationFailure: { profile: 'empty', stage: 'prepare' } }))).toBeUndefined()
+    expect(worker.record('draft', result({ failure: { ...result().failure!, observationUnavailable: 'redacted subject' } }))).toBeUndefined()
+    expect(new WorkerObservations('api').record('draft', result())).toBeUndefined()
+  })
+
+  it('rejects duplicate first-red and empty predictions on every surface', () => {
+    const worker = new WorkerObservations('cli')
+    expect(worker.resolve('draft', [red(), red()])).toHaveProperty('error')
+    expect(worker.resolve('draft', [red({ predictedActual: ' \n ' })])).toHaveProperty('error')
+    expect(worker.resolve('draft', [red({ predictedActual: '  absent  ' })])).toEqual({ expectedReds: [red({ predictedActual: 'absent' })] })
+    expect(redObservationMismatch(result(), red({ predictedActual: ' ' }))).toBeTruthy()
+  })
+
+  it('uses typed evidence despite wording changes and fails closed on lost or changed evidence', () => {
+    expect(redObservationMismatch(result(), red({ observation, predictedActual: 'nothing matches Save' }))).toBeUndefined()
+    expect(redObservationMismatch(result(), red())).toContain('observationId')
+    expect(redObservationMismatch(result({ failure: { ...result().failure!, observation: undefined } }), red({ observation }))).toBeTruthy()
+    expect(redObservationMismatch(result(), red({ observation: { ...observation, page: 'guard-server://web/login' } }))).toBeTruthy()
+    expect(redObservationMismatch(result({ failure: { ...result().failure!, observationUnavailable: 'unsafe evidence' } }), red({ observation }))).toBeTruthy()
+  })
+
+  it('retains legacy prose matching for unsupported failures', () => {
+    const legacy = result({ failure: { step: 1, expected: 'exit 0', actual: 'exit code 7' } })
+    expect(redObservationMismatch(legacy, red({ predictedActual: 'code 7' }))).toBeUndefined()
+    expect(redObservationMismatch(legacy, red({ predictedActual: 'code 8' }))).toBeTruthy()
+  })
+})

--- a/tests/guard-runner/api-seed.test.ts
+++ b/tests/guard-runner/api-seed.test.ts
@@ -43,6 +43,20 @@ const SEED: RecipeApiSeed = {
 }
 
 describe('runSeed', () => {
+  it('keeps port-bearing primary and peer configuration only for verifiers that allocate ports', async () => {
+    const r = repo();
+    writeSeedScript(r, `import fs from 'node:fs';
+      fs.writeFileSync(process.env.GUARD_SEED_OUT, JSON.stringify({fixtures:{env:{
+        port:process.env.PORT ?? null, peer:process.env.GUARD_PREPARATION_PEER_ENV ?? null
+      }}}));`);
+    const seed = { command: 'node seed.mjs', provides: { fixtures: { env: ['port', 'peer'] } } };
+    const env = { PORT: '${PORT}', GUARD_PREPARATION_PEER_ENV: JSON.stringify({ ORIGIN: 'http://localhost:${PORT}' }) };
+    const ordinary = await runSeed({ repoRoot: r, seed, env });
+    expect(ordinary.fixtures.get('env')).toEqual({ port: null, peer: null });
+    const verifier = await runSeed({ repoRoot: r, seed, env, preservePortTemplates: true });
+    expect(verifier.fixtures.get('env')).toEqual({ port: env.PORT, peer: env.GUARD_PREPARATION_PEER_ENV });
+  });
+
   it('runs the command, resolves declared credentials (header from provides, value from manifest) and keeps fixtures native', async () => {
     const r = repo()
     writeSeedScript(

--- a/tests/guard-runner/postgres-preparation.integration.test.ts
+++ b/tests/guard-runner/postgres-preparation.integration.test.ts
@@ -1,0 +1,184 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { prepareScenario, RecipeSchema, runGuard, type PreparedScenarioWorld } from '@truecourse/guard-runner';
+import { startApiServer } from '../../packages/guard-runner/src/api/server.js';
+import { GuardScenarioSchema } from '@truecourse/shared';
+import { specBinds, writeScenario, writeSpecDoc } from './helpers.js';
+
+const enabled = process.env.TRUECOURSE_TEST_POSTGRES === '1';
+const fixtureRoot = path.resolve('tests/fixtures/guard-preparation-postgres');
+const roots: string[] = [];
+const container = `tc-preparation-${randomUUID()}`;
+let containerCreated = false;
+let connection: any;
+let baseUrl: string;
+const docker = (...args: string[]) => execFileSync('docker', args, { encoding: 'utf8', timeout: 120_000 }).trim();
+
+describe.skipIf(!enabled)('real Postgres private preparations', () => {
+  beforeAll(async () => {
+    const require = createRequire(path.join(fixtureRoot, 'package.json'));
+    let pg: any;
+    try { pg = require('pg'); require.resolve('.prisma/client/default'); }
+    catch { throw new Error('Install the Postgres fixture with npm ci and npm run generate in tests/fixtures/guard-preparation-postgres'); }
+    docker('info', '--format', '{{.ServerVersion}}');
+    const password = randomUUID();
+    docker('run', '--detach', '--rm', '--name', container, '-e', `POSTGRES_PASSWORD=${password}`, '-p', '127.0.0.1::5432', 'postgres:16-alpine');
+    containerCreated = true;
+    const port = docker('port', container, '5432/tcp').split(':').at(-1);
+    baseUrl = `postgresql://postgres:${password}@127.0.0.1:${port}/postgres`;
+    const deadline = Date.now() + 30_000;
+    while (true) {
+      const attempt = new pg.Client({ connectionString: baseUrl });
+      try { await attempt.connect(); connection = attempt; break; }
+      catch {
+        await attempt.end();
+        if (Date.now() >= deadline) throw new Error('Disposable Postgres did not become ready');
+        await new Promise(resolve => setTimeout(resolve, 200));
+      }
+    }
+    await connection.query('CREATE TABLE sentinel (value text); INSERT INTO sentinel VALUES (\'shared state\')');
+  }, 150_000);
+
+  afterEach(async () => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+    if (!connection) return;
+    expect((await connection.query("SELECT datname FROM pg_database WHERE datname LIKE 'guard_%'")).rows).toEqual([]);
+    expect((await connection.query('SELECT value FROM sentinel')).rows).toEqual([{ value: 'shared state' }]);
+  });
+  afterAll(async () => {
+    await connection?.end();
+    if (containerCreated) docker('rm', '--force', container);
+  });
+
+  function fixture() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-postgres-fixture-')); roots.push(root);
+    fs.cpSync(fixtureRoot, root, { recursive: true, filter: source => path.basename(source) !== 'node_modules' });
+    fs.symlinkSync(path.join(fixtureRoot, 'node_modules'), path.join(root, 'node_modules'), 'dir');
+    const recipe = RecipeSchema.parse({
+      build: 'true', api: { serve: ['node', 'server.mjs'], healthPath: '/health', env: { DATABASE_URL: baseUrl, DIRECT_URL: baseUrl, APP_ORIGIN: 'http://127.0.0.1:${PORT}' } },
+      preparations: { documents: {
+        baseline: 'seeded', scope: 'instance', env: {},
+        postgres: { isolation: 'database', urlEnvs: ['DATABASE_URL', 'DIRECT_URL'] },
+        baselineChecks: [{ path: '/rpc/documents', query: { input: '{}' }, credential: 'owner', counts: { 'result.data.json.count': 2 } }],
+        seed: { script: 'seed.mjs', provides: { credentials: { owner: { header: 'x-world-token' } }, fixtures: { documents: ['count'] } } },
+        verify: { script: 'verify.mjs' }, cleanup: { script: 'cleanup.mjs' },
+      } },
+    });
+    return { root, recipe, prepare: () => prepareScenario({ repoRoot: root, recipe, profile: 'documents', timeoutMs: 60_000 }) };
+  }
+
+  async function serve(root: string, world: PreparedScenarioWorld) {
+    const started = await startApiServer({ resolvedServe: [process.execPath, path.join(root, 'server.mjs')], cwd: root, env: world.env, healthPath: '/health', readyTimeoutMs: 15_000 });
+    if (!started.ok) throw new Error('Fixture server did not start');
+    return {
+      request: (method = 'GET', route = '/rpc/documents?input=%7B%7D') => fetch(started.server.baseUrl + route, { method, headers: { 'x-world-token': world.credentials.get('owner')!.value } }),
+      close: () => started.server.stop(),
+    };
+  }
+
+  it('migrates qualified public SQL, isolates documents/sessions, and resets only on a new execution', async () => {
+    const { root, prepare } = fixture();
+    const a = await prepare();
+    let b: PreparedScenarioWorld | undefined;
+    let serverA: Awaited<ReturnType<typeof serve>> | undefined;
+    let serverB: Awaited<ReturnType<typeof serve>> | undefined;
+    let retry: PreparedScenarioWorld | undefined;
+    try {
+      b = await prepare();
+      expect(a.env.DATABASE_URL).not.toBe(b.env.DATABASE_URL);
+      expect(a.env.DATABASE_URL).toBe(a.env.DIRECT_URL);
+      expect(a.env).not.toHaveProperty('GUARD_PREPARATION_POSTGRES_BASE_URLS');
+      serverA = await serve(root, a); serverB = await serve(root, b);
+      expect((await (await serverA.request('POST')).json()).result.data.json.count).toBe(3);
+      await serverA.close(); serverA = await serve(root, a);
+      expect((await (await serverA.request()).json()).result.data.json.count).toBe(3);
+      await serverA.request('DELETE');
+      expect((await serverA.request()).status).toBe(401);
+      expect((await (await serverB.request()).json()).result.data.json.count).toBe(2);
+      await serverA.close(); serverA = undefined; await a.close();
+      retry = await prepare();
+      expect(retry.env.DATABASE_URL).not.toBe(a.env.DATABASE_URL);
+      expect(retry.credentials.get('owner')!.value).not.toBe(a.credentials.get('owner')!.value);
+      expect(retry.fixtures.get('documents')!.count).toBe(2);
+    } finally {
+      await serverA?.close(); await serverB?.close();
+      await a.close(); await b?.close(); await retry?.close();
+    }
+  }, 90_000);
+
+  it('fails real baseline filtering, false isolation and invalid credentials before scenario actions', async () => {
+    const { recipe, prepare } = fixture();
+    const check = recipe.preparations!.documents.baselineChecks![0];
+    check.query = { input: '{"tenant":"alpha"}' };
+    await expect(prepare()).rejects.toThrow('expected 2, observed 1');
+    check.query = { input: '{}' };
+    recipe.api!.env!.TEST_FALSE_ISOLATION = 'yes';
+    await expect(prepare()).rejects.toThrow();
+    delete recipe.api!.env!.TEST_FALSE_ISOLATION;
+    delete check.credential;
+    await expect(prepare()).rejects.toThrow('returned 401');
+  }, 90_000);
+
+  it('cleans a failed partial seed and redacts its private database URL', async () => {
+    const { recipe, prepare } = fixture();
+    recipe.api!.env!.TEST_SEED_FAILURE = 'yes';
+    let message = '';
+    try { await prepare(); } catch (error) { message = (error as Error).message; }
+    expect(message).toContain('failed before migration');
+    expect(message).not.toContain(new URL(baseUrl).password);
+    expect(message).not.toContain('postgresql://');
+    delete recipe.api!.env!.TEST_SEED_FAILURE;
+    recipe.api!.env!.TEST_SERVER_FAILURE = 'yes';
+    try { await prepare(); } catch (error) { message = (error as Error).message; }
+    expect(message).toContain('baseline server failed');
+    expect(message).toContain('boot failed:');
+    expect(message).not.toContain(new URL(baseUrl).password);
+    expect(message).not.toContain('postgresql://');
+  }, 60_000);
+
+  it('cleans after cancellation during seed and reports cleanup failure', async () => {
+    const { root, recipe } = fixture();
+    fs.appendFileSync(path.join(root, 'seed.mjs'), "\nfs.writeFileSync(path.join(root, 'seed-ready'), 'ready'); await new Promise(r => setTimeout(r, 60000));");
+    const controller = new AbortController();
+    const pending = prepareScenario({ repoRoot: root, recipe, profile: 'documents', signal: controller.signal, timeoutMs: 60_000 });
+    const rejected = expect(pending).rejects.toThrow();
+    const deadline = Date.now() + 30_000;
+    while (!fs.existsSync(path.join(root, 'seed-ready')) && Date.now() < deadline) await new Promise(r => setTimeout(r, 100));
+    controller.abort(); await rejected;
+    expect(fs.existsSync(path.join(root, 'seed-ready'))).toBe(true);
+    fs.copyFileSync(path.join(fixtureRoot, 'seed.mjs'), path.join(root, 'seed.mjs'));
+    recipe.api!.env!.TEST_CLEANUP_FAILURE = 'yes';
+    await expect(prepareScenario({ repoRoot: root, recipe, profile: 'documents' })).rejects.toThrow('cleanup');
+  }, 90_000);
+
+  it('uses private credentials/env in the runner and redacts database responses', async () => {
+    const { root, recipe } = fixture(); writeSpecDoc(root);
+    recipe.web = { serve: ['node', 'server.mjs'], healthPath: '/health',
+      env: { DATABASE_URL: 'postgres://wrong/shared', DIRECT_URL: 'postgres://wrong/shared' } };
+    writeScenario(root, 'private.yaml', GuardScenarioSchema.parse({
+      id: 'private-postgres', title: 'Private documents', binds: specBinds('spec/section'), setup: { preparation: 'documents' },
+      steps: [
+        { request: { method: 'GET', path: '/private-env', headers: { 'x-world-token': '{{cred:owner}}' } }, expect: { status: 200, json: { provisioning: { equals: false } } } },
+        { request: { method: 'GET', path: '/rpc/documents?input=%7B%7D', headers: { 'x-world-token': '{{cred:owner}}' } }, expect: { status: 200, json: { 'result.data.json.count': { equals: 2 } } } },
+        { request: { method: 'GET', path: '/echo-secret', headers: { 'x-world-token': '{{cred:owner}}' } }, expect: { status: 200 } },
+      ],
+    }));
+    writeScenario(root, 'private-web.yaml', GuardScenarioSchema.parse({
+      id: 'private-postgres-web', title: 'Private browser and API state', binds: specBinds('spec/section'), setup: { preparation: 'documents' },
+      steps: [
+        { driver: 'web', credential: 'owner' },
+        { driver: 'web', navigate: '/private-env', expect: { text: { contains: '/guard_' } } },
+        { request: { method: 'GET', path: '/rpc/documents?input=%7B%7D', headers: { 'x-world-token': '{{cred:owner}}' } }, expect: { status: 200, json: { 'result.data.json.count': { equals: 2 } } } },
+      ],
+    }));
+    const result = await runGuard({ repoRoot: root, recipe, skipBuild: true, capturePassEvidence: true, concurrency: 1 });
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') expect(result.latest.summary).toMatchObject({ pass: 2, error: 0 });
+    expect(JSON.stringify(result)).not.toContain(new URL(baseUrl).password);
+  }, 90_000);
+});

--- a/tests/guard-runner/postgres-preparation.test.ts
+++ b/tests/guard-runner/postgres-preparation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { RecipeSchema, bindPreparationPostgres, preparationCatalog, validateScenarioPreparation } from '@truecourse/guard-runner';
+import { scenario } from './helpers.js';
+
+const profile = {
+  baseline: 'seeded' as const, scope: 'instance' as const, env: {},
+  postgres: { isolation: 'database' as const, urlEnvs: ['DATABASE_URL', 'DIRECT_URL'] },
+  baselineChecks: [{ path: '/rpc/count', query: { input: '{}' }, counts: { count: 2 } }],
+  seed: { script: 'seed.mjs', provides: {} }, verify: { script: 'verify.mjs' }, cleanup: { script: 'cleanup.mjs' },
+};
+const namespace = `guard_${'a'.repeat(32)}`;
+
+describe('Postgres preparation bindings', () => {
+  it('preserves distinct endpoints and options while binding both connections to the owned database', () => {
+    const base = {
+      DATABASE_URL: 'postgresql://fixture:p%40ss@pool.local:6543/shared?schema=public&pgbouncer=true',
+      DIRECT_URL: 'postgres://fixture:p%40ss@direct.local:5432/shared?sslmode=require',
+    };
+    const bound = bindPreparationPostgres(profile, base, namespace);
+    for (const name of profile.postgres.urlEnvs) {
+      const before = new URL(base[name as keyof typeof base]);
+      const after = new URL(bound.env[name]);
+      expect(after.pathname).toBe(`/${namespace}`);
+      expect(after.host).toBe(before.host);
+      expect(after.password).toBe(before.password);
+      expect(after.search).toBe(before.search);
+    }
+    expect(JSON.parse(bound.provisioningEnv.GUARD_PREPARATION_POSTGRES_BASE_URLS)).toEqual(base);
+    expect(bound.env).not.toHaveProperty('GUARD_PREPARATION_POSTGRES_BASE_URLS');
+    expect([...bound.secrets.values()]).toContain('p@ss');
+    expect(bindPreparationPostgres(profile, base, `guard_${'b'.repeat(32)}`).env).not.toEqual(bound.env);
+    expect(base.DATABASE_URL).toContain('/shared?');
+  });
+
+  it('rejects missing, ambiguous or invalid URLs without echoing their contents', () => {
+    for (const value of ['', 'contains-private-password', 'https://private-password@example.test/db',
+      'postgres://private-password@localhost/', 'postgres://u:private-password@localhost/db#fragment',
+      'postgres://u:private-password@localhost/db?dbname=shared']) {
+      let message = '';
+      try { bindPreparationPostgres(profile, { DATABASE_URL: value }, namespace); }
+      catch (error) { message = (error as Error).message; }
+      expect(message).toContain('DATABASE_URL');
+      expect(message).not.toContain('private-password');
+    }
+    expect(() => bindPreparationPostgres(profile, {}, 'public')).toThrow('runner-owned');
+  });
+
+  it('requires explicit supported isolation, unique URL ownership and cleanup', () => {
+    const parse = (p: unknown) => RecipeSchema.safeParse({ build: 'true', entry: ['node', 'app.js'], preparations: { private: p } });
+    expect(parse(profile).success).toBe(true);
+    for (const patch of [
+      { postgres: undefined }, { cleanup: undefined },
+      { postgres: { isolation: 'prisma-schema', urlEnvs: ['DATABASE_URL'] } },
+      { postgres: { isolation: 'database', urlEnvs: [] } },
+      { postgres: { isolation: 'database', urlEnvs: ['DATABASE_URL', 'DATABASE_URL'] } },
+      { postgres: { isolation: 'database', urlEnvs: ['GUARD_REPO_ROOT'] } },
+      { env: { DATABASE_URL: 'postgres://local/${namespace}' } },
+    ]) expect(parse({ ...profile, ...patch }).success).toBe(false);
+  });
+
+  it('protects derived bindings across setup, commands, boots and teardown', () => {
+    const recipe = RecipeSchema.parse({ build: 'true', entry: ['node', 'app.js'], preparations: { private: profile } });
+    for (const key of profile.postgres.urlEnvs) {
+      const env = { [key]: 'postgres://local/shared' };
+      for (const spec of [
+        { setup: { preparation: 'private', env }, steps: [] },
+        { setup: { preparation: 'private' }, steps: [{ run: ['test'], env }] },
+        { setup: { preparation: 'private' }, steps: [{ boot: { env } }] },
+        { setup: { preparation: 'private' }, steps: [], teardown: [{ boot: { env } }] },
+      ]) expect(validateScenarioPreparation(recipe, scenario({ id: 'private', ...spec }))).toContain(`owns ${key}`);
+    }
+    expect(preparationCatalog(recipe)[0]).toMatchObject({ name: 'private', baselineChecks: profile.baselineChecks });
+    expect(preparationCatalog(recipe)[0]).not.toHaveProperty('env');
+    expect(preparationCatalog(recipe)[0]).not.toHaveProperty('postgres');
+  });
+});

--- a/tests/guard-runner/preparation-contract.test.ts
+++ b/tests/guard-runner/preparation-contract.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { runInNewContext } from 'node:vm';
+import { PREPARATION_VERIFY_ENV, PREPARATION_VERIFY_INPUTS_SOURCE } from '../../packages/guard-runner/src/preparation-contract';
+
+const environment = () => Object.fromEntries(Object.values(PREPARATION_VERIFY_ENV).map(name => [name, '{}']));
+const execute = (env: Record<string, string>, suffix = '') =>
+  runInNewContext(PREPARATION_VERIFY_INPUTS_SOURCE + '\n' + suffix, { process: { env } });
+
+describe('preparation verifier input example', () => {
+  it.each(Object.values(PREPARATION_VERIFY_ENV))('identifies missing input %s before making requests', name => {
+    const env = environment();
+    delete env[name];
+    expect(() => execute(env)).toThrow(`Missing preparation input: ${name}`);
+  });
+
+  it.each(['{secret-invalid-json', 'null', '[]', '42'])('rejects invalid maps without exposing their contents (%s)', value => {
+    const env = { ...environment(), [PREPARATION_VERIFY_ENV.peerCredentials]: value };
+    expect(() => execute(env)).toThrow(PREPARATION_VERIFY_ENV.peerCredentials);
+    try { execute(env); } catch (error) { expect(String(error)).not.toContain(value); }
+  });
+
+  it.each([undefined, '', '   ', 42])('rejects a missing or unusable peer credential value: %s', value => {
+    const env = { ...environment(), [PREPARATION_VERIFY_ENV.peerCredentials]: JSON.stringify({ owner: { value } }) };
+    expect(() => execute(env, "requiredPreparationCredential(peerCredentials, 'owner')")).toThrow('Missing preparation credential: owner');
+  });
+
+  it('does not accept the old unprefixed aliases as peer inputs', () => {
+    const env = { ...environment(), PEER_CREDENTIALS: '{"owner":{"value":"wrong"}}' };
+    delete env[PREPARATION_VERIFY_ENV.peerCredentials];
+    expect(() => execute(env)).toThrow(`Missing preparation input: ${PREPARATION_VERIFY_ENV.peerCredentials}`);
+  });
+});

--- a/tests/guard-runner/preparation-dependencies.test.ts
+++ b/tests/guard-runner/preparation-dependencies.test.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { preparationDependencyBriefing, resolvePreparationDependencies } from '../../packages/guard-runner/src/preparation-dependencies';
+
+const roots: string[] = [];
+afterEach(() => roots.splice(0).forEach(root => fs.rmSync(root, { recursive: true, force: true })));
+function fixture(env: Record<string, string> = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-preparation-dependencies-'));
+  roots.push(root);
+  const directory = path.join(root, '.truecourse/scenarios');
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(path.join(directory, 'dependencies.json'), JSON.stringify({ dependencies: [{
+    name: 'aws', class: 'supplied', summary: 'S3 object storage', services: ['s3'], needs: [],
+    condition: { predicates: [{ kind: 'config-value', key: 'NEXT_PUBLIC_UPLOAD_TRANSPORT', value: 's3' }], sentence: 'Only S3-backed operations' },
+    registration: { kind: 'env', vars: [
+      { name: 'AWS_ACCESS_KEY_ID', description: 'Key ID', secret: true },
+      { name: 'AWS_SECRET_ACCESS_KEY', description: 'Secret', secret: true },
+    ] },
+  }] }));
+  fs.writeFileSync(path.join(directory, 'dependencies.local.json'), JSON.stringify({ aws: { env } }));
+  return root;
+}
+
+describe('preparation dependency resolution', () => {
+  it.each(['aws', 's3'])('blocks unavailable canonical or service-alias requirement %s', name => {
+    const root = fixture();
+    expect(() => resolvePreparationDependencies(root, { build: 'true' }, [name])).toThrow('unprovided');
+    expect(() => resolvePreparationDependencies(root, { build: 'true' }, [])).not.toThrow();
+  });
+
+  it('does not mistake a partial account or recipe env for a provided registration', () => {
+    const root = fixture({ AWS_ACCESS_KEY_ID: 'partial-account' });
+    const recipe = { build: 'true', env: { AWS_SECRET_ACCESS_KEY: 'recipe-secret' } };
+    expect(() => resolvePreparationDependencies(root, recipe, ['aws'])).toThrow('incomplete');
+    const briefing = JSON.stringify(preparationDependencyBriefing(root, recipe));
+    expect(briefing).toContain('incomplete');
+    expect(briefing).toContain('Only S3-backed operations');
+    expect(briefing).not.toContain('partial-account');
+    expect(briefing).not.toContain('recipe-secret');
+  });
+
+  it('injects declared provided accounts and redacts their secrets without exposing values in the briefing', () => {
+    const root = fixture({ AWS_ACCESS_KEY_ID: 'provided-id', AWS_SECRET_ACCESS_KEY: 'provided-secret' });
+    const account = resolvePreparationDependencies(root, { build: 'true' }, ['s3']);
+    expect(account.env).toMatchObject({ AWS_ACCESS_KEY_ID: 'provided-id', AWS_SECRET_ACCESS_KEY: 'provided-secret' });
+    expect([...account.secrets.values()]).toContain('provided-secret');
+    expect(resolvePreparationDependencies(root, { build: 'true' }, []).env).not.toHaveProperty('AWS_SECRET_ACCESS_KEY');
+    const briefing = JSON.stringify(preparationDependencyBriefing(root, { build: 'true' }));
+    expect(briefing).toContain('provided');
+    expect(briefing).not.toContain('provided-id');
+    expect(briefing).not.toContain('provided-secret');
+  });
+
+  it.each(['path', 'config-dir'])('refuses %s registrations instead of pretending the instance was materialized', kind => {
+    const root = fixture();
+    fs.writeFileSync(path.join(root, '.truecourse/scenarios/dependencies.json'), JSON.stringify({ dependencies: [{
+      name: 'login', class: 'supplied', summary: 'Login state', needs: [],
+      registration: { kind, description: 'Supplied login', ...(kind === 'config-dir' ? { homePath: '.login' } : {}) },
+    }] }));
+    fs.writeFileSync(path.join(root, '.truecourse/scenarios/dependencies.local.json'), JSON.stringify({ login: { path: root } }));
+    expect(() => resolvePreparationDependencies(root, { build: 'true' }, ['login'])).toThrow('materialization');
+  });
+
+  it('refuses unknown names and malformed catalogs', () => {
+    const root = fixture();
+    expect(() => resolvePreparationDependencies(root, { build: 'true' }, ['invented'])).toThrow('unknown prerequisite');
+    fs.writeFileSync(path.join(root, '.truecourse/scenarios/dependencies.json'), '{"dependencies":"invalid"}');
+    expect(() => resolvePreparationDependencies(root, { build: 'true' }, [])).toThrow('dependencies.json');
+  });
+});

--- a/tests/guard-runner/scenario-preparation.test.ts
+++ b/tests/guard-runner/scenario-preparation.test.ts
@@ -86,6 +86,40 @@ const rows = (count: number) =>
   }));
 
 describe('runner-owned preparation profiles', () => {
+  it('blocks a scenario whose preparation needs unavailable AWS before building or seeding', async () => {
+    const { root, recipe } = fixture();
+    recipe.preparations!.ledger.needs = ['aws'];
+    recipe.build = "node -e \"require('fs').writeFileSync('build-ran', 'yes')\"";
+    fs.writeFileSync(path.join(root, 'scripts/seed.mjs'), "throw new Error('seed must not run')");
+    writeSpecDoc(root);
+    fs.mkdirSync(path.join(root, '.truecourse/scenarios'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.truecourse/scenarios/dependencies.json'), JSON.stringify({ dependencies: [{
+      name: 'aws', class: 'supplied', summary: 'S3', services: ['s3'], needs: [],
+      registration: { kind: 'env', vars: [{ name: 'AWS_SECRET_ACCESS_KEY', description: 'Secret', secret: true }] },
+    }] }));
+    await expect(prepareScenario({ repoRoot: root, recipe, profile: 'ledger' })).rejects.toThrow('Preparation dependency "aws"');
+    writeScenario(root, 'requires-aws.yaml', GuardScenarioSchema.parse({
+      id: 'requires-aws', title: 'Preparation dependency gate', binds: specBinds('spec/section'),
+      setup: { preparation: 'ledger' }, steps: [{ request: { method: 'GET', path: '/rows' }, expect: { status: 200 } }],
+    }));
+    const result = await runGuard({ repoRoot: root, recipe });
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') expect(result.latest.summary).toMatchObject({ blocked: 1, error: 0, pass: 0 });
+    expect(fs.existsSync(path.join(root, 'build-ran'))).toBe(false);
+    // An absent-account scenario cannot override its preparation's provided-account requirement.
+    fs.writeFileSync(path.join(root, '.truecourse/scenarios/dependencies.local.json'), JSON.stringify({ aws: { env: { AWS_SECRET_ACCESS_KEY: 'registered-secret' } } }));
+    writeScenario(root, 'requires-aws.yaml', GuardScenarioSchema.parse({
+      id: 'requires-aws', title: 'Conflicting preparation dependency', binds: specBinds('spec/section'),
+      prerequisites: [{ dependency: 'aws', mode: 'absent' }],
+      setup: { preparation: 'ledger', env: { AWS_SECRET_ACCESS_KEY: '' } },
+      steps: [{ request: { method: 'GET', path: '/rows' }, expect: { status: 200 } }],
+    }));
+    const conflict = await runGuard({ repoRoot: root, recipe });
+    expect(conflict.status).toBe('ok');
+    if (conflict.status === 'ok') expect(conflict.latest.summary).toMatchObject({ blocked: 1, error: 0, pass: 0 });
+    expect(fs.existsSync(path.join(root, 'build-ran'))).toBe(false);
+  });
+
   it.each(['external', 'catalog'] as const)('injects the same provided %s account into private seed, baseline checks, and scenario execution', async (source) => {
     const { root, recipe } = fixture();
     if (source === 'external') recipe.api!.externals = { currencybeacon: { baseUrlEnv: 'CURRENCYBEACON_BASE_URL', baseUrl: 'http://provider.test', env: { CURRENCYBEACON_API_KEY: {} } } };
@@ -109,9 +143,12 @@ describe('runner-owned preparation profiles', () => {
         CURRENCYBEACON_API_KEY: 'private-fixture-key', CURRENCYBEACON_BASE_URL: 'http://provider.test',
       } } }));
     }
+    recipe.preparations!.ledger.needs = ['currencybeacon'];
+    const directWorld = await prepareScenario({ repoRoot: root, recipe, profile: 'ledger' });
+    await directWorld.close();
     writeScenario(root, 'private-account.yaml', GuardScenarioSchema.parse({
       id: 'private-account', title: 'Private account injection', binds: specBinds('spec/section'),
-      prerequisites: [{ dependency: 'currencybeacon', mode: 'provided' }], setup: { preparation: 'ledger' },
+      setup: { preparation: 'ledger' },
       steps: [{ request: { method: 'GET', path: '/rows', headers: { 'x-world-token': '{{cred:owner}}' } }, expect: { status: 200, json: { count: { equals: 8 } } } }],
     }));
     const result = await runGuard({ repoRoot: root, recipe, skipBuild: true });
@@ -166,10 +203,29 @@ describe('runner-owned preparation profiles', () => {
     const { root, recipe } = fixture();
     delete recipe.preparations!.ledger.baselineChecks;
     await expect(prepareScenario({ repoRoot: root, recipe, profile: 'ledger' })).rejects.toThrow('refresh Guard Setup');
-    for (const query of ['/rows?q=none', '//foreign/rows']) {
+    for (const query of ['/rows?q=none', '//foreign/rows', '/\\foreign/rows', '/rows#fragment', '/ rows']) {
       expect(RecipeSchema.safeParse({ ...recipe, preparations: { ledger: { ...recipe.preparations!.ledger,
         baselineChecks: [{ path: query, counts: { count: 0 } }] } } }).success).toBe(false);
     }
+  });
+  it('reads serialized transport queries but refuses filtered counts, redirects and missing auth', async () => {
+    const { root, recipe } = fixture();
+    const check = recipe.preparations!.ledger.baselineChecks![0];
+    check.path = '/rpc/rows';
+    await expect(prepareScenario({ repoRoot: root, recipe, profile: 'ledger' })).rejects.toThrow('returned 400');
+    check.query = { input: JSON.stringify({}) };
+    const world = await prepareScenario({ repoRoot: root, recipe, profile: 'ledger' });
+    await world.close();
+    for (const input of [{ tenant: 'a' }, { status: 'pending' }]) {
+      check.query = { input: JSON.stringify(input) };
+      await expect(prepareScenario({ repoRoot: root, recipe, profile: 'ledger' })).rejects.toThrow('count expected 8, observed 4');
+    }
+    check.query = { input: '{}' };
+    delete check.credential;
+    await expect(prepareScenario({ repoRoot: root, recipe, profile: 'ledger' })).rejects.toThrow('returned 401');
+    check.credential = 'owner';
+    check.path = '/redirect';
+    await expect(prepareScenario({ repoRoot: root, recipe, profile: 'ledger' })).rejects.toThrow();
   });
   it('checks the real baseline again after a verifier mutates the primary', async () => {
     const { root, recipe } = fixture();

--- a/tests/guard-runner/web-driver.test.ts
+++ b/tests/guard-runner/web-driver.test.ts
@@ -241,6 +241,7 @@ describe('the web driver', () => {
       expect(result.failure?.step).toBe(2)
       expect(result.failure?.expected).toContain('button “Publish”')
       expect(result.failure?.actual).toContain('no button named “Publish” is on the page')
+      expect(result.failure?.observation).toMatchObject({ version: 1, kind: 'web-target', assertion: 'action', page: 'guard-server://web/', operation: 'to click', locator: { role: 'button', name: 'Publish' }, matchCount: 0, reason: 'absent' })
       // The evidence names what IS there — the answer is usually "it is called
       // something else now".
       const diff = fs.readFileSync(path.join(evidenceDir(repo), 'diff.txt'), 'utf-8')
@@ -279,6 +280,7 @@ describe('the web driver', () => {
       ])
       expect(result.outcome).toBe('fail')
       expect(result.failure?.expected).toContain('the page text contains')
+      expect(result.failure?.observation).toMatchObject({ version: 1, kind: 'web-text', assertion: 'text:0', page: 'guard-server://web/', operator: 'contains', matcher: { contains: 'Totally Different Product' }, observed: false })
       // The page's own words ride the failure the way a cli step's stdout does.
       expect(result.failure?.stdout).toContain('Guard Web Fixture')
     },

--- a/tests/guard-runner/web-expectations.test.ts
+++ b/tests/guard-runner/web-expectations.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { loadScenarios, launchWebBrowser, resolveWebStep, type WebBrowserHandle } from '@truecourse/guard-runner'
 import { describeWebExpect, GuardStepWebCheckSchema, GuardWebExpectSchema, GuardWebStepSchema, webStepPatterns, type GuardWebExpect, type GuardWebStep } from '@truecourse/shared'
 import { executeWebStep } from '../../packages/guard-runner/src/web/executor'
+import { compareFailureObservations } from '../../packages/guard-generator/src/failure-observation.js'
 import { makeTempRepo, rmrf, writeScenarioFile, specBinds } from './helpers.js'
 
 const dialog = { role: 'dialog' as const, name: 'Add expense', exact: true }
@@ -79,6 +80,89 @@ describe('closure, visible counts and DOM values in Chromium', () => {
     expect(result.mismatch).toBeUndefined()
     expect(result.checks).toMatchObject([{ subject: 'hidden', ok: true, actual: expect.stringContaining('0 visible matches') }])
     expect(GuardStepWebCheckSchema.safeParse(result.checks[0]).success).toBe(true)
+  })
+
+  it('records hidden, absent and ambiguous targets as distinct typed evidence', async () => {
+    const step: GuardWebStep = { driver: 'web', expect: { visible: { text: 'Save', exact: true } } }
+    await browser.page.setContent('<span style="display:none">Save</span>')
+    const hidden = await execute(step)
+    expect(hidden.mismatch?.observation).toMatchObject({ kind: 'web-target', assertion: 'visible:0', matchCount: 1, visibility: 'hidden', reason: 'hidden' })
+    await browser.page.setContent('<p>Other</p>')
+    const absent = await execute(step)
+    expect(absent.mismatch?.observation).toMatchObject({ matchCount: 0, reason: 'absent' })
+    await browser.page.setContent('<span>Save</span><span>Save</span>')
+    expect((await execute(step)).mismatch?.observation).toMatchObject({ matchCount: 2, reason: 'ambiguous' })
+  })
+
+  it.each(['assertion', 'click', 'scope'] as const)('distinguishes hidden and absent role targets in %s evidence', async kind => {
+    const target = { role: 'button' as const, name: 'Save', exact: true }
+    const step: GuardWebStep = kind === 'click'
+      ? { driver: 'web', click: target }
+      : { driver: 'web', expect: { visible: kind === 'scope'
+        ? { text: 'Save', within: dialog }
+        : target } }
+    await browser.page.setContent(kind === 'scope'
+      ? '<section role="dialog" aria-label="Add expense" hidden>Save</section>'
+      : '<button aria-label="Save" hidden>Save</button>')
+    const hidden = await execute(step)
+    expect(hidden.mismatch?.observation).toMatchObject({ kind: 'web-target', matchCount: 1, visibility: 'hidden', reason: 'hidden' })
+    expect(hidden.mismatch?.actual).toContain('not visible')
+    await browser.page.setContent('<p>Other</p>')
+    const absent = await execute(step)
+    expect(absent.mismatch?.observation).toMatchObject({ matchCount: 0, reason: 'absent' })
+    expect(compareFailureObservations(hidden.mismatch!.observation!, absent.mismatch!.observation!)).toBeDefined()
+  })
+
+  it('keeps hidden role duplicates out of successful visibility assertions and clicks', async () => {
+    const target = { role: 'button' as const, name: 'Save', exact: true }
+    await browser.page.setContent('<button aria-label="Save" hidden>Save</button><button aria-label="Save" onclick="this.textContent=\'Saved\'">Save</button>')
+    expect((await check({ visible: target })).mismatch).toBeUndefined()
+    const clicked = await execute({ driver: 'web', click: target, expect: { text: { contains: 'Saved' } } })
+    expect(clicked.infra).toBeUndefined()
+    expect(clicked.mismatch).toBeUndefined()
+  })
+
+  it('does not label a visible aria-hidden role target as physically hidden', async () => {
+    await browser.page.setContent('<button aria-label="Save" aria-hidden="true">Save</button>')
+    const result = await check({ visible: { role: 'button', name: 'Save', exact: true } })
+    expect(result.mismatch).toBeDefined()
+    expect(result.mismatch?.observation).toBeUndefined()
+    expect(result.mismatch?.observationUnavailable).toBeDefined()
+    expect(result.mismatch?.actual).toContain('could not establish')
+  })
+
+  it('captures the first failed text operator and full text beyond display truncation', async () => {
+    const step: GuardWebStep = { driver: 'web', expect: { text: { contains: 'prefix', equals: 'Required' } } }
+    await browser.page.setContent(`<p>prefix ${'x'.repeat(3000)} one</p>`)
+    const first = await execute(step)
+    expect(first.mismatch?.observation).toMatchObject({ kind: 'web-text', assertion: 'text:0', operator: 'equals', observed: false })
+    await browser.page.setContent(`<p>prefix ${'x'.repeat(3000)} two</p>`)
+    const second = await execute(step)
+    expect(first.mismatch?.actual).toBe(second.mismatch?.actual)
+    expect(first.mismatch?.observation).not.toEqual(second.mismatch?.observation)
+  })
+
+  it('normalizes only the runner origin in full captured text and page identity', async () => {
+    await browser.page.route('http://127.0.0.1:*/**', route => route.fulfill({ contentType: 'text/html', body: `<p>${route.request().url()}</p>` }))
+    try {
+      const runAt = async (port: number, pagePath = '/settings?team=123') => {
+        const baseUrl = `http://127.0.0.1:${port}`
+        await browser.page.goto(`${baseUrl}${pagePath}`)
+        return executeWebStep({ page: browser.page, baseUrl, originBinding: 'web', step: { driver: 'web', expect: { text: { contains: 'Saved' } } }, stepIndex: 1, evidenceDir, timeoutMs: 1 })
+      }
+      const first = await runAt(3011)
+      const second = await runAt(3012)
+      expect(first.mismatch?.observation).toEqual(second.mismatch?.observation)
+      expect((await runAt(3012, '/settings?team=456')).mismatch?.observation).not.toEqual(first.mismatch?.observation)
+    } finally { await browser.page.unroute('http://127.0.0.1:*/**') }
+  })
+
+  it('declines secret-bearing evidence rather than equating redacted values', async () => {
+    await browser.page.setContent('<p>private-secret</p>')
+    const result = await executeWebStep({ page: browser.page, baseUrl: 'http://localhost', step: { driver: 'web', expect: { text: { contains: 'Saved' } } }, stepIndex: 1, evidenceDir, timeoutMs: 1, redact: text => text.replaceAll('private-secret', '[secret]') })
+    expect(result.mismatch?.observation).toBeUndefined()
+    expect(result.mismatch?.observationUnavailable).toBe('failure evidence contains sensitive values')
+    expect(JSON.stringify({ observation: result.mismatch?.observation, unavailable: result.mismatch?.observationUnavailable })).not.toContain('private-secret')
   })
 
   it('fails a broken Cancel handler even though clicking succeeded', async () => {

--- a/tests/server/activity-stream.test.ts
+++ b/tests/server/activity-stream.test.ts
@@ -20,6 +20,26 @@ describe('dashboard activity journal and stream', () => {
   afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
   const create = () => createSessionRun(root, { command: 'spec-scan', gitRef: 'abc', activityStream: true });
 
+  it('pages a large replay and preserves all transcript events through completion', async () => {
+    const run = create();
+    const history: import('@truecourse/shared/activity-stream').ActivityEvent[] =
+      Array.from({ length: 300 }, (_, cursor) => ({ cursor, kind: 'session-event', sessionId: 's', event: event(cursor) }));
+    history.push({ cursor: 300, kind: 'run', run: { ...run.record(), status: 'completed' } });
+    run.readActivity = vi.fn(async () => { throw new Error('Unbounded replay'); });
+    run.readActivityPage = vi.fn(async (after, limit) => history.filter(e => e.cursor > after).slice(0, limit));
+    const reader = createActivityStream(run, -1, new AbortController().signal).getReader();
+    const received: number[] = [];
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      if (next.value.type === 'data-activity') received.push((next.value.data as { cursor: number }).cursor);
+    }
+    expect(received).toEqual(history.map(e => e.cursor));
+    expect(run.readActivity).not.toHaveBeenCalled();
+    expect(run.readActivityPage).toHaveBeenCalledTimes(3);
+    expect(run.readActivityPage).toHaveBeenLastCalledWith(255, 128);
+  });
+
   it('delivers local updates without replay and catches up periodically and on remote notification', async () => {
     vi.useFakeTimers();
     const run = create();
@@ -141,7 +161,8 @@ describe('dashboard activity journal and stream', () => {
     for await (const message of readUIMessageStream({ stream: createActivityStream(run, -1, new AbortController().signal), terminateOnError: true })) snapshots.push(message);
     const last = snapshots.at(-1)!;
     expect(last.id).toBe(run.runId);
-    expect(last.parts.filter(p => p.type === 'data-activity')).toHaveLength(3);
+    // The transcript and terminal snapshot survive; the initial snapshot is redundant.
+    expect(last.parts.filter(p => p.type === 'data-activity')).toHaveLength(2);
     expect(last.parts.some(p => p.type === 'data-progress' || p.type === 'data-heartbeat')).toBe(false);
   });
 

--- a/tests/server/sessions-routes.test.ts
+++ b/tests/server/sessions-routes.test.ts
@@ -218,7 +218,7 @@ describe('Sessions routes', () => {
 
   it('refuses bad activity cursors, limits, commands, run IDs, and legacy runs', async () => {
     const run = seedActivityRun();
-    for (const query of ['after=NaN', 'after=-2', 'after=1.2', 'after=1', 'after=999999', 'limit=0', 'limit=1001', 'limit=x']) {
+    for (const query of ['after=NaN', 'after=-2', 'after=1.2', 'after=1', 'after=999999', 'limit=0', 'limit=1001', 'limit=x', 'compact=bad']) {
       const res = await request(app).get(url(`runs/guard-setup/${run.runId}/activity?${query}`));
       expect([query, res.status]).toEqual([query, 400]);
     }
@@ -226,6 +226,27 @@ describe('Sessions routes', () => {
     await request(app).get(url('runs/guard-setup/..%2Foutside/activity')).expect(400);
     await request(app).get(url('runs/guard-setup/2026-01-01T00-00-00Z_00000000/activity')).expect(404);
     await request(app).get(url(`runs/spec-scan/${seedRun().runId}/activity`)).expect(409);
+  });
+
+  it('serves compact pages with the original cursor window and every transcript event', async () => {
+    const run = seedActivityRun();
+    let after = -1;
+    const transcripts: unknown[] = [];
+    for (;;) {
+      const endpoint = url(`runs/guard-setup/${run.runId}/activity?after=${after}&limit=2`);
+      const full = await request(app).get(endpoint).expect(200);
+      const compact = await request(app).get(`${endpoint}&compact=1`).expect(200);
+      const snapshots = full.body.events.filter((e: { kind: string }) => e.kind === 'run');
+      expect(compact.body).toEqual({
+        ...full.body,
+        events: full.body.events.filter((e: { kind: string; cursor: number }) => e.kind !== 'run' || e.cursor === snapshots.at(-1)?.cursor),
+      });
+      expect(compact.text).not.toContain('SECRET-TOKEN');
+      transcripts.push(...compact.body.events.filter((e: { kind: string }) => e.kind === 'session-event'));
+      after = compact.body.nextCursor;
+      if (compact.body.done) break;
+    }
+    expect(transcripts).toHaveLength(4);
   });
 });
 

--- a/tests/server/sessions-routes.test.ts
+++ b/tests/server/sessions-routes.test.ts
@@ -165,6 +165,26 @@ describe('Sessions routes', () => {
     expect(res.status).toBe(400);
   });
 
+  it('serves bounded newest, older, and live transcript pages', async () => {
+    const run = seedRun();
+    run.persistence.appendEvent('sibling', EVENT(0, { text: 'Not requested' }) as never);
+    const base = url(`runs/spec-scan/${run.runId}/transcript/ses-1`);
+    const latest = await request(app).get(`${base}?limit=2`);
+    expect(latest.status).toBe(200);
+    expect(latest.body.events.map((e: { seq: number }) => e.seq)).toEqual([1, 2]);
+    expect(latest.body.hasMore).toBe(true);
+    expect(latest.text).not.toContain('Not requested');
+    const older = await request(app).get(`${base}?limit=2&before=1`);
+    expect(older.body.events.map((e: { seq: number }) => e.seq)).toEqual([0]);
+    expect(older.body.hasMore).toBe(false);
+    const newer = await request(app).get(`${base}?limit=1&since=0`);
+    expect(newer.body.events.map((e: { seq: number }) => e.seq)).toEqual([1]);
+    expect(newer.body.hasMore).toBe(true);
+    for (const query of ['limit=101', 'limit=0', 'limit=2&before=-1', 'limit=2&since=0.5', 'limit=2&before=2&since=0']) {
+      expect((await request(app).get(`${base}?${query}`)).status).toBe(400);
+    }
+  });
+
   it('serves a transcript, and only past the ?since cursor', async () => {
     const run = seedRun();
     const all = await request(app).get(url(`runs/spec-scan/${run.runId}/transcript/ses-1`));

--- a/tests/shared/guard-failure-observation.test.ts
+++ b/tests/shared/guard-failure-observation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { GuardExpectedRedSchema, GuardFailureDetailSchema, GuardFailureObservationSchema } from '@truecourse/shared'
+
+const target = { version: 1, kind: 'web-target', assertion: 'visible:0', page: 'guard-server://web/settings', operation: 'to see', locator: { role: 'button', name: 'Save' }, matchCount: 0, visibility: 'hidden', reason: 'absent' }
+
+describe('versioned failure observations', () => {
+  it('keeps legacy failures and expected reds readable', () => {
+    expect(GuardFailureDetailSchema.parse({ step: 1, expected: 'Save', actual: 'absent' }).observation).toBeUndefined()
+    expect(GuardExpectedRedSchema.parse({ step: 1, predictedActual: 'absent', verdict: 'code-drift', brief: 'Save is missing' }).observation).toBeUndefined()
+  })
+  it('strictly validates versioned producer evidence', () => {
+    expect(GuardFailureObservationSchema.safeParse(target).success).toBe(true)
+    for (const change of [{ version: 2 }, { matchCount: -1 }, { injected: true }, { reason: 'timeout' }]) {
+      expect(GuardFailureObservationSchema.safeParse({ ...target, ...change }).success).toBe(false)
+    }
+  })
+  it('rejects whitespace-only predictions', () => {
+    expect(GuardExpectedRedSchema.safeParse({ step: 1, predictedActual: ' \n ', verdict: 'code-drift', brief: 'Missing' }).success).toBe(false)
+  })
+})


### PR DESCRIPTION
Browser authors previously received the full setup catalog, and confirmation relied on rendered failure text that could change between runs. This change scopes initial context, adds paged catalog lookup, and confirms supported browser failures using execution-owned observations tied to the exact scenario YAML.

- Preserve prerequisite, coverage, fidelity, and fresh-execution checks, including cached confirmations.
- Distinguish hidden and absent role targets without changing successful visible-target selection.
- Add catalog, evidence, cache-reuse, and offline benchmark regressions.

Agent conversations now request only the latest run snapshot in each history page and discard superseded snapshots during live updates. The Postgres reader omits those bodies before transfer, preserves transcript events and replay cursors, and pending history downloads abort when the view closes. A read-only check of the affected staging run reduced the projected history payload from 359 MB to 6 MB. No stored history is rewritten.

Validation: 90 Agent history, route, storage, and conversation tests passed, plus the full build. Earlier validation: `pnpm build`; guard-runner typecheck; 1,023 generator/core/shared tests and 74 focused browser/evidence tests passed, with one generator test skipped. The final browser expectation suite also passed all 30 tests.

Documentation changes are excluded. This PR changes no database schema, migration files, or deployment configuration.
